### PR TITLE
fix(release): switch runner Node versions for smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,6 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Set up Node for npm Trusted Publishing
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-
       - name: Require the release commit on main
         run: |
           git fetch --no-tags origin main
@@ -65,8 +59,19 @@ jobs:
       - name: Pack release artifacts
         run: bun run release:pack -- --tag "$GITHUB_REF_NAME" --skip-build
 
+      - name: Set up Node 22 for installed-tarball smoke
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Smoke installed tarballs on Node 22
-        run: bunx node@22 .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
+        run: node .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
+
+      - name: Set up Node 24 for smoke and npm Trusted Publishing
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - name: Smoke installed tarballs on Node 24
         run: node .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"


### PR DESCRIPTION
## Summary

- use `actions/setup-node` to select Node 22 before the installed-tarball smoke test
- restore Node 24 with the npm registry configuration before the Node 24 smoke and Trusted Publishing
- stop relying on the platform-dependent npm `node` package executable

## Root cause

The npm `node` package invocation worked locally on macOS but exposes no executable to Bun on a fresh Linux runner. The v0.1.0 workflow therefore stopped at the Node 22 smoke test before publication.

## Validation

The PR CI matrix uses the same `actions/setup-node` pattern and exercises installed tarballs on both Node 22 and Node 24.

## Release impact

No npm package, GitHub release, or moving `v0` tag exists. After this merges, the failed pre-publication `v0.1.0` tag can safely be recreated on corrected `main`.