### PR TITLE
Elevate adrkit.dev design and content

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,339 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-19T04:20:00Z",
+  "title": "Design System: adrkit",
+  "extensions": {
+    "colorMeta": {
+      "canvas": {
+        "role": "neutral",
+        "displayName": "True Canvas",
+        "canonical": "oklch(1 0 0)",
+        "tonalRamp": [
+          "oklch(0.15 0 0)",
+          "oklch(0.25 0 0)",
+          "oklch(0.35 0 0)",
+          "oklch(0.5 0 0)",
+          "oklch(0.65 0 0)",
+          "oklch(0.78 0 0)",
+          "oklch(0.9 0 0)",
+          "oklch(1 0 0)"
+        ]
+      },
+      "surface": {
+        "role": "neutral",
+        "displayName": "Instrument Surface",
+        "canonical": "oklch(0.965 0 0)",
+        "tonalRamp": [
+          "oklch(0.15 0 0)",
+          "oklch(0.25 0 0)",
+          "oklch(0.38 0 0)",
+          "oklch(0.52 0 0)",
+          "oklch(0.66 0 0)",
+          "oklch(0.78 0 0)",
+          "oklch(0.88 0 0)",
+          "oklch(0.965 0 0)"
+        ]
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Working Ink",
+        "canonical": "oklch(0.2 0.018 35)",
+        "tonalRamp": [
+          "oklch(0.15 0.018 35)",
+          "oklch(0.2 0.018 35)",
+          "oklch(0.3 0.018 35)",
+          "oklch(0.42 0.018 35)",
+          "oklch(0.56 0.018 35)",
+          "oklch(0.7 0.018 35)",
+          "oklch(0.83 0.018 35)",
+          "oklch(0.95 0.018 35)"
+        ]
+      },
+      "muted-ink": {
+        "role": "neutral",
+        "displayName": "Measured Ink",
+        "canonical": "oklch(0.43 0.018 35)",
+        "tonalRamp": [
+          "oklch(0.15 0.018 35)",
+          "oklch(0.24 0.018 35)",
+          "oklch(0.33 0.018 35)",
+          "oklch(0.43 0.018 35)",
+          "oklch(0.56 0.018 35)",
+          "oklch(0.69 0.018 35)",
+          "oklch(0.82 0.018 35)",
+          "oklch(0.95 0.018 35)"
+        ]
+      },
+      "border": {
+        "role": "neutral",
+        "displayName": "Calibration Rule",
+        "canonical": "oklch(0.82 0.012 35)",
+        "tonalRamp": [
+          "oklch(0.15 0.012 35)",
+          "oklch(0.25 0.012 35)",
+          "oklch(0.36 0.012 35)",
+          "oklch(0.48 0.012 35)",
+          "oklch(0.6 0.012 35)",
+          "oklch(0.7 0.012 35)",
+          "oklch(0.82 0.012 35)",
+          "oklch(0.95 0.012 35)"
+        ]
+      },
+      "decision-coral": {
+        "role": "primary",
+        "displayName": "Decision Coral",
+        "canonical": "oklch(0.58 0.17 34)",
+        "tonalRamp": [
+          "oklch(0.15 0.17 34)",
+          "oklch(0.25 0.17 34)",
+          "oklch(0.36 0.17 34)",
+          "oklch(0.47 0.17 34)",
+          "oklch(0.58 0.17 34)",
+          "oklch(0.7 0.17 34)",
+          "oklch(0.82 0.17 34)",
+          "oklch(0.94 0.17 34)"
+        ]
+      },
+      "decision-coral-deep": {
+        "role": "primary",
+        "displayName": "Decision Coral Deep",
+        "canonical": "oklch(0.47 0.16 30)",
+        "tonalRamp": [
+          "oklch(0.15 0.16 30)",
+          "oklch(0.24 0.16 30)",
+          "oklch(0.34 0.16 30)",
+          "oklch(0.47 0.16 30)",
+          "oklch(0.59 0.16 30)",
+          "oklch(0.71 0.16 30)",
+          "oklch(0.83 0.16 30)",
+          "oklch(0.95 0.16 30)"
+        ]
+      },
+      "blueprint-ink": {
+        "role": "secondary",
+        "displayName": "Blueprint Ink",
+        "canonical": "oklch(0.43 0.1 245)",
+        "tonalRamp": [
+          "oklch(0.15 0.1 245)",
+          "oklch(0.24 0.1 245)",
+          "oklch(0.33 0.1 245)",
+          "oklch(0.43 0.1 245)",
+          "oklch(0.56 0.1 245)",
+          "oklch(0.69 0.1 245)",
+          "oklch(0.82 0.1 245)",
+          "oklch(0.95 0.1 245)"
+        ]
+      },
+      "inverse-canvas": {
+        "role": "neutral",
+        "displayName": "Night Canvas",
+        "canonical": "oklch(0.145 0.01 30)",
+        "tonalRamp": [
+          "oklch(0.145 0.01 30)",
+          "oklch(0.24 0.01 30)",
+          "oklch(0.34 0.01 30)",
+          "oklch(0.46 0.01 30)",
+          "oklch(0.58 0.01 30)",
+          "oklch(0.7 0.01 30)",
+          "oklch(0.82 0.01 30)",
+          "oklch(0.95 0.01 30)"
+        ]
+      },
+      "inverse-ink": {
+        "role": "neutral",
+        "displayName": "Night Ink",
+        "canonical": "oklch(0.94 0.008 35)",
+        "tonalRamp": [
+          "oklch(0.15 0.008 35)",
+          "oklch(0.25 0.008 35)",
+          "oklch(0.37 0.008 35)",
+          "oklch(0.49 0.008 35)",
+          "oklch(0.61 0.008 35)",
+          "oklch(0.73 0.008 35)",
+          "oklch(0.84 0.008 35)",
+          "oklch(0.94 0.008 35)"
+        ]
+      },
+      "inverse-muted": {
+        "role": "neutral",
+        "displayName": "Night Measured Ink",
+        "canonical": "oklch(0.72 0.012 35)",
+        "tonalRamp": [
+          "oklch(0.15 0.012 35)",
+          "oklch(0.24 0.012 35)",
+          "oklch(0.33 0.012 35)",
+          "oklch(0.44 0.012 35)",
+          "oklch(0.55 0.012 35)",
+          "oklch(0.63 0.012 35)",
+          "oklch(0.72 0.012 35)",
+          "oklch(0.94 0.012 35)"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Display",
+        "purpose": "Homepage thesis only."
+      },
+      "headline": {
+        "displayName": "Headline",
+        "purpose": "Major narrative turns."
+      },
+      "title": {
+        "displayName": "Title",
+        "purpose": "Capabilities and documentation titles."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "Explanatory copy and documentation."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Status, metadata, and controls."
+      },
+      "code": {
+        "displayName": "Code",
+        "purpose": "Literal commands, paths, and schema data."
+      }
+    },
+    "shadows": [
+      {
+        "name": "responsive-lift",
+        "value": "0 10px 30px oklch(0.2 0.018 35 / 0.12)",
+        "purpose": "Interactive lift on primary actions and the affects map."
+      }
+    ],
+    "motion": [
+      {
+        "name": "ease-out-instrument",
+        "value": "cubic-bezier(0.16, 1, 0.3, 1)",
+        "purpose": "Short state transitions and the affects-map draw."
+      },
+      {
+        "name": "duration-state",
+        "value": "180ms",
+        "purpose": "Hover, focus, and active state response."
+      },
+      {
+        "name": "duration-map",
+        "value": "900ms",
+        "purpose": "The single choreographed hero connection sequence."
+      }
+    ],
+    "breakpoints": [
+      {
+        "name": "compact",
+        "value": "40rem"
+      },
+      {
+        "name": "wide",
+        "value": "64rem"
+      }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The single strongest route forward.",
+      "html": "<a class=\"ds-btn-primary\" href=\"#\">Start with the quickstart <span aria-hidden=\"true\">→</span></a>",
+      "css": ".ds-btn-primary { display:inline-flex; align-items:center; gap:.5rem; min-height:2.875rem; padding:.875rem 1.125rem; border-radius:var(--adr-radius-sm,6px); background:var(--adr-coral,oklch(.58 .17 34)); color:var(--adr-canvas,white); font:680 .8125rem/1.25 'Atkinson Hyperlegible Next Variable',sans-serif; text-decoration:none; transition:background 180ms cubic-bezier(.16,1,.3,1),transform 180ms cubic-bezier(.16,1,.3,1),box-shadow 180ms cubic-bezier(.16,1,.3,1)} .ds-btn-primary:hover { background:var(--adr-coral-deep,oklch(.47 .16 30)); transform:translateY(-1px); box-shadow:0 10px 30px oklch(.2 .018 35/.12)} .ds-btn-primary:focus-visible { outline:3px solid var(--adr-blue,oklch(.43 .1 245)); outline-offset:3px}"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "A durable secondary route with a full structural border.",
+      "html": "<a class=\"ds-btn-secondary\" href=\"#\">Browse decisions</a>",
+      "css": ".ds-btn-secondary { display:inline-flex; align-items:center; min-height:2.875rem; padding:.875rem 1.125rem; border:1px solid var(--adr-border,oklch(.82 .012 35)); border-radius:var(--adr-radius-sm,6px); background:var(--adr-canvas,white); color:var(--adr-ink,oklch(.2 .018 35)); font:680 .8125rem/1.25 'Atkinson Hyperlegible Next Variable',sans-serif; text-decoration:none; transition:border-color 180ms cubic-bezier(.16,1,.3,1),transform 180ms cubic-bezier(.16,1,.3,1)} .ds-btn-secondary:hover { border-color:var(--adr-ink,oklch(.2 .018 35)); transform:translateY(-1px)} .ds-btn-secondary:focus-visible { outline:3px solid var(--adr-coral,oklch(.58 .17 34)); outline-offset:3px}"
+    },
+    {
+      "name": "Site Title",
+      "kind": "nav",
+      "description": "Compact wordmark and decision-junction mark.",
+      "html": "<a class=\"ds-site-title\" href=\"#\"><svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M4 6h7v4h9M4 18h7v-4h9\"/><circle cx=\"4\" cy=\"6\" r=\"2\"/><circle cx=\"4\" cy=\"18\" r=\"2\"/><circle cx=\"20\" cy=\"10\" r=\"2\"/><circle cx=\"20\" cy=\"14\" r=\"2\"/></svg><span>adrkit</span></a>",
+      "css": ".ds-site-title { display:inline-flex; align-items:center; gap:.625rem; color:var(--adr-ink,oklch(.2 .018 35)); font:720 1.125rem/1 'Anybody Variable','Arial Narrow',sans-serif; letter-spacing:-.025em; text-decoration:none} .ds-site-title svg { width:1.5rem; height:1.5rem; fill:none; stroke:var(--adr-coral,oklch(.58 .17 34)); stroke-width:1.7; stroke-linecap:round; stroke-linejoin:round} .ds-site-title circle { fill:var(--adr-coral,oklch(.58 .17 34)); stroke:none} .ds-site-title:focus-visible { outline:3px solid var(--adr-blue,oklch(.43 .1 245)); outline-offset:4px}"
+    },
+    {
+      "name": "Current Status",
+      "kind": "chip",
+      "refersTo": "status-current",
+      "description": "Color-independent label for a capability available today.",
+      "html": "<span class=\"ds-status-current\"><svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><path d=\"m3 8 3 3 7-7\"/></svg>Works today</span>",
+      "css": ".ds-status-current { display:inline-flex; align-items:center; gap:.375rem; padding:.375rem .625rem; border-radius:999px; background:var(--adr-ink,oklch(.2 .018 35)); color:var(--adr-canvas,white); font:680 .8125rem/1.25 'Atkinson Hyperlegible Next Variable',sans-serif} .ds-status-current svg { width:.875rem; height:.875rem; fill:none; stroke:currentColor; stroke-width:2; stroke-linecap:round; stroke-linejoin:round}"
+    },
+    {
+      "name": "Capability Row",
+      "kind": "custom",
+      "description": "Rule-separated evidence row used instead of an icon card.",
+      "html": "<div class=\"ds-capability\"><code>adr explain</code><strong>Locate governing decisions</strong><span>Print every decision governing a path and the matcher that fired.</span></div>",
+      "css": ".ds-capability { display:grid; grid-template-columns:minmax(8rem,.6fr) minmax(12rem,1fr) minmax(16rem,1.4fr); gap:1.25rem; align-items:baseline; padding:1.25rem 0; border-block-start:1px solid var(--adr-border,oklch(.82 .012 35)); color:var(--adr-ink,oklch(.2 .018 35)); font:430 1rem/1.55 'Atkinson Hyperlegible Next Variable',sans-serif} .ds-capability code { color:var(--adr-coral-deep,oklch(.47 .16 30)); font:500 .875rem/1.55 ui-monospace,'SFMono-Regular',Consolas,monospace} .ds-capability strong { font-weight:680} .ds-capability span { color:var(--adr-muted,oklch(.43 .018 35))}"
+    },
+    {
+      "name": "Affects Map",
+      "kind": "custom",
+      "description": "The signature instrument connecting an ADR to governed code.",
+      "html": "<div class=\"ds-map\"><div class=\"ds-map-record\"><span>ADR-0042 · accepted</span><strong>Use server-side rendering</strong><code>affects:</code></div><div class=\"ds-map-route\"><code>apps/web/(authed)/**</code><code>next@>=16</code></div></div>",
+      "css": ".ds-map { display:grid; grid-template-columns:1fr .85fr; min-height:15rem; overflow:hidden; border-radius:10px; background:var(--adr-coral,oklch(.58 .17 34)); color:white; box-shadow:none; transition:transform 180ms cubic-bezier(.16,1,.3,1),box-shadow 180ms cubic-bezier(.16,1,.3,1)} .ds-map:hover { transform:translateY(-2px); box-shadow:0 10px 30px oklch(.2 .018 35/.12)} .ds-map-record,.ds-map-route { display:flex; flex-direction:column; justify-content:center; gap:.75rem; padding:2rem} .ds-map-record { border-inline-end:1px solid oklch(1 0 0/.45)} .ds-map-record span { font:680 .8125rem/1.25 'Atkinson Hyperlegible Next Variable',sans-serif} .ds-map-record strong { font:680 1.5rem/1.1 'Anybody Variable','Arial Narrow',sans-serif} .ds-map code { font:500 .8125rem/1.5 ui-monospace,'SFMono-Regular',Consolas,monospace} .ds-map-route code { padding:.625rem; border:1px solid oklch(1 0 0/.55); border-radius:3px}"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Decision Instrument",
+    "overview": "adrkit should feel like a precision instrument that makes architectural consequences visible. Its physical references are Braun technical manuals, NASA standards diagrams, and GitHub Primer's operational clarity: disciplined geometry, plain-language labels, durable controls, and one unmistakable signal color. The working scene is a Staff+ engineer evaluating the site on a bright desktop display during a design review, so the primary canvas is true white rather than a theatrical dark terminal.\n\nThe signature is the affects map: a decision record visibly routes to the code paths and packages it governs. Coral behaves like an operational redline, not decoration. The one orchestrated load sequence draws those connections in the hero; everything else uses restrained state transitions. The interface explicitly rejects generic developer-tool darkness, terminal cosplay, interchangeable SaaS card grids, and ornamental editorial styling.",
+    "keyCharacteristics": [
+      "True-white working canvas with committed coral fields.",
+      "Wide, expressive grotesk display type paired with a highly legible body face.",
+      "Structural rules, lists, and matrices instead of repeated cards.",
+      "Real records, commands, statuses, and constraints used as visual material.",
+      "One choreographed hero map; motion elsewhere is responsive and quiet."
+    ],
+    "rules": [
+      {
+        "name": "The Instrument Test",
+        "body": "Every visual device must help a visitor locate, compare, route, or verify a decision. If it only decorates the page, remove it.",
+        "section": "overview"
+      },
+      {
+        "name": "The Redline Rule",
+        "body": "Coral must carry meaning: decision, consequence, or the primary route forward. Never scatter it as decorative confetti.",
+        "section": "colors"
+      },
+      {
+        "name": "The White-Surface Rule",
+        "body": "Warmth lives in Decision Coral, never in a cream-tinted page background.",
+        "section": "colors"
+      },
+      {
+        "name": "The Code-Is-Evidence Rule",
+        "body": "Monospace appears only when the content is machine-readable evidence. It is never a brand costume.",
+        "section": "typography"
+      },
+      {
+        "name": "The Flat-Until-Active Rule",
+        "body": "Resting surfaces use no shadow. A shadow is a response to interaction, never permanent decoration.",
+        "section": "elevation"
+      },
+      {
+        "name": "The One-Orchestrated-Moment Rule",
+        "body": "The affects map owns the page-load choreography. All other motion is a short state response using exponential ease-out.",
+        "section": "components"
+      }
+    ],
+    "dos": [
+      "Do make the `affects` relationship the homepage's memorable visual proof.",
+      "Do use real commands, schema fields, ADR ids, and honest current/planned labels.",
+      "Do keep body copy below 70ch and preserve readable reflow at 200% zoom.",
+      "Do maintain WCAG 2.2 AA, visible keyboard focus, reduced motion, and color-independent status cues.",
+      "Do let Decision Coral carry 30–60% of the hero composition while True Canvas remains the dominant reading surface."
+    ],
+    "donts": [
+      "Don't build a generic dark developer-tool landing page with neon accents, terminal cosplay, glowing grids, or hacker aesthetics.",
+      "Don't use interchangeable SaaS layouts built from repeated icon cards, vague claims, and decorative metrics.",
+      "Don't let the documentation theme expose navigation and prose without first explaining why adrkit matters.",
+      "Don't use editorial-magazine treatments that make governance feel ornamental rather than operational.",
+      "Don't use gradient text, decorative glassmorphism, colored side-stripe borders, or tiny uppercase eyebrows above every section.",
+      "Don't use monospace for brand headings or ordinary body copy."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["site/dist/**/*.html"],
+  "insertBefore": "</body>",
+  "commentSyntax": "html",
+  "cspChecked": true
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,297 @@
+---
+name: adrkit
+description: Decision memory rendered as a precise, inspectable instrument.
+colors:
+  canvas: "oklch(1 0 0)"
+  surface: "oklch(0.965 0 0)"
+  ink: "oklch(0.2 0.018 35)"
+  muted-ink: "oklch(0.43 0.018 35)"
+  border: "oklch(0.82 0.012 35)"
+  decision-coral: "oklch(0.58 0.17 34)"
+  decision-coral-deep: "oklch(0.47 0.16 30)"
+  blueprint-ink: "oklch(0.43 0.1 245)"
+  inverse-canvas: "oklch(0.145 0.01 30)"
+  inverse-ink: "oklch(0.94 0.008 35)"
+  inverse-muted: "oklch(0.72 0.012 35)"
+typography:
+  display:
+    fontFamily: "'Anybody Variable', 'Arial Narrow', sans-serif"
+    fontSize: "clamp(3.25rem, 7.4vw, 5.75rem)"
+    fontWeight: 720
+    lineHeight: 0.94
+    letterSpacing: "-0.035em"
+  headline:
+    fontFamily: "'Anybody Variable', 'Arial Narrow', sans-serif"
+    fontSize: "clamp(2.25rem, 4.5vw, 4rem)"
+    fontWeight: 680
+    lineHeight: 1
+    letterSpacing: "-0.025em"
+  title:
+    fontFamily: "'Anybody Variable', 'Arial Narrow', sans-serif"
+    fontSize: "clamp(1.35rem, 2.2vw, 2rem)"
+    fontWeight: 660
+    lineHeight: 1.12
+    letterSpacing: "-0.015em"
+  body:
+    fontFamily: "'Atkinson Hyperlegible Next Variable', sans-serif"
+    fontSize: "1rem"
+    fontWeight: 430
+    lineHeight: 1.65
+    letterSpacing: "normal"
+  label:
+    fontFamily: "'Atkinson Hyperlegible Next Variable', sans-serif"
+    fontSize: "0.8125rem"
+    fontWeight: 680
+    lineHeight: 1.25
+    letterSpacing: "0.02em"
+  code:
+    fontFamily: "ui-monospace, 'SFMono-Regular', Consolas, monospace"
+    fontSize: "0.875rem"
+    fontWeight: 500
+    lineHeight: 1.55
+    letterSpacing: "-0.01em"
+rounded:
+  xs: "3px"
+  sm: "6px"
+  md: "10px"
+  pill: "999px"
+spacing:
+  xs: "0.375rem"
+  sm: "0.75rem"
+  md: "1.25rem"
+  lg: "2rem"
+  xl: "clamp(3rem, 7vw, 6rem)"
+  section: "clamp(5rem, 11vw, 10rem)"
+components:
+  button-primary:
+    backgroundColor: "{colors.decision-coral}"
+    textColor: "{colors.canvas}"
+    typography: "{typography.label}"
+    rounded: "{rounded.sm}"
+    padding: "0.875rem 1.125rem"
+    height: "2.875rem"
+  button-primary-hover:
+    backgroundColor: "{colors.decision-coral-deep}"
+    textColor: "{colors.canvas}"
+  button-secondary:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.label}"
+    rounded: "{rounded.sm}"
+    padding: "0.875rem 1.125rem"
+    height: "2.875rem"
+  status-current:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.canvas}"
+    typography: "{typography.label}"
+    rounded: "{rounded.pill}"
+    padding: "0.375rem 0.625rem"
+  status-planned:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.muted-ink}"
+    typography: "{typography.label}"
+    rounded: "{rounded.pill}"
+    padding: "0.375rem 0.625rem"
+---
+
+# Design System: adrkit
+
+## 1. Overview
+
+**Creative North Star: "The Decision Instrument"**
+
+adrkit should feel like a precision instrument that makes architectural
+consequences visible. Its physical references are Braun technical manuals, NASA
+standards diagrams, and GitHub Primer's operational clarity: disciplined
+geometry, plain-language labels, durable controls, and one unmistakable signal
+color. The working scene is a Staff+ engineer evaluating the site on a bright
+desktop display during a design review, so the primary canvas is true white
+rather than a theatrical dark terminal.
+
+The signature is the **affects map**: a decision record visibly routes to the
+code paths and packages it governs. Coral behaves like an operational redline,
+not decoration. The one orchestrated load sequence draws those connections in
+the hero; everything else uses restrained state transitions. The interface
+explicitly rejects generic developer-tool darkness, terminal cosplay,
+interchangeable SaaS card grids, and ornamental editorial styling.
+
+**Key Characteristics:**
+
+- True-white working canvas with committed coral fields.
+- Wide, expressive grotesk display type paired with a highly legible body face.
+- Structural rules, lists, and matrices instead of repeated cards.
+- Real records, commands, statuses, and constraints used as visual material.
+- One choreographed hero map; motion elsewhere is responsive and quiet.
+
+**The Instrument Test.** Every visual device must help a visitor locate,
+compare, route, or verify a decision. If it only decorates the page, remove it.
+
+## 2. Colors
+
+The palette treats coral as a decision redline, blueprint ink as a navigational
+signal, and neutral surfaces as working material.
+
+### Primary
+
+- **Decision Coral** (`decision-coral`): Carries the hero instrument, primary
+  actions, and high-consequence emphasis. White text is mandatory on this fill.
+- **Decision Coral Deep** (`decision-coral-deep`): Hover, active, and compact
+  high-emphasis states where extra contrast is required.
+
+### Secondary
+
+- **Blueprint Ink** (`blueprint-ink`): Links, focus-supporting details, and
+  route lines that mean "this connects to that." It never becomes a broad
+  background wash.
+
+### Neutral
+
+- **True Canvas** (`canvas`): The dominant light-mode background. It is literal
+  white, not cream, paper, sand, or parchment.
+- **Instrument Surface** (`surface`): Recessed documentation controls, code
+  gutters, and alternating table rows.
+- **Working Ink** (`ink`): Primary text and structural lines.
+- **Measured Ink** (`muted-ink`): Secondary copy that remains comfortably
+  readable at body sizes.
+- **Calibration Rule** (`border`): Dividers and table structure.
+- **Night Canvas / Night Ink** (`inverse-canvas`, `inverse-ink`,
+  `inverse-muted`): User-selected dark mode, kept neutral and matte rather than
+  neon or terminal-like.
+
+**The Redline Rule.** Coral must carry meaning: decision, consequence, or the
+primary route forward. Never scatter it as decorative confetti.
+
+**The White-Surface Rule.** Warmth lives in Decision Coral, never in a
+cream-tinted page background.
+
+## 3. Typography
+
+**Display Font:** Anybody Variable (with Arial Narrow fallback)  
+**Body Font:** Atkinson Hyperlegible Next Variable (with sans-serif fallback)  
+**Label/Mono Font:** Atkinson Hyperlegible Next Variable for labels; the native
+system monospace stack only for literal code and schema data.
+
+**Character:** Anybody's width and weight axes give headings the decisive,
+engineered silhouette of a technical manual without turning the page into
+terminal cosplay. Atkinson Hyperlegible Next makes dense explanations,
+navigation, and examples exceptionally easy to scan.
+
+### Hierarchy
+
+- **Display** (720, fluid to 5.75rem, 0.94): Homepage thesis only. Keep
+  letter-spacing no tighter than -0.035em and test every line at narrow widths.
+- **Headline** (680, fluid to 4rem, 1): Major narrative turns and section
+  conclusions.
+- **Title** (660, fluid to 2rem, 1.12): Capability names, documentation titles,
+  and compact calls to action.
+- **Body** (430, 1rem, 1.65): Explanatory copy capped at 70ch.
+- **Label** (680, 0.8125rem, 0.02em): Status, metadata, and short controls in
+  sentence case. Uppercase is reserved for genuinely coded states such as
+  `PRE-ALPHA`.
+- **Code** (500, 0.875rem, 1.55): Literal commands, frontmatter, paths, and
+  schema values only.
+
+**The Code-Is-Evidence Rule.** Monospace appears only when the content is
+machine-readable evidence. It is never a brand costume.
+
+## 4. Elevation
+
+The system is flat by default. Depth comes from tonal contrast, structural
+rules, overlap within the affects map, and one shallow state shadow when an
+interactive element lifts. Documentation surfaces never stack decorative
+shadows.
+
+### Shadow Vocabulary
+
+- **Responsive Lift** (`0 10px 30px oklch(0.2 0.018 35 / 0.12)`): Primary
+  actions and the decision instrument on hover-capable devices only.
+
+**The Flat-Until-Active Rule.** Resting surfaces use no shadow. A shadow is a
+response to interaction, never permanent decoration.
+
+## 5. Components
+
+Components should feel durable, compact, and inspectable. Controls read as parts
+of one instrument rather than soft promotional objects.
+
+### Buttons
+
+- **Shape:** Gently machined corners (`sm`) rather than pills.
+- **Primary:** Decision Coral with True Canvas text, compact label typography,
+  and a 2.875rem target height.
+- **Hover / Focus:** Shift to Decision Coral Deep and lift by one pixel. Focus
+  uses a two-color ring that remains visible on white, coral, and dark surfaces.
+- **Secondary:** True Canvas with Working Ink text and a full Calibration Rule
+  border. Ghost actions use underline offset rather than a floating container.
+
+### Chips
+
+- **Style:** Pills are reserved for finite status values such as `works today`
+  and `planned`. Every chip includes text or an icon plus text; color alone never
+  carries status.
+- **State:** Current capabilities use Working Ink fills. Planned capabilities use
+  Instrument Surface with a visible outline.
+
+### Cards / Containers
+
+- **Corner Style:** Purpose-built instruments may use `md`; content groups and
+  documentation sections remain square and rule-separated.
+- **Background:** True Canvas or Instrument Surface.
+- **Shadow Strategy:** None at rest; use Responsive Lift only for actual
+  interaction.
+- **Border:** Full one-pixel Calibration Rule borders only. Colored side stripes
+  are prohibited.
+- **Internal Padding:** `md` for compact controls and `lg` for instruments.
+
+### Navigation
+
+- The header is a quiet calibration bar: compact wordmark, wide search field,
+  GitHub link, and theme control.
+- The active documentation item uses Working Ink weight plus a Decision Coral
+  marker that does not rely on color alone.
+- Mobile navigation retains the same vocabulary and exposes a minimum 44px
+  target for every control.
+
+### Affects Map
+
+The signature component pairs a real ADR excerpt with the paths and packages in
+its `affects` field. Connection lines draw once on page load, remain visible by
+default, and become instant under reduced motion. The map is explanatory, not a
+fake terminal and not a decorative network graph.
+
+### Capability Matrix
+
+Current and planned capabilities use aligned rows with explicit status text,
+command evidence, and plain descriptions. Do not convert this matrix into a
+same-sized icon-card grid.
+
+**The One-Orchestrated-Moment Rule.** The affects map owns the page-load
+choreography. All other motion is a short state response using exponential
+ease-out.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** make the `affects` relationship the homepage's memorable visual proof.
+- **Do** use real commands, schema fields, ADR ids, and honest current/planned
+  labels.
+- **Do** keep body copy below 70ch and preserve readable reflow at 200% zoom.
+- **Do** maintain WCAG 2.2 AA, visible keyboard focus, reduced motion, and
+  color-independent status cues.
+- **Do** let Decision Coral carry 30–60% of the hero composition while True
+  Canvas remains the dominant reading surface.
+
+### Don't:
+
+- **Don't** build a generic dark developer-tool landing page with neon accents,
+  terminal cosplay, glowing grids, or hacker aesthetics.
+- **Don't** use interchangeable SaaS layouts built from repeated icon cards,
+  vague claims, and decorative metrics.
+- **Don't** let the documentation theme expose navigation and prose without
+  first explaining why adrkit matters.
+- **Don't** use editorial-magazine treatments that make governance feel
+  ornamental rather than operational.
+- **Don't** use gradient text, decorative glassmorphism, colored side-stripe
+  borders, or tiny uppercase eyebrows above every section.
+- **Don't** use monospace for brand headings or ordinary body copy.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,61 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Staff+ engineers, architecture leads, and platform-minded technical leaders who
+need architectural decisions to remain discoverable, enforceable, and useful
+after the original discussion ends. They are evaluating whether adrkit can make
+decision governance practical for both human- and agent-authored plans without
+introducing another external system of record.
+
+## Product Purpose
+
+adrkit turns architecture decision records into typed, machine-readable data
+that stays in git. It helps teams validate decisions, locate the records that
+govern a change, understand why a choice was made, and prevent accepted
+constraints from silently drifting. The website should make that difference
+immediately legible, establish technical credibility, and move qualified users
+into the quickstart or the decision corpus.
+
+## Brand Personality
+
+Exacting, consequential, trustworthy. The voice is direct and technically
+precise without becoming cold, theatrical, or bureaucratic. It treats
+architectural decisions as durable engineering infrastructure, not process
+ceremony.
+
+## Anti-references
+
+- Generic dark developer-tool landing pages that use neon accents, terminal
+  cosplay, glowing grids, or hacker aesthetics as a substitute for product
+  meaning.
+- Interchangeable SaaS layouts built from repeated icon cards, vague claims, and
+  decorative metrics.
+- Documentation themes that expose navigation and prose without first explaining
+  why the product matters.
+- Editorial-magazine treatments that make governance feel ornamental rather
+  than operational.
+
+## Design Principles
+
+1. Make the governing idea tangible: show how a decision connects to the code it
+   affects instead of relying on abstract claims.
+2. Earn trust with specificity: distinguish what works today from what is
+   planned, and use real commands, records, and constraints as proof.
+3. Treat decisions as infrastructure: the experience should feel durable,
+   inspectable, and operational rather than ceremonial.
+4. Keep humans visibly in control: adrkit routes and explains; it never pretends
+   to replace architectural judgment.
+5. Reward deeper inspection: the homepage should lead naturally into the
+   quickstart, schema, and dogfooded ADR corpus.
+
+## Accessibility & Inclusion
+
+Target WCAG 2.2 AA. Maintain visible keyboard focus, semantic structure, strong
+text and control contrast, reduced-motion alternatives, and color-independent
+status cues. Technical examples must remain readable at narrow widths and usable
+with zoom or reflow.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -12,6 +12,11 @@ export default defineConfig({
 			title: 'adrkit',
 			description:
 				'Decision memory for human- and agent-authored plans — machine-readable ADRs, enforceable in CI, legible to agents, without leaving git.',
+			customCss: ['./src/styles/custom.css'],
+			components: {
+				Hero: './src/components/Hero.astro',
+				SiteTitle: './src/components/SiteTitle.astro',
+			},
 			social: [
 				{ icon: 'github', label: 'GitHub', href: 'https://github.com/mbeacom/adrkit' },
 			],
@@ -22,7 +27,7 @@ export default defineConfig({
 				{
 					label: 'Start here',
 					items: [
-						{ label: 'Overview', link: '/' },
+						{ label: 'Why adrkit', link: '/' },
 						{ label: 'Quickstart', slug: 'quickstart' },
 					],
 				},

--- a/site/bun.lock
+++ b/site/bun.lock
@@ -6,6 +6,8 @@
       "name": "site",
       "dependencies": {
         "@astrojs/starlight": "^0.41.3",
+        "@fontsource-variable/anybody": "^5.2.7",
+        "@fontsource-variable/atkinson-hyperlegible-next": "^5.2.6",
         "astro": "^7.0.2",
         "sharp": "^0.34.5",
       },
@@ -152,6 +154,10 @@
     "@expressive-code/plugin-shiki": ["@expressive-code/plugin-shiki@0.44.0", "", { "dependencies": { "@expressive-code/core": "^0.44.0", "shiki": "^4.0.2" } }, "sha512-RZsdaqlbGqyAQKuoX4myQXxjmiE2l5KBpJ/gKPh62tCdIdpWyjbzVqSo8+5XsezZxkfi8AJ/J6EUaBTPROFX/Q=="],
 
     "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.44.0", "", { "dependencies": { "@expressive-code/core": "^0.44.0" } }, "sha512-0/m3A5b+lz2upyNq+wzZ1S69HRoJmyFs5LsR42lVZ9pmGRlBiSBYQpvqlji4DBj1+Riamxc0AvcCr5kuzOQeWA=="],
+
+    "@fontsource-variable/anybody": ["@fontsource-variable/anybody@5.2.7", "", {}, "sha512-9piOOIOHSI2U8qOQag7xxTaMHAFjsYKOq4W3zJyZoXAebcPTv0c1bPmbFpwBdgG9zUJshfWhMzSoDCiLAKFWcg=="],
+
+    "@fontsource-variable/atkinson-hyperlegible-next": ["@fontsource-variable/atkinson-hyperlegible-next@5.2.6", "", {}, "sha512-D0Z8peFkRGYACvmWp8Sl8YPGYLBEJbzqapugtsMEYSUUtpQDiZVDHjk9s7bqB4hSCRYCrKuW6V1V+mnHybVnPw=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 

--- a/site/package.json
+++ b/site/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.3",
+    "@fontsource-variable/anybody": "^5.2.7",
+    "@fontsource-variable/atkinson-hyperlegible-next": "^5.2.6",
     "astro": "^7.0.2",
     "sharp": "^0.34.5"
   },

--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,1 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"><path fill-rule="evenodd" d="M81 36 64 0 47 36l-1 2-9-10a6 6 0 0 0-9 9l10 10h-2L0 64l36 17h2L28 91a6 6 0 1 0 9 9l9-10 1 2 17 36 17-36v-2l9 10a6 6 0 1 0 9-9l-9-9 2-1 36-17-36-17-2-1 9-9a6 6 0 1 0-9-9l-9 10v-2Zm-17 2-2 5c-4 8-11 15-19 19l-5 2 5 2c8 4 15 11 19 19l2 5 2-5c4-8 11-15 19-19l5-2-5-2c-8-4-15-11-19-19l-2-5Z" clip-rule="evenodd"/><path d="M118 19a6 6 0 0 0-9-9l-3 3a6 6 0 1 0 9 9l3-3Zm-96 4c-2 2-6 2-9 0l-3-3a6 6 0 1 1 9-9l3 3c3 2 3 6 0 9Zm0 82c-2-2-6-2-9 0l-3 3a6 6 0 1 0 9 9l3-3c3-2 3-6 0-9Zm96 4a6 6 0 0 1-9 9l-3-3a6 6 0 1 1 9-9l3 3Z"/><style>path{fill:#000}@media (prefers-color-scheme:dark){path{fill:#fff}}</style></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+	<rect width="128" height="128" rx="24" fill="oklch(0.58 0.17 34)"/>
+	<g fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="8">
+		<path d="M24 34h36v22h44M24 94h36V72h44"/>
+	</g>
+	<g fill="white">
+		<circle cx="24" cy="34" r="10"/>
+		<circle cx="24" cy="94" r="10"/>
+		<circle cx="104" cy="56" r="10"/>
+		<circle cx="104" cy="72" r="10"/>
+	</g>
+</svg>

--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-	<rect width="128" height="128" rx="24" fill="oklch(0.58 0.17 34)"/>
+	<rect width="128" height="128" rx="24" fill="#cb492d"/>
 	<g fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="8">
 		<path d="M24 34h36v22h44M24 94h36V72h44"/>
 	</g>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -66,13 +66,26 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
 				<div class="adr-record__data" aria-hidden="true">
 					<span><b>reversibility:</b> one-way-door</span>
 					<span><b>blastRadius:</b> cross-team</span>
-					<span class="adr-record__affects"><b>affects:</b></span>
+					<span class="adr-record__affects" data-route-origin><b>affects:</b></span>
 				</div>
 			</div>
 
-			<svg class="adr-instrument__routes" viewBox="0 0 680 410" aria-hidden="true">
-				<path class="adr-route adr-route--first" d="M307 286 C 382 286, 376 171, 463 171" />
-				<path class="adr-route adr-route--second" d="M307 286 C 394 286, 387 284, 463 284" />
+			<svg
+				class="adr-instrument__routes"
+				viewBox="0 0 680 410"
+				preserveAspectRatio="none"
+				aria-hidden="true"
+			>
+				<path
+					class="adr-route adr-route--first"
+					pathLength="1"
+					d="M307 286 C 382 286, 376 171, 463 171"
+				/>
+				<path
+					class="adr-route adr-route--second"
+					pathLength="1"
+					d="M307 286 C 394 286, 387 284, 463 284"
+				/>
 				<circle class="adr-route-node adr-route-node--origin" cx="307" cy="286" r="6" />
 				<circle class="adr-route-node adr-route-node--first" cx="463" cy="171" r="6" />
 				<circle class="adr-route-node adr-route-node--second" cx="463" cy="284" r="6" />
@@ -80,11 +93,11 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
 
 			<div class="adr-targets" aria-hidden="true">
 				<span class="adr-targets__label">resolved targets</span>
-				<div class="adr-target">
+				<div class="adr-target" data-route-target>
 					<span>path</span>
 					<code>apps/web/app/(authed)/**</code>
 				</div>
-				<div class="adr-target">
+				<div class="adr-target" data-route-target>
 					<span>package</span>
 					<code>next@&gt;=16</code>
 				</div>
@@ -97,3 +110,57 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
 		</div>
 	</div>
 </section>
+
+<script>
+	const connectDecisionRoutes = (instrument: Element) => {
+		const body = instrument.querySelector('.adr-instrument__body');
+		const svg = instrument.querySelector<SVGSVGElement>('.adr-instrument__routes');
+		const origin = instrument.querySelector('[data-route-origin]');
+		const targets = [...instrument.querySelectorAll('[data-route-target]')];
+		const paths = [...instrument.querySelectorAll<SVGPathElement>('.adr-route')];
+		const originNode = instrument.querySelector<SVGCircleElement>('.adr-route-node--origin');
+		const targetNodes = [
+			instrument.querySelector<SVGCircleElement>('.adr-route-node--first'),
+			instrument.querySelector<SVGCircleElement>('.adr-route-node--second'),
+		];
+
+		if (!body || !svg || !origin || !originNode || targets.length !== paths.length) return;
+
+		const update = () => {
+			const bodyRect = body.getBoundingClientRect();
+			const originRect = origin.getBoundingClientRect();
+			const targetRects = targets.map((target) => target.getBoundingClientRect());
+			if (!bodyRect.width || !bodyRect.height) return;
+
+			const start = {
+				x: originRect.right - bodyRect.left + 8,
+				y: originRect.top + originRect.height / 2 - bodyRect.top,
+			};
+			const ends = targetRects.map((target) => ({
+				x: target.left - bodyRect.left,
+				y: target.top + target.height / 2 - bodyRect.top,
+			}));
+
+			svg.setAttribute('viewBox', `0 0 ${bodyRect.width} ${bodyRect.height}`);
+			originNode.setAttribute('cx', String(start.x));
+			originNode.setAttribute('cy', String(start.y));
+
+			paths.forEach((path, index) => {
+				const end = ends[index];
+				const bend = Math.max(48, (end.x - start.x) * 0.42);
+				path.setAttribute(
+					'd',
+					`M ${start.x} ${start.y} C ${start.x + bend} ${start.y}, ${end.x - bend} ${end.y}, ${end.x} ${end.y}`,
+				);
+				targetNodes[index]?.setAttribute('cx', String(end.x));
+				targetNodes[index]?.setAttribute('cy', String(end.y));
+			});
+		};
+
+		update();
+		new ResizeObserver(update).observe(body);
+		document.fonts.ready.then(update);
+	};
+
+	document.querySelectorAll('.adr-instrument').forEach(connectDecisionRoutes);
+</script>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,0 +1,99 @@
+---
+import DraftContentNotice from 'virtual:starlight/components/DraftContentNotice';
+
+const { data } = Astro.locals.starlightRoute.entry;
+const { title = data.title, tagline, actions = [] } = data.hero || {};
+---
+
+<section class="adr-hero">
+	<div class="adr-hero__copy">
+		<div class="adr-hero__meta">
+			<span class="adr-status adr-status--current">
+				<svg viewBox="0 0 16 16" aria-hidden="true">
+					<path d="m3 8 3 3 7-7" />
+				</svg>
+				CLI works today
+			</span>
+			<span>Pre-alpha · decision memory in git</span>
+		</div>
+
+		<h1 id="_top" data-page-title set:html={title} />
+		{data.draft && <DraftContentNotice />}
+		{tagline && <p class="adr-hero__tagline" set:html={tagline} />}
+
+		{
+			actions.length > 0 && (
+				<div class="adr-hero__actions">
+					{actions.map(({ link, text, variant }) => (
+						<a
+							href={link}
+							class:list={[
+								'adr-button',
+								variant === 'minimal' ? 'adr-button--secondary' : 'adr-button--primary',
+							]}
+						>
+							<span>{text}</span>
+							<span aria-hidden="true">→</span>
+						</a>
+					))}
+				</div>
+			)
+		}
+
+		<p class="adr-hero__truth">
+			The schema, resolver, and CLI are implemented. CI comments, the evaluator,
+			and the MCP server are clearly marked as planned.
+		</p>
+	</div>
+
+	<div
+		class="adr-instrument"
+		role="img"
+		aria-label="ADR 0042 declares two affected targets: authenticated web routes and Next.js version 16 or newer."
+	>
+		<div class="adr-instrument__bar">
+			<span>Decision route</span>
+			<span>ADR-0042 · accepted</span>
+		</div>
+
+		<div class="adr-instrument__body">
+			<div class="adr-record">
+				<div class="adr-record__heading">
+					<span>architecture decision</span>
+					<span class="adr-record__status">accepted</span>
+				</div>
+				<strong>Use server-side rendering for authenticated routes</strong>
+				<div class="adr-record__data" aria-hidden="true">
+					<span><b>reversibility:</b> one-way-door</span>
+					<span><b>blastRadius:</b> cross-team</span>
+					<span class="adr-record__affects"><b>affects:</b></span>
+				</div>
+			</div>
+
+			<svg class="adr-instrument__routes" viewBox="0 0 680 410" aria-hidden="true">
+				<path class="adr-route adr-route--first" d="M307 286 C 382 286, 376 171, 463 171" />
+				<path class="adr-route adr-route--second" d="M307 286 C 394 286, 387 284, 463 284" />
+				<circle class="adr-route-node adr-route-node--origin" cx="307" cy="286" r="6" />
+				<circle class="adr-route-node adr-route-node--first" cx="463" cy="171" r="6" />
+				<circle class="adr-route-node adr-route-node--second" cx="463" cy="284" r="6" />
+			</svg>
+
+			<div class="adr-targets" aria-hidden="true">
+				<span class="adr-targets__label">resolved targets</span>
+				<div class="adr-target">
+					<span>path</span>
+					<code>apps/web/app/(authed)/**</code>
+				</div>
+				<div class="adr-target">
+					<span>package</span>
+					<code>next@&gt;=16</code>
+				</div>
+			</div>
+		</div>
+
+		<div class="adr-instrument__footer">
+			<span>2 governing matches</span>
+			<span>pure function · reproducible in CI</span>
+		</div>
+	</div>
+</section>

--- a/site/src/components/SiteTitle.astro
+++ b/site/src/components/SiteTitle.astro
@@ -1,0 +1,14 @@
+---
+const { siteTitleHref } = Astro.locals.starlightRoute;
+---
+
+<a href={siteTitleHref} class="adr-site-title" aria-label="adrkit home">
+	<svg viewBox="0 0 28 28" aria-hidden="true">
+		<path d="M5 7h8v5h10M5 21h8v-5h10" />
+		<circle cx="5" cy="7" r="2.25" />
+		<circle cx="5" cy="21" r="2.25" />
+		<circle cx="23" cy="12" r="2.25" />
+		<circle cx="23" cy="16" r="2.25" />
+	</svg>
+	<span translate="no">adrkit</span>
+</a>

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -1,106 +1,190 @@
 ---
-title: adrkit
-description: Decision memory for human- and agent-authored plans — machine-readable ADRs, enforceable in CI, legible to agents, without leaving git.
+title: Decisions that reach the code.
+description: adrkit turns architecture decisions into typed, locatable records that stay useful in CI, tools, and agent-authored plans.
 template: splash
 hero:
-  tagline: Decision memory for human- and agent-authored plans. Machine-readable ADRs, enforceable in CI, legible to agents — without leaving git.
+  tagline: adrkit turns architecture decisions into typed, locatable records — so the constraints your team accepted remain visible where the next change is made.
   actions:
-    - text: Quickstart
+    - text: Start with the quickstart
       link: /quickstart/
-      icon: right-arrow
-    - text: JSON Schema
-      link: /schema/
-      icon: document
+    - text: Browse the decisions
+      link: /adr/
       variant: minimal
-    - text: View on GitHub
+    - text: GitHub
       link: https://github.com/mbeacom/adrkit
-      icon: external
       variant: minimal
 ---
 
-import { Card, CardGrid, Aside, LinkCard } from '@astrojs/starlight/components';
+<div class="adr-home">
+	<section class="adr-status-band" aria-label="Project status">
+		<div class="adr-status-band__item">
+			<span class="adr-status adr-status--current">Works today</span>
+			<p>Schema, corpus validation, graphing, migration, and path explanation.</p>
+		</div>
+		<div class="adr-status-band__item">
+			<span class="adr-status adr-status--planned">Planned</span>
+			<p>Pull-request comments, deterministic evaluation, and MCP retrieval.</p>
+		</div>
+		<div class="adr-status-band__item">
+			<span class="adr-status adr-status--planned">Pre-alpha</span>
+			<p>Run from source today. Registry packages have not shipped.</p>
+		</div>
+	</section>
 
-<Aside type="caution" title="Status: pre-alpha">
-	The schema and the decision corpus exist, and the CLI (`adr lint`, `new`,
-	`graph`, `explain`, `migrate`) works today. The CI comment surface, the
-	evaluator, and the MCP server described below are planned, not yet built.
-</Aside>
+	<section class="adr-home__section adr-thesis" aria-labelledby="failure-mode">
+		<h2 id="failure-mode">A decision should not disappear after the meeting.</h2>
+		<div class="adr-thesis__copy">
+			<p>
+				Six months later, the same choice gets debated again. The code has
+				drifted. The people — and now the agents — proposing the next change
+				cannot see what was already accepted or rejected.
+			</p>
+			<p>
+				Most ADR tools preserve prose. <strong>adrkit preserves consequence.</strong>
+			</p>
+		</div>
+	</section>
 
-## The problem
+	<section class="adr-home__section" aria-labelledby="works-today">
+		<header class="adr-section-heading">
+			<h2 id="works-today">Proof in the repository, not the pitch.</h2>
+			<p>
+				The current CLI reads typed frontmatter, validates the corpus, resolves
+				what a record governs, and keeps migration additive.
+			</p>
+		</header>
 
-Your organization decides something. Six months later nobody remembers, the
-decision gets re-litigated, and the code drifts from what was agreed. Now agents
-write plans too — faster than anyone can review them, with no memory of what was
-already decided and rejected.
+		<ul class="adr-capabilities">
+			<li class="adr-capability">
+				<div class="adr-capability__command">
+					<code>adr lint</code>
+					<span class="adr-status adr-status--current">Works today</span>
+				</div>
+				<h3>Validate the corpus</h3>
+				<p>
+					Check every record against the schema, enforce unique ids, catch
+					dangling links, and flag accepted records that declare conflicts.
+				</p>
+			</li>
 
-Most ADR tooling is a markdown template and a static site generator. That
-records decisions. It doesn't make them *do* anything.
+			<li class="adr-capability">
+				<div class="adr-capability__command">
+					<code>adr explain</code>
+					<span class="adr-status adr-status--current">Works today</span>
+				</div>
+				<h3>Locate governing decisions</h3>
+				<p>
+					Give adrkit a path. It returns every decision that governs it and
+					the matcher that fired — as readable output or JSON.
+				</p>
+			</li>
 
-## The idea
+			<li class="adr-capability">
+				<div class="adr-capability__command">
+					<code>adr graph</code>
+					<span class="adr-status adr-status--current">Works today</span>
+				</div>
+				<h3>Inspect the decision graph</h3>
+				<p>
+					Render supersession and relationships as Graphviz DOT or structured
+					JSON instead of leaving the links trapped in individual files.
+				</p>
+			</li>
 
-Treat a decision record as **typed data with a markdown body**, and give it one
-field that changes everything — `affects`, declaring what the decision governs:
+			<li class="adr-capability">
+				<div class="adr-capability__command">
+					<code>adr migrate --from madr</code>
+					<span class="adr-status adr-status--current">Works today</span>
+				</div>
+				<h3>Adopt without a rewrite</h3>
+				<p>
+					Add adrkit fields to an existing MADR corpus in place. The migration
+					is additive and preserves current tooling and prose.
+				</p>
+			</li>
+		</ul>
+	</section>
 
-```yaml
----
-id: "0042"
-title: Use server-side rendering for authenticated routes
-status: accepted
-reversibility: one-way-door
-blastRadius: cross-team
-affects:
-  - type: path
-    pattern: "apps/web/app/(authed)/**"
-  - type: package
-    pattern: "next@>=16"
----
-```
+	<section class="adr-home__section adr-flow" aria-labelledby="one-field">
+		<header class="adr-section-heading">
+			<h2 id="one-field">One field makes a decision locatable.</h2>
+			<p>
+				<code>affects</code> declares what a record governs. That turns an ADR
+				from passive documentation into data a tool can resolve.
+			</p>
+		</header>
 
-Now a tool can answer *"which decisions govern this pull request?"* — and put the
-answer where the next decision is actually being made.
+		<ol class="adr-flow__steps">
+			<li>
+				<h3>Declare the reach</h3>
+				<p>
+					A record names the paths, packages, APIs, resources, or data it
+					governs.
+				</p>
+			</li>
+			<li>
+				<h3>Resolve the match</h3>
+				<p>
+					A pure function compares a changed target with the corpus and
+					explains every match.
+				</p>
+			</li>
+			<li>
+				<h3>Surface the constraint</h3>
+				<p>
+					Today, <code>adr explain</code> prints it. The planned CI and MCP
+					surfaces will put it directly in review and agent context.
+				</p>
+			</li>
+		</ol>
+	</section>
 
-## What works today
+	<section class="adr-home__section adr-roadmap" aria-labelledby="roadmap">
+		<header class="adr-section-heading">
+			<h2 id="roadmap">Built next, stated plainly.</h2>
+			<p>
+				These are committed directions, not shipping claims. Each remains
+				planned until the repository proves otherwise.
+			</p>
+		</header>
 
-<CardGrid>
-	<Card title="Typed, validated records" icon="approve-check">
-		A strict [JSON Schema](/schema/) — a superset of MADR — that editors and
-		CI in any language can validate against.
-	</Card>
-	<Card title="adr lint" icon="error">
-		Validate records against the schema, enforce unique ids, and flag dangling
-		references or an accepted record that declares a conflict.
-	</Card>
-	<Card title="adr migrate --from madr" icon="random">
-		Adopt an existing MADR corpus in place, additively, without breaking your
-		current tooling.
-	</Card>
-	<Card title="adr explain / graph" icon="puzzle">
-		Print every decision governing a file and the matcher that fired, or emit
-		the decision graph as DOT or JSON.
-	</Card>
-</CardGrid>
+		<ul class="adr-roadmap__list">
+			<li class="adr-roadmap__item">
+				<span class="adr-status adr-status--planned">Planned</span>
+				<h3>Pull-request context</h3>
+				<p>Comment with the accepted decisions governing touched files.</p>
+			</li>
+			<li class="adr-roadmap__item">
+				<span class="adr-status adr-status--planned">Planned</span>
+				<h3>Agent retrieval</h3>
+				<p>
+					Expose accepted and rejected decisions through MCP before a new plan
+					repeats an old argument.
+				</p>
+			</li>
+			<li class="adr-roadmap__item">
+				<span class="adr-status adr-status--planned">Planned</span>
+				<h3>Deterministic evaluation</h3>
+				<p>
+					Check published rules first, then route the conditions that need
+					human judgment.
+				</p>
+			</li>
+		</ul>
+	</section>
 
-## On the roadmap
-
-<CardGrid>
-	<Card title="CI comment" icon="comment">
-		Surface governing decisions on the pull requests that touch them.
-	</Card>
-	<Card title="MCP server" icon="seti:default">
-		Let agents retrieve prior decisions — including the rejected ones — before
-		proposing something already tried.
-	</Card>
-	<Card title="Evaluator" icon="rocket">
-		Score proposals against a published rubric and route them; deterministic
-		checks first, humans on the conditions that warrant them.
-	</Card>
-</CardGrid>
-
-It never approves anything. It routes, and humans decide.
-
-## Design commitments
-
-These are enforced, not aspirational — and the project governs itself with them.
-Each links to the record that decided it.
-
-<LinkCard title="Browse the decision records" href="/adr/" description="adrkit's first commit is its own decision corpus. Every choice here is a typed ADR." />
+	<section class="adr-home__section adr-closing" aria-label="Human control">
+		<blockquote>It never approves anything. It routes, and humans decide.</blockquote>
+		<div class="adr-closing__action">
+			<p>
+				adrkit governs itself. The repository's first commit is its own decision
+				corpus, including the trade-offs and rejected alternatives behind the
+				project.
+			</p>
+			<a class="adr-button adr-button--primary" href="/adr/">
+				<span>Read the decisions that built adrkit</span>
+				<span aria-hidden="true">→</span>
+			</a>
+		</div>
+	</section>
+</div>

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -405,11 +405,11 @@ main > .content-panel:first-child > .sl-container {
 .adr-instrument__body {
 	position: relative;
 	display: grid;
-	grid-template-columns: minmax(0, 1fr) minmax(13rem, 0.82fr);
+	grid-template-columns: minmax(0, 1.18fr) minmax(0, 0.92fr);
 	flex: 1;
 	align-items: center;
 	min-height: 32rem;
-	padding: clamp(1.5rem, 4vw, 3.5rem);
+	padding: clamp(1.5rem, 5%, 3.5rem);
 }
 
 .adr-record {
@@ -478,7 +478,7 @@ main > .content-panel:first-child > .sl-container {
 	display: flex;
 	flex-direction: column;
 	gap: 1rem;
-	padding-inline-start: clamp(2rem, 5vw, 4.5rem);
+	padding-inline-start: clamp(1.5rem, 8%, 3.5rem);
 }
 
 .adr-targets__label {
@@ -523,8 +523,8 @@ main > .content-panel:first-child > .sl-container {
 	fill: none;
 	stroke: oklch(1 0 0 / 0.88);
 	stroke-width: 2;
-	stroke-dasharray: 220;
-	stroke-dashoffset: 220;
+	stroke-dasharray: 1;
+	stroke-dashoffset: 1;
 	animation: adr-route-draw 900ms var(--adr-ease-out) forwards;
 }
 
@@ -931,7 +931,8 @@ main > .content-panel:first-child > .sl-container {
 	background: transparent;
 	color: var(--adr-coral-deep);
 	font-size: 0.78em;
-	white-space: nowrap;
+	overflow-wrap: anywhere;
+	white-space: normal;
 }
 
 :root[data-theme='dark'] .sl-heading-wrapper code {
@@ -1172,9 +1173,9 @@ tbody tr:nth-child(even) {
 	*::before,
 	*::after {
 		scroll-behavior: auto;
-		transition-duration: 0.01ms;
-		animation-duration: 0.01ms;
-		animation-iteration-count: 1;
+		transition-duration: 0.01ms !important;
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
 	}
 
 	.adr-route {

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -1,0 +1,1187 @@
+@import '@fontsource-variable/anybody/standard.css';
+@import '@fontsource-variable/atkinson-hyperlegible-next/wght.css';
+
+:root {
+	--adr-canvas: oklch(1 0 0);
+	--adr-surface: oklch(0.965 0 0);
+	--adr-ink: oklch(0.2 0.018 35);
+	--adr-muted: oklch(0.43 0.018 35);
+	--adr-border: oklch(0.82 0.012 35);
+	--adr-coral: oklch(0.58 0.17 34);
+	--adr-coral-deep: oklch(0.47 0.16 30);
+	--adr-coral-soft: oklch(0.93 0.035 34);
+	--adr-blue: oklch(0.43 0.1 245);
+	--adr-night: oklch(0.145 0.01 30);
+	--adr-night-surface: oklch(0.2 0.012 30);
+	--adr-night-ink: oklch(0.94 0.008 35);
+	--adr-night-muted: oklch(0.72 0.012 35);
+	--adr-night-border: oklch(0.37 0.012 35);
+	--adr-radius-xs: 3px;
+	--adr-radius-sm: 6px;
+	--adr-radius-md: 10px;
+	--adr-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+	--adr-duration: 180ms;
+	--adr-bg: var(--adr-canvas);
+	--adr-panel: var(--adr-surface);
+	--adr-text: var(--adr-ink);
+	--adr-text-muted: var(--adr-muted);
+	--adr-line: var(--adr-border);
+	--adr-link: var(--adr-blue);
+	--sl-font: 'Atkinson Hyperlegible Next Variable', sans-serif;
+	--sl-font-mono: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+	--sl-content-width: 52rem;
+	--sl-content-pad-x: clamp(1.25rem, 4vw, 3rem);
+	--sl-nav-height: 4.5rem;
+	--sl-nav-pad-x: clamp(1rem, 3vw, 2.5rem);
+	--sl-nav-gap: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+:root[data-theme='light'] {
+	--sl-color-white: var(--adr-ink);
+	--sl-color-gray-1: oklch(0.27 0.018 35);
+	--sl-color-gray-2: var(--adr-muted);
+	--sl-color-gray-3: oklch(0.54 0.015 35);
+	--sl-color-gray-4: oklch(0.67 0.014 35);
+	--sl-color-gray-5: var(--adr-border);
+	--sl-color-gray-6: oklch(0.92 0.006 35);
+	--sl-color-gray-7: var(--adr-surface);
+	--sl-color-black: var(--adr-canvas);
+	--sl-color-accent-low: var(--adr-coral-soft);
+	--sl-color-accent: var(--adr-coral);
+	--sl-color-accent-high: var(--adr-coral-deep);
+	--sl-color-bg: var(--adr-canvas);
+	--sl-color-bg-nav: var(--adr-canvas);
+	--sl-color-bg-sidebar: var(--adr-surface);
+	--sl-color-hairline: var(--adr-border);
+	--sl-color-hairline-light: oklch(0.9 0.006 35);
+	--sl-color-text: var(--adr-muted);
+	--sl-color-text-accent: var(--adr-coral-deep);
+}
+
+:root[data-theme='dark'] {
+	--adr-bg: var(--adr-night);
+	--adr-panel: var(--adr-night-surface);
+	--adr-text: var(--adr-night-ink);
+	--adr-text-muted: var(--adr-night-muted);
+	--adr-line: var(--adr-night-border);
+	--adr-link: oklch(0.78 0.09 245);
+	--sl-color-white: var(--adr-night-ink);
+	--sl-color-gray-1: oklch(0.86 0.01 35);
+	--sl-color-gray-2: var(--adr-night-muted);
+	--sl-color-gray-3: oklch(0.62 0.012 35);
+	--sl-color-gray-4: oklch(0.49 0.012 35);
+	--sl-color-gray-5: var(--adr-night-border);
+	--sl-color-gray-6: oklch(0.24 0.012 30);
+	--sl-color-gray-7: var(--adr-night-surface);
+	--sl-color-black: var(--adr-night);
+	--sl-color-accent-low: oklch(0.28 0.07 30);
+	--sl-color-accent: oklch(0.72 0.15 35);
+	--sl-color-accent-high: oklch(0.86 0.07 35);
+	--sl-color-bg: var(--adr-night);
+	--sl-color-bg-nav: var(--adr-night);
+	--sl-color-bg-sidebar: var(--adr-night-surface);
+	--sl-color-hairline: var(--adr-night-border);
+	--sl-color-hairline-light: oklch(0.27 0.012 30);
+	--sl-color-text: var(--adr-night-muted);
+	--sl-color-text-accent: oklch(0.83 0.09 35);
+}
+
+html {
+	scroll-behavior: smooth;
+}
+
+body {
+	background: var(--adr-bg);
+	color: var(--adr-text);
+	font-family: var(--sl-font);
+	font-size: 1.03125rem;
+	font-weight: 430;
+	letter-spacing: 0.002em;
+}
+
+:where(h1, h2, h3, h4, h5, h6) {
+	color: var(--adr-text);
+	font-family: 'Anybody Variable', 'Arial Narrow', sans-serif;
+	font-stretch: 112%;
+	font-weight: 680;
+	letter-spacing: -0.025em;
+	text-wrap: balance;
+}
+
+:where(p, li, dd) {
+	text-wrap: pretty;
+}
+
+:where(a, button, input, summary):focus-visible {
+	outline: 3px solid var(--adr-link);
+	outline-offset: 3px;
+}
+
+a {
+	text-underline-offset: 0.18em;
+}
+
+.header.header {
+	border-block-end: 1px solid var(--adr-line);
+	background: var(--adr-bg);
+}
+
+.adr-site-title {
+	display: inline-flex;
+	gap: 0.625rem;
+	align-items: center;
+	min-height: 2.75rem;
+	color: var(--adr-text);
+	font-family: 'Anybody Variable', 'Arial Narrow', sans-serif;
+	font-size: 1.2rem;
+	font-stretch: 118%;
+	font-weight: 740;
+	letter-spacing: -0.035em;
+	text-decoration: none;
+}
+
+.adr-site-title svg {
+	width: 1.65rem;
+	height: 1.65rem;
+	overflow: visible;
+	fill: none;
+	stroke: var(--adr-coral);
+	stroke-width: 1.75;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+}
+
+.adr-site-title circle {
+	fill: var(--adr-coral);
+	stroke: none;
+}
+
+site-search > button {
+	min-width: clamp(8rem, 16vw, 14rem);
+	min-height: 2.75rem;
+	border-color: var(--adr-line);
+	border-radius: var(--adr-radius-sm);
+	background: var(--adr-panel);
+	color: var(--adr-text-muted);
+	box-shadow: none;
+	transition:
+		border-color var(--adr-duration) var(--adr-ease-out),
+		background var(--adr-duration) var(--adr-ease-out);
+}
+
+site-search > button > kbd {
+	display: none;
+}
+
+site-search > button:hover {
+	border-color: var(--adr-text-muted);
+	background: var(--adr-bg);
+}
+
+.social-icons a {
+	color: var(--adr-text-muted);
+}
+
+starlight-theme-select select {
+	border-radius: var(--adr-radius-xs);
+}
+
+.sidebar-pane {
+	border-inline-end-color: var(--adr-line);
+}
+
+.sidebar-content a {
+	border-radius: var(--adr-radius-xs);
+}
+
+.sidebar-content a[aria-current='page'] {
+	background: var(--adr-coral-deep);
+	color: var(--adr-canvas);
+	font-weight: 700;
+	text-decoration: none;
+}
+
+.content-panel {
+	border-block-end-color: var(--adr-line);
+}
+
+main > .content-panel:first-child > .sl-container {
+	max-width: 100%;
+	padding-inline: 0;
+}
+
+:root[data-has-hero] main > .content-panel:first-child {
+	padding: 0;
+}
+
+.adr-hero {
+	display: grid;
+	grid-template-columns: minmax(0, 0.92fr) minmax(30rem, 1.08fr);
+	min-height: min(49rem, calc(100svh - var(--sl-nav-height)));
+	border-block-end: 1px solid var(--adr-line);
+	background: var(--adr-bg);
+}
+
+.adr-hero__copy {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: clamp(3.5rem, 8vw, 8rem) clamp(1.5rem, 6vw, 7rem);
+}
+
+.adr-hero__meta {
+	display: flex;
+	gap: 0.75rem 1rem;
+	align-items: center;
+	flex-wrap: wrap;
+	margin-block-end: clamp(2rem, 5vw, 4.5rem);
+	color: var(--adr-text-muted);
+	font-size: 0.8125rem;
+	font-weight: 650;
+}
+
+.adr-status {
+	display: inline-flex;
+	gap: 0.375rem;
+	align-items: center;
+	width: fit-content;
+	padding: 0.375rem 0.625rem;
+	border-radius: 999px;
+	font-size: 0.8125rem;
+	font-weight: 700;
+	line-height: 1.2;
+}
+
+.adr-status svg {
+	width: 0.875rem;
+	height: 0.875rem;
+	fill: none;
+	stroke: currentColor;
+	stroke-width: 2;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+}
+
+.adr-status--current {
+	background: var(--adr-text);
+	color: var(--adr-bg);
+}
+
+.adr-status--planned {
+	border: 1px solid currentColor;
+	background: transparent;
+	color: inherit;
+}
+
+.adr-hero h1 {
+	max-width: 10ch;
+	margin: 0;
+	color: var(--adr-text);
+	font-family: 'Anybody Variable', 'Arial Narrow', sans-serif;
+	font-size: clamp(3.5rem, 6vw, 5.5rem);
+	font-stretch: 110%;
+	font-weight: 740;
+	letter-spacing: -0.035em;
+	line-height: 0.94;
+	overflow-wrap: normal;
+	text-wrap: balance;
+}
+
+.adr-hero__tagline {
+	max-width: 37rem;
+	margin: clamp(1.5rem, 3vw, 2.25rem) 0 0;
+	color: var(--adr-text-muted);
+	font-size: clamp(1.125rem, 1.5vw, 1.35rem);
+	font-weight: 430;
+	line-height: 1.55;
+}
+
+.adr-hero__actions {
+	display: flex;
+	gap: 0.75rem;
+	flex-wrap: wrap;
+	margin-block-start: 2.25rem;
+}
+
+.adr-button {
+	display: inline-flex;
+	gap: 0.75rem;
+	align-items: center;
+	justify-content: space-between;
+	min-height: 2.875rem;
+	padding: 0.875rem 1.125rem;
+	border: 1px solid transparent;
+	border-radius: var(--adr-radius-sm);
+	font-size: 0.875rem;
+	font-weight: 720;
+	line-height: 1;
+	text-decoration: none;
+	transition:
+		background var(--adr-duration) var(--adr-ease-out),
+		border-color var(--adr-duration) var(--adr-ease-out),
+		color var(--adr-duration) var(--adr-ease-out),
+		transform var(--adr-duration) var(--adr-ease-out),
+		box-shadow var(--adr-duration) var(--adr-ease-out);
+}
+
+.adr-button--primary {
+	background: var(--adr-coral);
+	color: var(--adr-canvas);
+}
+
+.adr-button--primary:hover {
+	background: var(--adr-coral-deep);
+	color: var(--adr-canvas);
+	transform: translateY(-1px);
+	box-shadow: 0 10px 30px oklch(0.2 0.018 35 / 0.12);
+}
+
+.adr-button--secondary {
+	border-color: var(--adr-line);
+	background: var(--adr-bg);
+	color: var(--adr-text);
+}
+
+.adr-button--secondary:hover {
+	border-color: var(--adr-text);
+	color: var(--adr-text);
+	transform: translateY(-1px);
+}
+
+.adr-hero__truth {
+	max-width: 39rem;
+	margin: 1.25rem 0 0;
+	color: var(--adr-text-muted);
+	font-size: 0.8125rem;
+	line-height: 1.45;
+}
+
+.adr-instrument {
+	display: flex;
+	flex-direction: column;
+	align-self: center;
+	min-width: 0;
+	width: calc(100% - clamp(2rem, 4vw, 3rem));
+	height: min(42rem, calc(100svh - 7.5rem));
+	min-height: 35rem;
+	max-height: 42rem;
+	margin: clamp(1rem, 2vw, 1.5rem);
+	overflow: hidden;
+	border-radius: var(--adr-radius-md);
+	background: var(--adr-coral);
+	color: var(--adr-canvas);
+	transition:
+		transform var(--adr-duration) var(--adr-ease-out),
+		box-shadow var(--adr-duration) var(--adr-ease-out);
+}
+
+@media (hover: hover) {
+	.adr-instrument:hover {
+		transform: translateY(-2px);
+		box-shadow: 0 10px 30px oklch(0.2 0.018 35 / 0.12);
+	}
+}
+
+.adr-instrument__bar,
+.adr-instrument__footer {
+	display: flex;
+	justify-content: space-between;
+	padding: 0.875rem 1rem;
+	border-color: oklch(1 0 0 / 0.42);
+	color: var(--adr-canvas);
+	font-size: 0.75rem;
+	font-weight: 680;
+	line-height: 1.25;
+}
+
+.adr-instrument__bar {
+	border-block-end: 1px solid oklch(1 0 0 / 0.42);
+}
+
+.adr-instrument__footer {
+	border-block-start: 1px solid oklch(1 0 0 / 0.42);
+}
+
+.adr-instrument__body {
+	position: relative;
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(13rem, 0.82fr);
+	flex: 1;
+	align-items: center;
+	min-height: 32rem;
+	padding: clamp(1.5rem, 4vw, 3.5rem);
+}
+
+.adr-record {
+	position: relative;
+	z-index: 2;
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+	align-self: center;
+	padding: clamp(1.25rem, 3vw, 2rem);
+	border: 1px solid oklch(1 0 0 / 0.58);
+	border-radius: var(--adr-radius-sm);
+	background: oklch(0.47 0.16 30 / 0.38);
+}
+
+.adr-record__heading {
+	display: flex;
+	gap: 0.75rem;
+	justify-content: space-between;
+	align-items: center;
+	font-size: 0.75rem;
+	font-weight: 700;
+}
+
+.adr-record__status {
+	display: inline-flex;
+	padding: 0.25rem 0.45rem;
+	border: 1px solid currentColor;
+	border-radius: 999px;
+}
+
+.adr-record strong {
+	max-width: 18ch;
+	color: var(--adr-canvas);
+	font-family: 'Anybody Variable', 'Arial Narrow', sans-serif;
+	font-size: clamp(1.35rem, 2.6vw, 2rem);
+	font-stretch: 112%;
+	font-weight: 680;
+	letter-spacing: -0.02em;
+	line-height: 1.08;
+	text-wrap: balance;
+}
+
+.adr-record__data {
+	display: flex;
+	flex-direction: column;
+	gap: 0.425rem;
+	font-family: var(--sl-font-mono);
+	font-size: clamp(0.675rem, 1vw, 0.8rem);
+	line-height: 1.45;
+}
+
+.adr-record__data b {
+	color: var(--adr-canvas);
+	font-weight: 500;
+}
+
+.adr-record__affects {
+	margin-block-start: 0.5rem;
+	color: var(--adr-canvas);
+}
+
+.adr-targets {
+	position: relative;
+	z-index: 2;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	padding-inline-start: clamp(2rem, 5vw, 4.5rem);
+}
+
+.adr-targets__label {
+	color: var(--adr-canvas);
+	font-size: 0.75rem;
+	font-weight: 680;
+}
+
+.adr-target {
+	display: flex;
+	flex-direction: column;
+	gap: 0.375rem;
+	padding: 0.875rem;
+	border: 1px solid oklch(1 0 0 / 0.58);
+	border-radius: var(--adr-radius-xs);
+	background: oklch(0.47 0.16 30 / 0.26);
+}
+
+.adr-target span {
+	font-size: 0.6875rem;
+	font-weight: 720;
+}
+
+.adr-target code {
+	overflow-wrap: anywhere;
+	color: var(--adr-canvas);
+	font-family: var(--sl-font-mono);
+	font-size: clamp(0.65rem, 1vw, 0.78rem);
+}
+
+.adr-instrument__routes {
+	position: absolute;
+	z-index: 1;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	overflow: visible;
+	pointer-events: none;
+}
+
+.adr-route {
+	fill: none;
+	stroke: oklch(1 0 0 / 0.88);
+	stroke-width: 2;
+	stroke-dasharray: 220;
+	stroke-dashoffset: 220;
+	animation: adr-route-draw 900ms var(--adr-ease-out) forwards;
+}
+
+.adr-route--second {
+	animation-delay: 180ms;
+}
+
+.adr-route-node {
+	fill: var(--adr-canvas);
+	stroke: var(--adr-coral-deep);
+	stroke-width: 3;
+	transform: scale(0);
+	transform-box: fill-box;
+	transform-origin: center;
+	animation: adr-node-set 300ms var(--adr-ease-out) forwards;
+}
+
+.adr-route-node--origin {
+	animation-delay: 120ms;
+}
+
+.adr-route-node--first {
+	animation-delay: 740ms;
+}
+
+.adr-route-node--second {
+	animation-delay: 920ms;
+}
+
+@keyframes adr-route-draw {
+	to {
+		stroke-dashoffset: 0;
+	}
+}
+
+@keyframes adr-node-set {
+	to {
+		transform: scale(1);
+	}
+}
+
+:root[data-has-hero] .sl-markdown-content {
+	max-width: none;
+}
+
+.adr-home {
+	width: 100%;
+	color: var(--adr-text);
+}
+
+.adr-home > section {
+	margin: 0;
+}
+
+.adr-status-band {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	border-block-end: 1px solid var(--adr-line);
+}
+
+.adr-status-band__item {
+	display: flex;
+	gap: 0.875rem;
+	align-items: center;
+	min-width: 0;
+	padding: 1.125rem clamp(1rem, 3vw, 2.25rem);
+	border-inline-end: 1px solid var(--adr-line);
+}
+
+.adr-status-band__item:last-child {
+	border-inline-end: 0;
+}
+
+.adr-status-band__item p {
+	margin: 0;
+	color: var(--adr-text-muted);
+	font-size: 0.875rem;
+	line-height: 1.35;
+}
+
+.adr-home__section {
+	padding: clamp(4.5rem, 10vw, 9rem) clamp(1.25rem, 7vw, 8rem);
+}
+
+.adr-home__section + .adr-home__section {
+	border-block-start: 1px solid var(--adr-line);
+}
+
+.adr-thesis {
+	display: grid;
+	grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
+	gap: clamp(3rem, 9vw, 9rem);
+	align-items: end;
+}
+
+.adr-thesis h2 {
+	max-width: 13ch;
+	margin: 0;
+	font-size: clamp(2.75rem, 6.5vw, 5.5rem);
+	font-stretch: 118%;
+	font-weight: 720;
+	letter-spacing: -0.035em;
+	line-height: 0.96;
+}
+
+.adr-thesis__copy {
+	max-width: 36rem;
+}
+
+.adr-thesis__copy p {
+	margin: 0;
+	color: var(--adr-text-muted);
+	font-size: clamp(1.05rem, 1.5vw, 1.25rem);
+	line-height: 1.6;
+}
+
+.adr-thesis__copy p + p {
+	margin-block-start: 1.25rem;
+}
+
+.adr-thesis__copy strong {
+	color: var(--adr-text);
+	font-weight: 720;
+}
+
+.adr-section-heading {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.55fr);
+	gap: 2rem;
+	align-items: end;
+	margin-block-end: clamp(2.5rem, 6vw, 5rem);
+}
+
+.adr-section-heading h2 {
+	max-width: 14ch;
+	margin: 0;
+	font-size: clamp(2.5rem, 5vw, 4.5rem);
+	font-stretch: 114%;
+	font-weight: 700;
+	letter-spacing: -0.03em;
+	line-height: 0.98;
+}
+
+.adr-section-heading p {
+	max-width: 34rem;
+	margin: 0;
+	color: var(--adr-text-muted);
+	font-size: 1.05rem;
+	line-height: 1.55;
+}
+
+.adr-capabilities {
+	margin: 0;
+	padding: 0;
+	border-block-end: 1px solid var(--adr-line);
+	list-style: none;
+}
+
+.adr-capability {
+	display: grid;
+	grid-template-columns: minmax(9rem, 0.55fr) minmax(13rem, 0.8fr) minmax(18rem, 1.3fr);
+	gap: clamp(1.25rem, 4vw, 4rem);
+	align-items: start;
+	padding: clamp(1.25rem, 2.5vw, 2rem) 0;
+	border-block-start: 1px solid var(--adr-line);
+}
+
+.adr-capability__command {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	align-items: flex-start;
+}
+
+.adr-capability code,
+.adr-flow code,
+.adr-roadmap code {
+	padding: 0;
+	border: 0;
+	background: transparent;
+	color: var(--adr-coral-deep);
+	font-family: var(--sl-font-mono);
+	font-size: 0.8125rem;
+	font-weight: 560;
+}
+
+:root[data-theme='dark'] :is(.adr-capability, .adr-flow, .adr-roadmap) code {
+	color: var(--sl-color-text-accent);
+}
+
+.adr-capability h3 {
+	margin: 0;
+	font-size: clamp(1.25rem, 2vw, 1.65rem);
+	font-stretch: 110%;
+	line-height: 1.12;
+}
+
+.adr-capability p {
+	max-width: 42rem;
+	margin: 0;
+	color: var(--adr-text-muted);
+	line-height: 1.55;
+}
+
+.adr-capability > p:empty,
+.adr-roadmap__item > p:empty {
+	display: none;
+}
+
+.adr-flow {
+	background: var(--adr-panel);
+}
+
+.adr-flow__steps {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	counter-reset: adr-flow;
+}
+
+.adr-flow__steps li {
+	position: relative;
+	min-width: 0;
+	padding: clamp(1.25rem, 3vw, 2.25rem);
+	border: 1px solid var(--adr-line);
+	border-inline-end: 0;
+	counter-increment: adr-flow;
+}
+
+.adr-flow__steps li:last-child {
+	border-inline-end: 1px solid var(--adr-line);
+}
+
+.adr-flow__steps li::before {
+	content: counter(adr-flow);
+	display: grid;
+	width: 2rem;
+	height: 2rem;
+	margin-block-end: 3rem;
+	place-items: center;
+	border-radius: 50%;
+	background: var(--adr-text);
+	color: var(--adr-bg);
+	font-size: 0.75rem;
+	font-weight: 720;
+}
+
+.adr-flow__steps li:not(:last-child)::after {
+	content: '→';
+	position: absolute;
+	z-index: 2;
+	inset-block-start: 2rem;
+	inset-inline-end: -0.72rem;
+	display: grid;
+	width: 1.4rem;
+	height: 1.4rem;
+	place-items: center;
+	border-radius: 50%;
+	background: var(--adr-coral);
+	color: var(--adr-canvas);
+	font-size: 0.75rem;
+}
+
+.adr-flow__steps h3 {
+	margin: 0 0 0.75rem;
+	font-size: clamp(1.25rem, 2vw, 1.75rem);
+	font-stretch: 110%;
+	line-height: 1.1;
+}
+
+.adr-flow__steps p {
+	margin: 0;
+	color: var(--adr-text-muted);
+	line-height: 1.55;
+}
+
+.adr-roadmap {
+	background: var(--adr-coral);
+	color: var(--adr-canvas);
+}
+
+.adr-roadmap .adr-section-heading h2,
+.adr-roadmap .adr-section-heading p {
+	color: var(--adr-canvas);
+}
+
+.adr-roadmap .adr-section-heading p {
+	color: var(--adr-canvas);
+}
+
+.adr-roadmap__list {
+	margin: 0;
+	padding: 0;
+	border-block-end: 1px solid oklch(1 0 0 / 0.48);
+	list-style: none;
+}
+
+.adr-roadmap__item {
+	display: grid;
+	grid-template-columns: minmax(10rem, 0.6fr) minmax(13rem, 0.8fr) minmax(18rem, 1.3fr);
+	gap: clamp(1.25rem, 4vw, 4rem);
+	align-items: baseline;
+	padding: clamp(1.25rem, 2.5vw, 2rem) 0;
+	border-block-start: 1px solid oklch(1 0 0 / 0.48);
+}
+
+.adr-roadmap__item .adr-status {
+	color: var(--adr-canvas);
+}
+
+.adr-roadmap__item h3 {
+	margin: 0;
+	color: var(--adr-canvas);
+	font-size: clamp(1.25rem, 2vw, 1.65rem);
+	font-stretch: 110%;
+}
+
+.adr-roadmap__item p {
+	margin: 0;
+	color: var(--adr-canvas);
+	line-height: 1.55;
+}
+
+.adr-roadmap code {
+	color: var(--adr-canvas);
+}
+
+.adr-closing {
+	display: grid;
+	grid-template-columns: minmax(0, 1.1fr) minmax(19rem, 0.9fr);
+	gap: clamp(3rem, 9vw, 9rem);
+	align-items: end;
+}
+
+.adr-closing blockquote {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	color: var(--adr-text);
+	font-family: 'Anybody Variable', 'Arial Narrow', sans-serif;
+	font-size: clamp(2.6rem, 5.8vw, 5rem);
+	font-stretch: 118%;
+	font-style: normal;
+	font-weight: 720;
+	letter-spacing: -0.035em;
+	line-height: 0.98;
+}
+
+.adr-closing__action {
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+	align-items: flex-start;
+}
+
+.adr-closing__action p {
+	margin: 0;
+	color: var(--adr-text-muted);
+	font-size: 1.05rem;
+	line-height: 1.55;
+}
+
+.sl-markdown-content:not(:has(.adr-home)) {
+	font-size: 1.03125rem;
+	line-height: 1.7;
+}
+
+.sl-markdown-content:not(:has(.adr-home)) > :where(p, ul, ol, blockquote) {
+	max-width: 70ch;
+}
+
+.sl-markdown-content:not(:has(.adr-home)) h1,
+.sl-markdown-content:not(:has(.adr-home)) h2,
+.sl-markdown-content:not(:has(.adr-home)) h3 {
+	font-stretch: 110%;
+}
+
+.sl-markdown-content:not(:has(.adr-home)) h2 {
+	margin-block-start: 3.5rem;
+	font-size: clamp(1.9rem, 3vw, 2.65rem);
+}
+
+.sl-markdown-content:not(:has(.adr-home)) h3 {
+	font-size: clamp(1.35rem, 2vw, 1.75rem);
+}
+
+.sl-markdown-content a:not(.sl-link-card, .adr-button) {
+	color: var(--adr-link);
+	font-weight: 650;
+	text-decoration-thickness: 0.08em;
+}
+
+.sl-markdown-content :not(pre) > code {
+	border: 1px solid var(--adr-line);
+	border-radius: var(--adr-radius-xs);
+	background: var(--adr-panel);
+	color: var(--adr-text);
+}
+
+.sl-heading-wrapper code {
+	border: 0;
+	background: transparent;
+	color: var(--adr-coral-deep);
+	font-size: 0.78em;
+	white-space: nowrap;
+}
+
+:root[data-theme='dark'] .sl-heading-wrapper code {
+	color: var(--sl-color-text-accent);
+}
+
+.expressive-code {
+	--ec-brdRad: var(--adr-radius-sm);
+	--ec-brdCol: var(--adr-line);
+}
+
+.starlight-aside {
+	border: 1px solid var(--adr-line);
+	border-inline-start: 1px solid var(--adr-line);
+	border-radius: var(--adr-radius-sm);
+	background: var(--adr-panel);
+	box-shadow: none;
+}
+
+.starlight-aside__title {
+	font-family: 'Anybody Variable', 'Arial Narrow', sans-serif;
+	font-stretch: 108%;
+	font-weight: 700;
+	letter-spacing: -0.01em;
+}
+
+.sl-link-card {
+	border: 1px solid var(--adr-line);
+	border-radius: var(--adr-radius-sm);
+	background: var(--adr-bg);
+	box-shadow: none;
+	transition:
+		border-color var(--adr-duration) var(--adr-ease-out),
+		transform var(--adr-duration) var(--adr-ease-out);
+}
+
+.sl-link-card:hover {
+	border-color: var(--adr-text);
+	transform: translateY(-1px);
+}
+
+table {
+	border-collapse: collapse;
+	border-block: 1px solid var(--adr-line);
+}
+
+th {
+	color: var(--adr-text);
+	font-family: 'Anybody Variable', 'Arial Narrow', sans-serif;
+	font-stretch: 108%;
+	font-weight: 680;
+}
+
+th,
+td {
+	border-color: var(--adr-line);
+}
+
+tbody tr:nth-child(even) {
+	background: var(--adr-panel);
+}
+
+@media (max-width: 72rem) {
+	.adr-hero {
+		grid-template-columns: minmax(0, 0.9fr) minmax(27rem, 1.1fr);
+	}
+
+	.adr-hero__copy {
+		padding-inline: clamp(1.5rem, 4vw, 4rem);
+	}
+
+	.adr-instrument__body {
+		min-height: 28rem;
+		padding: 1.5rem;
+	}
+}
+
+@media (max-width: 60rem) {
+	.adr-hero {
+		grid-template-columns: 1fr;
+		min-height: auto;
+	}
+
+	.adr-hero__copy {
+		padding-block: clamp(4rem, 10vw, 7rem);
+	}
+
+	.adr-hero h1 {
+		max-width: 12ch;
+		font-size: clamp(3.5rem, 10vw, 5.75rem);
+	}
+
+	.adr-instrument {
+		min-height: 34rem;
+		height: auto;
+		max-height: none;
+		margin-block-start: 0;
+	}
+
+	.adr-thesis,
+	.adr-section-heading,
+	.adr-closing {
+		grid-template-columns: 1fr;
+	}
+
+	.adr-section-heading p {
+		max-width: 44rem;
+	}
+}
+
+@media (max-width: 48rem) {
+	.adr-status-band {
+		grid-template-columns: 1fr;
+	}
+
+	.adr-status-band__item {
+		border-inline-end: 0;
+		border-block-end: 1px solid var(--adr-line);
+	}
+
+	.adr-status-band__item:last-child {
+		border-block-end: 0;
+	}
+
+	.adr-capability,
+	.adr-roadmap__item {
+		grid-template-columns: 1fr;
+		gap: 0.75rem;
+	}
+
+	.adr-flow__steps {
+		grid-template-columns: 1fr;
+	}
+
+	.adr-flow__steps li {
+		border-block-end: 0;
+		border-inline-end: 1px solid var(--adr-line);
+	}
+
+	.adr-flow__steps li:last-child {
+		border-block-end: 1px solid var(--adr-line);
+	}
+
+	.adr-flow__steps li:not(:last-child)::after {
+		content: '↓';
+		inset-block-start: auto;
+		inset-block-end: -0.72rem;
+		inset-inline-end: 50%;
+		transform: translateX(50%);
+	}
+
+	.adr-flow__steps li::before {
+		margin-block-end: 2rem;
+	}
+}
+
+@media (max-width: 40rem) {
+	:root {
+		--sl-content-pad-x: 1rem;
+	}
+
+	.adr-hero__copy {
+		padding: 3.5rem 1.25rem;
+	}
+
+	.adr-hero__meta {
+		align-items: flex-start;
+		flex-direction: column;
+		margin-block-end: 2.5rem;
+	}
+
+	.adr-hero h1 {
+		max-width: 100%;
+		font-size: clamp(3rem, 15vw, 4.35rem);
+		overflow-wrap: normal;
+	}
+
+	.adr-hero__actions {
+		flex-direction: column;
+	}
+
+	.adr-button {
+		width: 100%;
+	}
+
+	.adr-instrument {
+		min-height: 0;
+		width: auto;
+		margin: 0.75rem;
+	}
+
+	.adr-instrument__bar,
+	.adr-instrument__footer {
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.adr-instrument__body {
+		grid-template-columns: 1fr;
+		gap: 2.75rem;
+		min-height: 0;
+		padding: 1rem;
+	}
+
+	.adr-record strong {
+		max-width: 21ch;
+	}
+
+	.adr-targets {
+		padding-inline-start: 0;
+	}
+
+	.adr-instrument__routes {
+		display: none;
+	}
+
+	.adr-targets__label::after {
+		content: ' ↓';
+	}
+
+	.adr-home__section {
+		padding: 4rem 1.25rem;
+	}
+
+	.adr-thesis h2,
+	.adr-section-heading h2,
+	.adr-closing blockquote {
+		font-size: clamp(2.35rem, 12vw, 3.6rem);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	html {
+		scroll-behavior: auto;
+	}
+
+	*,
+	*::before,
+	*::after {
+		scroll-behavior: auto;
+		transition-duration: 0.01ms;
+		animation-duration: 0.01ms;
+		animation-iteration-count: 1;
+	}
+
+	.adr-route {
+		stroke-dashoffset: 0;
+	}
+
+	.adr-route-node {
+		transform: scale(1);
+	}
+}


### PR DESCRIPTION
## Summary
- establish `PRODUCT.md` and `DESIGN.md` around the “Decision Instrument” brand direction
- replace the default Starlight splash page with a custom proof-led hero, animated `affects` map, capability matrix, roadmap, and human-control narrative
- add local variable fonts, custom theming, dark mode, responsive layouts, reduced-motion behavior, refined documentation styles, and a new favicon
- configure Impeccable design and live-mode context for future UI work

## Validation
- `cd site && bun run build`
- `cd site && bun run check:schema`
- production Lighthouse desktop: 100 Accessibility, Best Practices, SEO, and Agentic Browsing
- production Lighthouse mobile: 100 Accessibility, Best Practices, and SEO