### PR TITLE
Prepare adrkit v0.1.0 distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: bun run typecheck
       - name: Build
         run: bun run build
+      - name: Verify publishable package tarballs
+        run: bun run release:pack -- --skip-build --skip-smoke-install
       - name: Lint
         run: bun run lint
       - name: Test (includes resolution-is-pure)
@@ -57,8 +59,12 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Build
         run: bun run build
+      - name: Pack and install publishable packages
+        run: bun run release:pack -- --skip-build
       - name: Smoke test built Node artifacts (core, evaluator, CLI incl. offline adr evaluate, Action bundle)
         run: node scripts/smoke-node.mjs
+      - name: Smoke test installed npm tarballs
+        run: node .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
 
   self-dogfood:
     # Run the CI surface against the project that ships it: adr check on the PR's

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.repository == 'mbeacom/adrkit'
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Set up Node for npm Trusted Publishing
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Require the release commit on main
+        run: |
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Build
+        run: bun run build
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Test
+        run: bun test
+
+      - name: Verify generated artifacts and dependency boundaries
+        run: |
+          bun run schema:emit
+          git diff --exit-code schema/adr.schema.json packages/ci/dist
+          bun run check:deps
+          bun run adr lint
+
+      - name: Pack release artifacts
+        run: bun run release:pack -- --tag "$GITHUB_REF_NAME" --skip-build
+
+      - name: Smoke installed tarballs on Node 22
+        run: bunx --package node@22 node .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
+
+      - name: Smoke installed tarballs on Node 24
+        run: node .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
+
+      - name: Smoke installed tarballs on Bun
+        run: bun .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
+
+      - name: Publish npm packages with provenance
+        run: bun run release:publish
+        env:
+          # Used only to bootstrap packages that do not yet exist. Once npm
+          # Trusted Publishers are configured, remove this environment secret.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "GitHub release $GITHUB_REF_NAME already exists"
+          else
+            gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes
+          fi
+
+      - name: Update the major Action tag
+        run: bun run release:action-tag -- "$GITHUB_REF_NAME"

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,9 @@ vite.config.ts.timestamp-*
 # Test scratch data
 .test-output/
 
+# Reproducible npm release tarballs and installed-package smoke project
+.release/
+
 # The @adrkit/ci GitHub Action ships a committed, self-contained bundle (a JS
 # Action runs directly from the referenced repo — GitHub does not install deps).
 # Keep it tracked despite the blanket `dist` ignore above (ADR-0007/R10).

--- a/README.md
+++ b/README.md
@@ -86,6 +86,46 @@ answer where the next decision is actually being made.
 
 It never approves anything. It routes, and humans decide.
 
