### PR TITLE
feat: Add Bun config & instructions for using Bun as primary toolchain

### DIFF
--- a/.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc
+++ b/.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc
@@ -1,0 +1,111 @@
+---
+description: Use Bun instead of Node.js, npm, pnpm, or vite.
+globs: "*.ts, *.tsx, *.html, *.css, *.js, *.jsx, package.json"
+alwaysApply: false
+---
+
+Default to using Bun instead of Node.js.
+
+- Use `bun <file>` instead of `node <file>` or `ts-node <file>`
+- Use `bun test` instead of `jest` or `vitest`
+- Use `bun build <file.html|file.ts|file.css>` instead of `webpack` or `esbuild`
+- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
+- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
+- Use `bunx <package> <command>` instead of `npx <package> <command>`
+- Bun automatically loads .env, so don't use dotenv.
+
+## APIs
+
+- `Bun.serve()` supports WebSockets, HTTPS, and routes. Don't use `express`.
+- `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
+- `Bun.redis` for Redis. Don't use `ioredis`.
+- `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
+- `WebSocket` is built-in. Don't use `ws`.
+- Prefer `Bun.file` over `node:fs`'s readFile/writeFile
+- Bun.$`ls` instead of execa.
+
+## Testing
+
+Use `bun test` to run tests.
+
+```ts#index.test.ts
+import { test, expect } from "bun:test";
+
+test("hello world", () => {
+  expect(1).toBe(1);
+});
+```
+
+## Frontend
+
+Use HTML imports with `Bun.serve()`. Don't use `vite`. HTML imports fully support React, CSS, Tailwind.
+
+Server:
+
+```ts#index.ts
+import index from "./index.html"
+
+Bun.serve({
+  routes: {
+    "/": index,
+    "/api/users/:id": {
+      GET: (req) => {
+        return new Response(JSON.stringify({ id: req.params.id }));
+      },
+    },
+  },
+  // optional websocket support
+  websocket: {
+    open: (ws) => {
+      ws.send("Hello, world!");
+    },
+    message: (ws, message) => {
+      ws.send(message);
+    },
+    close: (ws) => {
+      // handle close
+    }
+  },
+  development: {
+    hmr: true,
+    console: true,
+  }
+})
+```
+
+HTML files can import .tsx, .jsx or .js files directly and Bun's bundler will transpile & bundle automatically. `<link>` tags can point to stylesheets and Bun's CSS bundler will bundle.
+
+```html#index.html
+<html>
+  <body>
+    <h1>Hello, world!</h1>
+    <script type="module" src="./frontend.tsx"></script>
+  </body>
+</html>
+```
+
+With the following `frontend.tsx`:
+
+```tsx#frontend.tsx
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+// import .css files directly and it works
+import './index.css';
+
+const root = createRoot(document.body);
+
+export default function Frontend() {
+  return <h1>Hello, world!</h1>;
+}
+
+root.render(<Frontend />);
+```
+
+Then, run index.ts
+
+```sh
+bun --hot ./index.ts
+```
+
+For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.

--- a/.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc
+++ b/.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc
@@ -1,6 +1,6 @@
 ---
 description: Use Bun instead of Node.js, npm, pnpm, or vite.
-globs: "*.ts, *.tsx, *.html, *.css, *.js, *.jsx, package.json"
+globs: "**/*.ts, **/*.tsx, **/*.html, **/*.css, **/*.js, **/*.jsx, **/package.json"
 alwaysApply: false
 ---
 
