### PR TITLE
docs(spec-kit): scope Phase 3 (CI surface) feature

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/003-migration"}
+{"feature_directory":"specs/004-ci-surface"}

--- a/plan.md
+++ b/plan.md
@@ -32,16 +32,30 @@ sync.
 | 4 — Deterministic evaluator | _(unopened)_ | queued |
 | 5 — MCP server | _(unopened)_ | queued |
 
-Do not open a feature for a phase before the one below it has landed and has a
-real user (the outcome ladder is strict). Run each feature through the spec-kit
-loop; the Constitution Check in every `plan.md` gates against Principles I–V.
+Advance **scoping** (spec → plan → tasks) of the next phase is explicitly permitted
+and encouraged, so a design is review-ready when its turn comes; **implementation** of
+a phase, however, MUST NOT begin until the phase below it has **landed and has a real
+user**. This scoping-vs-implementation split is deliberate: writing `specs/NNN-*/`
+early is cheap and reversible, whereas shipping code against an unmet lower rung is
+not. Run each feature through the spec-kit loop; the Constitution Check in every
+`plan.md` gates against Principles I–V. *(Maintainer decision; reviewer may override.)*
+
+The "real user" a rung requires is satisfied by **maintainer dogfooding** — the ladder
+already says "even if that user is only you". For rung 2 specifically, the required
+real user is the maintainer running `adr migrate --from madr` against a **real public
+MADR corpus** (see the outcome ladder); a third-party human adopter is **not** a
+precondition for opening Phase 3 *implementation*.
 
 ---
 
 ## Outcome ladder
 
 Each rung is independently valuable and independently shippable. Do not start a
-rung before the one below it has a real user — even if that user is only you.
+rung's **implementation** before the one below it has a real user — **even if that
+user is only you** (maintainer dogfooding counts; advance scoping is exempt, per the
+Spec-kit realization note above). For rung 2, that dogfood is the maintainer running
+`adr migrate --from madr` against a real public MADR corpus — which *is* the required
+"real user"; no external human adopter is required to proceed to rung 3.
 
 | # | Outcome | Shipped when |
 |---|---|---|