+## Install
+
+The CLI is published as `@adrkit/cli` and exposes the `adr` binary:
+
+```sh
+bun add --dev @adrkit/cli
+bunx adr lint
+```
+
+For one-off use:
+
+```sh
+bunx @adrkit/cli explain src/payments/api.ts
+```
+
+The pure library surfaces are independently installable:
+
+```sh
+bun add @adrkit/core @adrkit/evaluator
+```
+
+Published artifacts are ESM and require Node.js 22 or newer. Bun remains the
+project's development package manager and test/build runtime.
+
+Use the GitHub Action from its moving major tag, or pin the immutable release
+tag/commit for maximum reproducibility:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+
+steps:
+  - uses: actions/checkout@v4
+  - uses: mbeacom/adrkit/packages/ci@v0
+```
+
+The npm packages and `v0` Action tag are created by the first `v0.1.0` release.
+Until then, source checkouts can run the CLI with `bun run adr`.
+
 ## Design commitments
 
 These are enforced, not aspirational. Each links to the record that decided it.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,91 @@
+# Releasing adrkit
+
+adrkit distributes three public npm packages and one repository-backed GitHub
+Action:
+
+| Artifact | Distribution |
+|---|---|
+| `@adrkit/core` | npm |
+| `@adrkit/evaluator` | npm |
+| `@adrkit/cli` (`adr`) | npm |
+| `packages/ci/action.yml` | Git tag (`v0.1.0`, moving `v0`) |
+
+`@adrkit/ci` stays private because GitHub executes the committed Action bundle
+directly from the referenced repository ref.
+
+## Release guarantees
+
+- All public package versions are identical.
+- The tag is exactly `v<package version>`.
+- Packages publish in dependency order: core, evaluator, CLI.
+- Bun 1.3.14 builds and packs the artifacts.
+- Packed manifests contain no `workspace:` protocols.
+- Tarballs include compiled ESM, declarations, README, LICENSE, and NOTICE.
+- Installed tarballs run on Node.js 22 and 24 before publication.
+- npm Trusted Publishing supplies short-lived OIDC authentication and automatic
+  provenance. npm CLI 11.5.1 is used only as the registry transport because Bun
+  1.3.14 does not implement npm's OIDC exchange.
+- A rerun skips an already-published package only when its registry integrity
+  exactly matches the local tarball.
+- The GitHub release and moving major Action tag are created only after every
+  npm package succeeds.
+
+## Local release simulation
+
+From a clean checkout:
+
+```sh
+bun install --frozen-lockfile
+bun run release:pack -- --tag v0.1.0
+bunx --package node@22 node .release/smoke/smoke.mjs "$PWD"
+bunx --package node@24 node .release/smoke/smoke.mjs "$PWD"
+bun run release:publish -- --dry-run
+```
+
+The generated tarballs and manifest live under `.release/npm/` and are ignored
+by git.
+
+## One-time npm bootstrap
+
+The npm scope and packages must exist before Trusted Publishers can be attached.
+For the first release only:
+
+1. Create or verify ownership of the public npm `@adrkit` organization/scope.
+2. Create a protected GitHub environment named `npm`; require a maintainer
+   approval for deployments to it.
+3. Create a short-lived granular npm token that can create the three packages,
+   add it as the `npm` environment secret `NPM_TOKEN`, and retain 2FA on the
+   publishing account.
+4. Merge the release-ready change and push the initial version tag. The release
+   workflow uses the token only as a bootstrap fallback and still publishes
+   provenance:
+
+   ```sh
+   git tag -a v0.1.0 -m "adrkit v0.1.0"
+   git push origin v0.1.0
+   ```
+
+5. In each package's npm settings, configure the GitHub Actions Trusted
+   Publisher with:
+   - repository owner: `mbeacom`
+   - repository: `adrkit`
+   - workflow filename: `release.yml`
+   - environment: `npm`
+6. Delete the `NPM_TOKEN` environment secret. For maximum security, set each
+   package's publishing access to require 2FA and disallow tokens.
+
+All later releases are tokenless.
+
+## Subsequent releases
+
+1. Update the version in all three public package manifests. Update any
+   inter-package expectations and run `bun install` with stable Bun 1.3.14 when
+   the lockfile changes.
+2. Merge the version change only after CI passes.
+3. Create and push the matching annotated tag, such as `v0.2.0`.
+4. Approve the protected `npm` environment deployment.
+5. Confirm the workflow published all packages, created the immutable GitHub
+   release, and moved `v0` to the released commit.
+
+Never move an immutable `vX.Y.Z` tag. The release workflow may force-update only
+the moving major Action tag (`v0`, later `v1`, and so on).

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Decision memory for human and agent-authored plans — machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,
+  "packageManager": "bun@1.3.14",
   "license": "Apache-2.0",
   "author": "Mark Beacom (@mbeacom)",
   "homepage": "https://github.com/mbeacom/adrkit#readme",
@@ -29,7 +30,10 @@
     "lint": "bun run --filter='*' lint",
     "schema:emit": "bun run --filter='@adrkit/core' schema:emit",
     "check:deps": "bun run scripts/check-deps.ts",
-    "adr": "bun packages/cli/src/index.ts"
+    "adr": "bun packages/cli/src/index.ts",
+    "release:pack": "bun scripts/release-pack.ts",
+    "release:publish": "bun scripts/release-publish.ts",
+    "release:action-tag": "bun scripts/update-action-tag.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,23 @@
+# @adrkit/cli
+
+Git-native architecture decision record tooling from adrkit.
+
+```sh
+bun add --dev @adrkit/cli
+bunx adr lint
+```
+
+For one-off use:
+
+```sh
+bunx @adrkit/cli lint
+```
+
+The `adr` binary includes `new`, `lint`, `graph`, `explain`, `check`,
+`migrate --from madr`, and the offline deterministic `evaluate` command.
+
+The published ESM CLI runs on Node.js 22 or newer.
+
+Documentation: <https://adrkit.dev>
+
+License: Apache-2.0

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,8 +1,30 @@
 {
   "name": "@adrkit/cli",
   "version": "0.1.0",
+  "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",
+  "homepage": "https://adrkit.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mbeacom/adrkit.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/mbeacom/adrkit/issues"
+  },
+  "keywords": [
+    "adr",
+    "architecture-decision-records",
+    "cli",
+    "governance"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "adr": "./dist/index.js"
   },
@@ -16,8 +38,9 @@
   },
   "scripts": {
     "adr": "bun ./src/index.ts",
-    "build": "rm -rf dist && bun build ./src/index.ts --target=node --outdir=dist --packages=external && tsc --project tsconfig.build.json && bun ../../scripts/normalize-dts-imports.ts dist && chmod +x dist/index.js",
+    "build": "rm -rf dist && bun build ./src/index.ts --target=node --outdir=dist --packages=external && tsc --project tsconfig.build.json && bun ../../scripts/normalize-dts-imports.ts dist && cp ../../LICENSE ../../NOTICE dist/ && chmod +x dist/index.js",
     "lint": "bun run typecheck",
+    "prepack": "bun run build",
     "typecheck": "tsc --noEmit --customConditions bun --project ../../tsconfig.json"
   },
   "dependencies": {
@@ -28,6 +51,8 @@
     "@types/bun": "latest"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "src"
   ]
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 
 import { parseArgs, type ParseArgsConfig } from 'node:util';
-import { fileURLToPath } from 'node:url';
-import { existsSync, realpathSync } from 'node:fs';
 import {
   buildAdrGraph,
   checkChanges,
@@ -19,6 +17,7 @@ import {
   type Finding,
 } from '@adrkit/core';
 import { evaluate } from './evaluate.ts';
+import { isMainModule } from './main-module.ts';
 
 function writeStdout(text: string): void {
   process.stdout.write(text);
@@ -403,11 +402,6 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
     writeStderr(`${error instanceof Error ? error.message : String(error)}\n`);
     return 1;
   }
-}
-
-export function isMainModule(moduleUrl: string, argvPath: string | undefined): boolean {
-  if (!argvPath || !existsSync(argvPath)) return false;
-  return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvPath);
 }
 
 if (isMainModule(import.meta.url, process.argv[1])) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { parseArgs, type ParseArgsConfig } from 'node:util';
 import { fileURLToPath } from 'node:url';
+import { existsSync, realpathSync } from 'node:fs';
 import {
   buildAdrGraph,
   checkChanges,
@@ -404,6 +405,11 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   }
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+export function isMainModule(moduleUrl: string, argvPath: string | undefined): boolean {
+  if (!argvPath || !existsSync(argvPath)) return false;
+  return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvPath);
+}
+
+if (isMainModule(import.meta.url, process.argv[1])) {
   process.exitCode = await main();
 }

--- a/packages/cli/src/main-module.ts
+++ b/packages/cli/src/main-module.ts
@@ -1,0 +1,7 @@
+import { existsSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export function isMainModule(moduleUrl: string, argvPath: string | undefined): boolean {
+  if (!argvPath || !existsSync(argvPath)) return false;
+  return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvPath);
+}

--- a/packages/cli/test/main-module.test.ts
+++ b/packages/cli/test/main-module.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdir, symlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { cleanupTestDir, resetTestDir, writeText } from '../../core/test/helpers.ts';
+import { isMainModule } from '../src/index.ts';
+
+const DIR_NAME = 'cli-main-module';
+
+afterEach(async () => {
+  await cleanupTestDir(DIR_NAME);
+});
+
+describe('CLI main-module detection', () => {
+  test('recognizes an installed package-manager bin symlink', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const target = join(root, 'dist', 'index.js');
+    const bin = join(root, 'node_modules', '.bin', 'adr');
+    await writeText(target, '#!/usr/bin/env node\n');
+    await mkdir(join(root, 'node_modules', '.bin'), { recursive: true });
+    await symlink(target, bin);
+
+    expect(isMainModule(pathToFileURL(target).href, bin)).toBe(true);
+  });
+
+  test('rejects a missing argv path', () => {
+    expect(isMainModule(import.meta.url, undefined)).toBe(false);
+  });
+});

--- a/packages/cli/test/main-module.test.ts
+++ b/packages/cli/test/main-module.test.ts
@@ -3,7 +3,7 @@ import { mkdir, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { cleanupTestDir, resetTestDir, writeText } from '../../core/test/helpers.ts';
-import { isMainModule } from '../src/index.ts';
+import { isMainModule } from '../src/main-module.ts';
 
 const DIR_NAME = 'cli-main-module';
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,22 @@
+# @adrkit/core
+
+Pure, deterministic building blocks for working with adrkit architecture
+decision records: parsing, schema validation, corpus invariants, MADR migration,
+graph construction, and `affects` resolution.
+
+```sh
+bun add @adrkit/core
+```
+
+```ts
+import { lintCorpus } from '@adrkit/core';
+
+const findings = lintCorpus(records);
+```
+
+The published ESM artifacts run on Node.js 22 or newer. Development in the
+adrkit repository uses Bun.
+
+Documentation: <https://adrkit.dev>
+
+License: Apache-2.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,29 @@
 {
   "name": "@adrkit/core",
   "version": "0.1.0",
+  "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",
+  "homepage": "https://adrkit.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mbeacom/adrkit.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/mbeacom/adrkit/issues"
+  },
+  "keywords": [
+    "adr",
+    "architecture-decision-records",
+    "governance"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "bun": "./src/index.ts",
@@ -30,8 +51,9 @@
     }
   },
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts ./src/schema/index.ts ./src/schema/adr.schema.ts ./src/schema/emit.ts --target=node --outdir=dist --packages=external && tsc --project tsconfig.build.json && bun ../../scripts/normalize-dts-imports.ts dist",
+    "build": "rm -rf dist && bun build ./src/index.ts ./src/schema/index.ts ./src/schema/adr.schema.ts ./src/schema/emit.ts --target=node --outdir=dist --packages=external && tsc --project tsconfig.build.json && bun ../../scripts/normalize-dts-imports.ts dist && cp ../../LICENSE ../../NOTICE dist/",
     "lint": "bun run typecheck",
+    "prepack": "bun run build",
     "schema:emit": "bun ./src/schema/emit.cli.ts",
     "typecheck": "tsc --noEmit --customConditions bun --project ../../tsconfig.json"
   },
@@ -47,6 +69,8 @@
     "@types/semver": "^7"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "src"
   ]
 }

--- a/packages/evaluator/README.md
+++ b/packages/evaluator/README.md
@@ -1,0 +1,23 @@
+# @adrkit/evaluator
+
+The pure, deterministic Pass 0 evaluator for adrkit. It applies the fixed
+eleven-rule rubric to caller-supplied immutable inputs, produces canonical
+reports and schema-compatible patches, and routes proposals without approving
+or persisting them.
+
+```sh
+bun add @adrkit/evaluator
+```
+
+```ts
+import { evaluatePass0 } from '@adrkit/evaluator';
+
+const result = evaluatePass0(input);
+```
+
+No model, network, clock, filesystem traversal, or database is used by the
+library. The published ESM artifacts run on Node.js 22 or newer.
+
+Documentation: <https://adrkit.dev>
+
+License: Apache-2.0

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,8 +1,30 @@
 {
   "name": "@adrkit/evaluator",
   "version": "0.1.0",
+  "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",
+  "homepage": "https://adrkit.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mbeacom/adrkit.git",
+    "directory": "packages/evaluator"
+  },
+  "bugs": {
+    "url": "https://github.com/mbeacom/adrkit/issues"
+  },
+  "keywords": [
+    "adr",
+    "architecture-decision-records",
+    "governance",
+    "policy"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "bun": "./src/index.ts",
@@ -12,8 +34,9 @@
     }
   },
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --target=node --outdir=dist --packages=external && tsc --project tsconfig.build.json && bun ../../scripts/normalize-dts-imports.ts dist",
+    "build": "rm -rf dist && bun build ./src/index.ts --target=node --outdir=dist --packages=external && tsc --project tsconfig.build.json && bun ../../scripts/normalize-dts-imports.ts dist && cp ../../LICENSE ../../NOTICE dist/",
     "lint": "bun run typecheck",
+    "prepack": "bun run build",
     "typecheck": "tsc --noEmit --customConditions bun --project ../../tsconfig.json"
   },
   "dependencies": {
@@ -24,6 +47,8 @@
     "@types/bun": "latest"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "src"
   ]
 }

--- a/plan.md
+++ b/plan.md
@@ -29,7 +29,7 @@ sync.
 | 1 — Affects resolution | `specs/002-affects-resolution/` | landed (PR #6 merged) |
 | 2 — Migration | `specs/003-migration/` | landed (PR #7 merged) |
 | 3 — CI surface | `specs/004-ci-surface/` | landed (PR #12 merged) |
-| 4 — Deterministic evaluator | `specs/005-deterministic-evaluator/` | implementation in progress; Phase 3 T018 gate cleared |
+| 4 — Deterministic evaluator | `specs/005-deterministic-evaluator/` | landed (PR #14 merged) |
 | 5 — MCP server | _(unopened)_ | queued |
 
 Advance **scoping** (spec → plan → tasks) of the next phase is explicitly permitted

--- a/scripts/release-pack.test.ts
+++ b/scripts/release-pack.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  RELEASE_PACKAGES,
+  findWorkspaceProtocols,
+  validatePackedManifest,
+  validateSourceManifests,
+  type PackageManifest,
+} from './release-pack.ts';
+
+function sourceManifest(name: string, directory: string, version = '0.1.0'): PackageManifest {
+  return {
+    name,
+    version,
+    description: `${name} description`,
+    repository: {
+      type: 'git',
+      url: 'git+https://github.com/mbeacom/adrkit.git',
+      directory,
+    },
+    engines: { node: '>=22' },
+    publishConfig: { access: 'public' },
+    files: ['dist', 'README.md'],
+  };
+}
+
+describe('release package validation', () => {
+  test('accepts aligned public source manifests and matching tag', () => {
+    const manifests = new Map(
+      RELEASE_PACKAGES.map((definition) => [
+        definition.name,
+        sourceManifest(definition.name, definition.directory),
+      ]),
+    );
+    expect(validateSourceManifests(manifests, 'v0.1.0')).toBe('0.1.0');
+  });
+
+  test('rejects version drift before packing', () => {
+    const manifests = new Map(
+      RELEASE_PACKAGES.map((definition, index) => [
+        definition.name,
+        sourceManifest(definition.name, definition.directory, index === 2 ? '0.2.0' : '0.1.0'),
+      ]),
+    );
+    expect(() => validateSourceManifests(manifests)).toThrow('versions must match');
+  });
+
+  test('finds workspace protocols at any manifest depth', () => {
+    expect(
+      findWorkspaceProtocols({
+        dependencies: { '@adrkit/core': 'workspace:*' },
+        overrides: { nested: ['workspace:^'] },
+      }),
+    ).toEqual(['package.json.dependencies.@adrkit/core', 'package.json.overrides.nested[0]']);
+  });
+
+  test('requires packed workspace dependencies to resolve to the release version', () => {
+    const evaluator = RELEASE_PACKAGES[1]!;
+    expect(() =>
+      validatePackedManifest(
+        evaluator,
+        {
+          name: evaluator.name,
+          version: '0.1.0',
+          dependencies: { '@adrkit/core': '^0.1.0' },
+        },
+        '0.1.0',
+      ),
+    ).toThrow('must resolve @adrkit/core to 0.1.0');
+  });
+});

--- a/scripts/release-pack.ts
+++ b/scripts/release-pack.ts
@@ -129,7 +129,7 @@ export function validateSourceManifests(
     assert(manifest.private !== true, `${definition.name} must not be private`);
     assert(typeof manifest.description === 'string' && manifest.description.length > 0, `${definition.name} needs a description`);
     assert(manifest.repository?.url === REPOSITORY_URL, `${definition.name} repository URL must be ${REPOSITORY_URL}`);
-    assert(manifest.repository.directory === definition.directory, `${definition.name} repository directory is incorrect`);
+    assert(manifest.repository?.directory === definition.directory, `${definition.name} repository directory is incorrect`);
     assert(manifest.engines?.node === '>=22', `${definition.name} must require Node >=22`);
     assert(manifest.publishConfig?.access === 'public', `${definition.name} must publish with public access`);
     assert(manifest.files?.includes('dist'), `${definition.name} must publish dist`);

--- a/scripts/release-pack.ts
+++ b/scripts/release-pack.ts
@@ -1,0 +1,337 @@
+import { createHash } from 'node:crypto';
+import { mkdir, rm } from 'node:fs/promises';
+import { basename, join, relative, resolve } from 'node:path';
+
+const REPOSITORY_URL = 'git+https://github.com/mbeacom/adrkit.git';
+const RELEASE_ROOT = resolve(import.meta.dir, '..');
+const DEFAULT_OUTPUT_DIR = join(RELEASE_ROOT, '.release');
+
+export interface PackageManifest {
+  name?: string;
+  version?: string;
+  private?: boolean;
+  description?: string;
+  repository?: { type?: string; url?: string; directory?: string };
+  engines?: { node?: string };
+  publishConfig?: { access?: string };
+  dependencies?: Record<string, string>;
+  files?: string[];
+  bin?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+export interface ReleasePackageDefinition {
+  name: string;
+  directory: string;
+  expectedFiles: readonly string[];
+  workspaceDependencies: readonly string[];
+}
+
+export interface ReleaseArtifact {
+  name: string;
+  version: string;
+  tarball: string;
+  integrity: string;
+}
+
+export interface ReleaseManifest {
+  version: string;
+  artifacts: ReleaseArtifact[];
+}
+
+export const RELEASE_PACKAGES: readonly ReleasePackageDefinition[] = [
+  {
+    name: '@adrkit/core',
+    directory: 'packages/core',
+    expectedFiles: [
+      'README.md',
+      'dist/LICENSE',
+      'dist/NOTICE',
+      'dist/index.d.ts',
+      'dist/index.js',
+      'dist/schema/index.d.ts',
+      'dist/schema/index.js',
+      'package.json',
+      'src/index.ts',
+    ],
+    workspaceDependencies: [],
+  },
+  {
+    name: '@adrkit/evaluator',
+    directory: 'packages/evaluator',
+    expectedFiles: [
+      'README.md',
+      'dist/LICENSE',
+      'dist/NOTICE',
+      'dist/index.d.ts',
+      'dist/index.js',
+      'package.json',
+      'src/index.ts',
+    ],
+    workspaceDependencies: ['@adrkit/core'],
+  },
+  {
+    name: '@adrkit/cli',
+    directory: 'packages/cli',
+    expectedFiles: [
+      'README.md',
+      'dist/LICENSE',
+      'dist/NOTICE',
+      'dist/index.d.ts',
+      'dist/index.js',
+      'package.json',
+      'src/index.ts',
+    ],
+    workspaceDependencies: ['@adrkit/core', '@adrkit/evaluator'],
+  },
+] as const;
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await Bun.file(path).text()) as T;
+}
+
+async function run(command: readonly string[], cwd: string, label: string): Promise<string> {
+  const process = Bun.spawn([...command], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'inherit',
+    env: { ...Bun.env, FORCE_COLOR: '1' },
+  });
+  const output = await new Response(process.stdout).text();
+  const exitCode = await process.exited;
+  assert(exitCode === 0, `${label} failed with exit ${exitCode}`);
+  return output.trim();
+}
+
+export function findWorkspaceProtocols(value: unknown, path = 'package.json'): string[] {
+  if (typeof value === 'string') return value.startsWith('workspace:') ? [path] : [];
+  if (Array.isArray(value)) {
+    return value.flatMap((entry, index) => findWorkspaceProtocols(entry, `${path}[${index}]`));
+  }
+  if (!value || typeof value !== 'object') return [];
+  return Object.entries(value).flatMap(([key, entry]) => findWorkspaceProtocols(entry, `${path}.${key}`));
+}
+
+export function validateSourceManifests(
+  manifests: ReadonlyMap<string, PackageManifest>,
+  tag?: string,
+): string {
+  const versions = new Set<string>();
+  for (const definition of RELEASE_PACKAGES) {
+    const manifest = manifests.get(definition.name);
+    assert(manifest, `Missing source manifest for ${definition.name}`);
+    assert(manifest.name === definition.name, `Expected package name ${definition.name}`);
+    assert(typeof manifest.version === 'string' && manifest.version.length > 0, `${definition.name} needs a version`);
+    assert(manifest.private !== true, `${definition.name} must not be private`);
+    assert(typeof manifest.description === 'string' && manifest.description.length > 0, `${definition.name} needs a description`);
+    assert(manifest.repository?.url === REPOSITORY_URL, `${definition.name} repository URL must be ${REPOSITORY_URL}`);
+    assert(manifest.repository.directory === definition.directory, `${definition.name} repository directory is incorrect`);
+    assert(manifest.engines?.node === '>=22', `${definition.name} must require Node >=22`);
+    assert(manifest.publishConfig?.access === 'public', `${definition.name} must publish with public access`);
+    assert(manifest.files?.includes('dist'), `${definition.name} must publish dist`);
+    assert(manifest.files?.includes('README.md'), `${definition.name} must publish README.md`);
+    versions.add(manifest.version);
+  }
+  assert(versions.size === 1, `Release package versions must match: ${[...versions].join(', ')}`);
+  const [version] = versions;
+  assert(version, 'Release version is missing');
+  assert(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version), `Release version ${version} must be stable SemVer`);
+  if (tag) assert(tag === `v${version}`, `Release tag ${tag} must match package version v${version}`);
+  return version;
+}
+
+export function validatePackedManifest(
+  definition: ReleasePackageDefinition,
+  manifest: PackageManifest,
+  version: string,
+): void {
+  assert(manifest.name === definition.name, `Packed package name mismatch for ${definition.name}`);
+  assert(manifest.version === version, `Packed version mismatch for ${definition.name}`);
+  const workspaceProtocols = findWorkspaceProtocols(manifest);
+  assert(
+    workspaceProtocols.length === 0,
+    `${definition.name} leaked workspace protocols at ${workspaceProtocols.join(', ')}`,
+  );
+  for (const dependency of definition.workspaceDependencies) {
+    assert(
+      manifest.dependencies?.[dependency] === version,
+      `${definition.name} must resolve ${dependency} to ${version}, got ${manifest.dependencies?.[dependency]}`,
+    );
+  }
+}
+
+function parseArguments(args: readonly string[]): {
+  outputDir: string;
+  skipBuild: boolean;
+  skipSmokeInstall: boolean;
+  tag?: string;
+} {
+  let outputDir = DEFAULT_OUTPUT_DIR;
+  let skipBuild = false;
+  let skipSmokeInstall = false;
+  let tag: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--skip-build') {
+      skipBuild = true;
+    } else if (argument === '--skip-smoke-install') {
+      skipSmokeInstall = true;
+    } else if (argument === '--tag') {
+      tag = args[index + 1];
+      assert(tag, '--tag requires a value');
+      index += 1;
+    } else if (argument === '--output') {
+      const value = args[index + 1];
+      assert(value, '--output requires a value');
+      outputDir = resolve(RELEASE_ROOT, value);
+      index += 1;
+    } else {
+      throw new Error(`Unknown release-pack argument: ${argument}`);
+    }
+  }
+  return { outputDir, skipBuild, skipSmokeInstall, tag };
+}
+
+async function tarEntries(tarball: string): Promise<string[]> {
+  const output = await run(['tar', '-tzf', tarball], RELEASE_ROOT, `listing ${basename(tarball)}`);
+  return output
+    .split('\n')
+    .map((entry) => entry.replace(/^package\//, '').replace(/\/$/, ''))
+    .filter(Boolean);
+}
+
+async function packedPackageJson(tarball: string): Promise<PackageManifest> {
+  const output = await run(
+    ['tar', '-xOzf', tarball, 'package/package.json'],
+    RELEASE_ROOT,
+    `reading ${basename(tarball)} package.json`,
+  );
+  return JSON.parse(output) as PackageManifest;
+}
+
+async function sha512Integrity(path: string): Promise<string> {
+  const bytes = await Bun.file(path).arrayBuffer();
+  return `sha512-${createHash('sha512').update(new Uint8Array(bytes)).digest('base64')}`;
+}
+
+async function prepareSmokeProject(outputDir: string, artifacts: readonly ReleaseArtifact[]): Promise<void> {
+  const smokeDir = join(outputDir, 'smoke');
+  await mkdir(smokeDir, { recursive: true });
+  const dependencies = Object.fromEntries(
+    artifacts.map((artifact) => [artifact.name, `file:../npm/${artifact.tarball}`]),
+  );
+  await Bun.write(
+    join(smokeDir, 'package.json'),
+    `${JSON.stringify(
+      { name: 'adrkit-release-smoke', private: true, type: 'module', dependencies, overrides: dependencies },
+      null,
+      2,
+    )}\n`,
+  );
+  await Bun.write(
+    join(smokeDir, 'smoke.mjs'),
+    `import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import * as core from '@adrkit/core';
+import * as cli from '@adrkit/cli';
+import * as evaluator from '@adrkit/evaluator';
+
+if (typeof core.lintCorpus !== 'function') throw new Error('Installed @adrkit/core is missing lintCorpus');
+if (typeof cli.main !== 'function') throw new Error('Installed @adrkit/cli is missing main');
+if (typeof evaluator.evaluatePass0 !== 'function') throw new Error('Installed @adrkit/evaluator is missing evaluatePass0');
+
+const repoRoot = process.argv[2];
+if (!repoRoot) throw new Error('Expected repository root argument');
+const bin = join(import.meta.dirname, 'node_modules', '.bin', process.platform === 'win32' ? 'adr.cmd' : 'adr');
+const lint = spawnSync(bin, ['lint', join(repoRoot, 'docs/adr')], { cwd: repoRoot, encoding: 'utf8' });
+if (lint.stdout) process.stdout.write(lint.stdout);
+if (lint.stderr) process.stderr.write(lint.stderr);
+if (lint.status !== 0) throw new Error(\`Installed adr lint failed with exit \${lint.status}\`);
+
+const evaluate = spawnSync(bin, [
+  'evaluate',
+  join(repoRoot, 'packages/evaluator/test/fixtures/proposal-0042.md'),
+  '--snapshot',
+  join(repoRoot, 'packages/evaluator/test/fixtures/snapshot.clean.json'),
+  '--date',
+  '2026-07-19',
+  '--json',
+], { cwd: repoRoot, encoding: 'utf8' });
+if (evaluate.stderr) process.stderr.write(evaluate.stderr);
+if (evaluate.status !== 0) throw new Error(\`Installed adr evaluate failed with exit \${evaluate.status}\`);
+const payload = JSON.parse(evaluate.stdout);
+if (payload.result?.report?.results?.length !== 11) throw new Error('Installed evaluator did not emit eleven rules');
+
+console.log(\`release-smoke: installed packages passed on \${process.version}\`);
+`,
+  );
+  await run([process.execPath, 'install', '--ignore-scripts'], smokeDir, 'installing release tarballs');
+}
+
+export async function packRelease(args = Bun.argv.slice(2)): Promise<ReleaseManifest> {
+  const options = parseArguments(args);
+  const npmDir = join(options.outputDir, 'npm');
+  await rm(options.outputDir, { recursive: true, force: true });
+  await mkdir(npmDir, { recursive: true });
+
+  const sourceManifests = new Map<string, PackageManifest>();
+  for (const definition of RELEASE_PACKAGES) {
+    sourceManifests.set(
+      definition.name,
+      await readJson<PackageManifest>(join(RELEASE_ROOT, definition.directory, 'package.json')),
+    );
+  }
+  const version = validateSourceManifests(sourceManifests, options.tag);
+
+  if (!options.skipBuild) {
+    await run([process.execPath, 'run', 'build'], RELEASE_ROOT, 'building release packages');
+  }
+
+  const artifacts: ReleaseArtifact[] = [];
+  for (const definition of RELEASE_PACKAGES) {
+    const filename = `${definition.name.slice(1).replace('/', '-')}-${version}.tgz`;
+    const packageDir = join(RELEASE_ROOT, definition.directory);
+    await run(
+      [
+        process.execPath,
+        'pm',
+        'pack',
+        '--ignore-scripts',
+        '--destination',
+        npmDir,
+      ],
+      packageDir,
+      `packing ${definition.name}`,
+    );
+    const tarball = join(npmDir, filename);
+    const entries = new Set(await tarEntries(tarball));
+    for (const expectedFile of definition.expectedFiles) {
+      assert(entries.has(expectedFile), `${definition.name} tarball is missing ${expectedFile}`);
+    }
+    const packedManifest = await packedPackageJson(tarball);
+    validatePackedManifest(definition, packedManifest, version);
+    if (definition.name === '@adrkit/cli') {
+      assert(packedManifest.bin?.adr === './dist/index.js', 'Packed CLI must expose the adr binary');
+    }
+    artifacts.push({
+      name: definition.name,
+      version,
+      tarball: relative(npmDir, tarball),
+      integrity: await sha512Integrity(tarball),
+    });
+  }
+
+  const manifest: ReleaseManifest = { version, artifacts };
+  await Bun.write(join(npmDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  if (!options.skipSmokeInstall) await prepareSmokeProject(options.outputDir, artifacts);
+  console.log(`release-pack: prepared ${artifacts.length} packages at v${version}`);
+  return manifest;
+}
+
+if (import.meta.main) {
+  await packRelease();
+}

--- a/scripts/release-publish.test.ts
+++ b/scripts/release-publish.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  existingIntegrity,
+  shouldPublishArtifact,
+} from './release-publish.ts';
+import type { ReleaseArtifact } from './release-pack.ts';
+
+const artifact: ReleaseArtifact = {
+  name: '@adrkit/core',
+  version: '0.1.0',
+  tarball: 'adrkit-core-0.1.0.tgz',
+  integrity: 'sha512-local',
+};
+
+function fetchResponse(status: number, body?: unknown): (url: string) => Promise<Response> {
+  return async () =>
+    new Response(body === undefined ? undefined : JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+}
+
+describe('release registry safety', () => {
+  test('treats a registry 404 as an unpublished artifact', async () => {
+    await expect(existingIntegrity(artifact, fetchResponse(404))).resolves.toBeUndefined();
+  });
+
+  test('rejects non-success registry responses', async () => {
+    await expect(existingIntegrity(artifact, fetchResponse(503))).rejects.toThrow(
+      'failed with 503',
+    );
+  });
+
+  test('rejects registry metadata without integrity', async () => {
+    await expect(existingIntegrity(artifact, fetchResponse(200, { dist: {} }))).rejects.toThrow(
+      'has no integrity',
+    );
+  });
+
+  test('returns the published registry integrity', async () => {
+    await expect(
+      existingIntegrity(artifact, fetchResponse(200, { dist: { integrity: artifact.integrity } })),
+    ).resolves.toBe(artifact.integrity);
+  });
+
+  test('publishes only absent artifacts and skips exact reruns', () => {
+    expect(shouldPublishArtifact(artifact, undefined)).toBe(true);
+    expect(shouldPublishArtifact(artifact, artifact.integrity)).toBe(false);
+  });
+
+  test('hard-fails when an existing version has different bytes', () => {
+    expect(() => shouldPublishArtifact(artifact, 'sha512-other')).toThrow(
+      'already exists with different integrity',
+    );
+  });
+});

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -21,9 +21,10 @@ async function existingIntegrity(artifact: ReleaseArtifact): Promise<string | un
   });
   if (response.status === 404) return undefined;
   assert(response.ok, `Registry lookup for ${artifact.name}@${artifact.version} failed with ${response.status}`);