@@ -22,7 +22,7 @@ Default to using Bun instead of Node.js.
 - `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
 - `WebSocket` is built-in. Don't use `ws`.
 - Prefer `Bun.file` over `node:fs`'s readFile/writeFile
-- Bun.$`ls` instead of execa.
+- ``Bun.$`ls` `` instead of execa.
 
 ## Testing
 

--- a/.github/instructions/use-bun.instructions.md
+++ b/.github/instructions/use-bun.instructions.md
@@ -1,0 +1,110 @@
+---
+description: Use Bun instead of Node.js, npm, pnpm, or vite.
+applyTo: "**/*.ts,**/*.tsx,**/*.html,**/*.css,**/*.js,**/*.jsx,**/package.json"
+---
+
+Default to using Bun instead of Node.js.
+
+- Use `bun <file>` instead of `node <file>` or `ts-node <file>`
+- Use `bun test` instead of `jest` or `vitest`
+- Use `bun build <file.html|file.ts|file.css>` instead of `webpack` or `esbuild`
+- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
+- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
+- Use `bunx <package> <command>` instead of `npx <package> <command>`
+- Bun automatically loads .env, so don't use dotenv.
+
+## APIs
+
+- `Bun.serve()` supports WebSockets, HTTPS, and routes. Don't use `express`.
+- `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
+- `Bun.redis` for Redis. Don't use `ioredis`.
+- `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
+- `WebSocket` is built-in. Don't use `ws`.
+- Prefer `Bun.file` over `node:fs`'s readFile/writeFile
+- Bun.$`ls` instead of execa.
+
+## Testing
+
+Use `bun test` to run tests.
+
+```ts#index.test.ts
+import { test, expect } from "bun:test";
+
+test("hello world", () => {
+  expect(1).toBe(1);
+});
+```
+
+## Frontend
+
+Use HTML imports with `Bun.serve()`. Don't use `vite`. HTML imports fully support React, CSS, Tailwind.
+
+Server:
+
+```ts#index.ts
+import index from "./index.html"
+
+Bun.serve({
+  routes: {
+    "/": index,
+    "/api/users/:id": {
+      GET: (req) => {
+        return new Response(JSON.stringify({ id: req.params.id }));
+      },
+    },
+  },
+  // optional websocket support
+  websocket: {
+    open: (ws) => {
+      ws.send("Hello, world!");
+    },
+    message: (ws, message) => {
+      ws.send(message);
+    },
+    close: (ws) => {
+      // handle close
+    }
+  },
+  development: {
+    hmr: true,
+    console: true,
+  }
+})
+```
+
+HTML files can import .tsx, .jsx or .js files directly and Bun's bundler will transpile & bundle automatically. `<link>` tags can point to stylesheets and Bun's CSS bundler will bundle.
+
+```html#index.html
+<html>
+  <body>
+    <h1>Hello, world!</h1>
+    <script type="module" src="./frontend.tsx"></script>
+  </body>
+</html>
+```
+
+With the following `frontend.tsx`:
+
+```tsx#frontend.tsx
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+// import .css files directly and it works
+import './index.css';
+
+const root = createRoot(document.body);
+
+export default function Frontend() {
+  return <h1>Hello, world!</h1>;
+}
+
+root.render(<Frontend />);
+```
+
+Then, run index.ts
+
+```sh
+bun --hot ./index.ts
+```
+
+For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.

--- a/.github/instructions/use-bun.instructions.md
+++ b/.github/instructions/use-bun.instructions.md
@@ -21,7 +21,7 @@ Default to using Bun instead of Node.js.
 - `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
 - `WebSocket` is built-in. Don't use `ws`.
 - Prefer `Bun.file` over `node:fs`'s readFile/writeFile
-- Bun.$`ls` instead of execa.
+- ``Bun.$`ls` `` instead of execa.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# adrkit
+
+Decision memory for human- and agent-authored plans — machine-readable ADRs
+that are enforceable in CI and legible to agents, without leaving git.
+Status: pre-alpha (see [`plan.md`](./plan.md)).
+
+## Toolchain
+
+This project uses **Bun** as its runtime, package manager, test runner, and
+bundler. Default to Bun instead of Node.js, npm, pnpm, or Vite:
+
+- `bun install` / `bun add`, not `npm`/`yarn`/`pnpm`
+- `bun run <script>`, `bunx <pkg>`
+- `bun test`, not `jest`/`vitest`
+- `bun build`, not `webpack`/`esbuild`
+
+See [ADR-0010](./docs/adr/0010-bun-toolchain.md) for the rationale (Bun for
+development; Node-targeted published artifacts).
+
+Full, editor-scoped Bun conventions live in the subcontext rule files — keep
+them in sync when the tooling guidance changes:
+
+- Cursor: [`.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc`](./.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc)
+- GitHub Copilot / VS Code: [`.github/instructions/use-bun.instructions.md`](./.github/instructions/use-bun.instructions.md)

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ consideration at all.
 Built with [Bun](https://bun.com) — see
 [ADR-0010](docs/adr/0010-bun-toolchain.md). **Bun is a development dependency
 only.** Nothing published by this project requires it: the CLI, the GitHub
-Action, and the MCP server are Node-targeted and smoke-tested under Node 22 and
-24 in CI.
+Action, and the MCP server are Node-targeted, and will be smoke-tested under
+Node 22 and 24 in CI once the publish pipeline lands (see [`plan.md`](./plan.md)).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ consideration at all.
 Built with [Bun](https://bun.com) — see
 [ADR-0010](docs/adr/0010-bun-toolchain.md). **Bun is a development dependency
 only.** Nothing published by this project requires it: the CLI, the GitHub
-Action, and the MCP server are Node-targeted and smoke-tested under Node 20, 22,
-and 24 in CI.
+Action, and the MCP server are Node-targeted and smoke-tested under Node 22 and
+24 in CI.
 
 ## Contributing
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,27 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "adrkit",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^6",
+        "zod": "^4",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+  }
+}

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,9 @@
-# ADR-0010. The linker setting is load-bearing, not a preference.
+# ADR-0010 install settings. These MUST live under [install]; Bun silently
+# ignores install keys placed at the top level of bunfig.toml, so a top-level
+# `linker`/`saveTextLockfile` reads as a preference the tool never applies.
+[install]
+
+# The linker setting is load-bearing, not a preference.
 #
 # The default "hoisted" linker mimics npm and permits phantom dependencies — a
 # package importing something it never declared, resolved from the hoisted root.