--- a/plan.md
+++ b/plan.md
@@ -27,8 +27,8 @@ sync.
 |---|---|---|
 | 0 — Schema and core | `specs/001-schema-and-core/` | landed (PR #5 merged) |
 | 1 — Affects resolution | `specs/002-affects-resolution/` | landed (PR #6 merged) |
-| 2 — Migration | `specs/003-migration/` | **scoping** (spec cycle landed) |
-| 3 — CI surface | _(unopened)_ | queued |
+| 2 — Migration | `specs/003-migration/` | landed (PR #7 merged) |
+| 3 — CI surface | `specs/004-ci-surface/` | **scoping** (spec cycle landed) |
 | 4 — Deterministic evaluator | _(unopened)_ | queued |
 | 5 — MCP server | _(unopened)_ | queued |
 

--- a/specs/004-ci-surface/checklists/requirements.md
+++ b/specs/004-ci-surface/checklists/requirements.md
@@ -32,10 +32,16 @@
 ## Notes
 
 - **Upstream gate is the headline.** Phase 2 (rung 2) landed its *code* (PR #7) but
-  its rung-2 *outcome* — `adr migrate` round-tripping a **real public MADR corpus**
-  with a real user — is met only by a **synthetic** fixture (see research.md §R0).
-  Per the strict outcome ladder, **scoping proceeds but Phase 3 implementation is
-  blocked** until the gate genuinely clears (tasks.md T000).
+  its rung-2 *outcome* — `adr migrate` round-tripping a **real public MADR corpus** —
+  is met only by a **synthetic** fixture (see research.md §R0). Per the strict outcome
+  ladder, **scoping proceeds but Phase 3 implementation is blocked** until the gate
+  clears. **Resolved (maintainer decision; reviewer may override):** the gate clears by
+  vendoring a subset of a real, permissively-licensed public MADR corpus as an offline
+  fixture (attribution + provenance) and round-tripping it — a live external human user
+  is a higher rung, *not* a Phase-3 precondition (tasks.md T000/T00A).
+- **Placement resolved.** `@adrkit/ci` is a first-party surface package under
+  `packages/ci/` (peer of `@adrkit/cli`), not an adapter and not core; `check-deps`
+  asserts the boundary and that the GitHub toolkit never reaches core/schema (R2/R3).
 - **Selectivity (SC-003) and idempotency (SC-004) are load-bearing.** Exit criterion
   (b): a comment that lists everything means the `affects` matchers or the renderer
   are wrong — the comment reflects the resolver's union verbatim, never a padded or

--- a/specs/004-ci-surface/checklists/requirements.md
+++ b/specs/004-ci-surface/checklists/requirements.md
@@ -33,15 +33,26 @@
 
 - **Upstream gate is the headline.** Phase 2 (rung 2) landed its *code* (PR #7) but
   its rung-2 *outcome* — `adr migrate` round-tripping a **real public MADR corpus** —
-  is met only by a **synthetic** fixture (see research.md §R0). Per the strict outcome
-  ladder, **scoping proceeds but Phase 3 implementation is blocked** until the gate
-  clears. **Resolved (maintainer decision; reviewer may override):** the gate clears by
-  vendoring a subset of a real, permissively-licensed public MADR corpus as an offline
-  fixture (attribution + provenance) and round-tripping it — a live external human user
-  is a higher rung, *not* a Phase-3 precondition (tasks.md T000/T00A).
+  is met only by a **synthetic** fixture (see research.md §R0). Per the outcome ladder,
+  **scoping proceeds but Phase 3 implementation is blocked** until the gate clears.
+  **Resolved (maintainer decision; reviewer may override):** the ladder permits advance
+  scoping while gating implementation; the gate clears by vendoring a subset of a real,
+  permissively-licensed public MADR corpus as an offline fixture (attribution +
+  provenance) and round-tripping it via `adr migrate` — and that maintainer dogfood
+  round-trip **is** the required "real user" (no external human adopter needed, tasks.md
+  T000/T00A).
 - **Placement resolved.** `@adrkit/ci` is a first-party surface package under
   `packages/ci/` (peer of `@adrkit/cli`), not an adapter and not core; `check-deps`
   asserts the boundary and that the GitHub toolkit never reaches core/schema (R2/R3).
+- **Shared logic lives in core (RC3).** The neutral `checkChanges` is in `@adrkit/core`,
+  takes the **full lint result** (so dropped-malformed-file errors count) + snapshots,
+  and is called by both `adr check` and the Action — neither surface imports the other.
+- **Complete inputs & robust idempotency (RC4/RC5).** Changed files come from a
+  paginated PR-files listing or merge-base diff (never the truncating compare API); the
+  comment is located by marker **and** author across all pages, with tests for a foreign
+  marker and a paged marker.
+- **Distribution (RC6/RC7).** The Action ships a committed self-contained Node bundle
+  (drift + Node-24 smoke checks) and declares `runs.using: node24`.
 - **Selectivity (SC-003) and idempotency (SC-004) are load-bearing.** Exit criterion
   (b): a comment that lists everything means the `affects` matchers or the renderer
   are wrong — the comment reflects the resolver's union verbatim, never a padded or
@@ -53,7 +64,7 @@
 - **No new schema/record contract.** This phase consumes the Phase 0/1/2 schema,
   resolver, and validators; it writes only a PR comment (ADR-0004) and imports no
   adapter (ADR-0007).
-- Open engineering choices captured as Assumptions A1–A6 (changed-file extraction,
+- Open engineering choices captured as Assumptions A1–A7 (changed-file extraction,
   comment identity, selectivity source, backing snapshots, validation scope, GitHub
-  client) — none is a one-way door; ADR-0009/0007/0004 fix the semantics they
-  implement.
+  client, packaged bundle) — none is a one-way door; ADR-0009/0007/0004 fix the
+  semantics they implement.

--- a/specs/004-ci-surface/checklists/requirements.md
+++ b/specs/004-ci-surface/checklists/requirements.md
@@ -1,0 +1,53 @@
+# Specification Quality Checklist: CI Surface (Phase 3)
+
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2026-07-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **Upstream gate is the headline.** Phase 2 (rung 2) landed its *code* (PR #7) but
+  its rung-2 *outcome* — `adr migrate` round-tripping a **real public MADR corpus**
+  with a real user — is met only by a **synthetic** fixture (see research.md §R0).
+  Per the strict outcome ladder, **scoping proceeds but Phase 3 implementation is
+  blocked** until the gate genuinely clears (tasks.md T000).
+- **Selectivity (SC-003) and idempotency (SC-004) are load-bearing.** Exit criterion
+  (b): a comment that lists everything means the `affects` matchers or the renderer
+  are wrong — the comment reflects the resolver's union verbatim, never a padded or
+  trimmed set.
+- **Default-token-only (SC-006)** is exit criterion (c) and the ADR-0007 clean-clone
+  principle applied to the runtime; the GitHub toolkit dependency is confined to the
+  `@adrkit/ci` surface package and stubbed in tests so `clean-clone-builds` needs no
+  token.
+- **No new schema/record contract.** This phase consumes the Phase 0/1/2 schema,
+  resolver, and validators; it writes only a PR comment (ADR-0004) and imports no
+  adapter (ADR-0007).
+- Open engineering choices captured as Assumptions A1–A6 (changed-file extraction,
+  comment identity, selectivity source, backing snapshots, validation scope, GitHub
+  client) — none is a one-way door; ADR-0009/0007/0004 fix the semantics they
+  implement.

--- a/specs/004-ci-surface/contracts/check-and-comment.md
+++ b/specs/004-ci-surface/contracts/check-and-comment.md
@@ -2,27 +2,28 @@
 
 ## CLI: `adr check <changed-files...> [--dir docs/adr] [--json]`
 
-The deterministic, provider-agnostic substrate (seed 21). Reuses `resolveAffects`
-(ADR-0009) and the existing corpus validators; adds no new resolution or validation.
+The deterministic, provider-agnostic substrate (seed 21). Builds the full `lintCorpus`
+result and calls the neutral core function `checkChanges` (RC3); adds no new resolution
+or validation.
 
 - **Positionals**: one or more repo-relative changed-file paths (POSIX, no leading
   slash). An empty list is a no-op success.
 - **`--dir`**: corpus directory (default `docs/adr`).
 - **`--json`**: emit the machine-readable `Check outcome` (see data-model), stably
   sorted; otherwise print a human summary.
-- **Behavior**: load the corpus; run `resolveAffects({ records, changedFiles })`;
-  identify changed records (corpus ∩ changed files) and collect their findings;
-  print the governing decisions (id + title + fired matcher, like `adr explain`) and
-  any changed-record findings.
+- **Behavior**: load the corpus via `lintCorpus` (keeping its full findings, including
+  those for malformed files it drops from `records`); call `checkChanges({ lint,
+  changedFiles, dir })`; print the governing decisions (id + title + fired matcher, like
+  `adr explain`) and the changed-record findings.
 - **Exit**: `0` on success; **non-zero** iff a **changed record** has an
   `error`-severity finding (FR-002); `2` on usage error. `info`/`warn` never fail.
-- **Purity/determinism**: identical `(corpus, changedFiles)` → identical output; no
-  clock, no network, no traversal beyond the corpus load and the supplied list
+- **Purity/determinism**: identical `(lint result, changedFiles, snapshots)` → identical
+  output; no clock, no network, no traversal beyond the corpus load and the supplied list
   (ADR-0009). No model (Principle IV).
 
 **Human output (sketch)**:
 
-```
+```text
 Decisions governing this change:
   0007  Isolate integrations as optional adapters
     via path: packages/*/package.json
@@ -34,7 +35,7 @@ checked: 3 governing, 0 changed-record errors
 
 `--json` output shape:
 
-```
+```ts
 {
   changedFiles: string[];
   governedBy: { recordId: string; title: string; firedMatchers: { type: string; pattern: string }[] }[];
@@ -44,11 +45,14 @@ checked: 3 governing, 0 changed-record errors
 }
 ```
 
-## Library reuse (`@adrkit/core`, unchanged)
+## Library reuse (`@adrkit/core`)
 
-`adr check` and the Action call the **existing** exports — no new core surface:
+`adr check` and the Action call into `@adrkit/core`. The **existing** `resolveAffects`
+and validators are unchanged; a **new neutral** core entrypoint (`checkChanges`, R1)
+composes them so both surfaces share one implementation without either depending on
+the other (see the contract below):
 
-```
+```ts
 resolveAffects(input: {
   records: readonly Adr[];
   changedFiles: readonly string[];
@@ -56,20 +60,48 @@ resolveAffects(input: {
 }): { matches: AffectsMatch[]; findings: Finding[] }
 
 deriveChangedDependenciesFromBunLockDiff(...)   // for `package` matcher snapshots
-lintCorpus({ dir }) / the existing validators   // for changed-record findings
+lintCorpus({ dir }): { records: Adr[]; findings: Finding[]; checked: number }  // full lint result
 ```
+
+## Neutral shared function: `checkChanges` (`@adrkit/core`, RC3)
+
+The single implementation of "resolve governing decisions + validate changed records",
+called by **both** `adr check` (CLI) and the Action. It lives in **core** so neither
+surface imports the other (RC3/R2). It takes the **full lint result** (so findings kept
+for malformed files dropped from `records` are not lost) plus optional snapshots:
+
+```ts
+checkChanges(input: {
+  lint: { records: Adr[]; findings: Finding[]; checked: number };  // full lintCorpus result
+  changedFiles: string[];
+  dir?: string;                                 // corpus dir, to identify changed records
+  snapshots?: {
+    changedDependencies?: ChangedDependency[];  // Action-supplied lockfile diff (package matchers)
+    catalog?: CatalogSnapshot;                  // inert this phase
+  };
+}): CheckOutcome
+```
+
+Pure and deterministic (no fs/clock/network beyond the already-loaded lint result).
+`adr check` builds `lint` via `lintCorpus`; the Action does the same after checkout.
 
 ## GitHub Action: `@adrkit/ci` (`action.yml`)
 
+- **Metadata**: `runs.using: node24` (FR-016/R11) with `runs.main` pointing at the
+  **committed self-contained bundle** (core + toolkit, FR-015/R10).
 - **Inputs**:
   - `dir` (default `docs/adr`) — corpus directory.
   - `token` (default `${{ github.token }}`) — the default `GITHUB_TOKEN`; **no other
     secret** (FR-008).
 - **Runtime steps**:
-  1. Extract the PR's changed-file list (base…head) from the event/compare API
-     (impure; lives in the Action, not the resolver — R4/FR-003).
-  2. Run the shared check logic (`resolveAffects` + validate) over that list.
-  3. Render the comment (selective, marker-bearing) and **create or update** it.
+  1. Extract the PR's **complete** changed-file list via a **fully paginated
+     `pulls.listFiles`** or a local **merge-base diff** — never the truncation-prone
+     compare API; handle the provider file cap explicitly (impure; lives in the Action,
+     not the resolver — R4/FR-003).
+  2. Build the lint result + snapshots and run `checkChanges` (RC3).
+  3. Render the comment (selective, marker-bearing) and **create or update** it,
+     locating the prior comment by marker **and** author identity across **all** comment
+     pages (R5/FR-005).
   4. Set the job outcome: **fail** iff a changed record has an `error` finding
      (FR-002); otherwise succeed regardless of governing-list size.
 - **Permissions**: needs `pull-requests: write` to comment. With a read-only token
@@ -91,8 +123,11 @@ lintCorpus({ dir }) / the existing validators   // for changed-record findings
   matcher type and MAY cap an extreme list with a "+N more" tail, but MUST NOT add or
   drop records from the resolver's set.
 - **Idempotency (FR-005/SC-004)**: the comment carries a stable hidden marker
-  (`<!-- adrkit:ci -->`); a second run edits that comment rather than posting a new
-  one.
+  (`<!-- adrkit:ci -->`). To update in place the Action **paginates all PR comments**
+  and matches on **both** the marker **and** its own author identity; a second run edits
+  that comment rather than posting a new one. A foreign comment bearing the marker is
+  ignored; the Action's own comment on a later page is found, not duplicated. **Tests**
+  cover a foreign/pre-existing marker and a marker on a later page.
 - **Empty state (FR-007/SC-005)**: when nothing governs the diff, render a concise
   "No governing decisions for the changed files." — not a corpus dump.
 - **Validation surfacing (R7)**: when a changed record has an `error` finding, the

--- a/specs/004-ci-surface/contracts/check-and-comment.md
+++ b/specs/004-ci-surface/contracts/check-and-comment.md
@@ -78,7 +78,9 @@ lintCorpus({ dir }) / the existing validators   // for changed-record findings
 - **Side effects**: exactly one PR comment (created or edited). **No** record write,
   **no** database/index (ADR-0004/FR-010). It never approves or merges (FR-011).
 - **Isolation**: `@adrkit/ci` imports `@adrkit/core` + public Action libs only; **no**
-  `packages/adapters/*` import (FR-013). `core-has-no-adapter-deps` covers it.
+  `packages/adapters/*` import (FR-013). `core-has-no-adapter-deps` covers it **and**
+  asserts the GitHub toolkit (`@actions/*`, Octokit) never reaches `@adrkit/core` or
+  the schema (maintainer-resolved).
 
 ## PR comment contract
 

--- a/specs/004-ci-surface/contracts/check-and-comment.md
+++ b/specs/004-ci-surface/contracts/check-and-comment.md
@@ -1,0 +1,107 @@
+# Contract: `adr check`, the `@adrkit/ci` Action, and the PR comment (Phase 3)
+
+## CLI: `adr check <changed-files...> [--dir docs/adr] [--json]`
+
+The deterministic, provider-agnostic substrate (seed 21). Reuses `resolveAffects`
+(ADR-0009) and the existing corpus validators; adds no new resolution or validation.
+
+- **Positionals**: one or more repo-relative changed-file paths (POSIX, no leading
+  slash). An empty list is a no-op success.
+- **`--dir`**: corpus directory (default `docs/adr`).
+- **`--json`**: emit the machine-readable `Check outcome` (see data-model), stably
+  sorted; otherwise print a human summary.
+- **Behavior**: load the corpus; run `resolveAffects({ records, changedFiles })`;
+  identify changed records (corpus ∩ changed files) and collect their findings;
+  print the governing decisions (id + title + fired matcher, like `adr explain`) and
+  any changed-record findings.
+- **Exit**: `0` on success; **non-zero** iff a **changed record** has an
+  `error`-severity finding (FR-002); `2` on usage error. `info`/`warn` never fail.
+- **Purity/determinism**: identical `(corpus, changedFiles)` → identical output; no
+  clock, no network, no traversal beyond the corpus load and the supplied list
+  (ADR-0009). No model (Principle IV).
+
+**Human output (sketch)**:
+
+```
+Decisions governing this change:
+  0007  Isolate integrations as optional adapters
+    via path: packages/*/package.json
+  0009  Pin affects resolution semantics ...
+    via path: packages/core/src/affects/**
+Changed records: 0
+checked: 3 governing, 0 changed-record errors
+```
+
+`--json` output shape:
+
+```
+{
+  changedFiles: string[];
+  governedBy: { recordId: string; title: string; firedMatchers: { type: string; pattern: string }[] }[];
+  changedRecords: string[];
+  findings: Finding[];
+  ok: boolean;
+}
+```
+
+## Library reuse (`@adrkit/core`, unchanged)
+
+`adr check` and the Action call the **existing** exports — no new core surface:
+
+```
+resolveAffects(input: {
+  records: readonly Adr[];
+  changedFiles: readonly string[];
+  snapshots?: { changedDependencies?: ChangedDependency[]; catalog?: CatalogSnapshot };
+}): { matches: AffectsMatch[]; findings: Finding[] }
+
+deriveChangedDependenciesFromBunLockDiff(...)   // for `package` matcher snapshots
+lintCorpus({ dir }) / the existing validators   // for changed-record findings
+```
+
+## GitHub Action: `@adrkit/ci` (`action.yml`)
+
+- **Inputs**:
+  - `dir` (default `docs/adr`) — corpus directory.
+  - `token` (default `${{ github.token }}`) — the default `GITHUB_TOKEN`; **no other
+    secret** (FR-008).
+- **Runtime steps**:
+  1. Extract the PR's changed-file list (base…head) from the event/compare API
+     (impure; lives in the Action, not the resolver — R4/FR-003).
+  2. Run the shared check logic (`resolveAffects` + validate) over that list.
+  3. Render the comment (selective, marker-bearing) and **create or update** it.
+  4. Set the job outcome: **fail** iff a changed record has an `error` finding
+     (FR-002); otherwise succeed regardless of governing-list size.
+- **Permissions**: needs `pull-requests: write` to comment. With a read-only token
+  (e.g. fork PRs), it **still runs the check** and downgrades commenting to a job-log
+  notice — it does **not** fail the job on a comment-permission error (FR-014/R8).
+- **Side effects**: exactly one PR comment (created or edited). **No** record write,
+  **no** database/index (ADR-0004/FR-010). It never approves or merges (FR-011).
+- **Isolation**: `@adrkit/ci` imports `@adrkit/core` + public Action libs only; **no**
+  `packages/adapters/*` import (FR-013). `core-has-no-adapter-deps` covers it.
+
+## PR comment contract
+
+- **Selectivity (FR-006/SC-003)**: the comment lists **exactly** the resolver's union
+  for the changed files — one entry per governing record with its fired matcher(s).
+  A record that governs no changed file MUST NOT appear. On a >10-record corpus with a
+  subset diff, the comment MUST NOT list the whole corpus. The renderer MAY group by
+  matcher type and MAY cap an extreme list with a "+N more" tail, but MUST NOT add or
+  drop records from the resolver's set.
+- **Idempotency (FR-005/SC-004)**: the comment carries a stable hidden marker
+  (`<!-- adrkit:ci -->`); a second run edits that comment rather than posting a new
+  one.
+- **Empty state (FR-007/SC-005)**: when nothing governs the diff, render a concise
+  "No governing decisions for the changed files." — not a corpus dump.
+- **Validation surfacing (R7)**: when a changed record has an `error` finding, the
+  comment names the failing record + rule, and the job fails (FR-002).
+
+## Non-goals (contract-level)
+
+- No database/index use (ADR-0004); no record mutation or write path; no approval or
+  merge gating beyond validation (FR-011).
+- No catalog/IaC/OpenAPI backing — `entity`/`resource`/`api`/`data` stay inert
+  (ADR-0009/FR-009).
+- No non-GitHub CI provider packaging in this phase (the CLI is portable; the Action
+  is GitHub-specific).
+- No probabilistic/LLM ranking or summarization of the comment (Principle IV).

--- a/specs/004-ci-surface/data-model.md
+++ b/specs/004-ci-surface/data-model.md
@@ -1,0 +1,105 @@
+# Data Model: CI Surface (Phase 3)
+
+Entities the CI surface operates on. **No record-schema change** — this phase
+consumes the existing schema, resolver output, and `Finding` type. Everything below
+is either a reuse of a Phase 0/1 type or a small, derived, non-persistent structure.
+
+## Input: Changed-file set
+
+The repo-relative paths a PR touches (base…head), produced by the **Action** (not the
+resolver):
+
+- `changedFiles: string[]` — POSIX, repo-relative, no leading slash (the resolver's
+  `path` grammar, ADR-0009). Includes added/modified/renamed/deleted paths as the
+  source reports them.
+- `changedDependencies?: ChangedDependency[]` — derived from the lockfile diff via the
+  existing `deriveChangedDependenciesFromBunLockDiff`, for `package` matchers.
+
+This is the resolver's input; resolution never walks the tree (ADR-0009 purity).
+
+## Reuse: Governing-decision result
+
+The Phase 1 resolver output, rendered verbatim (R6). Per governing record:
+
+| Field | Source |
+|---|---|
+| `recordId` | `AffectsMatch.recordId` |
+| `title` | record frontmatter `title` (looked up by id) |
+| `firedMatchers` | `FiredMatcher[]` — `{ type, pattern }` that fired (a union) |
+
+The full result is `{ matches: AffectsMatch[]; findings: Finding[] }` from
+`resolveAffects` — matches sorted by `recordId`, findings sorted deterministically.
+Records with **no** fired matcher are absent (FR-006 selectivity).
+
+## Reuse: Changed-record validation set
+
+The ADR files under `--dir` that appear in the changed-file set, plus their reused
+Phase 0/2 `Finding`s:
+
+- `changedRecords: string[]` — corpus paths ∩ changed files.
+- `findings: Finding[]` — from the existing validators over those records.
+- `hasError: boolean` — any changed-record finding at `error` severity (drives exit
+  code, FR-002).
+
+Pre-existing errors on **unchanged** records do not fail the job (A5).
+
+## Entity: Check outcome (`adr check` result)
+
+The stable structure `adr check --json` emits and the Action consumes:
+
+```
+{
+  changedFiles: string[];
+  governedBy: { recordId: string; title: string; firedMatchers: FiredMatcher[] }[];
+  changedRecords: string[];
+  findings: Finding[];         // resolver + validation findings, deterministically sorted
+  ok: boolean;                 // false iff a changed record has an error finding
+}
+```
+
+- **Exit code**: `0` when `ok`, non-zero when a changed record has an `error` finding
+  (FR-002). Usage errors exit `2` (mirrors the other subcommands).
+- Deterministic and pure: identical `(corpus, changedFiles)` → identical output.
+
+## Entity: PR comment
+
+A rendered markdown comment; a **derived projection of git**, never a record and
+never persisted outside the PR (ADR-0004).
+
+| Part | Content |
+|---|---|
+| Hidden marker | stable `<!-- adrkit:ci -->` used to locate the comment for update (R5) |
+| Heading | e.g. "Decisions governing this change" |
+| Governing list | one entry per governing record: `id — title`, with `via <type>: <pattern>` per fired matcher |
+| Empty state | concise "No governing decisions for the changed files." (FR-007) |
+| Validation notice | when a changed record has an error finding, the failing record + rule (R7) |
+
+**Identity/lifecycle**: located by the marker; **created** on first run, **edited**
+on subsequent runs (FR-005). Exactly one comment per PR from this Action.
+
+## Entity: Action configuration & context
+
+Inputs the Action reads (FR-008 — default token only):
+
+| Input | Source | Default |
+|---|---|---|
+| `dir` | Action input | `docs/adr` |
+| `token` | Action input | `${{ github.token }}` (the default `GITHUB_TOKEN`) |
+| PR head/base SHAs | `pull_request` event payload | — |
+| `canComment` | derived from token permission | degrade if false (FR-014) |
+
+No other secret, service, or network is read (FR-008).
+
+## Rule ids (reused / referenced — no new record-schema rule)
+
+The CI surface introduces no new schema invariant. It **surfaces** existing findings:
+
+| rule | severity | origin |
+|---|---|---|
+| `affects-unresolvable` | info | inert matcher (entity/resource/api/data, or package w/o lockfile diff) — ADR-0009 |
+| `affects-bad-pattern` | warn | malformed path/package matcher — Phase 1 |
+| `affects-unknown-type` | warn | forward-compat unknown matcher type — Phase 1 |
+| *(existing corpus/contract findings)* | info/warn/error | Phase 0/2 validators over changed records |
+
+`error`-severity findings on **changed** records drive the non-zero exit (FR-002);
+`info`/`warn` inform only.

--- a/specs/004-ci-surface/data-model.md
+++ b/specs/004-ci-surface/data-model.md
@@ -47,7 +47,7 @@ Pre-existing errors on **unchanged** records do not fail the job (A5).
 
 The stable structure `adr check --json` emits and the Action consumes:
 
-```
+```ts
 {
   changedFiles: string[];
   governedBy: { recordId: string; title: string; firedMatchers: FiredMatcher[] }[];
@@ -59,7 +59,29 @@ The stable structure `adr check --json` emits and the Action consumes:
 
 - **Exit code**: `0` when `ok`, non-zero when a changed record has an `error` finding
   (FR-002). Usage errors exit `2` (mirrors the other subcommands).
-- Deterministic and pure: identical `(corpus, changedFiles)` → identical output.
+- Deterministic and pure: identical `(lintResult, changedFiles, snapshots)` → identical
+  output.
+
+## Entity: Neutral check input (`checkChanges`, R1/RC3)
+
+The shared core entrypoint takes the **full lint result** (not just `records`) plus the
+optional resolution snapshots, so it sees the findings `lintCorpus` keeps for malformed
+files that it drops from `records`, and so `package` matching has its snapshot:
+
+```ts
+checkChanges(input: {
+  lint: { records: Adr[]; findings: Finding[]; checked: number };  // full lintCorpus result
+  changedFiles: string[];
+  dir?: string;                              // corpus dir, to identify changed records
+  snapshots?: {
+    changedDependencies?: ChangedDependency[];  // from the Action's lockfile diff (T007)
+    catalog?: CatalogSnapshot;                  // inert in this phase
+  };
+}): CheckOutcome
+```
+
+Both `adr check` (CLI) and the Action build this input and call the same function; neither
+surface imports the other (R2/RC3).
 
 ## Entity: PR comment
 

--- a/specs/004-ci-surface/plan.md
+++ b/specs/004-ci-surface/plan.md
@@ -1,0 +1,145 @@
+# Implementation Plan: CI Surface (Phase 3)
+
+**Branch**: `004-ci-surface` | **Date**: 2026-07-18 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/004-ci-surface/spec.md`
+**Normative sources**: [ADR-0009](../../docs/adr/0009-affects-resolution-and-catalog-binding.md), [ADR-0007](../../docs/adr/0007-adapter-isolation-and-public-surface-build.md), [ADR-0004](../../docs/adr/0004-git-is-source-of-truth-database-is-an-index.md).
+
+> **⚠️ Gate status — implementation blocked.** This plan is authored during
+> scoping. Per the strict outcome ladder, Phase 3 code MUST NOT start until the
+> **rung-2** outcome is genuinely met (a **real public MADR corpus** round-tripped
+> by `adr migrate`, with a real user). Today it is met only by a **synthetic**
+> fixture — see [research.md §R0](./research.md) and `tasks.md` **T000**. Scoping
+> proceeds; building does not.
+
+## Summary
+
+Make the decision→code mapping visible at review time. Add `@adrkit/ci` as a GitHub
+Action and `adr check <changed-files>` as its provider-agnostic CLI equivalent. The
+Action extracts the PR's changed-file list, hands it to the **existing pure resolver**
+(`resolveAffects`, ADR-0009), validates the changed records with the **existing
+validators**, and posts a single, **selective**, idempotently-updated PR comment
+naming the governing decisions and the matcher that fired for each. It runs with
+nothing but the default `GITHUB_TOKEN`, touches no database (ADR-0004), imports no
+adapter (ADR-0007), and never approves or mutates anything — it routes attention.
+Exit condition: on a repo that isn't this one and has more than ten records, a PR
+touching a governed subset gets a comment naming exactly that subset, updated in
+place on each push, using only the default token.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ESNext), Bun for development; the CLI (`adr check`)
+ships as a Node-targeted artifact (`node >=22`, ADR-0010). The Action runs on the
+GitHub-hosted Node runner.
+
+**Primary Dependencies**: `@adrkit/core` (`workspace:*`) for resolution + validation;
+the public GitHub Action toolkit (`@actions/core`, `@actions/github`/Octokit) in
+`@adrkit/ci` only. No new dependency in core. Changed-dependency snapshots reuse the
+existing `deriveChangedDependenciesFromBunLockDiff` export.
+
+**Storage**: Git working tree + the PR itself only. **No database, no index** — the
+Action never calls the ADR-0004 projection; comment identity is a hidden marker in
+the PR, not stored state.
+
+**Testing**: `bun test`. Deterministic `adr check` tests (governing list + validation
++ exit codes per severity, `--json` shape); comment-renderer tests (selectivity,
+empty state, idempotent marker); an injected fake GitHub client for the Action
+(create-vs-update, read-only-token degradation) — **no network, no token in CI**. An
+end-to-end selectivity assertion on a fixture corpus with more than ten records.
+
+**Target Platform**: GitHub Actions (Node runner) for the Action; portable CLI for
+any provider.
+
+**Project Type**: Bun-workspace monorepo — adds a `@adrkit/ci` surface package and an
+`adr check` subcommand to `@adrkit/cli`.
+
+**Performance Goals**: Resolution is linear in `records × matchers × changed-files`;
+a PR comment renders in well under a second for hundreds of changed files.
+
+**Constraints**: Pure resolution (ADR-0009 `resolution-is-pure` stays green — the
+Action does the impure file-list extraction); clean clone builds/tests/lints green
+with no credentials (ADR-0007 `clean-clone-builds`); `@adrkit/ci` imports no adapter
+(`core-has-no-adapter-deps`, extended to cover it); default-token-only at runtime
+(FR-008); read-only-token degradation, not job failure (FR-014); comment is
+selective and idempotent (FR-005/FR-006).
+
+**Bun-version note**: use the pinned stable Bun (CI pins `1.3.14`) for all installs so
+`bun.lock` stays lockfileVersion 1; the env default `bun` is a canary that writes an
+unreadable v2 lockfile and breaks CI.
+
+## Constitution Check
+
+*GATE: passed before design; re-check after design. No violations. (The rung-2
+outcome gate above is an **outcome-ladder** precondition on implementation, not a
+Principle I–V violation of this design.)*
+
+| Principle | Assessment |
+|---|---|
+| **I. Git is the source of truth** | PASS — the Action reads records from git and writes **only** a PR comment (a derived projection); it mutates no record and writes to no database (FR-010, ADR-0004). Lifecycle stays PR-driven. |
+| **II. Clean clone builds green** | PASS — the GitHub toolkit is a public registry dependency confined to `@adrkit/ci` and stubbed in tests (R3); install/build/test/lint need no token, service, or network. `clean-clone-builds` continues to guard (SC-007). |
+| **III. Core depends on no adapter** | PASS — `@adrkit/ci` is a first-party **surface** package (peer of `@adrkit/cli`), under `packages/ci/`, **not** `packages/adapters/*`; it imports `@adrkit/core` and public Action libs only, never an adapter (FR-013). `core-has-no-adapter-deps` is extended to assert this. |
+| **IV. Deterministic before probabilistic** | PASS — the CI surface adds **no** model step. Governing-decision resolution is the existing pure resolver; validation is the existing deterministic validators; the comment renders their output verbatim (R1/R6). The surface routes/informs; it never decides (FR-011). |
+| **V. The schema is the contract** | PASS — `adr check` and the Action consume the existing schema, validators, and resolver output; **no** schema change and no new record field. The comment renders records against the existing contract. |
+
+**Result**: PASS — Complexity Tracking is empty (no deviations to justify). The
+GitHub-toolkit dependency is explicitly *permitted* under ADR-0007 (public surface,
+confined to `@adrkit/ci`, stubbed in tests), so it is not a violation.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-ci-surface/
+├── spec.md                        # Feature spec (done)
+├── plan.md                        # This file
+├── research.md                    # R0 gate assessment + R1–R9 decisions
+├── data-model.md                  # changed-file set / governing result / comment / outcome
+├── quickstart.md                  # How to run adr check + wire the Action; what green means
+├── contracts/
+│   └── check-and-comment.md       # adr check CLI + Action I/O + comment/idempotency contract
+├── checklists/
+│   └── requirements.md            # Spec quality checklist (done)
+└── tasks.md                       # Produced next (T000 = the rung-2 gate precondition)
+```
+
+### Source Code (repository root — extends merged Phase 0/1/2)
+
+```text
+packages/cli/src/
+├── index.ts                 # add `check` to dispatch: adr check <files...> [--dir] [--json]
+└── (check rendering: governing list like `adr explain` + changed-record findings; --json)
+
+packages/ci/                 # NEW first-party surface package @adrkit/ci (peer of cli)
+├── package.json             # deps: @adrkit/core workspace:*, @actions/core, @actions/github
+├── action.yml               # GitHub Action metadata (inputs: dir, token; runs: node20/node-dist)
+├── tsconfig.json
+├── tsconfig.build.json
+├── src/
+│   ├── index.ts             # Action entrypoint: extract files → check → render → comment
+│   ├── changed-files.ts     # PR base…head changed-file extraction (impure; not in core)
+│   ├── github.ts            # thin GitHub client port (find/create/update marker comment)
+│   ├── comment.ts           # comment renderer (selective; hidden marker; empty/error states)
+│   └── check.ts             # shared: run resolveAffects + validate over the file list
+└── test/
+    ├── check.test.ts            # governing list + validation + exit codes per severity; --json
+    ├── comment-render.test.ts   # selectivity (>10 records), empty state, marker present
+    ├── comment-idempotent.test.ts # fake client: create then update same comment
+    ├── token-degrade.test.ts    # read-only token → check runs, comment skipped, job not failed
+    └── fixtures/                # a >10-record corpus + changed-file lists
+
+scripts/check-deps.ts             # extend to assert @adrkit/ci has no adapter dependency
+.github/workflows/ci.yml          # add adr check job (self-dogfood); gate set otherwise unchanged
+```
+
+**Structure Decision**: `adr check` is a new subcommand on the existing `@adrkit/cli`
+dispatch, reusing `resolveAffects` and the corpus validators — no new resolution
+logic. `@adrkit/ci` is a **new surface package** under `packages/ci/` (not
+`packages/adapters/*`), holding the only impure code (changed-file extraction, GitHub
+API) behind small ports so the deterministic core stays pure and offline-testable.
+The GitHub client is injected in tests; nothing in the default build needs a token.
+
+## Complexity Tracking
+
+No constitution violations — table intentionally empty. (Outcome-ladder gate on
+implementation is tracked in research.md §R0 and tasks.md T000, not here.)

--- a/specs/004-ci-surface/plan.md
+++ b/specs/004-ci-surface/plan.md
@@ -7,9 +7,12 @@
 
 > **⚠️ Gate status — implementation blocked.** This plan is authored during
 > scoping. Per the strict outcome ladder, Phase 3 code MUST NOT start until the
-> **rung-2** outcome is genuinely met (a **real public MADR corpus** round-tripped
-> by `adr migrate`, with a real user). Today it is met only by a **synthetic**
-> fixture — see [research.md §R0](./research.md) and `tasks.md` **T000**. Scoping
+> **rung-2** gate clears. **Resolved (maintainer decision; reviewer may override):**
+> the gate clears when a subset of a genuinely real, permissively-licensed public
+> MADR corpus is vendored as an **offline fixture** (attribution + provenance) and
+> round-tripped by `adr migrate` — a live external human user is a higher rung, *not*
+> a Phase-3 precondition. Today it is met only by a **synthetic** fixture — see
+> [research.md §R0](./research.md) and `tasks.md` **T000** / **T00A**. Scoping
 > proceeds; building does not.
 
 ## Summary
@@ -77,7 +80,7 @@ Principle I–V violation of this design.)*
 |---|---|
 | **I. Git is the source of truth** | PASS — the Action reads records from git and writes **only** a PR comment (a derived projection); it mutates no record and writes to no database (FR-010, ADR-0004). Lifecycle stays PR-driven. |
 | **II. Clean clone builds green** | PASS — the GitHub toolkit is a public registry dependency confined to `@adrkit/ci` and stubbed in tests (R3); install/build/test/lint need no token, service, or network. `clean-clone-builds` continues to guard (SC-007). |
-| **III. Core depends on no adapter** | PASS — `@adrkit/ci` is a first-party **surface** package (peer of `@adrkit/cli`), under `packages/ci/`, **not** `packages/adapters/*`; it imports `@adrkit/core` and public Action libs only, never an adapter (FR-013). `core-has-no-adapter-deps` is extended to assert this. |
+| **III. Core depends on no adapter** | PASS — `@adrkit/ci` is a first-party **surface** package (peer of `@adrkit/cli`), under `packages/ci/`, **not** `packages/adapters/*`; it imports `@adrkit/core` + public Action libs only, never an adapter (FR-013). `core-has-no-adapter-deps` is extended to assert this **and** that the GitHub toolkit (`@actions/*`, Octokit) never reaches `@adrkit/core` or the schema (R3, maintainer-resolved). |
 | **IV. Deterministic before probabilistic** | PASS — the CI surface adds **no** model step. Governing-decision resolution is the existing pure resolver; validation is the existing deterministic validators; the comment renders their output verbatim (R1/R6). The surface routes/informs; it never decides (FR-011). |
 | **V. The schema is the contract** | PASS — `adr check` and the Action consume the existing schema, validators, and resolver output; **no** schema change and no new record field. The comment renders records against the existing contract. |
 
@@ -100,7 +103,7 @@ specs/004-ci-surface/
 │   └── check-and-comment.md       # adr check CLI + Action I/O + comment/idempotency contract
 ├── checklists/
 │   └── requirements.md            # Spec quality checklist (done)
-└── tasks.md                       # Produced next (T000 = the rung-2 gate precondition)
+└── tasks.md                       # Produced next (T000 = rung-2 gate precondition; T00A = vendor the gating corpus)
 ```
 
 ### Source Code (repository root — extends merged Phase 0/1/2)
@@ -128,7 +131,7 @@ packages/ci/                 # NEW first-party surface package @adrkit/ci (peer 
     ├── token-degrade.test.ts    # read-only token → check runs, comment skipped, job not failed
     └── fixtures/                # a >10-record corpus + changed-file lists
 
-scripts/check-deps.ts             # extend to assert @adrkit/ci has no adapter dependency
+scripts/check-deps.ts             # extend: assert @adrkit/ci has no adapter dep AND the github toolkit never reaches core/schema
 .github/workflows/ci.yml          # add adr check job (self-dogfood); gate set otherwise unchanged
 ```
 
@@ -142,4 +145,4 @@ The GitHub client is injected in tests; nothing in the default build needs a tok
 ## Complexity Tracking
 
 No constitution violations — table intentionally empty. (Outcome-ladder gate on
-implementation is tracked in research.md §R0 and tasks.md T000, not here.)
+implementation is tracked in research.md §R0 and tasks.md T000/T00A, not here.)

--- a/specs/004-ci-surface/plan.md
+++ b/specs/004-ci-surface/plan.md
@@ -6,12 +6,13 @@
 **Normative sources**: [ADR-0009](../../docs/adr/0009-affects-resolution-and-catalog-binding.md), [ADR-0007](../../docs/adr/0007-adapter-isolation-and-public-surface-build.md), [ADR-0004](../../docs/adr/0004-git-is-source-of-truth-database-is-an-index.md).
 
 > **⚠️ Gate status — implementation blocked.** This plan is authored during
-> scoping. Per the strict outcome ladder, Phase 3 code MUST NOT start until the
-> **rung-2** gate clears. **Resolved (maintainer decision; reviewer may override):**
-> the gate clears when a subset of a genuinely real, permissively-licensed public
-> MADR corpus is vendored as an **offline fixture** (attribution + provenance) and
-> round-tripped by `adr migrate` — a live external human user is a higher rung, *not*
-> a Phase-3 precondition. Today it is met only by a **synthetic** fixture — see
+> scoping (which the ladder permits). Per the outcome ladder, Phase 3 code MUST NOT
+> start until the **rung-2** gate clears. **Resolved (maintainer decision; reviewer may
+> override):** the gate clears when a subset of a genuinely real, permissively-licensed
+> public MADR corpus is vendored as an **offline fixture** (attribution + provenance) and
+> round-tripped by `adr migrate` — that maintainer dogfood round-trip **is** the required
+> "real user"; a live external human adopter is a higher rung, *not* a Phase-3
+> precondition. Today it is met only by a **synthetic** fixture — see
 > [research.md §R0](./research.md) and `tasks.md` **T000** / **T00A**. Scoping
 > proceeds; building does not.
 
@@ -32,29 +33,33 @@ place on each push, using only the default token.
 ## Technical Context
 
 **Language/Version**: TypeScript (ESNext), Bun for development; the CLI (`adr check`)
-ships as a Node-targeted artifact (`node >=22`, ADR-0010). The Action runs on the
-GitHub-hosted Node runner.
+ships as a Node-targeted artifact (`node >=22`, ADR-0010). The Action ships a committed
+`bun build` bundle and declares `runs.using: node24` (RC6/RC7).
 
-**Primary Dependencies**: `@adrkit/core` (`workspace:*`) for resolution + validation;
-the public GitHub Action toolkit (`@actions/core`, `@actions/github`/Octokit) in
-`@adrkit/ci` only. No new dependency in core. Changed-dependency snapshots reuse the
-existing `deriveChangedDependenciesFromBunLockDiff` export.
+**Primary Dependencies**: `@adrkit/core` (`workspace:*`) for the neutral `checkChanges`
+(resolution + validation); the public GitHub Action toolkit (`@actions/core`,
+`@actions/github`/Octokit) in `@adrkit/ci` only, **bundled** into the committed `dist/`.
+No new dependency in core. Changed-dependency snapshots reuse the existing
+`deriveChangedDependenciesFromBunLockDiff` export.
 
 **Storage**: Git working tree + the PR itself only. **No database, no index** — the
-Action never calls the ADR-0004 projection; comment identity is a hidden marker in
-the PR, not stored state.
+Action never calls the ADR-0004 projection; comment identity is a hidden marker + author,
+matched over paginated PR comments, not stored state.
 
 **Testing**: `bun test`. Deterministic `adr check` tests (governing list + validation
 + exit codes per severity, `--json` shape); comment-renderer tests (selectivity,
 empty state, idempotent marker); an injected fake GitHub client for the Action
-(create-vs-update, read-only-token degradation) — **no network, no token in CI**. An
-end-to-end selectivity assertion on a fixture corpus with more than ten records.
+(create-vs-update, **foreign marker ignored, marker on a later page found**,
+read-only-token degradation) — **no network, no token in CI**. An end-to-end selectivity
+assertion on a fixture corpus with more than ten records, plus a **bundle-drift** check
+and a **Node-24 smoke** of the committed bundle.
 
-**Target Platform**: GitHub Actions (Node runner) for the Action; portable CLI for
+**Target Platform**: GitHub Actions (`node24` runner) for the Action; portable CLI for
 any provider.
 
-**Project Type**: Bun-workspace monorepo — adds a `@adrkit/ci` surface package and an
-`adr check` subcommand to `@adrkit/cli`.
+**Project Type**: Bun-workspace monorepo — adds the neutral `checkChanges` to
+`@adrkit/core`, a `@adrkit/ci` surface package, and an `adr check` subcommand to
+`@adrkit/cli`.
 
 **Performance Goals**: Resolution is linear in `records × matchers × changed-files`;
 a PR comment renders in well under a second for hundreds of changed files.
@@ -109,38 +114,46 @@ specs/004-ci-surface/
 ### Source Code (repository root — extends merged Phase 0/1/2)
 
 ```text
+packages/core/src/
+├── check/
+│   └── index.ts             # NEW neutral checkChanges(): full lintCorpus result + files + snapshots → CheckOutcome (RC3/R1)
+└── (existing schema/ parse/ load/ validate/ affects/ import/ …)
+
 packages/cli/src/
 ├── index.ts                 # add `check` to dispatch: adr check <files...> [--dir] [--json]
-└── (check rendering: governing list like `adr explain` + changed-record findings; --json)
+└── (build lintCorpus result → core checkChanges; render governing list + findings; --json)
 
 packages/ci/                 # NEW first-party surface package @adrkit/ci (peer of cli)
 ├── package.json             # deps: @adrkit/core workspace:*, @actions/core, @actions/github
-├── action.yml               # GitHub Action metadata (inputs: dir, token; runs: node20/node-dist)
+├── action.yml               # Action metadata: inputs dir, token; runs.using node24; runs.main → committed dist bundle (RC6/RC7)
+├── dist/                    # COMMITTED self-contained bun-build bundle (core + toolkit) (RC6/FR-015)
 ├── tsconfig.json
 ├── tsconfig.build.json
 ├── src/
-│   ├── index.ts             # Action entrypoint: extract files → check → render → comment
-│   ├── changed-files.ts     # PR base…head changed-file extraction (impure; not in core)
-│   ├── github.ts            # thin GitHub client port (find/create/update marker comment)
-│   ├── comment.ts           # comment renderer (selective; hidden marker; empty/error states)
-│   └── check.ts             # shared: run resolveAffects + validate over the file list
+│   ├── index.ts             # Action entrypoint: extract files → checkChanges → render → comment
+│   ├── changed-files.ts     # COMPLETE paginated PR-files listing OR merge-base diff; handles GitHub cap (RC4)
+│   ├── github.ts            # GitHub client port: paginate comments; match marker AND author (RC5)
+│   └── comment.ts           # comment renderer (selective; hidden marker; empty/error states)
 └── test/
     ├── check.test.ts            # governing list + validation + exit codes per severity; --json
     ├── comment-render.test.ts   # selectivity (>10 records), empty state, marker present
-    ├── comment-idempotent.test.ts # fake client: create then update same comment
+    ├── comment-idempotent.test.ts # fake client: create/update; foreign marker ignored; marker on later page (RC5)
     ├── token-degrade.test.ts    # read-only token → check runs, comment skipped, job not failed
     └── fixtures/                # a >10-record corpus + changed-file lists
 
 scripts/check-deps.ts             # extend: assert @adrkit/ci has no adapter dep AND the github toolkit never reaches core/schema
-.github/workflows/ci.yml          # add adr check job (self-dogfood); gate set otherwise unchanged
+.github/workflows/ci.yml          # add adr check self-dogfood + bundle-drift + node24 smoke; gate set otherwise unchanged
 ```
 
-**Structure Decision**: `adr check` is a new subcommand on the existing `@adrkit/cli`
-dispatch, reusing `resolveAffects` and the corpus validators — no new resolution
-logic. `@adrkit/ci` is a **new surface package** under `packages/ci/` (not
-`packages/adapters/*`), holding the only impure code (changed-file extraction, GitHub
-API) behind small ports so the deterministic core stays pure and offline-testable.
-The GitHub client is injected in tests; nothing in the default build needs a token.
+**Structure Decision**: the neutral resolve+validate function (`checkChanges`) lives in
+**`@adrkit/core`** (not `@adrkit/ci`), takes the **full `lintCorpus` result** + snapshots,
+and is called by both `adr check` and the Action so neither surface depends on the other
+(RC3/R1/R2). `adr check` is a new subcommand on the existing `@adrkit/cli` dispatch.
+`@adrkit/ci` is a **new surface package** under `packages/ci/` (not `packages/adapters/*`),
+holding the only impure code (complete changed-file extraction, GitHub API) behind small
+ports, and ships a **committed self-contained bundle** (`dist/`) that `action.yml`
+(`runs.using: node24`) points at. The GitHub client is injected in tests; nothing in the
+default build needs a token.
 
 ## Complexity Tracking
 

--- a/specs/004-ci-surface/quickstart.md
+++ b/specs/004-ci-surface/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart: CI Surface (Phase 3)
+
+> **⚠️ Implementation is gated.** Do not build this feature until the rung-2 outcome
+> is genuinely met (a **real public MADR corpus** round-tripped by `adr migrate`,
+> with a real user). See [research.md §R0](./research.md). The commands below
+> describe the *intended* surface for the future implement thread.
+
+Prerequisites: a **published stable Bun** (CI pins `1.3.14`) — not the canary that
+self-reports 1.4.0 (it writes an unreadable lockfile). Clean clone, no network, no
+credentials.
+
+## `adr check` — the deterministic CLI (any provider)
+
+```bash
+bun install
+
+# Validate changed records + list the decisions governing a changed-file set
+bun run adr check packages/core/src/affects/index.ts packages/cli/src/index.ts
+bun run adr check <files...> --dir docs/adr --json      # stable machine-readable output
+
+# Exit code: 0 on success; non-zero iff a CHANGED record has an error finding.
+echo $?
+```
+
+## The GitHub Action — `@adrkit/ci`
+
+Add to a consuming repo's workflow. It needs only the default `GITHUB_TOKEN`:
+
+```yaml
+# .github/workflows/adr.yml (in a repo that adopts adrkit)
+name: ADR
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write        # to post/update the governing-decisions comment
+jobs:
+  adr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }   # base…head diff for changed-file extraction
+      - uses: mbeacom/adrkit/packages/ci@v0     # @adrkit/ci Action
+        with:
+          dir: docs/adr
+          # token defaults to ${{ github.token }} — no other secret required
+```
+
+On a PR, the Action extracts the changed files, resolves the governing decisions,
+validates the changed records, and posts (or updates) a single comment.
+
+## What "green" means
+
+- On a PR touching governed paths (on a repo that isn't this one), a comment names
+  **exactly** the governing decisions — id + title + fired matcher (SC-001).
+- `adr check <files>` exits non-zero **iff** a changed record has an error finding
+  (SC-002).
+- On a **>10-record** repo with a subset diff, the comment lists only the governing
+  subset — never the whole corpus (SC-003).
+- A second push **updates the same comment** rather than adding a new one (SC-004).
+- A diff nothing governs yields a concise "no governing decisions" note (SC-005).
+- The Action completes with only the default `GITHUB_TOKEN`, and degrades commenting
+  (not the check) on a read-only fork token (SC-006).
+- Clean clone builds/tests/lints green with the new `@adrkit/ci` package;
+  `clean-clone-builds` and `core-has-no-adapter-deps` stay green and now also cover
+  `@adrkit/ci` (SC-007).
+
+## Self-dogfood
+
+This repo can run `adr check` on its own PRs (an added CI job) so the CI surface
+governs the project that ships it — the same dogfooding stance as `adr lint`.

--- a/specs/004-ci-surface/quickstart.md
+++ b/specs/004-ci-surface/quickstart.md
@@ -2,14 +2,13 @@
 
 > **⚠️ Implementation is gated.** Do not build this feature until the rung-2 gate
 > clears — a subset of a real, permissively-licensed public MADR corpus vendored as
-> an **offline fixture** and round-tripped by `adr migrate` (a live external human
-> user is *not* required). See [research.md §R0](./research.md) and tasks.md
-> **T000/T00A**. The commands below describe the *intended* surface for the future
-> implement thread.
+> an **offline fixture** and round-tripped by `adr migrate` (that maintainer dogfood
+> round-trip **is** the required "real user"; no external human adopter needed). See
+> [research.md §R0](./research.md) and tasks.md **T000/T00A**. The commands below
+> describe the *intended* surface for the future implement thread.
 
-Prerequisites: a **published stable Bun** (CI pins `1.3.14`) — not the canary that
-self-reports 1.4.0 (it writes an unreadable lockfile). Clean clone, no network, no
-credentials.
+Prerequisites: **stable Bun 1.3.14** (CI pins it) — not the canary that self-reports
+1.4.0 (it writes an unreadable lockfile). Clean clone, no network, no credentials.
 
 ## `adr check` — the deterministic CLI (any provider)
 
@@ -26,7 +25,9 @@ echo $?
 
 ## The GitHub Action — `@adrkit/ci`
 
-Add to a consuming repo's workflow. It needs only the default `GITHUB_TOKEN`:
+Add to a consuming repo's workflow. It needs only the default `GITHUB_TOKEN`, runs on
+the `node24` runner, and executes a committed self-contained bundle (no install in the
+consumer checkout):
 
 ```yaml
 # .github/workflows/adr.yml (in a repo that adopts adrkit)
@@ -40,8 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }   # base…head diff for changed-file extraction
-      - uses: mbeacom/adrkit/packages/ci@v0     # @adrkit/ci Action
+        with: { fetch-depth: 0 }   # full history for the merge-base changed-file diff
+      - uses: mbeacom/adrkit/packages/ci@v0     # @adrkit/ci Action (runs.using: node24)
         with:
           dir: docs/adr
           # token defaults to ${{ github.token }} — no other secret required
@@ -64,7 +65,8 @@ validates the changed records, and posts (or updates) a single comment.
   (not the check) on a read-only fork token (SC-006).
 - Clean clone builds/tests/lints green with the new `@adrkit/ci` package;
   `clean-clone-builds` and `core-has-no-adapter-deps` stay green and now also cover
-  `@adrkit/ci` (SC-007).
+  `@adrkit/ci` (incl. the toolkit→core boundary), plus the **bundle-drift** check and a
+  **Node-24 smoke** of the committed bundle pass (SC-007, RC6/RC7).
 
 ## Self-dogfood
 

--- a/specs/004-ci-surface/quickstart.md
+++ b/specs/004-ci-surface/quickstart.md
@@ -1,9 +1,11 @@
 # Quickstart: CI Surface (Phase 3)
 
-> **⚠️ Implementation is gated.** Do not build this feature until the rung-2 outcome
-> is genuinely met (a **real public MADR corpus** round-tripped by `adr migrate`,
-> with a real user). See [research.md §R0](./research.md). The commands below
-> describe the *intended* surface for the future implement thread.
+> **⚠️ Implementation is gated.** Do not build this feature until the rung-2 gate
+> clears — a subset of a real, permissively-licensed public MADR corpus vendored as
+> an **offline fixture** and round-tripped by `adr migrate` (a live external human
+> user is *not* required). See [research.md §R0](./research.md) and tasks.md
+> **T000/T00A**. The commands below describe the *intended* surface for the future
+> implement thread.
 
 Prerequisites: a **published stable Bun** (CI pins `1.3.14`) — not the canary that
 self-reports 1.4.0 (it writes an unreadable lockfile). Clean clone, no network, no

--- a/specs/004-ci-surface/research.md
+++ b/specs/004-ci-surface/research.md
@@ -44,16 +44,33 @@ correction is bookkeeping and does **not** assert the rung-2 outcome is met.
 
 - **Scoping (this spec cycle) proceeds** — that is this thread's mandate, and having
   the design ready de-risks the moment the gate clears.
-- **Phase 3 _implementation_ is BLOCKED** until rung 2 is genuinely met: run
-  `adr migrate --from madr` against at least one **real public MADR corpus**
-  (vendored with attribution, or exercised via a documented external command) and,
-  ideally, in front of a real user. `tasks.md` records this as a hard precondition
-  (T000).
+- **Phase 3 _implementation_ is BLOCKED** until the gate is cleared per the resolved
+  condition below. `tasks.md` records this as a hard precondition (**T000**), plus a
+  scoped task to source and vendor the gating corpus (**T00A**).
 
-**Not this thread's job to fix**: closing the gate means either vendoring a real
-public MADR subset into the Phase 2 corpus test (respecting its license) or
-documenting and running an external-corpus exercise. That is Phase-2 remediation,
-tracked here only so the team sees it before starting Phase 3 code.
+**RESOLVED — what "cleared" means (maintainer decision; reviewer may override).**
+A vendored **subset of a genuinely real, permissively-licensed public MADR corpus**
+clears the rung-2 corpus gate and unblocks Phase 3 implementation. A live external
+**human user** is **not** a Phase-3 precondition — that is a higher rung (3+), not
+this gate. To count as cleared, the corpus subset MUST satisfy all of:
+
+- **Real third-party prose** — not synthetic or authored-to-pass. The point is to
+  exercise real-world MADR frontmatter/body variance the current synthetic fixture
+  cannot reproduce.
+- **Committed as an OFFLINE fixture** — vendored into the repo, never fetched at test
+  time (ADR-0007 forbids network at CI time).
+- **Licensing respected** — a permissive/public-domain license (e.g. CC0/CC-BY/MIT/
+  Apache, or the MADR project's own example records). Vendor a **small** subset with
+  **attribution + provenance** (source URL, license, commit/date) recorded in the
+  fixture directory. **If no cleanly-licensed real corpus can be found, stop and
+  flag it — do not vendor prose of unknown license.**
+- **Exercised through `adr migrate --from madr`** with the same assertions as the
+  synthetic test: idempotency + body-byte preservation + clean lint.
+
+**Not this thread's job — and Phase 2 is NOT reopened.** Clearing the gate is a small,
+well-scoped Phase-2 follow-up / Phase-3 precondition: source + vendor the corpus
+subset and point the existing corpus test at it. It does **not** re-implement or
+re-open Phase 2's migration logic; it only supplies the gating fixture.
 
 ## R1 — `adr check` is the deterministic substrate; the Action is a thin wrapper
 
@@ -76,18 +93,23 @@ CLI (fails seed 21 and locks adopters to one provider).
 
 ## R2 — `@adrkit/ci` is a surface package, not core and not an adapter
 
-**Decision**: Add `packages/ci/` as a first-party **surface** package (`@adrkit/ci`),
-a peer of `@adrkit/cli`. It depends on `@adrkit/core` (`workspace:*`) and public
-GitHub Action libraries; it MUST NOT import from `packages/adapters/*`. The
-`core-has-no-adapter-deps` check is extended to assert `@adrkit/ci` carries no
-adapter dependency.
+**Decision (RESOLVED — maintainer-confirmed; reviewer may override)**: Add
+`packages/ci/` as a first-party **surface** package (`@adrkit/ci`), a peer of
+`@adrkit/cli`, **not** under `packages/adapters/*` and **not** in core. It depends on
+`@adrkit/core` (`workspace:*`) and public GitHub Action libraries; it MUST NOT import
+from `packages/adapters/*`. The `core-has-no-adapter-deps` check is extended to assert
+`@adrkit/ci` carries no adapter dependency **and** that the GitHub toolkit dependency
+never reaches `@adrkit/core` or the schema (see R3).
 
 **Rationale**: ADR-0007 forbids *core* and *cli* from importing adapters and bounds
-what may enter the default build. `@adrkit/ci` is analogous to `@adrkit/cli`: it is
-a consumer surface, permitted its own public dependencies, but it is not an adapter
-(it is not an integration with a churning third-party governance target) and it is
-not core. Placing it under `packages/ci/` (not `packages/adapters/*`) keeps it inside
-the isolation boundary the constitution's Principle III draws.
+what may enter the default build. Adapters (`packages/adapters/*`) are **external-source
+integrations** (import/catalog) that are *allowed to break* on upstream churn. An
+Action that consumes core to render governing decisions is a **consumer surface** —
+the same category as the CLI — not an integration with a churning third-party
+governance target, and it must not be allowed to break. `@adrkit/ci` is therefore
+analogous to `@adrkit/cli`: a consumer surface permitted its own public dependencies,
+but not core and not an adapter. Placing it under `packages/ci/` keeps it inside the
+isolation boundary the constitution's Principle III draws.
 
 **Alternatives rejected**: `packages/adapters/ci-github` (wrong — the Action is a
 first-party surface, not an optional integration; and adapters are *allowed to
@@ -106,6 +128,13 @@ fetchable* surfaces; the GitHub API with the default token qualifies. The bindin
 constraint is that *install/build/test/lint* pass on a clean clone with no secrets —
 satisfied by stubbing the client. Runtime token use happens only when the Action
 actually runs in CI (FR-008).
+
+**Boundary assertion (RESOLVED — maintainer decision; reviewer may override)**:
+`scripts/check-deps.ts` (the `core-has-no-adapter-deps` gate) is extended so it also
+asserts the GitHub toolkit dependency (`@actions/*`, Octokit) **never reaches
+`@adrkit/core` or the schema** — it stays confined to the `@adrkit/ci` surface. This
+turns "the toolkit is confined" from a review-time promise into a CI-enforced gate,
+the same posture ADR-0007 takes for adapter isolation.
 
 **Alternatives rejected**: shelling out to `gh` (an undeclared system dependency,
 breaks clean-clone determinism); raw `fetch` against the REST API (re-implements what
@@ -204,6 +233,20 @@ failing validation.
 evaluator boundary (Phase 4 routes/escalates; Phase 3 does even less — it informs).
 Keeping the surface read-only + comment-only preserves "git is truth" and defers all
 judgment to humans and the later evaluator.
+
+## Resolved open questions (from PR #9 review)
+
+The two questions raised when this feature was opened are now **resolved as maintainer
+decisions the reviewer may still override**:
+
+1. **`packages/ci/` vs `packages/adapters/*` placement** — CONFIRMED: `@adrkit/ci` is a
+   first-party surface package (peer of `@adrkit/cli`), not an adapter and not core.
+   See **R2**, and the extended `check-deps` boundary assertion in **R3**.
+2. **What clears the rung-2 gate** — RESOLVED: a vendored subset of a genuinely real,
+   permissively-licensed public MADR corpus (offline fixture, attribution + provenance,
+   exercised via `adr migrate`) clears it and unblocks Phase 3 implementation; a live
+   external human user is a higher rung, not a Phase-3 precondition. See **R0** and
+   tasks **T000** / **T00A**.
 
 ## Deferred (not decided here)
 

--- a/specs/004-ci-surface/research.md
+++ b/specs/004-ci-surface/research.md
@@ -6,11 +6,25 @@ assessment, not a design decision — read it first.**
 
 ## R0 — ⚠️ Upstream gate: is rung 2 actually met? (BLOCKING for implementation)
 
-**Question (per the phase brief and plan.md)**: The outcome ladder is strict — do
-not open a phase before the one below it has landed **and has a real user**. Rung 2
-is *"`adr migrate --from madr` round-trips a real third-party corpus."* ADR-0008's
-exit criterion and Phase 2 **SC-007** both say migration must be *"exercised against
-at least one real public MADR corpus, **not a fixture**."* **Has it been?**
+**Question (per the phase brief and plan.md)**: The outcome ladder is strict — a rung's
+*implementation* must not start before the one below it has landed **and has a real
+user**. Rung 2 is *"`adr migrate --from madr` round-trips a real third-party corpus."*
+ADR-0008's exit criterion and Phase 2 **SC-007** both say migration must be *"exercised
+against at least one real public MADR corpus, **not a fixture**."* **Has it been?**
+
+**Resolved reading of the gate (maintainer decision; reviewer may override).** Rung 2
+clears when **both** of these hold — and nothing more:
+
+1. a **vendored subset of a genuinely real, permissively-licensed public MADR corpus**
+   exists as an **offline** fixture, and
+2. it is **exercised through `adr migrate --from madr`** with idempotency + body-byte
+   preservation (+ clean lint).
+
+That maintainer dogfood exercise **is** the required "real user" — the ladder says "even
+if that user is only you" — so **no live external human adopter is required** to start
+Phase 3 implementation. Both the real corpus **and** the exercise are required; a real
+corpus that is never migrated, or a migration only ever run on synthetic prose, does not
+clear it.
 
 **Finding: NO — not by the letter of the ladder.** Phase 2's code landed (PR #7,
 `ed5b3d4`), and a "real corpus" test exists, but it exercises a **synthetic**
@@ -26,14 +40,16 @@ sample, not a real third-party corpus:
 - Phase 2's own `research.md` **R8** anticipated exactly this: *"If licensing
   prevents vendoring, the test documents the external corpus + command instead and a
   synthetic-but-realistic corpus covers CI."* The synthetic path was taken. That
-  keeps CI offline (good), **but it does not satisfy the rung-2 shipping condition**,
-  which demands a real corpus **and** a real user.
+  keeps CI offline (good), **but it does not satisfy the rung-2 shipping condition** —
+  the migration has never been exercised on **real** third-party MADR prose.
 
-**Second half of the gate — the "real user":** there is no evidence in-repo of
-`adr migrate` having been run against an external adopter's corpus, nor of a
-third-party user. The ledger flip to "landed" reflects *code merged*, not the
-*outcome achieved*. So the gate is unmet on **both** counts: (a) no real public
-corpus exercised end-to-end, and (b) no real third-party user.
+**What this means against the resolved gate:** criterion 1 (a real, permissively-licensed
+public MADR corpus, vendored offline) is **not** met — today's fixture is synthetic — and
+therefore criterion 2 (the `adr migrate` exercise **on real prose**) is not met either.
+The "real user" half is **not** a separate missing third-party human: per the resolved
+reading it is the maintainer dogfood exercise, which lands *with* criterion 2. So exactly
+one thing is missing — the real corpus and its migration run. The ledger flip to "landed"
+reflects *code merged*, not this *outcome achieved*.
 
 **Also flag — stale ledger**: at the time this feature was opened, `plan.md`'s phase
 table still showed Phase 2 as *"scoping"* despite PR #7 having merged the
@@ -48,11 +64,9 @@ correction is bookkeeping and does **not** assert the rung-2 outcome is met.
   condition below. `tasks.md` records this as a hard precondition (**T000**), plus a
   scoped task to source and vendor the gating corpus (**T00A**).
 
-**RESOLVED — what "cleared" means (maintainer decision; reviewer may override).**
-A vendored **subset of a genuinely real, permissively-licensed public MADR corpus**
-clears the rung-2 corpus gate and unblocks Phase 3 implementation. A live external
-**human user** is **not** a Phase-3 precondition — that is a higher rung (3+), not
-this gate. To count as cleared, the corpus subset MUST satisfy all of:
+**Detailed constraints — what the gating corpus MUST satisfy (maintainer decision;
+reviewer may override).** Restating the resolved gate above as an actionable checklist;
+the corpus subset MUST satisfy all of:
 
 - **Real third-party prose** — not synthetic or authored-to-pass. The point is to
   exercise real-world MADR frontmatter/body variance the current synthetic fixture
@@ -72,24 +86,40 @@ well-scoped Phase-2 follow-up / Phase-3 precondition: source + vendor the corpus
 subset and point the existing corpus test at it. It does **not** re-implement or
 re-open Phase 2's migration logic; it only supplies the gating fixture.
 
-## R1 — `adr check` is the deterministic substrate; the Action is a thin wrapper
+## R1 — `adr check` and the Action share one neutral core function; both are thin
 
-**Decision**: Implement `adr check <changed-files> [--dir] [--json]` in `@adrkit/cli`
-as the portable, provider-agnostic core: it loads the corpus, runs the **existing**
-`resolveAffects` over the supplied changed-file list, validates the changed records
-with the **existing** validators, and returns a stable result. `@adrkit/ci` (the
-GitHub Action) extracts the changed-file list and renders/posts the comment, calling
-into the same core logic — it adds **no** new resolution or validation.
+**Decision (revised per PR #9 review, RC3)**: The shared "resolve + validate over a
+changed-file set" logic lives in **`@adrkit/core`** as a neutral, pure function
+(`checkChanges`), **not** in `@adrkit/ci`. `adr check` (in `@adrkit/cli`) and the Action
+(`@adrkit/ci`) each build its input and call it; neither surface depends on the other.
+The function takes the **full `lintCorpus` result** (`{ records, findings, checked }`) —
+not just `records` — plus the optional resolution snapshots
+(`changedDependencies`, `catalog`). It returns the `CheckOutcome` (data-model).
 
-**Rationale**: Principle IV — the CI surface introduces no probabilistic step and
-no second source of truth for "what governs this." Seed 21 makes the CLI equivalent
-first-class. Keeping the Action thin means it is testable without GitHub and portable
-to other providers, and it keeps all governance logic in the already-pinned,
-CI-asserted resolver (ADR-0009), not duplicated in an Action.
+**Why the full lint result, not `(records, changedFiles)`**: `lintCorpus` **drops
+malformed files from `records` but keeps their errors in `findings`**. A function given
+only `records` would silently lose those errors and could pass a PR that introduced an
+unparseable record. Passing the whole lint result preserves every finding. Likewise,
+`package` matching needs the `changedDependencies` snapshot the Action derives from the
+lockfile diff (R4/T007), so the input carries optional `snapshots` rather than assuming
+`path`-only.
 
-**Alternatives rejected**: putting resolution logic inside the Action (duplicates
-ADR-0009 semantics, unversioned, untestable offline); a GitHub-only surface with no
-CLI (fails seed 21 and locks adopters to one provider).
+**Why in core, not in `@adrkit/ci`**: putting the neutral function in the Action package
+would force `@adrkit/cli` to depend on `@adrkit/ci` **and its GitHub toolkit deps** just
+to run `adr check` — violating R2 (the CLI must not pull the Action's `@actions/*` tree)
+and Principle III. Core is the one place both surfaces already depend on.
+
+**Rationale**: Principle IV — one deterministic implementation of "what governs this +
+are the changed records valid," reused by both surfaces, with no probabilistic step and
+no second source of truth. It stays pure (ADR-0009): given the lint result + file list +
+snapshots, it computes the outcome with no clock, network, or fs traversal. Seed 21 makes
+the CLI equivalent first-class.
+
+**Alternatives rejected**: a `(records, changedFiles)` signature (loses dropped-file
+errors and the package snapshot — the specific defect this revision fixes); putting the
+shared function in `@adrkit/ci` (forces the CLI onto the Action's dependency tree,
+violates R2); duplicating resolution/validation inside the Action (unversioned, untestable
+offline, two sources of truth).
 
 ## R2 — `@adrkit/ci` is a surface package, not core and not an adapter
 
@@ -140,38 +170,54 @@ the same posture ADR-0007 takes for adapter isolation.
 breaks clean-clone determinism); raw `fetch` against the REST API (re-implements what
 the toolkit already does, including auth and pagination).
 
-## R4 — Changed-file extraction lives in the Action; resolution stays pure
+## R4 — Complete changed-file extraction (paginated PR files or merge-base diff); resolution stays pure
 
-**Decision**: The Action produces the changed-file list from the `pull_request` event
-(head/base SHAs → compare API, or a `base…head` diff on the checkout) and passes it
-to `resolveAffects`. The resolver is never given a repo to walk; it receives the file
-list, exactly as in Phase 1. For `package` matchers, the Action derives the
-changed-dependency snapshot from the lockfile diff using the **existing**
-`deriveChangedDependenciesFromBunLockDiff` helper (already exported from
-`@adrkit/core`'s affects module).
+**Decision (revised per PR #9 review, RC4)**: The Action produces the **complete**
+changed-file list via **either** a **fully paginated `pulls.listFiles`** listing (all
+pages) **or** a local **merge-base (`base…head`) `git diff`** on the checkout, and
+passes it to `checkChanges`/`resolveAffects`. It MUST **not** rely on the **compare
+API's** file list, which GitHub **caps** (documented at 300 files) and silently
+truncates. The provider's hard limit is handled **explicitly**: paginate to the end,
+or when the listing would exceed the cap fall back to the local merge-base diff, and
+surface a notice if a complete list cannot be obtained. For `package` matchers, the
+Action derives the changed-dependency snapshot from the lockfile diff using the
+**existing** `deriveChangedDependenciesFromBunLockDiff` helper.
 
 **Rationale**: ADR-0009 — resolution is a pure function of `(matchers, fileList,
-catalogSnapshot)`; the `resolution-is-pure` assertion must keep passing. Impurity
-(git, network) is quarantined in the Action, which is allowed to touch the
+catalogSnapshot)`; the `resolution-is-pure` assertion must keep passing. A **truncated**
+file list would silently drop governed files — a correctness bug in exactly the mapping
+this phase exists to provide — so completeness is a requirement, not a nicety. Impurity
+(git, network, pagination) is quarantined in the Action, which is allowed to touch the
 environment.
 
-**Alternatives rejected**: letting the resolver diff the working tree (violates
+**Alternatives rejected**: the compare API file list (capped/truncated — the specific
+defect this revision fixes); letting the resolver diff the working tree (violates
 ADR-0009 purity and the CI assertion); requiring the adopter to pass the file list
 manually (the Action exists precisely to compute it).
 
-## R5 — Comment identity and idempotency via a hidden marker
+## R5 — Comment identity: marker AND author, across all comment pages
 
-**Decision**: The rendered comment carries a stable hidden HTML marker (e.g.
-`<!-- adrkit:ci -->`). On each run the Action lists the PR's comments, finds the one
-bearing the marker, and **edits** it; absent, it **creates** one. No external state
-is stored (ADR-0004 — nothing but git and the PR itself).
+**Decision (revised per PR #9 review, RC5)**: The comment carries a stable hidden HTML
+marker (e.g. `<!-- adrkit:ci -->`). On each run the Action **paginates the PR's comments
+to completion** and selects the one matching **both** the marker **and** the Action's own
+author identity (the bot/app user that posts it); it **edits** that comment, else
+**creates** one. Marker-only matching is insufficient: a human could quote the marker,
+and the Action's own comment could sit on a later page. No external state is stored
+(ADR-0004 — nothing but git and the PR itself).
 
-**Rationale**: FR-005/SC-004. The marker is the minimal, stateless mechanism for
-"one comment, updated in place." Storing a comment id anywhere else would introduce a
-side database, which ADR-0004 forbids for this surface.
+**Rationale**: FR-005/SC-004. Matching on marker **and** author prevents two failure
+modes — editing a foreign comment that contains the marker, and posting a duplicate
+because the real comment was on an unfetched page. It remains stateless (no stored
+comment id), so it does not introduce the side database ADR-0004 forbids.
 
-**Alternatives rejected**: a fresh comment per push (spam — the exact anti-pattern
-exit criterion b guards against); a commit status/check-run only (loses the
+**Test coverage (required)**: fake-client tests for (a) a **foreign/pre-existing comment
+bearing the marker** (must be ignored, a new one created or the Action's own edited) and
+(b) the Action's **own marker comment on a later page** (must be found and edited, not
+duplicated).
+
+**Alternatives rejected**: marker-only matching (edits foreign comments / misses paged
+comments — the defect this revision fixes); a fresh comment per push (spam — the exact
+anti-pattern exit criterion b guards against); a commit status/check-run only (loses the
 human-readable governing list); an external key/value store (violates ADR-0004).
 
 ## R6 — Selectivity is the resolver's union, rendered verbatim
@@ -234,19 +280,69 @@ evaluator boundary (Phase 4 routes/escalates; Phase 3 does even less — it info
 Keeping the surface read-only + comment-only preserves "git is truth" and defers all
 judgment to humans and the later evaluator.
 
+## R10 — Ship a committed, self-contained Node bundle (RC6)
+
+**Decision (per PR #9 review)**: `@adrkit/ci` is a **JavaScript Action** that runs
+directly from the referenced repo; GitHub does **not** run `bun/npm install` in the
+consumer checkout. Therefore the Action ships a **committed, self-contained Node
+bundle** — `bun build` bundling `@adrkit/core` **and** the GitHub toolkit into a single
+`dist/` entrypoint — and `action.yml`'s `runs.main` points at it. CI adds a **bundle
+drift check** (rebuild and fail if the committed artifact differs, mirroring
+`schema-emit-matches`) and a **Node smoke test** that the bundle runs on the target
+runtime.
+
+**Rationale**: FR-015. Without a committed bundle the Action would fail at consumer
+runtime with unresolved imports (`@adrkit/core`, `@actions/*`). Committing the built
+artifact is the standard JS-Action distribution model; the drift check keeps the
+committed bundle honest the same way the schema emit-check does.
+
+**Alternatives rejected**: a **composite/Docker Action** (Docker adds a container build
+and violates the lightweight, clean-clone spirit; composite would still need an install
+step in the consumer); publishing to npm and `npx`-ing at runtime (adds a network
+install to every run, and a release step the repo does not yet have); assuming the
+consumer installs deps (a JS Action does not — the defect this addresses).
+
+## R11 — Action runtime is Node 24 (RC7)
+
+**Decision (maintainer decision; reviewer may override)**: `action.yml` uses
+`runs.using: node24`. The project requires Node `>=22` and smoke-tests **22/24**
+(ADR-0010); Node 24 is the current supported GitHub Actions runner and is already in the
+smoke matrix, so it is the consistent choice.
+
+**Rationale**: FR-016. The earlier draft said `node20`, which is inconsistent with the
+project's `>=22` floor and its smoke matrix — an Action targeting an unsupported/older
+runtime than the code it bundles is a latent break. Picking Node 24 aligns the runtime
+with what CI already verifies.
+
+**Alternatives rejected**: `node20` (below the project's `>=22` floor and not in the
+smoke matrix — the inconsistency this fixes); deliberately targeting a runtime **without**
+adding it to the Node smoke matrix (would ship an unverified runtime).
+
 ## Resolved open questions (from PR #9 review)
 
-The two questions raised when this feature was opened are now **resolved as maintainer
-decisions the reviewer may still override**:
+Round 1 (feature-open questions) and round 2 (7 review comments) are now **resolved as
+maintainer decisions the reviewer may still override**:
 
 1. **`packages/ci/` vs `packages/adapters/*` placement** — CONFIRMED: `@adrkit/ci` is a
    first-party surface package (peer of `@adrkit/cli`), not an adapter and not core.
    See **R2**, and the extended `check-deps` boundary assertion in **R3**.
-2. **What clears the rung-2 gate** — RESOLVED: a vendored subset of a genuinely real,
-   permissively-licensed public MADR corpus (offline fixture, attribution + provenance,
-   exercised via `adr migrate`) clears it and unblocks Phase 3 implementation; a live
-   external human user is a higher rung, not a Phase-3 precondition. See **R0** and
-   tasks **T000** / **T00A**.
+2. **What clears the rung-2 gate** — RESOLVED (governance, RC8): a vendored subset of a
+   genuinely real, permissively-licensed public MADR corpus (offline fixture, attribution
+   + provenance, exercised via `adr migrate`) clears it and unblocks Phase 3
+   implementation; the maintainer dogfood exercise **is** the required "real user" — no
+   external human adopter needed. See **R0**, plan.md policy, and tasks **T000**/**T00A**.
+3. **Shared-function API & placement** (RC3) — the neutral `checkChanges` lives in
+   `@adrkit/core`, takes the **full lint result** + snapshots, and is called by both
+   `adr check` and the Action (neither imports the other). See **R1**.
+4. **Changed-file source** (RC4) — complete paginated PR-files listing or local
+   merge-base diff, provider cap handled explicitly; not the truncating compare API.
+   See **R4**.
+5. **Comment idempotency** (RC5) — match marker **and** author across all comment pages;
+   tests for a foreign marker and a marker on a later page. See **R5**.
+6. **Packaged distribution** (RC6) — committed self-contained Node bundle + drift/smoke
+   checks. See **R10**.
+7. **Action runtime** (RC7) — `node24`, consistent with the `>=22` floor and smoke
+   matrix. See **R11**.
 
 ## Deferred (not decided here)
 

--- a/specs/004-ci-surface/research.md
+++ b/specs/004-ci-surface/research.md
@@ -1,0 +1,212 @@
+# Research & Decisions: CI Surface (Phase 3)
+
+Decisions resolving the Technical Context, each constrained by ADR-0009/ADR-0007/
+ADR-0004 or the constitution. None reopens a settled ADR. **R0 is a gate
+assessment, not a design decision — read it first.**
+
+## R0 — ⚠️ Upstream gate: is rung 2 actually met? (BLOCKING for implementation)
+
+**Question (per the phase brief and plan.md)**: The outcome ladder is strict — do
+not open a phase before the one below it has landed **and has a real user**. Rung 2
+is *"`adr migrate --from madr` round-trips a real third-party corpus."* ADR-0008's
+exit criterion and Phase 2 **SC-007** both say migration must be *"exercised against
+at least one real public MADR corpus, **not a fixture**."* **Has it been?**
+
+**Finding: NO — not by the letter of the ladder.** Phase 2's code landed (PR #7,
+`ed5b3d4`), and a "real corpus" test exists, but it exercises a **synthetic**
+sample, not a real third-party corpus:
+
+- `packages/core/test/migrate-real-corpus.test.ts` — the test name is literally
+  *"migrates the **synthetic** real-world-shaped corpus with body preservation and
+  clean lint."*
+- Its fixture `packages/core/test/fixtures/madr-corpus/` is hand-authored. The first
+  record's own `context` says: *"A small **synthetic**, real-world-shaped MADR
+  sample is used here **to avoid vendoring third-party ADR prose** while still
+  exercising block scalars."*
+- Phase 2's own `research.md` **R8** anticipated exactly this: *"If licensing
+  prevents vendoring, the test documents the external corpus + command instead and a
+  synthetic-but-realistic corpus covers CI."* The synthetic path was taken. That
+  keeps CI offline (good), **but it does not satisfy the rung-2 shipping condition**,
+  which demands a real corpus **and** a real user.
+
+**Second half of the gate — the "real user":** there is no evidence in-repo of
+`adr migrate` having been run against an external adopter's corpus, nor of a
+third-party user. The ledger flip to "landed" reflects *code merged*, not the
+*outcome achieved*. So the gate is unmet on **both** counts: (a) no real public
+corpus exercised end-to-end, and (b) no real third-party user.
+
+**Also flag — stale ledger**: at the time this feature was opened, `plan.md`'s phase
+table still showed Phase 2 as *"scoping"* despite PR #7 having merged the
+implementation. This scoping change corrects it to *"landed (PR #7 merged)"*, but the
+correction is bookkeeping and does **not** assert the rung-2 outcome is met.
+
+**Consequence**:
+
+- **Scoping (this spec cycle) proceeds** — that is this thread's mandate, and having
+  the design ready de-risks the moment the gate clears.
+- **Phase 3 _implementation_ is BLOCKED** until rung 2 is genuinely met: run
+  `adr migrate --from madr` against at least one **real public MADR corpus**
+  (vendored with attribution, or exercised via a documented external command) and,
+  ideally, in front of a real user. `tasks.md` records this as a hard precondition
+  (T000).
+
+**Not this thread's job to fix**: closing the gate means either vendoring a real
+public MADR subset into the Phase 2 corpus test (respecting its license) or
+documenting and running an external-corpus exercise. That is Phase-2 remediation,
+tracked here only so the team sees it before starting Phase 3 code.
+
+## R1 — `adr check` is the deterministic substrate; the Action is a thin wrapper
+
+**Decision**: Implement `adr check <changed-files> [--dir] [--json]` in `@adrkit/cli`
+as the portable, provider-agnostic core: it loads the corpus, runs the **existing**
+`resolveAffects` over the supplied changed-file list, validates the changed records
+with the **existing** validators, and returns a stable result. `@adrkit/ci` (the
+GitHub Action) extracts the changed-file list and renders/posts the comment, calling
+into the same core logic — it adds **no** new resolution or validation.
+
+**Rationale**: Principle IV — the CI surface introduces no probabilistic step and
+no second source of truth for "what governs this." Seed 21 makes the CLI equivalent
+first-class. Keeping the Action thin means it is testable without GitHub and portable
+to other providers, and it keeps all governance logic in the already-pinned,
+CI-asserted resolver (ADR-0009), not duplicated in an Action.
+
+**Alternatives rejected**: putting resolution logic inside the Action (duplicates
+ADR-0009 semantics, unversioned, untestable offline); a GitHub-only surface with no
+CLI (fails seed 21 and locks adopters to one provider).
+
+## R2 — `@adrkit/ci` is a surface package, not core and not an adapter
+
+**Decision**: Add `packages/ci/` as a first-party **surface** package (`@adrkit/ci`),
+a peer of `@adrkit/cli`. It depends on `@adrkit/core` (`workspace:*`) and public
+GitHub Action libraries; it MUST NOT import from `packages/adapters/*`. The
+`core-has-no-adapter-deps` check is extended to assert `@adrkit/ci` carries no
+adapter dependency.
+
+**Rationale**: ADR-0007 forbids *core* and *cli* from importing adapters and bounds
+what may enter the default build. `@adrkit/ci` is analogous to `@adrkit/cli`: it is
+a consumer surface, permitted its own public dependencies, but it is not an adapter
+(it is not an integration with a churning third-party governance target) and it is
+not core. Placing it under `packages/ci/` (not `packages/adapters/*`) keeps it inside
+the isolation boundary the constitution's Principle III draws.
+
+**Alternatives rejected**: `packages/adapters/ci-github` (wrong — the Action is a
+first-party surface, not an optional integration; and adapters are *allowed to
+break*, which a shipped Action must not); building the Action into `@adrkit/cli`
+(pulls the GitHub toolkit into the CLI's dependency tree for a non-CLI concern).
+
+## R3 — GitHub API dependency is confined to the surface and stubbed in tests
+
+**Decision**: `@adrkit/ci` may depend on the public GitHub Action toolkit
+(`@actions/core`, `@actions/github`/Octokit). All GitHub API access is behind a small
+internal port so tests inject a fake client; no test performs a real network call or
+requires a token. `clean-clone-builds` therefore stays green with **no** credentials.
+
+**Rationale**: ADR-0007 permits building against *publicly documented, publicly
+fetchable* surfaces; the GitHub API with the default token qualifies. The binding
+constraint is that *install/build/test/lint* pass on a clean clone with no secrets —
+satisfied by stubbing the client. Runtime token use happens only when the Action
+actually runs in CI (FR-008).
+
+**Alternatives rejected**: shelling out to `gh` (an undeclared system dependency,
+breaks clean-clone determinism); raw `fetch` against the REST API (re-implements what
+the toolkit already does, including auth and pagination).
+
+## R4 — Changed-file extraction lives in the Action; resolution stays pure
+
+**Decision**: The Action produces the changed-file list from the `pull_request` event
+(head/base SHAs → compare API, or a `base…head` diff on the checkout) and passes it
+to `resolveAffects`. The resolver is never given a repo to walk; it receives the file
+list, exactly as in Phase 1. For `package` matchers, the Action derives the
+changed-dependency snapshot from the lockfile diff using the **existing**
+`deriveChangedDependenciesFromBunLockDiff` helper (already exported from
+`@adrkit/core`'s affects module).
+
+**Rationale**: ADR-0009 — resolution is a pure function of `(matchers, fileList,
+catalogSnapshot)`; the `resolution-is-pure` assertion must keep passing. Impurity
+(git, network) is quarantined in the Action, which is allowed to touch the
+environment.
+
+**Alternatives rejected**: letting the resolver diff the working tree (violates
+ADR-0009 purity and the CI assertion); requiring the adopter to pass the file list
+manually (the Action exists precisely to compute it).
+
+## R5 — Comment identity and idempotency via a hidden marker
+
+**Decision**: The rendered comment carries a stable hidden HTML marker (e.g.
+`<!-- adrkit:ci -->`). On each run the Action lists the PR's comments, finds the one
+bearing the marker, and **edits** it; absent, it **creates** one. No external state
+is stored (ADR-0004 — nothing but git and the PR itself).
+
+**Rationale**: FR-005/SC-004. The marker is the minimal, stateless mechanism for
+"one comment, updated in place." Storing a comment id anywhere else would introduce a
+side database, which ADR-0004 forbids for this surface.
+
+**Alternatives rejected**: a fresh comment per push (spam — the exact anti-pattern
+exit criterion b guards against); a commit status/check-run only (loses the
+human-readable governing list); an external key/value store (violates ADR-0004).
+
+## R6 — Selectivity is the resolver's union, rendered verbatim
+
+**Decision**: The comment lists **exactly** the resolver's union output for the
+changed files — each governing record with its fired matcher(s) — and nothing else.
+There is no "related decisions" padding. If the list is large, it is because many
+records genuinely fire; if it is *everything*, that is surfaced as a signal that a
+matcher is over-broad, not smoothed over.
+
+**Rationale**: Exit criterion (b) and ADR-0009's union semantics. The comment's job
+is to reflect the mapping faithfully; making it *pretty* by adding or trimming
+records would make it lie. The renderer MAY group by matcher type and MAY cap an
+absurd list with a "+N more" tail for readability, but the underlying set is the
+resolver's, unmodified.
+
+**Alternatives rejected**: heuristic "top-N most relevant" ranking (that is a
+probabilistic judgment — Principle IV — and hides conflicts ADR-0009 wants surfaced);
+always listing the whole corpus "for context" (defeats the phase).
+
+## R7 — Empty and error outcomes
+
+**Decision**: When the resolver returns **no** governing records, the Action renders
+a one-line "no governing decisions for the changed files" note (still a single
+marker-bearing comment, so it updates cleanly next push) — never a corpus dump
+(FR-007). When a **changed record** has an **error** finding, `adr check` exits
+non-zero (the job fails, FR-002) and the comment surfaces the validation failure
+alongside (or instead of) the governing list.
+
+**Rationale**: FR-002/FR-007/SC-005. The two axes — "what governs this" and "are the
+changed records valid" — are independent; the outcome must communicate both, and a
+quiet empty state keeps the surface trustworthy on unrelated PRs.
+
+## R8 — Degrade on read-only tokens; never fail the job on a comment permission
+
+**Decision**: On a fork PR (or any context where the token lacks
+`pull-requests: write`), the Action runs the deterministic `adr check` and, if it
+cannot comment, downgrades to a job-log annotation/notice rather than throwing.
+Validation failures (FR-002) still fail the job; a **commenting** permission error
+does not.
+
+**Rationale**: FR-014/SC-006 and ADR-0009's "degrade, never fail" posture applied to
+the runtime. Fork PRs with read-only `GITHUB_TOKEN` are a normal GitHub reality;
+failing the whole job because the bot could not comment would make the Action hostile
+to the exact contributors it should serve.
+
+**Alternatives rejected**: requiring a PAT to guarantee comment rights (violates
+FR-008 "default token only"); silently succeeding with no signal at all (the reviewer
+should still see the check result).
+
+## R9 — No index, no write path, routes-not-decides
+
+**Decision**: `adr check`/`@adrkit/ci` read the corpus + supplied file list and write
+**only** the PR comment. No database/projection is touched (ADR-0004); no record is
+mutated; nothing is approved or merged. The only failure signal is a changed record
+failing validation.
+
+**Rationale**: ADR-0004 ("the CLI and CI action never require the index") and the
+evaluator boundary (Phase 4 routes/escalates; Phase 3 does even less — it informs).
+Keeping the surface read-only + comment-only preserves "git is truth" and defers all
+judgment to humans and the later evaluator.
+
+## Deferred (not decided here)
+
+Non-GitHub CI provider packaging; catalog/IaC/OpenAPI backing for the inert matcher
+types; wiring the Phase 2 divergence report into a PR; any evaluator/rubric pass
+(Phase 4); comment summarization or ranking.

--- a/specs/004-ci-surface/spec.md
+++ b/specs/004-ci-surface/spec.md
@@ -8,11 +8,15 @@
 
 > **⚠️ Upstream gate — read [research.md §R0](./research.md) first.** Phase 2
 > (rung 2) shipped its code (PR #7) but its rung-2 *outcome* — `adr migrate
-> --from madr` round-tripping a **real** third-party MADR corpus with a real user —
-> was satisfied only by a **synthetic** fixture. The strict outcome ladder is not
-> yet met. **Scoping (this document) proceeds; Phase 3 _implementation_ is
-> blocked** until the rung-2 gate is genuinely met. This spec is written now so the
-> design is ready the moment the gate clears.
+> --from madr` round-tripping a **real** third-party MADR corpus — was satisfied only
+> by a **synthetic** fixture. **Scoping (this document) proceeds; Phase 3
+> _implementation_ is blocked** until the gate clears. **Resolved (maintainer
+> decision; reviewer may override):** the gate is cleared by vendoring a subset of a
+> genuinely real, permissively-licensed public MADR corpus as an **offline fixture**
+> (attribution + provenance) and exercising it through `adr migrate` — a live external
+> human user is a higher rung, *not* a Phase-3 precondition. See
+> [research.md §R0](./research.md) and `tasks.md` **T000** / **T00A**. This spec is
+> written now so the design is ready the moment the gate clears.
 
 ## Overview
 
@@ -216,7 +220,9 @@ and comments end-to-end with no other secret present.
   and public GitHub Action libraries; it MUST NOT import from `packages/adapters/*`
   (ADR-0007). `@adrkit/ci` is a first-party **surface** package (a peer of
   `@adrkit/cli`), **not** core and **not** an adapter. The `core-has-no-adapter-deps`
-  check MUST cover it.
+  check MUST cover it **and** MUST assert the GitHub toolkit dependency (`@actions/*`,
+  Octokit) never reaches `@adrkit/core` or the schema — the toolkit stays confined to
+  the `@adrkit/ci` surface.
 - **FR-014**: On a fork PR whose token cannot comment, the Action MUST still run the
   deterministic check and **degrade** commenting to a non-fatal notice rather than
   failing the job on a permissions error (FR-008 clean-degradation, consistent with

--- a/specs/004-ci-surface/spec.md
+++ b/specs/004-ci-surface/spec.md
@@ -175,23 +175,38 @@ and comments end-to-end with no other secret present.
 ### Functional Requirements
 
 - **FR-001**: `adr check <changed-files...> [--dir docs/adr] [--json]` MUST, for the
-  supplied changed-file list, (a) resolve the governing decisions using the
-  existing **pure** resolver (ADR-0009) and (b) validate any changed records via
-  the existing validators — deterministically, with no clock, no network, and no
-  filesystem traversal beyond the corpus load and the supplied list.
+  supplied changed-file list, (a) resolve the governing decisions using the existing
+  **pure** resolver (ADR-0009) and (b) validate the changed records via the existing
+  validators — deterministically, with no clock, no network, and no filesystem
+  traversal beyond the corpus load and the supplied list. This logic MUST be a
+  **single neutral function in `@adrkit/core`** (`checkChanges`) that both `adr check`
+  and the Action call; it MUST accept the **full `lintCorpus` result**
+  (`{ records, findings, checked }`) — not only `records` — so findings that
+  `lintCorpus` keeps for malformed files it dropped from `records` are not lost, plus
+  the optional resolution `snapshots` (`changedDependencies`, `catalog`). Neither
+  surface may import the other (RC3, ADR-0007/Principle III).
 - **FR-002**: `adr check` MUST exit **non-zero** when a **changed record** has an
   **error**-severity finding, and `0` when findings are only `info`/`warn` — mirroring
   `adr lint` exit semantics.
-- **FR-003**: The Action MUST derive the PR's changed-file list (base…head) and pass
-  it to the resolver/`adr check`. File-list extraction is the **Action's**
-  responsibility; the resolver MUST remain pure (ADR-0009) and MUST NOT traverse the
-  working tree to discover changes.
+- **FR-003**: The Action MUST derive the PR's **complete** changed-file list and pass
+  it to `checkChanges`. It MUST obtain the full list via a **fully paginated PR-files
+  listing** (all pages) **or** a local **merge-base (`base…head`) diff** on the
+  checkout — **not** the compare API's file list, which GitHub **caps** (e.g. 300
+  files) and silently truncates. The Action MUST **explicitly handle** the provider's
+  hard limit (paginate to completion, or fall back to the local diff) rather than
+  evaluating a truncated list, and MUST surface a notice if it cannot obtain the
+  complete list. File-list extraction is the **Action's** responsibility; the resolver
+  MUST remain pure (ADR-0009) and MUST NOT traverse the working tree to discover
+  changes.
 - **FR-004**: The Action MUST post a single PR comment listing the governing
   decisions for the changed files, each with `id`, `title`, and the matcher(s) that
   fired (mirroring `adr explain`). Records are a **union**; ordering is stable.
 - **FR-005**: The comment MUST be **idempotent**: subsequent runs on the same PR
-  update the same comment (located by a stable hidden HTML marker) rather than
-  posting a new one.
+  update the same comment rather than posting a new one. To locate it the Action MUST
+  **paginate the PR's comments** (all pages) and match on **both** the stable hidden
+  adrkit marker **and** the Action's own author identity (the bot/app user), so it
+  never edits a human's comment that happens to contain the marker and never misses
+  its own comment on a later page. Absent a match, it creates one.
 - **FR-006**: The comment MUST be **selective** — only records whose matchers fire
   on the changed files appear. A record that governs no changed file MUST NOT
   appear. On a corpus of more than ten records touched by a subset diff, the comment
@@ -227,18 +242,37 @@ and comments end-to-end with no other secret present.
   deterministic check and **degrade** commenting to a non-fatal notice rather than
   failing the job on a permissions error (FR-008 clean-degradation, consistent with
   ADR-0009's "degrade, never fail" posture).
+- **FR-015**: **Packaged distribution.** As a JavaScript Action, `@adrkit/ci` runs
+  directly from the referenced repo and does **not** install this package's
+  dependencies in the consumer's checkout. The Action MUST therefore ship a
+  **self-contained, committed Node bundle** (bundling `@adrkit/core` **and** the
+  GitHub toolkit) with `action.yml`'s `runs.main` pointing at that bundle. CI MUST
+  include a **drift check** (rebuild the bundle and fail if the committed artifact
+  differs, mirroring `schema-emit-matches`) plus a **smoke test** that the bundle runs
+  under the target Node.
+- **FR-016**: **Runtime.** The Action MUST declare a supported Node runtime. This
+  project requires Node `>=22` and smoke-tests 22/24 (ADR-0010), so the Action MUST use
+  **`runs.using: node24`** (a supported runner) rather than an unsupported/older
+  runtime, unless a runtime is deliberately targeted **and** added to the Node smoke
+  matrix.
 
 ### Key Entities
 
-- **Changed-file set**: the list of repo-relative paths the PR touches (base…head),
-  produced by the Action from the GitHub event/API or a git range; the input to the
-  pure resolver.
+- **Changed-file set**: the **complete** list of repo-relative paths the PR touches,
+  produced by the Action via a fully paginated PR-files listing or a local merge-base
+  diff (never the truncation-prone compare API — FR-003); the input to the pure
+  resolver.
 - **Governing-decision result**: reuse of the Phase 1 resolver output —
   `{ recordId, title, firedMatchers[] }` per governing record (a union).
+- **Neutral check function** (`checkChanges`, in `@adrkit/core`): the single shared
+  entrypoint both `adr check` and the Action call; takes the full `lintCorpus` result +
+  changed files + optional snapshots, returns the check outcome (RC3).
 - **Changed-record / validation set**: the ADR files under the corpus dir that
-  appear in the diff, plus their reused Phase 0/2 `Finding`s.
+  appear in the diff, plus their reused Phase 0/2 `Finding`s (including findings kept
+  for malformed files `lintCorpus` dropped from `records`).
 - **PR comment**: rendered markdown carrying a stable hidden marker for idempotent
-  update; a **derived projection** of git, never a record.
+  update, located by marker **and** author identity across all comment pages (FR-005);
+  a **derived projection** of git, never a record.
 - **Check outcome**: `pass | fail` (fail iff a changed record has an error finding),
   plus the human/`--json` payload the Action consumes.
 
@@ -268,13 +302,18 @@ and comments end-to-end with no other secret present.
 
 Documented, ADR-consistent choices (revisit at plan stage):
 
-- **A1 — Changed-file extraction**: the Action derives the changed-file list from the
-  PR (the `pull_request` event payload and/or the compare API, or a `base…head` git
-  range on the checkout). The list is the resolver's input; resolution never walks
-  the tree (ADR-0009). Extraction lives in `@adrkit/ci`, not in core.
-- **A2 — Comment identity**: idempotency is achieved with a stable hidden HTML
-  marker (e.g. `<!-- adrkit:ci -->`) the Action searches for among PR comments; the
-  first run creates, later runs edit. No state is stored outside the PR (ADR-0004).
+- **A1 — Changed-file extraction**: the Action derives the **complete** changed-file
+  list via a **fully paginated PR-files listing** or a local **merge-base diff** on the
+  checkout — **not** the compare API's file list (GitHub caps it and truncates). The
+  provider's hard limit is handled explicitly (paginate to completion or fall back to
+  the local diff; surface a notice if the full list cannot be obtained). The list is
+  the resolver's input; resolution never walks the tree (ADR-0009). Extraction lives in
+  `@adrkit/ci`, not in core (FR-003).
+- **A2 — Comment identity**: idempotency uses a stable hidden HTML marker (e.g.
+  `<!-- adrkit:ci -->`) **and** the Action's author identity, matched across a **fully
+  paginated** listing of PR comments; the first run creates, later runs edit its own
+  comment. A foreign comment that happens to contain the marker is never edited, and a
+  match on a later page is not missed. No state is stored outside the PR (ADR-0004).
 - **A3 — Selectivity is resolver-driven**: the comment contains exactly the resolver's
   union output for the changed files — nothing is added. "Lists everything" can only
   happen if a record's matchers are genuinely over-broad (e.g. `**`), which is a
@@ -291,6 +330,10 @@ Documented, ADR-consistent choices (revisit at plan stage):
   `@actions/github`/Octokit) is an acceptable dependency of the **surface** package
   `@adrkit/ci` (like `@adrkit/cli`'s own deps), never of core, and is stubbed in
   tests so `clean-clone-builds` needs no token (ADR-0007).
+- **A7 — Packaged bundle**: because a JavaScript Action does not `bun/npm install` in
+  the consumer checkout, `@adrkit/ci` ships a **committed, self-contained Node bundle**
+  (core + toolkit) that `action.yml` points at, guarded by a build-drift check and a
+  Node smoke test (FR-015). The bundler is Bun (`bun build`, ADR-0010).
 
 ## Out of Scope
 

--- a/specs/004-ci-surface/spec.md
+++ b/specs/004-ci-surface/spec.md
@@ -1,0 +1,302 @@
+# Feature Specification: CI Surface
+
+**Feature Branch**: `004-ci-surface`
+**Created**: 2026-07-18
+**Status**: Draft
+**Phase**: 3 (outcome ladder rung 3)
+**Normative sources**: [ADR-0009](../../docs/adr/0009-affects-resolution-and-catalog-binding.md) (resolution semantics, one-way-door), [ADR-0007](../../docs/adr/0007-adapter-isolation-and-public-surface-build.md) (isolation / clean clone), [ADR-0004](../../docs/adr/0004-git-is-source-of-truth-database-is-an-index.md) (git is truth; the CI action never requires the index), [ADR-0001](../../docs/adr/0001-record-architecture-decisions-in-git.md). Where this spec and an ADR disagree, the ADR wins.
+
+> **⚠️ Upstream gate — read [research.md §R0](./research.md) first.** Phase 2
+> (rung 2) shipped its code (PR #7) but its rung-2 *outcome* — `adr migrate
+> --from madr` round-tripping a **real** third-party MADR corpus with a real user —
+> was satisfied only by a **synthetic** fixture. The strict outcome ladder is not
+> yet met. **Scoping (this document) proceeds; Phase 3 _implementation_ is
+> blocked** until the rung-2 gate is genuinely met. This spec is written now so the
+> design is ready the moment the gate clears.
+
+## Overview
+
+Phase 0 made records valid, Phase 1 made them **locatable** (the pure `affects`
+resolver), and Phase 2 let an existing corpus move in. This phase makes the
+mapping **visible at review time**: on a pull request, tell the author *which
+decisions govern this change* and *whether the changed records are still valid* —
+without leaving git, without a database, and with no credential beyond the token
+GitHub already hands every workflow.
+
+The deliverable is **`@adrkit/ci`**, a GitHub Action, plus **`adr check
+<changed-files>`** as its provider-agnostic CLI equivalent. The Action extracts
+the PR's changed-file list, hands it to the existing pure resolver (ADR-0009),
+lints the changed records, and posts a single, **selective**, idempotently-updated
+PR comment naming the governing decisions and the matcher that fired for each.
+
+The load-bearing property is **selectivity**: on a repo with more than ten
+records, a comment that lists *everything* is a defect — it means the `affects`
+matchers are too broad or the comment renderer is wrong. The comment must earn its
+place by saying only what governs the diff in front of the reviewer.
+
+## User Scenarios & Testing
+
+### User Story 1 — A PR tells you which decisions govern it (Priority: P1) 🎯 MVP
+
+As a reviewer (or author) on a pull request, I want a comment that names the
+decision records governing the files this PR changed — each with the matcher that
+fired — so I can see the relevant prior decisions without hunting through
+`docs/adr/`.
+
+**Why this priority**: This is rung 3 ("a PR tells you which decisions govern
+it") and the whole point of the phase. It is independently valuable and is the MVP.
+
+**Independent Test**: On a test repository (not this one) with a records corpus,
+open a PR touching files a record's `path` matcher covers; assert a PR comment
+appears naming exactly that record (id + title + fired matcher) and not the
+records that don't govern the diff.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR whose changed files are matched by one record's `path` matcher,
+   **When** the Action runs, **Then** it posts a PR comment listing that record's
+   `id`, `title`, and the `path` matcher that fired.
+2. **Given** a PR whose changed files are governed by several records, **When** the
+   Action runs, **Then** the comment lists all of them (a **union**, per ADR-0009),
+   each with its fired matcher(s), in a stable order.
+3. **Given** a record whose matchers do **not** fire on any changed file, **When**
+   the Action runs, **Then** that record does **not** appear in the comment.
+4. **Given** an `entity`/`resource`/`api`/`data` matcher (no backing snapshot in
+   this phase), **When** the Action runs, **Then** that matcher is **inert** (an
+   `info` finding) and neither blocks the run nor pads the comment (ADR-0009).
+
+### User Story 2 — `adr check` validates changed records deterministically (Priority: P1)
+
+As a maintainer, I want a single deterministic command — `adr check
+<changed-files>` — that both validates the changed records and reports the
+governing decisions for a changed-file set, so CI (any provider) has a stable,
+scriptable contract and the Action stays a thin wrapper.
+
+**Why this priority**: This is the deterministic substrate the Action wraps
+(Principle IV: the CI surface adds no probabilistic step). It is what makes the
+Action portable and testable **without GitHub**, and it is seed 21. It ships with
+US1.
+
+**Independent Test**: Run `adr check <files> --json` over a fixed changed-file list
+against a fixture corpus; assert the JSON names the governing records and the
+lint findings for the changed records, and that the exit code is non-zero iff a
+changed record has an error-severity finding.
+
+**Acceptance Scenarios**:
+
+1. **Given** a changed-file list and a corpus, **When** I run `adr check
+   <files>`, **Then** it prints the governing decisions (id + title + fired
+   matcher, like `adr explain`) and validates any changed records.
+2. **Given** a changed record with an **error**-severity finding, **When** I run
+   `adr check`, **Then** the command exits non-zero.
+3. **Given** changed records with only `info`/`warn` findings, **When** I run
+   `adr check`, **Then** the command exits `0` (warnings inform, they do not fail).
+4. **Given** `--json`, **When** I run `adr check`, **Then** the output is a stable,
+   sorted machine-readable object the Action (and other CI providers) can consume.
+
+### User Story 3 — The comment stays useful and doesn't spam (Priority: P2)
+
+As a maintainer of a repo with more than ten records, I want the comment to list
+only the governing subset and to **update in place** on each push, so the PR isn't
+buried under a wall of every decision or a new comment per commit.
+
+**Why this priority**: This is exit criterion (b) — the usefulness gate. A first
+comment (US1) is worthless if it dumps the corpus or posts N copies. Essential for
+real adoption, but not required to prove the mapping fires (US1).
+
+**Independent Test**: On a >10-record repo, push twice to the same PR touching a
+small subset of governed paths; assert the comment names only the governing subset
+and that the second push **updates the same comment** rather than adding a new one.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo with more than ten records where the diff touches a subset,
+   **When** the Action runs, **Then** the comment lists only the governing subset,
+   never the full corpus.
+2. **Given** a prior comment from a previous push, **When** the Action runs again,
+   **Then** it edits that same comment (located by a stable hidden marker) instead
+   of posting a new one.
+3. **Given** a diff that **no** decision governs, **When** the Action runs, **Then**
+   it renders a concise "no governing decisions" note (or removes/updates its
+   comment to say so) — never a dump of every record.
+4. **Given** a very large diff (hundreds of files), **When** the Action runs,
+   **Then** resolution is linear and the comment stays selective and readable.
+
+### User Story 4 — Runs with only the default token (Priority: P1)
+
+As an adopter, I want the Action to work with nothing but the workflow's default
+`GITHUB_TOKEN`, so I can add it to a repo without provisioning secrets, services,
+or network access.
+
+**Why this priority**: This is exit criterion (c) and the ADR-0007 clean-clone
+principle applied to the runtime. It ships with US1 because a commenting Action
+that needs a bespoke token is a non-starter for the target adopter.
+
+**Independent Test**: Configure a workflow that grants only the default
+`GITHUB_TOKEN` (with `pull-requests: write`); assert the Action validates, resolves,
+and comments end-to-end with no other secret present.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workflow with only the default `GITHUB_TOKEN`, **When** the Action
+   runs, **Then** it completes validation + resolution + commenting with no other
+   credential.
+2. **Given** a fork PR whose token is read-only, **When** the Action runs, **Then**
+   it still runs the check and **degrades gracefully** on commenting (skips or logs
+   a notice) rather than failing the job on a permissions error.
+3. **Given** no network access beyond the GitHub API, **When** the Action runs,
+   **Then** it needs nothing else — resolution and validation are local and pure.
+
+### Edge Cases
+
+- **PR changes code but no records**: validation is a no-op; resolution still runs
+  and the comment names the governing decisions for the changed code.
+- **PR changes only records**: the changed records are validated; the
+  governing-decisions section may be empty or self-referential (a record whose
+  `path` matcher covers `docs/adr/**`) — rendered gracefully, never a crash.
+- **A changed record has an error finding**: `adr check` exits non-zero (the job
+  fails); the comment still posts, and surfaces the validation failure.
+- **First run vs. subsequent runs**: no prior comment → create one; prior comment
+  present → update it (idempotent via the hidden marker).
+- **Fork PR / read-only token**: commenting is skipped or downgraded to a job log
+  annotation; the deterministic check still runs.
+- **Renamed or deleted files in the diff**: included in the changed-file list as
+  the source provides them; deletions still resolve against matchers.
+- **Empty diff / no changed files**: no-op with a clear, quiet outcome.
+- **A matcher backing source is absent** (no lockfile diff for `package`, no
+  catalog for `entity`): inert `info` finding; never an error, never in the comment.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `adr check <changed-files...> [--dir docs/adr] [--json]` MUST, for the
+  supplied changed-file list, (a) resolve the governing decisions using the
+  existing **pure** resolver (ADR-0009) and (b) validate any changed records via
+  the existing validators — deterministically, with no clock, no network, and no
+  filesystem traversal beyond the corpus load and the supplied list.
+- **FR-002**: `adr check` MUST exit **non-zero** when a **changed record** has an
+  **error**-severity finding, and `0` when findings are only `info`/`warn` — mirroring
+  `adr lint` exit semantics.
+- **FR-003**: The Action MUST derive the PR's changed-file list (base…head) and pass
+  it to the resolver/`adr check`. File-list extraction is the **Action's**
+  responsibility; the resolver MUST remain pure (ADR-0009) and MUST NOT traverse the
+  working tree to discover changes.
+- **FR-004**: The Action MUST post a single PR comment listing the governing
+  decisions for the changed files, each with `id`, `title`, and the matcher(s) that
+  fired (mirroring `adr explain`). Records are a **union**; ordering is stable.
+- **FR-005**: The comment MUST be **idempotent**: subsequent runs on the same PR
+  update the same comment (located by a stable hidden HTML marker) rather than
+  posting a new one.
+- **FR-006**: The comment MUST be **selective** — only records whose matchers fire
+  on the changed files appear. A record that governs no changed file MUST NOT
+  appear. On a corpus of more than ten records touched by a subset diff, the comment
+  MUST NOT list the whole corpus.
+- **FR-007**: On a diff that **no** decision governs, the Action MUST render a
+  concise "no governing decisions" outcome (note, or an updated/removed comment) —
+  never a full-corpus dump.
+- **FR-008**: The Action MUST run with **no credential beyond the default
+  `GITHUB_TOKEN`**; it MUST NOT require any other secret, service, or network access
+  besides the GitHub API (ADR-0007).
+- **FR-009**: A matcher whose backing source is absent (`entity`/`resource`/`api`/
+  `data`, or `package` without a changed-dependency snapshot) MUST remain **inert**
+  with an `info` finding; it MUST NOT block the check nor appear in the governing
+  list (ADR-0009 degradation).
+- **FR-010**: The Action and `adr check` MUST NOT write decision content, mutate
+  records, or require a database/index (ADR-0004). They read the corpus + the
+  supplied file list and write **only** the PR comment.
+- **FR-011**: The CI surface **routes attention; it never decides.** It MUST NOT
+  approve, merge, or auto-resolve anything; its only failure signal is a changed
+  record failing validation (FR-002). No probabilistic/model step runs (Principle IV;
+  the evaluator is Phase 4).
+- **FR-012**: `adr check` MUST provide `--json` output with a **stable, sorted**
+  shape so the Action and other CI providers consume a contract rather than scraping
+  human text.
+- **FR-013**: **Package boundary.** `@adrkit/ci` MUST depend only on `@adrkit/core`
+  and public GitHub Action libraries; it MUST NOT import from `packages/adapters/*`
+  (ADR-0007). `@adrkit/ci` is a first-party **surface** package (a peer of
+  `@adrkit/cli`), **not** core and **not** an adapter. The `core-has-no-adapter-deps`
+  check MUST cover it.
+- **FR-014**: On a fork PR whose token cannot comment, the Action MUST still run the
+  deterministic check and **degrade** commenting to a non-fatal notice rather than
+  failing the job on a permissions error (FR-008 clean-degradation, consistent with
+  ADR-0009's "degrade, never fail" posture).
+
+### Key Entities
+
+- **Changed-file set**: the list of repo-relative paths the PR touches (base…head),
+  produced by the Action from the GitHub event/API or a git range; the input to the
+  pure resolver.
+- **Governing-decision result**: reuse of the Phase 1 resolver output —
+  `{ recordId, title, firedMatchers[] }` per governing record (a union).
+- **Changed-record / validation set**: the ADR files under the corpus dir that
+  appear in the diff, plus their reused Phase 0/2 `Finding`s.
+- **PR comment**: rendered markdown carrying a stable hidden marker for idempotent
+  update; a **derived projection** of git, never a record.
+- **Check outcome**: `pass | fail` (fail iff a changed record has an error finding),
+  plus the human/`--json` payload the Action consumes.
+
+## Success Criteria
+
+- **SC-001**: On a PR touching governed paths **on a repo that is not this one**, the
+  Action posts a comment naming exactly the governing decisions (id + title + fired
+  matcher). (rung 3; exit a)
+- **SC-002**: `adr check <changed-files>` validates the changed records and exits
+  non-zero **iff** a changed record has an error-severity finding (SC verified per
+  severity).
+- **SC-003**: On a repo with **more than ten** records where the diff touches a
+  subset, the comment lists **only** the governing subset — never all records.
+  (exit b)
+- **SC-004**: A second push to the same PR **updates the existing comment** rather
+  than adding a new one (idempotent).
+- **SC-005**: A diff that no decision governs yields a concise "no governing
+  decisions" outcome, not a full-corpus dump.
+- **SC-006**: The Action completes end-to-end using **only** the default
+  `GITHUB_TOKEN`, and degrades commenting (not the check) on a read-only fork token.
+  (exit c)
+- **SC-007**: A clean clone builds, tests, and lints green with the new
+  `@adrkit/ci` package; `clean-clone-builds` and `core-has-no-adapter-deps` remain
+  green and the dependency check now also covers `@adrkit/ci`.
+
+## Assumptions
+
+Documented, ADR-consistent choices (revisit at plan stage):
+
+- **A1 — Changed-file extraction**: the Action derives the changed-file list from the
+  PR (the `pull_request` event payload and/or the compare API, or a `base…head` git
+  range on the checkout). The list is the resolver's input; resolution never walks
+  the tree (ADR-0009). Extraction lives in `@adrkit/ci`, not in core.
+- **A2 — Comment identity**: idempotency is achieved with a stable hidden HTML
+  marker (e.g. `<!-- adrkit:ci -->`) the Action searches for among PR comments; the
+  first run creates, later runs edit. No state is stored outside the PR (ADR-0004).
+- **A3 — Selectivity is resolver-driven**: the comment contains exactly the resolver's
+  union output for the changed files — nothing is added. "Lists everything" can only
+  happen if a record's matchers are genuinely over-broad (e.g. `**`), which is a
+  corpus/authoring defect the comment should make visible, not hide.
+- **A4 — Backing snapshots**: in this phase only `path` and `package` matchers have
+  backing (repo contents + lockfile diff, both available with the default token);
+  `entity`/`resource`/`api`/`data` stay inert (ADR-0009). No catalog adapter is
+  configured or required.
+- **A5 — Validation scope**: "changed records" are ADR files under `--dir` that
+  appear in the changed-file set. The Action MAY lint the whole corpus for context
+  but only **changed** records failing at error severity fail the job (FR-002), so a
+  PR is never blocked by a pre-existing error it did not introduce.
+- **A6 — GitHub API client**: a public Action toolkit (e.g. `@actions/core` +
+  `@actions/github`/Octokit) is an acceptable dependency of the **surface** package
+  `@adrkit/ci` (like `@adrkit/cli`'s own deps), never of core, and is stubbed in
+  tests so `clean-clone-builds` needs no token (ADR-0007).
+
+## Out of Scope
+
+- **No database / index** (ADR-0004): the Action targets the corpus + supplied file
+  list only; `adr index rebuild` and any projection are explicitly not used here.
+- **No write path, no approval, no merge gating beyond validation** — the CI surface
+  comments and checks; it never mutates records or decides (FR-011). The evaluator is
+  Phase 4.
+- **No catalog / IaC / OpenAPI adapters**: `entity`/`resource`/`api`/`data` matchers
+  stay inert. No cloud catalog (ADR-0009, as amended).
+- **No non-GitHub CI provider integration** in this phase: `adr check` is
+  provider-agnostic and portable, but the packaged Action targets GitHub only.
+- **No probabilistic/LLM summarization** of the comment (Principle IV).
+- **No emission of the Phase 2 divergence report as a PR** — wiring migration into
+  a PR/Action surface remains a separate, later concern.

--- a/specs/004-ci-surface/tasks.md
+++ b/specs/004-ci-surface/tasks.md
@@ -1,0 +1,175 @@
+---
+description: "Task list for CI Surface (Phase 3)"
+---
+
+# Tasks: CI Surface (Phase 3)
+
+**Input**: Design docs from `specs/004-ci-surface/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/check-and-comment.md
+**Normative**: [ADR-0009](../../docs/adr/0009-affects-resolution-and-catalog-binding.md), [ADR-0007](../../docs/adr/0007-adapter-isolation-and-public-surface-build.md), [ADR-0004](../../docs/adr/0004-git-is-source-of-truth-database-is-an-index.md).
+
+> **⛔ T000 IS A HARD PRECONDITION — DO NOT START T001+ UNTIL IT IS MET.** The strict
+> outcome ladder forbids opening a phase for implementation before the one below has
+> landed **and has a real user**. Rung 2 is met only by a **synthetic** fixture today
+> (research.md §R0). Building Phase 3 before the gate clears violates the ladder.
+
+**Tests**: REQUIRED. SC-001..007 and Principles IV/V require deterministic
+`adr check` tests (governing list + validation + exit code per severity, `--json`
+shape), comment-renderer tests (selectivity on a >10-record corpus, empty state,
+marker), and Action tests against an **injected fake GitHub client** (create-vs-update,
+read-only-token degradation) — **no network, no token in CI**.
+
+**Toolchain**: Bun. **Use stable Bun (`/tmp/bun-stable/bin/bun`, 1.3.14) for
+`bun install`** — the env default is a canary that writes an unreadable lockfile.
+Keep `bun.lock` at lockfileVersion 1.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different files, no dependency on an unbuilt file)
+- **[Story]**: US1 (governing comment), US2 (`adr check`), US3 (selective/idempotent),
+  US4 (default token), or GATE/SETUP/FOUND/CI/POLISH.
+
+---
+
+## Phase 0: Gate (blocking — outcome ladder)
+
+- [ ] T000 [GATE] **Confirm rung 2 is genuinely met before any Phase 3 code.** Run
+  `adr migrate --from madr` against at least one **real public MADR corpus** — vendor
+  a licensed subset into `packages/core/test/fixtures/madr-corpus/` (with attribution)
+  and rename/replace the *synthetic* `migrate-real-corpus.test.ts`, **or** run and
+  document an external-corpus exercise — and confirm a real user has round-tripped a
+  corpus. Until this is done, **STOP**: do not start T001. (This is Phase-2
+  remediation surfaced here; see research.md §R0.)
+
+## Phase 1: Setup
+
+- [ ] T001 [P] [SETUP] Scaffold the `@adrkit/ci` surface package at `packages/ci/`
+  (peer of `@adrkit/cli`): `package.json` (deps `@adrkit/core` `workspace:*`,
+  `@actions/core`, `@actions/github`), `tsconfig.json`, `tsconfig.build.json`,
+  `action.yml` (inputs `dir`, `token`; Node runner). Install with **stable Bun**;
+  confirm `bun.lock` stays lockfileVersion 1.
+- [ ] T002 [SETUP] Extend `scripts/check-deps.ts` so `core-has-no-adapter-deps` also
+  asserts `@adrkit/ci` imports nothing from `packages/adapters/*` (FR-013); confirm
+  the check still passes.
+
+## Phase 2: Foundational (blocking)
+
+- [ ] T003 [FOUND] Implement the shared check logic `packages/ci/src/check.ts` (also
+  used by `adr check`): given `(records, changedFiles)`, call `resolveAffects`,
+  compute changed records (corpus ∩ files) + their findings, and return the
+  `Check outcome` shape (data-model): `{ changedFiles, governedBy, changedRecords,
+  findings, ok }`. Pure; no GitHub, no fs traversal beyond corpus load.
+- [ ] T004 [FOUND] Implement `packages/ci/src/comment.ts` — render the comment from a
+  `Check outcome`: hidden marker `<!-- adrkit:ci -->`, governing list (`id — title`
+  + `via <type>: <pattern>`), concise empty state (FR-007), and a validation notice
+  when a changed record has an `error` finding (R7). Selective by construction —
+  renders the resolver's set verbatim (R6/FR-006).
+
+**Checkpoint**: check logic + comment renderer exist and are unit-testable offline.
+
+## Phase 3: User Story 2 — `adr check` CLI (Priority: P1) 🎯 substrate
+
+- [ ] T005 [US2] Add `check` to `packages/cli/src/index.ts` dispatch:
+  `adr check <files...> [--dir docs/adr] [--json]`; reuse the T003 logic; print the
+  governing list (like `adr explain`) + changed-record findings; `--json` emits the
+  stable sorted `Check outcome`; exit non-zero iff a changed record has an `error`
+  finding (FR-002), `2` on usage error. Update the `usage()` help text.
+- [ ] T006 [P] [US2] Tests `packages/cli/test/check.test.ts` (or core-adjacent):
+  governing list correct for a fixed file list; changed-record error → non-zero;
+  only info/warn → `0`; `--json` shape stable and sorted (SC-002).
+
+**Checkpoint**: `adr check` validates + resolves deterministically for any provider.
+
+## Phase 4: User Story 1 — Governing-decisions PR comment (Priority: P1) 🎯 MVP
+
+- [ ] T007 [US1] Implement `packages/ci/src/changed-files.ts` — extract the PR's
+  base…head changed-file list from the `pull_request` event/compare API (impure;
+  Action-only, R4/FR-003); derive `changedDependencies` from the lockfile diff via
+  the existing `deriveChangedDependenciesFromBunLockDiff` for `package` matchers.
+- [ ] T008 [US1] Implement `packages/ci/src/github.ts` — a thin injectable client port:
+  find the marker comment, create, and update. Real impl uses `@actions/github`;
+  tests inject a fake.
+- [ ] T009 [US1] Implement `packages/ci/src/index.ts` — the Action entrypoint: read
+  inputs (`dir`, `token` default `${{ github.token }}`), extract files (T007), run
+  the check (T003), render (T004), create/update the comment (T008), and set job
+  outcome — **fail iff** a changed record has an `error` finding (FR-002), succeed
+  otherwise regardless of governing-list size.
+- [ ] T010 [P] [US1] Tests `packages/ci/test/comment-render.test.ts`: governing entry
+  shape (id + title + fired matcher); union of multiple records; inert matchers
+  (entity/resource/api/data) absent from the list but present as `info` findings
+  (FR-009).
+
+**Checkpoint**: the Action posts a governing-decisions comment on a governed PR (US1).
+
+## Phase 5: User Story 3 — Selective & idempotent (Priority: P2)
+
+- [ ] T011 [P] [US3] Tests `packages/ci/test/comment-idempotent.test.ts` (fake client):
+  first run creates a marker comment; second run **edits the same** comment, not a new
+  one (SC-004).
+- [ ] T012 [P] [US3] Tests `packages/ci/test/selectivity.test.ts`: a **>10-record**
+  fixture corpus with a subset diff yields a comment listing **only** the governing
+  subset (SC-003); a diff nothing governs yields the concise empty note (SC-005), not
+  a corpus dump.
+
+**Checkpoint**: the comment is useful on a big corpus and never spams the PR.
+
+## Phase 6: User Story 4 — Default-token-only & degradation (Priority: P1)
+
+- [ ] T013 [US4] In the Action, detect a read-only/insufficient token and **degrade**:
+  still run the check, skip commenting with a job-log notice, and **do not** fail the
+  job on a comment-permission error (FR-014/R8). Require no secret beyond `token`
+  (default `GITHUB_TOKEN`).
+- [ ] T014 [P] [US4] Tests `packages/ci/test/token-degrade.test.ts` (fake client that
+  rejects writes): the check still runs and the job is not failed by the comment
+  failure (SC-006).
+
+**Checkpoint**: works with only the default token; friendly to fork PRs.
+
+## Phase 7: CI wiring & Polish
+
+- [ ] T015 [CI] Add a self-dogfood job to `.github/workflows/ci.yml` that runs
+  `adr check` on the repo's changed ADR files (and optionally the packaged Action on
+  PRs), so the CI surface governs the project that ships it. Keep the existing gate
+  set (`clean-clone-builds`, `schema-emit-matches`, `core-has-no-adapter-deps`,
+  `adr lint`) unchanged and green.
+- [ ] T016 [POLISH] Document the Action + `adr check` in `README`/`quickstart`
+  (inputs, permissions, default-token-only, portability), and note the CI surface is
+  read-only + comment-only (no DB, no approval — ADR-0004/FR-011).
+- [ ] T017 [POLISH] Run the full gate with **stable Bun 1.3.14**: `bun install`,
+  `bun run typecheck`, `bun test` (incl. selectivity + idempotency + degradation),
+  `bun run build`, `bun run lint`, `bun run check:deps` (now covering `@adrkit/ci`),
+  `bun run schema:emit && git diff --exit-code schema/adr.schema.json` (must be clean
+  — no schema change), and the Node smoke. All green.
+- [ ] T018 [P] [POLISH] Manually validate on a **second repo** (not this one) with a
+  >10-record corpus: open a PR touching a governed subset, confirm the comment names
+  exactly the subset, push again and confirm the same comment updates (SC-001/003/004),
+  using only the default token (SC-006).
+
+---
+
+## Dependencies & Execution Order
+
+- **T000 (gate) blocks everything.** No implementation task starts until rung 2 is
+  genuinely met.
+- Setup (T001–T002) → Foundational (T003–T004) block all stories.
+- US2 (`adr check`, T005–T006) is the deterministic substrate; land first.
+- US1 (comment, T007–T010) depends on Foundational + US2's check logic; it is the MVP
+  outcome (rung 3).
+- US3 (T011–T012) and US4 (T013–T014) depend on the Action path (US1).
+- CI wiring + polish (T015–T018) last; T018 is the exit-criterion verification on a
+  second repo.
+
+## Parallel Opportunities
+
+- `[P]` test tasks run together once their target module exists.
+- After Foundational: `changed-files.ts` (T007) and `github.ts` (T008) are independent
+  and parallelizable; the comment renderer (T004) and check logic (T003) are too.
+
+## Implementation Strategy (MVP first)
+
+1. **Clear T000 first** — do not start otherwise.
+2. Setup + Foundational (shared check + comment renderer).
+3. US2 `adr check` → verify SC-002 (portable, deterministic substrate).
+4. US1 Action comment → verify SC-001 (rung 3 MVP) on a second repo.
+5. US3 selective/idempotent + US4 default-token/degradation → SC-003..006.
+6. CI dogfood + full verification with stable Bun; second-repo exit check.

--- a/specs/004-ci-surface/tasks.md
+++ b/specs/004-ci-surface/tasks.md
@@ -8,10 +8,13 @@ description: "Task list for CI Surface (Phase 3)"
 **Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/check-and-comment.md
 **Normative**: [ADR-0009](../../docs/adr/0009-affects-resolution-and-catalog-binding.md), [ADR-0007](../../docs/adr/0007-adapter-isolation-and-public-surface-build.md), [ADR-0004](../../docs/adr/0004-git-is-source-of-truth-database-is-an-index.md).
 
-> **⛔ T000 IS A HARD PRECONDITION — DO NOT START T001+ UNTIL IT IS MET.** The strict
-> outcome ladder forbids opening a phase for implementation before the one below has
-> landed **and has a real user**. Rung 2 is met only by a **synthetic** fixture today
-> (research.md §R0). Building Phase 3 before the gate clears violates the ladder.
+> **⛔ T000 IS A HARD PRECONDITION — DO NOT START T001+ UNTIL IT IS MET.** The outcome
+> ladder gates a phase's **implementation** (not its scoping) on the one below being
+> landed **and having a real user**. **Resolved (maintainer decision; reviewer may
+> override):** that "real user" for rung 2 is the **maintainer dogfooding** `adr migrate`
+> against a **real** public MADR corpus — no external human adopter required. Rung 2 is
+> met only by a **synthetic** fixture today (research.md §R0), so the gate is not yet
+> cleared; complete **T00A** first. Building Phase 3 before then violates the ladder.
 
 **Tests**: REQUIRED. SC-001..007 and Principles IV/V require deterministic
 `adr check` tests (governing list + validation + exit code per severity, `--json`
@@ -19,9 +22,8 @@ shape), comment-renderer tests (selectivity on a >10-record corpus, empty state,
 marker), and Action tests against an **injected fake GitHub client** (create-vs-update,
 read-only-token degradation) — **no network, no token in CI**.
 
-**Toolchain**: Bun. **Use stable Bun (`/tmp/bun-stable/bin/bun`, 1.3.14) for
-`bun install`** — the env default is a canary that writes an unreadable lockfile.
-Keep `bun.lock` at lockfileVersion 1.
+**Toolchain**: Bun. **Use stable Bun 1.3.14 for `bun install`** — the env default is a
+canary that writes an unreadable lockfile. Keep `bun.lock` at lockfileVersion 1.
 
 ## Format: `[ID] [P?] [Story] Description`
 
@@ -56,8 +58,16 @@ Keep `bun.lock` at lockfileVersion 1.
 - [ ] T001 [P] [SETUP] Scaffold the `@adrkit/ci` surface package at `packages/ci/`
   (peer of `@adrkit/cli`): `package.json` (deps `@adrkit/core` `workspace:*`,
   `@actions/core`, `@actions/github`), `tsconfig.json`, `tsconfig.build.json`,
-  `action.yml` (inputs `dir`, `token`; Node runner). Install with **stable Bun**;
+  `action.yml` with **`runs.using: node24`** (FR-016/R11) and `runs.main` pointing at the
+  committed bundle (T00B). Inputs `dir`, `token`. Install with **stable Bun 1.3.14**;
   confirm `bun.lock` stays lockfileVersion 1.
+- [ ] T00B [SETUP] **Committed self-contained bundle (FR-015/R10).** Add a `bun build`
+  step that bundles the Action entrypoint **plus `@adrkit/core` and the GitHub toolkit**
+  into a single committed `packages/ci/dist/` artifact, and point `action.yml`'s
+  `runs.main` at it. Add a **bundle drift check** to `.github/workflows/ci.yml` (rebuild
+  and `git diff --exit-code` the committed bundle, mirroring `schema-emit-matches`) and a
+  **Node smoke test** that the bundle runs under Node 24 (extend `scripts/smoke-node.mjs`
+  or add a sibling). Commit the built bundle.
 - [ ] T002 [SETUP] Extend `scripts/check-deps.ts` so `core-has-no-adapter-deps` also
   asserts (a) `@adrkit/ci` imports nothing from `packages/adapters/*` and (b) the
   GitHub toolkit (`@actions/*`, Octokit) never reaches `@adrkit/core` or the schema —
@@ -66,11 +76,17 @@ Keep `bun.lock` at lockfileVersion 1.
 
 ## Phase 2: Foundational (blocking)
 
-- [ ] T003 [FOUND] Implement the shared check logic `packages/ci/src/check.ts` (also
-  used by `adr check`): given `(records, changedFiles)`, call `resolveAffects`,
-  compute changed records (corpus ∩ files) + their findings, and return the
-  `Check outcome` shape (data-model): `{ changedFiles, governedBy, changedRecords,
-  findings, ok }`. Pure; no GitHub, no fs traversal beyond corpus load.
+- [ ] T003 [FOUND] Implement the neutral shared function **in `@adrkit/core`**
+  (`checkChanges`, e.g. `packages/core/src/check/index.ts`, exported from the core
+  index): it takes the **full `lintCorpus` result** (`{ records, findings, checked }`) +
+  `changedFiles` + optional `dir` + optional `snapshots` (`changedDependencies`,
+  `catalog`), calls `resolveAffects`, identifies changed records (corpus ∩ files), and
+  returns the `CheckOutcome` (`{ changedFiles, governedBy, changedRecords, findings, ok }`).
+  **Takes the full lint result, not just `records`** — `lintCorpus` drops malformed files
+  from `records` but keeps their errors in `findings`, and those errors MUST still count
+  toward `ok` (RC3/R1). Pure; no GitHub, no adapter import, no fs traversal beyond the
+  supplied lint result. (Placing it in core lets both `adr check` and the Action call it
+  without the CLI depending on `@adrkit/ci` or its GitHub deps — R2.)
 - [ ] T004 [FOUND] Implement `packages/ci/src/comment.ts` — render the comment from a
   `Check outcome`: hidden marker `<!-- adrkit:ci -->`, governing list (`id — title`
   + `via <type>: <pattern>`), concise empty state (FR-007), and a validation notice
@@ -82,10 +98,11 @@ Keep `bun.lock` at lockfileVersion 1.
 ## Phase 3: User Story 2 — `adr check` CLI (Priority: P1) 🎯 substrate
 
 - [ ] T005 [US2] Add `check` to `packages/cli/src/index.ts` dispatch:
-  `adr check <files...> [--dir docs/adr] [--json]`; reuse the T003 logic; print the
-  governing list (like `adr explain`) + changed-record findings; `--json` emits the
-  stable sorted `Check outcome`; exit non-zero iff a changed record has an `error`
-  finding (FR-002), `2` on usage error. Update the `usage()` help text.
+  `adr check <files...> [--dir docs/adr] [--json]`; build the full `lintCorpus` result
+  and call the core `checkChanges` (T003); print the governing list (like `adr explain`)
+  + changed-record findings; `--json` emits the stable sorted `CheckOutcome`; exit
+  non-zero iff a changed record has an `error` finding (FR-002), `2` on usage error.
+  Update the `usage()` help text.
 - [ ] T006 [P] [US2] Tests `packages/cli/test/check.test.ts` (or core-adjacent):
   governing list correct for a fixed file list; changed-record error → non-zero;
   only info/warn → `0`; `--json` shape stable and sorted (SC-002).
@@ -95,17 +112,23 @@ Keep `bun.lock` at lockfileVersion 1.
 ## Phase 4: User Story 1 — Governing-decisions PR comment (Priority: P1) 🎯 MVP
 
 - [ ] T007 [US1] Implement `packages/ci/src/changed-files.ts` — extract the PR's
-  base…head changed-file list from the `pull_request` event/compare API (impure;
-  Action-only, R4/FR-003); derive `changedDependencies` from the lockfile diff via
-  the existing `deriveChangedDependenciesFromBunLockDiff` for `package` matchers.
+  **complete** changed-file list via a **fully paginated `pulls.listFiles`** (all pages)
+  or a local **merge-base (`base…head`) `git diff`** on the checkout; **do not** use the
+  compare API's file list (GitHub caps it, e.g. 300 files, and truncates). Handle the
+  cap **explicitly** — paginate to completion, or fall back to the local diff, and emit a
+  notice if a complete list cannot be obtained (impure; Action-only, R4/FR-003). Derive
+  `changedDependencies` from the lockfile diff via the existing
+  `deriveChangedDependenciesFromBunLockDiff` for `package` matchers.
 - [ ] T008 [US1] Implement `packages/ci/src/github.ts` — a thin injectable client port:
-  find the marker comment, create, and update. Real impl uses `@actions/github`;
-  tests inject a fake.
+  **paginate all PR comments** and find the Action's prior comment by matching **both**
+  the `<!-- adrkit:ci -->` marker **and** the Action's own author identity; create or
+  update accordingly (R5/FR-005). Real impl uses `@actions/github`; tests inject a fake.
 - [ ] T009 [US1] Implement `packages/ci/src/index.ts` — the Action entrypoint: read
-  inputs (`dir`, `token` default `${{ github.token }}`), extract files (T007), run
-  the check (T003), render (T004), create/update the comment (T008), and set job
-  outcome — **fail iff** a changed record has an `error` finding (FR-002), succeed
-  otherwise regardless of governing-list size.
+  inputs (`dir`, `token` default `${{ github.token }}`), extract the complete file list
+  (T007), build the lint result + snapshots and run the core `checkChanges` (T003),
+  render (T004), create/update the comment (T008), and set job outcome — **fail iff** a
+  changed record has an `error` finding (FR-002), succeed otherwise regardless of
+  governing-list size.
 - [ ] T010 [P] [US1] Tests `packages/ci/test/comment-render.test.ts`: governing entry
   shape (id + title + fired matcher); union of multiple records; inert matchers
   (entity/resource/api/data) absent from the list but present as `info` findings
@@ -117,7 +140,10 @@ Keep `bun.lock` at lockfileVersion 1.
 
 - [ ] T011 [P] [US3] Tests `packages/ci/test/comment-idempotent.test.ts` (fake client):
   first run creates a marker comment; second run **edits the same** comment, not a new
-  one (SC-004).
+  one (SC-004). Plus RC5 coverage: (a) a **foreign/pre-existing comment bearing the
+  marker** (different author) is **not** edited — the Action creates/edits only its own;
+  (b) the Action's **own marker comment on a later page** is found and edited, not
+  duplicated (requires the client to paginate).
 - [ ] T012 [P] [US3] Tests `packages/ci/test/selectivity.test.ts`: a **>10-record**
   fixture corpus with a subset diff yields a comment listing **only** the governing
   subset (SC-003); a diff nothing governs yields the concise empty note (SC-005), not
@@ -143,15 +169,19 @@ Keep `bun.lock` at lockfileVersion 1.
   `adr check` on the repo's changed ADR files (and optionally the packaged Action on
   PRs), so the CI surface governs the project that ships it. Keep the existing gate
   set (`clean-clone-builds`, `schema-emit-matches`, `core-has-no-adapter-deps`,
-  `adr lint`) unchanged and green.
+  `adr lint`) unchanged and green, and include the new bundle-drift + Node-24 smoke
+  gates from T00B.
 - [ ] T016 [POLISH] Document the Action + `adr check` in `README`/`quickstart`
-  (inputs, permissions, default-token-only, portability), and note the CI surface is
-  read-only + comment-only (no DB, no approval — ADR-0004/FR-011).
+  (inputs, permissions, default-token-only, portability, `node24` runtime, committed
+  bundle), and note the CI surface is read-only + comment-only (no DB, no approval —
+  ADR-0004/FR-011).
 - [ ] T017 [POLISH] Run the full gate with **stable Bun 1.3.14**: `bun install`,
-  `bun run typecheck`, `bun test` (incl. selectivity + idempotency + degradation),
-  `bun run build`, `bun run lint`, `bun run check:deps` (now covering `@adrkit/ci`),
-  `bun run schema:emit && git diff --exit-code schema/adr.schema.json` (must be clean
-  — no schema change), and the Node smoke. All green.
+  `bun run typecheck`, `bun test` (incl. selectivity + idempotency + RC5 marker/author +
+  degradation), `bun run build`, `bun run lint`, `bun run check:deps` (now covering
+  `@adrkit/ci` + the toolkit→core boundary), `bun run schema:emit && git diff
+  --exit-code schema/adr.schema.json` (must be clean — no schema change), the **bundle
+  drift check** (`git diff --exit-code packages/ci/dist`), and the Node smoke on **22/24**
+  incl. the Action bundle. All green.
 - [ ] T018 [P] [POLISH] Manually validate on a **second repo** (not this one) with a
   >10-record corpus: open a PR touching a governed subset, confirm the comment names
   exactly the subset, push again and confirm the same comment updates (SC-001/003/004),
@@ -164,7 +194,8 @@ Keep `bun.lock` at lockfileVersion 1.
 - **T000/T00A (gate) block everything.** No implementation task starts until the
   rung-2 gate is cleared by T00A (real, permissively-licensed, offline MADR corpus
   subset vendored + round-tripped). A live human user is *not* a precondition.
-- Setup (T001–T002) → Foundational (T003–T004) block all stories.
+- Setup (T001, T00B, T002) → Foundational (T003–T004) block all stories. T00B (bundle)
+  can proceed in parallel with T002 once T001 scaffolds the package.
 - US2 (`adr check`, T005–T006) is the deterministic substrate; land first.
 - US1 (comment, T007–T010) depends on Foundational + US2's check logic; it is the MVP
   outcome (rung 3).

--- a/specs/004-ci-surface/tasks.md
+++ b/specs/004-ci-surface/tasks.md
@@ -33,13 +33,23 @@ Keep `bun.lock` at lockfileVersion 1.
 
 ## Phase 0: Gate (blocking — outcome ladder)
 
-- [ ] T000 [GATE] **Confirm rung 2 is genuinely met before any Phase 3 code.** Run
-  `adr migrate --from madr` against at least one **real public MADR corpus** — vendor
-  a licensed subset into `packages/core/test/fixtures/madr-corpus/` (with attribution)
-  and rename/replace the *synthetic* `migrate-real-corpus.test.ts`, **or** run and
-  document an external-corpus exercise — and confirm a real user has round-tripped a
-  corpus. Until this is done, **STOP**: do not start T001. (This is Phase-2
-  remediation surfaced here; see research.md §R0.)
+- [ ] T000 [GATE] **Do not start T001+ until the rung-2 gate is cleared.** The gate is
+  cleared by completing **T00A** below (vendor + exercise a real, permissively-licensed
+  public MADR corpus subset). **Resolved (maintainer decision; reviewer may override):**
+  a live external **human user** is **not** required for Phase 3 — that is a higher rung
+  (3+). The precondition is the *real-corpus fixture*, not a real adopter. Until T00A is
+  merged and green, **STOP**: do not start T001. (See research.md §R0.)
+- [ ] T00A [GATE] **Source + vendor the gating corpus (Phase-2 follow-up / Phase-3
+  precondition — does NOT reopen or re-implement Phase 2).** Find a genuinely real,
+  permissively-licensed public MADR corpus (e.g. CC0/CC-BY/MIT/Apache, or the MADR
+  project's own example records). Vendor a **small subset of real third-party prose**
+  into `packages/core/test/fixtures/madr-corpus/` (replacing the synthetic sample),
+  with **attribution + provenance** (source URL, license, commit/date) recorded in the
+  fixture directory. Point the existing corpus test at it and assert the **same**
+  properties as today via `adr migrate --from madr`: idempotency + body-byte
+  preservation + clean lint. Keep it OFFLINE (vendored, never fetched at CI time —
+  ADR-0007). **If no cleanly-licensed real corpus can be found, STOP and flag it —
+  do not vendor prose of unknown license.**
 
 ## Phase 1: Setup
 
@@ -49,8 +59,10 @@ Keep `bun.lock` at lockfileVersion 1.
   `action.yml` (inputs `dir`, `token`; Node runner). Install with **stable Bun**;
   confirm `bun.lock` stays lockfileVersion 1.
 - [ ] T002 [SETUP] Extend `scripts/check-deps.ts` so `core-has-no-adapter-deps` also
-  asserts `@adrkit/ci` imports nothing from `packages/adapters/*` (FR-013); confirm
-  the check still passes.
+  asserts (a) `@adrkit/ci` imports nothing from `packages/adapters/*` and (b) the
+  GitHub toolkit (`@actions/*`, Octokit) never reaches `@adrkit/core` or the schema —
+  it stays confined to the `@adrkit/ci` surface (FR-013, R2/R3); confirm the check
+  passes.
 
 ## Phase 2: Foundational (blocking)
 
@@ -149,8 +161,9 @@ Keep `bun.lock` at lockfileVersion 1.
 
 ## Dependencies & Execution Order
 
-- **T000 (gate) blocks everything.** No implementation task starts until rung 2 is
-  genuinely met.
+- **T000/T00A (gate) block everything.** No implementation task starts until the
+  rung-2 gate is cleared by T00A (real, permissively-licensed, offline MADR corpus
+  subset vendored + round-tripped). A live human user is *not* a precondition.
 - Setup (T001–T002) → Foundational (T003–T004) block all stories.
 - US2 (`adr check`, T005–T006) is the deterministic substrate; land first.
 - US1 (comment, T007–T010) depends on Foundational + US2's check logic; it is the MVP
@@ -167,7 +180,8 @@ Keep `bun.lock` at lockfileVersion 1.
 
 ## Implementation Strategy (MVP first)
 
-1. **Clear T000 first** — do not start otherwise.
+1. **Clear the gate first (T00A, satisfying T000)** — vendor + round-trip the real
+   MADR corpus subset; do not start T001 otherwise.
 2. Setup + Foundational (shared check + comment renderer).
 3. US2 `adr check` → verify SC-002 (portable, deterministic substrate).
 4. US1 Action comment → verify SC-001 (rung 3 MVP) on a second repo.


### PR DESCRIPTION
## Summary

Scopes **Phase 3 — CI surface** as a spec-kit feature under `specs/004-ci-surface/`, mirroring the shape of `specs/001–003`. **No feature code** — this is the `spec → plan → tasks` cycle only, authored the way phases 0–2 were before any implementation.

Deliverable scoped: **`@adrkit/ci`** as a GitHub Action, plus **`adr check <changed-files>`** as its provider-agnostic CLI equivalent (seeds 19–21). The Action extracts the PR's changed-file list, runs the **existing pure resolver** (ADR-0009) and validators, and posts a single, **selective**, idempotently-updated PR comment naming the governing decisions and the matcher that fired — with **no credential beyond the default `GITHUB_TOKEN`**, no database (ADR-0004), and no adapter import (ADR-0007).

## ⚠️ Upstream rung-2 gate (must read — `research.md` §R0, `tasks.md` T000)

The strict outcome ladder forbids opening a phase before the one below has landed **and has a real user**. Rung 2 is *"`adr migrate --from madr` round-trips a **real** third-party corpus."*

**Finding: the rung-2 outcome is NOT met by the letter of the ladder.** Phase 2's *code* landed (PR #7), but its "real corpus" exercise is a **synthetic** fixture:
- `packages/core/test/migrate-real-corpus.test.ts` is literally named *"migrates the **synthetic** real-world-shaped corpus."*
- `packages/core/test/fixtures/madr-corpus/` is hand-authored; its own record says it is synthetic *"to avoid vendoring third-party ADR prose."*
- No evidence of a real external corpus or a real third-party user.

**Consequence:** scoping (this PR) proceeds so the design is ready; **Phase 3 _implementation_ is blocked** until the gate genuinely clears. `tasks.md` records this as a hard precondition (**T000**) ahead of all build tasks.

Also corrects a **stale ledger**: `plan.md` still showed Phase 2 as *"scoping"* despite PR #7 having merged. This PR flips it to *"landed (PR #7 merged)"* and marks Phase 3 *"scoping."*

## Key decisions

- **`adr check` is the deterministic substrate; the Action is a thin wrapper** (Principle IV — no probabilistic step; portable across providers).
- **`@adrkit/ci` is a first-party *surface* package** under `packages/ci/` (peer of `@adrkit/cli`), **not** an adapter and **not** core; the GitHub toolkit dependency is confined to it and stubbed in tests so `clean-clone-builds` needs no token. `core-has-no-adapter-deps` is extended to cover it.
- **Selectivity** (exit criterion b): the comment renders the resolver's union **verbatim** — listing everything is a defect signal, not smoothed over.
- **Idempotency** via a hidden `<!-- adrkit:ci -->` marker; **degrade, never fail** on read-only fork tokens.
- **Constitution Check (Principles I–V): PASS**, Complexity Tracking empty.

## Contents

`specs/004-ci-surface/`: `spec.md` (US1–US4, FR-001..014, SC-001..007), `plan.md` (Constitution Check + gate status), `research.md` (R0 gate + R1–R9), `data-model.md`, `contracts/check-and-comment.md`, `quickstart.md`, `checklists/requirements.md`, `tasks.md` (T000 gate + 18 tasks). Ledger: `plan.md` + `.specify/feature.json`.

## Open questions for reviewers

- Confirm `@adrkit/ci` belongs at `packages/ci/` (surface) rather than `packages/adapters/*` (isolation boundary).
- Confirm the rung-2 gate reading — do you consider a vendored *subset* of a real public MADR corpus sufficient to clear it, or is a live external-corpus run + real user required before Phase 3 code starts?

🤖 Generated with Copilot CLI. DCO signed-off; `Co-authored-by: Copilot App` trailer on the commit.