### PR TITLE
fix(release): invoke Node 22 package binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         run: bun run release:pack -- --tag "$GITHUB_REF_NAME" --skip-build
 
       - name: Smoke installed tarballs on Node 22
-        run: bunx --package node@22 node .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
+        run: bunx node@22 .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
 
       - name: Smoke installed tarballs on Node 24
         run: node .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"


### PR DESCRIPTION
## Summary

- use Bun's direct `bunx node@22` package form for the release smoke test
- avoid `bunx --package node@22 node`, which Bun 1.3.14 rejects on the GitHub runner because the package binary is not resolved in that form

## Validation

- `bunx bun@1.3.14 x node@22 --version` -> `v22.23.1`
- `bunx bun@1.3.14 x node@22 .release/smoke/smoke.mjs "$PWD"` -> installed packages passed

## Release impact

The failed v0.1.0 workflow stopped before npm publication, GitHub release creation, or moving `v0`; after this merges, the unpublished release tag can be recreated on the corrected main commit.