@@ -8,9 +13,8 @@
 linker = "isolated"
 
 # ADR-0001/0004 make this a git-native, review-centric project. The lockfile is
-# reviewed like any other file, so it must stay text.
-save-text-lockfile = true
+# reviewed like any other file, so it must stay text (bun.lock, never bun.lockb).
+saveTextLockfile = true
 
-[install]
 exact = false
-frozen-lockfile = false  # CI passes --frozen-lockfile explicitly
+frozenLockfile = false  # CI passes --frozen-lockfile explicitly

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -18,3 +18,6 @@ saveTextLockfile = true
 
 exact = false
 frozenLockfile = false  # CI passes --frozen-lockfile explicitly
+
+# Install only packages of 3 days or older
+minimumReleaseAge = 259200

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+console.log("Hello via Bun!");

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "adrkit",
+  "version": "0.1.0",
+  "description": "Decision memory for human and agent-authored plans — machine-readable, CI-enforceable architecture decision records.",
+  "type": "module",
+  "private": true,
+  "license": "Apache-2.0",
+  "author": "Mark Beacom (@mbeacom)",
+  "homepage": "https://github.com/mbeacom/adrkit#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mbeacom/adrkit.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mbeacom/adrkit/issues"
+  },
+  "workspaces": [
+    "packages/*",
+    "packages/adapters/*"
+  ],
+  "engines": {
+    "node": ">=22",
+    "bun": ">=1.2"
+  },
+  "scripts": {
+    "build": "bun run --filter='*' build",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "bun run --filter='*' lint",
+    "schema:emit": "bun run --filter='@adrkit/core' schema:emit",
+    "check:deps": "bun run scripts/check-deps.ts"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^6",
+    "zod": "^4"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "types": ["bun"],
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "exclude": ["node_modules", "dist", "**/dist"]
+}


### PR DESCRIPTION
This pull request introduces Bun as the default toolchain for development, updates documentation and configuration to reflect this change, and adds initial project scaffolding. The most important changes are summarized below.

**Adoption of Bun Toolchain**

- Added Bun-specific configuration and instructions:
  - New `.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc` and `.github/instructions/use-bun.instructions.md` files provide detailed guidance for using Bun instead of Node.js, npm, pnpm, or Vite. [[1]](diffhunk://#diff-adc76b8732de1ede5ada5dfd6162c2243fe4e8f1b22365a60d535118823dedf3R1-R111) [[2]](diffhunk://#diff-c9141340a9a75fca6199cb9821c0b30b28a9759bc7a293c7e728c61b7c9fd564R1-R110)
  - Updated `bunfig.toml` to use correct Bun configuration keys and clarified comments about load-bearing settings. [[1]](diffhunk://#diff-d20a1d3c8f2bd65984a8a4aa51992df69e00dc2d9af53508fab7a080ad526e58L1-R6) [[2]](diffhunk://#diff-d20a1d3c8f2bd65984a8a4aa51992df69e00dc2d9af53508fab7a080ad526e58L11-R20)

- Updated documentation to reflect Bun usage:
  - `CLAUDE.md` now describes Bun as the project's runtime, package manager, test runner, and bundler, and references the new guidance files.
  - `README.md` notes that Bun is a development dependency only, and updates CI Node versions.

**Project Initialization and Metadata**

- Added `package.json` with project metadata, workspace settings, engine requirements (Node >=22, Bun >=1.2), scripts, and devDependencies.
- Added a simple `index.ts` entry point that logs a message via Bun.