-  const metadata = (await response.json()) as { dist?: { integrity?: string } };
-  assert(metadata.dist?.integrity, `Registry metadata for ${artifact.name}@${artifact.version} has no integrity`);
-  return metadata.dist.integrity;
+  const metadata = (await response.json()) as { dist?: { integrity?: string } } | null;
+  const integrity = metadata?.dist?.integrity;
+  assert(integrity, `Registry metadata for ${artifact.name}@${artifact.version} has no integrity`);
+  return integrity;
 }
 
 async function npmPublish(artifact: ReleaseArtifact, dryRun: boolean): Promise<void> {

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -5,6 +5,7 @@ const REPOSITORY_ROOT = resolve(import.meta.dir, '..');
 const RELEASE_DIR = join(REPOSITORY_ROOT, '.release', 'npm');
 const NPM_CLI_VERSION = '11.5.1';
 const REGISTRY = 'https://registry.npmjs.org';
+type RegistryFetch = (url: string) => Promise<Response>;
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
@@ -14,17 +15,30 @@ async function readManifest(): Promise<ReleaseManifest> {
   return JSON.parse(await Bun.file(join(RELEASE_DIR, 'manifest.json')).text()) as ReleaseManifest;
 }
 
-async function existingIntegrity(artifact: ReleaseArtifact): Promise<string | undefined> {
+export async function existingIntegrity(
+  artifact: ReleaseArtifact,
+  fetcher: RegistryFetch = fetch,
+): Promise<string | undefined> {
   const encodedName = encodeURIComponent(artifact.name);
-  const response = await fetch(`${REGISTRY}/${encodedName}/${artifact.version}`, {
-    headers: { accept: 'application/json' },
-  });
+  const response = await fetcher(`${REGISTRY}/${encodedName}/${artifact.version}`);
   if (response.status === 404) return undefined;
   assert(response.ok, `Registry lookup for ${artifact.name}@${artifact.version} failed with ${response.status}`);
   const metadata = (await response.json()) as { dist?: { integrity?: string } } | null;
   const integrity = metadata?.dist?.integrity;
   assert(integrity, `Registry metadata for ${artifact.name}@${artifact.version} has no integrity`);
   return integrity;
+}
+
+export function shouldPublishArtifact(
+  artifact: ReleaseArtifact,
+  registryIntegrity: string | undefined,
+): boolean {
+  if (!registryIntegrity) return true;
+  assert(
+    registryIntegrity === artifact.integrity,
+    `${artifact.name}@${artifact.version} already exists with different integrity`,
+  );
+  return false;
 }
 
 async function npmPublish(artifact: ReleaseArtifact, dryRun: boolean): Promise<void> {
@@ -70,11 +84,7 @@ export async function publishRelease(args = Bun.argv.slice(2)): Promise<void> {
   for (const artifact of manifest.artifacts) {
     if (!dryRun) {
       const integrity = await existingIntegrity(artifact);
-      if (integrity) {
-        assert(
-          integrity === artifact.integrity,
-          `${artifact.name}@${artifact.version} already exists with different integrity`,
-        );
+      if (!shouldPublishArtifact(artifact, integrity)) {
         console.log(`release-publish: ${artifact.name}@${artifact.version} already matches; skipping`);
         continue;
       }

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -1,0 +1,87 @@
+import { join, resolve } from 'node:path';
+import type { ReleaseArtifact, ReleaseManifest } from './release-pack.ts';
+
+const REPOSITORY_ROOT = resolve(import.meta.dir, '..');
+const RELEASE_DIR = join(REPOSITORY_ROOT, '.release', 'npm');
+const NPM_CLI_VERSION = '11.5.1';
+const REGISTRY = 'https://registry.npmjs.org';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+async function readManifest(): Promise<ReleaseManifest> {
+  return JSON.parse(await Bun.file(join(RELEASE_DIR, 'manifest.json')).text()) as ReleaseManifest;
+}
+
+async function existingIntegrity(artifact: ReleaseArtifact): Promise<string | undefined> {
+  const encodedName = encodeURIComponent(artifact.name);
+  const response = await fetch(`${REGISTRY}/${encodedName}/${artifact.version}`, {
+    headers: { accept: 'application/json' },
+  });
+  if (response.status === 404) return undefined;
+  assert(response.ok, `Registry lookup for ${artifact.name}@${artifact.version} failed with ${response.status}`);
+  const metadata = (await response.json()) as { dist?: { integrity?: string } };
+  assert(metadata.dist?.integrity, `Registry metadata for ${artifact.name}@${artifact.version} has no integrity`);
+  return metadata.dist.integrity;
+}
+
+async function npmPublish(artifact: ReleaseArtifact, dryRun: boolean): Promise<void> {
+  const bunx = Bun.which('bunx');
+  assert(bunx, 'bunx is required to run the OIDC-aware npm publishing client');
+  const command = [
+    bunx,
+    '--package',
+    `npm@${NPM_CLI_VERSION}`,
+    'npm',
+    'publish',
+    join(RELEASE_DIR, artifact.tarball),
+    '--access',
+    'public',
+  ];
+  if (dryRun) command.push('--dry-run');
+  else command.push('--provenance');
+  const process = Bun.spawn(command, {
+    cwd: REPOSITORY_ROOT,
+    stdout: 'inherit',
+    stderr: 'inherit',
+    env: Bun.env,
+  });
+  const exitCode = await process.exited;
+  assert(exitCode === 0, `Publishing ${artifact.name}@${artifact.version} failed with exit ${exitCode}`);
+}
+
+export async function publishRelease(args = Bun.argv.slice(2)): Promise<void> {
+  const unknownArgs = args.filter((argument) => argument !== '--dry-run');
+  assert(unknownArgs.length === 0, `Unknown release-publish arguments: ${unknownArgs.join(', ')}`);
+  const dryRun = args.includes('--dry-run');
+  const manifest = await readManifest();
+
+  if (!dryRun) {
+    assert(Bun.env.GITHUB_ACTIONS === 'true', 'Real publication is restricted to GitHub Actions');
+    assert(Bun.env.GITHUB_REF_TYPE === 'tag', 'Real publication requires a tag workflow');
+    assert(
+      Bun.env.GITHUB_REF_NAME === `v${manifest.version}`,
+      `Tag ${Bun.env.GITHUB_REF_NAME ?? '(missing)'} must match v${manifest.version}`,
+    );
+  }
+
+  for (const artifact of manifest.artifacts) {
+    if (!dryRun) {
+      const integrity = await existingIntegrity(artifact);
+      if (integrity) {
+        assert(
+          integrity === artifact.integrity,
+          `${artifact.name}@${artifact.version} already exists with different integrity`,
+        );
+        console.log(`release-publish: ${artifact.name}@${artifact.version} already matches; skipping`);
+        continue;
+      }
+    }
+    await npmPublish(artifact, dryRun);
+  }
+}
+
+if (import.meta.main) {
+  await publishRelease();
+}

--- a/scripts/update-action-tag.test.ts
+++ b/scripts/update-action-tag.test.ts
@@ -12,6 +12,24 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
   return output;
 }
 
+async function remoteTagCommit(cwd: string, tag: string): Promise<string> {
+  const refs = await git(
+    cwd,
+    'ls-remote',
+    '--tags',
+    'origin',
+    `refs/tags/${tag}`,
+    `refs/tags/${tag}^{}`,
+  );
+  const lines = refs.split('\n');
+  const line = lines.find((entry) => entry.endsWith(`refs/tags/${tag}^{}`))
+    ?? lines.find((entry) => entry.endsWith(`refs/tags/${tag}`));
+  if (!line) throw new Error(`Remote tag ${tag} was not found`);
+  const sha = line.split(/\s+/)[0];
+  if (!sha) throw new Error(`Remote tag ${tag} has no object ID`);
+  return sha;
+}
+
 afterEach(async () => {
   await cleanupTestDir(DIR_NAME);
 });
@@ -52,12 +70,12 @@ describe('moving Action tag version guard', () => {
     await writeText(join(work, 'release.txt'), 'v0.2.0\n');
     await git(work, 'commit', '-am', 'v0.2.0');
     await git(work, 'tag', '-a', 'v0.2.0', '-m', 'v0.2.0');
-    await git(work, 'tag', 'v0');
+    await git(work, 'tag', '-a', 'v0', '-m', 'v0');
     await git(work, 'push', 'origin', '--tags');
 
     expect(await updateActionTag('v0.1.0', { repositoryRoot: work })).toBe(false);
     const v02Sha = await git(work, 'rev-list', '-n', '1', 'v0.2.0');
-    expect((await git(work, 'ls-remote', 'origin', 'refs/tags/v0')).split(/\s+/)[0]).toBe(v02Sha);
+    expect(await remoteTagCommit(work, 'v0')).toBe(v02Sha);
 
     await writeText(join(work, 'release.txt'), 'v0.3.0\n');
     await git(work, 'commit', '-am', 'v0.3.0');
@@ -66,6 +84,6 @@ describe('moving Action tag version guard', () => {
 
     expect(await updateActionTag('v0.3.0', { repositoryRoot: work })).toBe(true);
     const v03Sha = await git(work, 'rev-list', '-n', '1', 'v0.3.0');
-    expect((await git(work, 'ls-remote', 'origin', 'refs/tags/v0')).split(/\s+/)[0]).toBe(v03Sha);
+    expect(await remoteTagCommit(work, 'v0')).toBe(v03Sha);
   });
 });

--- a/scripts/update-action-tag.test.ts
+++ b/scripts/update-action-tag.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import { cleanupTestDir, resetTestDir, writeText } from '../packages/core/test/helpers.ts';
+import { compareStableVersions, parseStableVersionTag, updateActionTag } from './update-action-tag.ts';
+
+const DIR_NAME = 'update-action-tag';
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const process = Bun.spawn(['git', ...args], { cwd, stdout: 'pipe', stderr: 'inherit' });
+  const output = (await new Response(process.stdout).text()).trim();
+  expect(await process.exited).toBe(0);
+  return output;
+}
+
+afterEach(async () => {
+  await cleanupTestDir(DIR_NAME);
+});
+
+describe('moving Action tag version guard', () => {
+  test('parses stable release tags', () => {
+    expect(parseStableVersionTag('v12.34.56')).toEqual({ major: 12, minor: 34, patch: 56 });
+  });
+
+  test('rejects prerelease and malformed tags', () => {
+    expect(() => parseStableVersionTag('v0.2.0-rc.1')).toThrow('stable SemVer');
+    expect(() => parseStableVersionTag('v01.2.3')).toThrow('stable SemVer');
+  });
+
+  test('orders versions monotonically', () => {
+    expect(compareStableVersions(parseStableVersionTag('v0.2.0'), parseStableVersionTag('v0.1.9'))).toBeGreaterThan(0);
+    expect(compareStableVersions(parseStableVersionTag('v1.0.0'), parseStableVersionTag('v0.99.99'))).toBeGreaterThan(0);
+    expect(compareStableVersions(parseStableVersionTag('v0.1.0'), parseStableVersionTag('v0.1.0'))).toBe(0);
+  });
+
+  test('never rolls a moving major tag backward and advances it for a newer release', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const remote = join(root, 'remote.git');
+    const work = join(root, 'work');
+    await git(root, 'init', '--bare', '--initial-branch=main', remote);
+    await git(root, 'init', '--initial-branch=main', work);
+    await git(work, 'config', 'user.name', 'adrkit test');
+    await git(work, 'config', 'user.email', 'test@adrkit.dev');
+    await git(work, 'config', 'commit.gpgSign', 'false');
+    await git(work, 'config', 'tag.gpgSign', 'false');
+    await git(work, 'remote', 'add', 'origin', remote);
+
+    await writeText(join(work, 'release.txt'), 'v0.1.0\n');
+    await git(work, 'add', 'release.txt');
+    await git(work, 'commit', '-m', 'v0.1.0');
+    await git(work, 'tag', '-a', 'v0.1.0', '-m', 'v0.1.0');
+
+    await writeText(join(work, 'release.txt'), 'v0.2.0\n');
+    await git(work, 'commit', '-am', 'v0.2.0');
+    await git(work, 'tag', '-a', 'v0.2.0', '-m', 'v0.2.0');
+    await git(work, 'tag', 'v0');
+    await git(work, 'push', 'origin', '--tags');
+
+    expect(await updateActionTag('v0.1.0', { repositoryRoot: work })).toBe(false);
+    const v02Sha = await git(work, 'rev-list', '-n', '1', 'v0.2.0');
+    expect((await git(work, 'ls-remote', 'origin', 'refs/tags/v0')).split(/\s+/)[0]).toBe(v02Sha);
+
+    await writeText(join(work, 'release.txt'), 'v0.3.0\n');
+    await git(work, 'commit', '-am', 'v0.3.0');
+    await git(work, 'tag', '-a', 'v0.3.0', '-m', 'v0.3.0');
+    await git(work, 'push', 'origin', 'refs/tags/v0.3.0');
+
+    expect(await updateActionTag('v0.3.0', { repositoryRoot: work })).toBe(true);
+    const v03Sha = await git(work, 'rev-list', '-n', '1', 'v0.3.0');
+    expect((await git(work, 'ls-remote', 'origin', 'refs/tags/v0')).split(/\s+/)[0]).toBe(v03Sha);
+  });
+});

--- a/scripts/update-action-tag.ts
+++ b/scripts/update-action-tag.ts
@@ -59,20 +59,28 @@ export async function updateActionTag(
   if (remote) {
     const remoteSha = remote.split(/\s+/)[0];
     assert(remoteSha, `Could not parse remote ${majorTag} ref`);
-    const releaseTags = await run(['git', 'tag', '--list', `${majorTag}.*.*`], repositoryRoot, true);
-    const candidates = releaseTags
+    const releaseTags = await run(
+      [
+        'git',
+        'for-each-ref',
+        '--format=%(refname:strip=2)%09%(objectname)%09%(*objectname)',
+        `refs/tags/${majorTag}.*.*`,
+      ],
+      repositoryRoot,
+      true,
+    );
+    const currentVersions = releaseTags
       .split('\n')
       .filter(Boolean)
-      .map((tag) => ({ tag, version: parseStableVersionTag(tag) }));
-    const currentVersions: typeof candidates = [];
-    for (const candidate of candidates) {
-      const candidateSha = await run(['git', 'rev-list', '-n', '1', candidate.tag], repositoryRoot);
-      if (candidateSha === remoteSha) currentVersions.push(candidate);
-    }
-    const matchingVersions = currentVersions
-      .filter(({ version }) => version.major === releaseVersion.major)
+      .map((line) => {
+        const [tag, objectSha, peeledSha] = line.split('\t');
+        if (!tag || !objectSha || !/^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(tag)) return undefined;
+        return { tag, sha: peeledSha || objectSha, version: parseStableVersionTag(tag) };
+      })
+      .filter((candidate) => candidate !== undefined)
+      .filter(({ sha, version }) => sha === remoteSha && version.major === releaseVersion.major)
       .sort((left, right) => compareStableVersions(right.version, left.version));
-    const current = matchingVersions[0];
+    const current = currentVersions[0];
     assert(current, `Remote ${majorTag} does not point at an immutable ${majorTag}.x.y release tag`);
     if (compareStableVersions(releaseVersion, current.version) <= 0) {
       console.log(`release-action-tag: ${majorTag} remains at ${current.tag}; ${releaseTag} is not newer`);

--- a/scripts/update-action-tag.ts
+++ b/scripts/update-action-tag.ts
@@ -51,13 +51,23 @@ export async function updateActionTag(
   const releaseVersion = parseStableVersionTag(releaseTag);
   const majorTag = `v${releaseVersion.major}`;
   const remote = await run(
-    ['git', 'ls-remote', '--tags', remoteName, `refs/tags/${majorTag}`],
+    [
+      'git',
+      'ls-remote',
+      '--tags',
+      remoteName,
+      `refs/tags/${majorTag}`,
+      `refs/tags/${majorTag}^{}`,
+    ],
     repositoryRoot,
     true,
   );
 
   if (remote) {
-    const remoteSha = remote.split(/\s+/)[0];
+    const remoteLines = remote.split('\n').filter(Boolean);
+    const remoteLine = remoteLines.find((line) => line.endsWith(`refs/tags/${majorTag}^{}`))
+      ?? remoteLines.find((line) => line.endsWith(`refs/tags/${majorTag}`));
+    const remoteSha = remoteLine?.split(/\s+/)[0];
     assert(remoteSha, `Could not parse remote ${majorTag} ref`);
     const releaseTags = await run(
       [

--- a/scripts/update-action-tag.ts
+++ b/scripts/update-action-tag.ts
@@ -1,0 +1,98 @@
+import { resolve } from 'node:path';
+
+const REPOSITORY_ROOT = resolve(import.meta.dir, '..');
+
+export interface StableVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+export function parseStableVersionTag(tag: string): StableVersion {
+  const match = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(tag);
+  assert(match, `Release tag ${tag} must be stable SemVer (vMAJOR.MINOR.PATCH)`);
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+export function compareStableVersions(left: StableVersion, right: StableVersion): number {
+  if (left.major !== right.major) return left.major - right.major;
+  if (left.minor !== right.minor) return left.minor - right.minor;
+  return left.patch - right.patch;
+}
+
+async function run(command: string[], repositoryRoot: string, allowEmpty = false): Promise<string> {
+  const process = Bun.spawn(command, {
+    cwd: repositoryRoot,
+    stdout: 'pipe',
+    stderr: 'inherit',
+    env: Bun.env,
+  });
+  const output = (await new Response(process.stdout).text()).trim();
+  const exitCode = await process.exited;
+  assert(exitCode === 0, `${command.join(' ')} failed with exit ${exitCode}`);
+  if (!allowEmpty) assert(output, `${command.join(' ')} returned no output`);
+  return output;
+}
+
+export async function updateActionTag(
+  releaseTag: string,
+  options: { repositoryRoot?: string; remote?: string } = {},
+): Promise<boolean> {
+  const repositoryRoot = options.repositoryRoot ?? REPOSITORY_ROOT;
+  const remoteName = options.remote ?? 'origin';
+  const releaseVersion = parseStableVersionTag(releaseTag);
+  const majorTag = `v${releaseVersion.major}`;
+  const remote = await run(
+    ['git', 'ls-remote', '--tags', remoteName, `refs/tags/${majorTag}`],
+    repositoryRoot,
+    true,
+  );
+
+  if (remote) {
+    const remoteSha = remote.split(/\s+/)[0];
+    assert(remoteSha, `Could not parse remote ${majorTag} ref`);
+    const releaseTags = await run(['git', 'tag', '--list', `${majorTag}.*.*`], repositoryRoot, true);
+    const candidates = releaseTags
+      .split('\n')
+      .filter(Boolean)
+      .map((tag) => ({ tag, version: parseStableVersionTag(tag) }));
+    const currentVersions: typeof candidates = [];
+    for (const candidate of candidates) {
+      const candidateSha = await run(['git', 'rev-list', '-n', '1', candidate.tag], repositoryRoot);
+      if (candidateSha === remoteSha) currentVersions.push(candidate);
+    }
+    const matchingVersions = currentVersions
+      .filter(({ version }) => version.major === releaseVersion.major)
+      .sort((left, right) => compareStableVersions(right.version, left.version));
+    const current = matchingVersions[0];
+    assert(current, `Remote ${majorTag} does not point at an immutable ${majorTag}.x.y release tag`);
+    if (compareStableVersions(releaseVersion, current.version) <= 0) {
+      console.log(`release-action-tag: ${majorTag} remains at ${current.tag}; ${releaseTag} is not newer`);
+      return false;
+    }
+  }
+
+  const releaseSha = await run(['git', 'rev-list', '-n', '1', releaseTag], repositoryRoot);
+  await run(['git', 'tag', '--force', majorTag, releaseSha], repositoryRoot, true);
+  await run(
+    ['git', 'push', '--force', remoteName, `refs/tags/${majorTag}`],
+    repositoryRoot,
+    true,
+  );
+  console.log(`release-action-tag: moved ${majorTag} to ${releaseTag} (${releaseSha})`);
+  return true;
+}
+
+if (import.meta.main) {
+  const [releaseTag, ...extra] = Bun.argv.slice(2);
+  assert(releaseTag && extra.length === 0, 'Usage: bun scripts/update-action-tag.ts vMAJOR.MINOR.PATCH');
+  await updateActionTag(releaseTag);
+}


### PR DESCRIPTION
## Summary

- harden `@adrkit/core`, `@adrkit/evaluator`, and `@adrkit/cli` as public Node 22+ packages with complete metadata, legal files, READMEs, and valid Bun/Node export targets
- add deterministic Bun packing, workspace-version validation, installed-tarball smoke coverage, integrity-safe npm publication, and monotonic major Action tags
- add a protected tag-driven release workflow using npm Trusted Publishing/provenance, with `NPM_TOKEN` only as the documented first-publish bootstrap fallback
- fix installed `adr` bin execution through package-manager symlinks
- document installation, initial npm bootstrap, later tokenless releases, and mark Phase 4 landed

## Validation

- 377 tests pass
- full typecheck/build/lint/dependency/schema/ADR gates pass
- all three tarballs install and run under Bun 1.3.14, Node 22, and Node 24
- npm publication dry-run passes for all packages
- generated schema and committed Action bundle remain byte-stable

## Release follow-up

After merge, push annotated tag `v0.1.0`. The protected `npm` environment already contains the one-time bootstrap token. Once the packages exist, configure each package's Trusted Publisher for `mbeacom/adrkit`, workflow `release.yml`, environment `npm`, then delete the token.