### PR TITLE
feat: add read-only MCP server

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/005-deterministic-evaluator"}
+{"feature_directory":"specs/006-mcp-server"}

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,16 +1,39 @@
 <!--
 SYNC IMPACT REPORT
-Version change: 1.0.0 → 1.0.1
-Ratification: PATCH clarification reconciling adapter isolation with vetted deterministic public libraries and correcting the authored schema path.
+Version change: 1.0.1 → 1.0.2
+Bump rationale: PATCH clarification of the existing clean-clone policy. The
+public, frozen dependency install already permitted by ADR-0007, contributor
+guidance, and CI is now distinguished from the network-free post-install gates.
 Modified principles:
-  - III. Core Depends on No Adapter — clarified that `zod` and `yaml` are permitted vetted, deterministic, network-free, credential-free libraries, while adapter and authenticated/network/service dependencies remain forbidden.
-  - V. The Schema Is the Contract — corrected the authored Zod source path to `packages/core/src/schema/adr.schema.ts` and documented the root schema file as a compatibility re-export.
+  - II. Clean Clone Builds Green → II. Clean Clone Builds Green — permits only
+    unauthenticated public-registry access during `bun install
+    --frozen-lockfile`; all later gates and runtime remain credential-free,
+    service-free, and network-free.
 Added sections: none.
 Removed sections: none.
 Templates reviewed:
-  ✅ .specify/templates/plan-template.md — no change required; Principle III/V gate wording remains applicable.
-  ✅ .specify/templates/spec-template.md — no change required; spec stays implementation-agnostic.
-  ✅ .specify/templates/tasks-template.md — no change required; tests remain opt-in per feature, consistent with Principle IV/V verification tasks.
+  ✅ .specify/templates/plan-template.md — no change required; it derives the
+    Constitution Check from this file and contains no duplicated Principle II text.
+  ✅ .specify/templates/spec-template.md — no change required; it contains no
+    duplicated Principle II text.
+  ✅ .specify/templates/tasks-template.md — no change required; it contains no
+    duplicated Principle II text.
+  ✅ .github/agents/speckit.*.agent.md and
+    .github/prompts/speckit.*.prompt.md — no change required; installed
+    instructions load the constitution dynamically and contain no Principle II
+    wording.
+Dependent policy and runtime guidance:
+  ✅ CONTRIBUTING.md — updated to distinguish the sole public-registry install
+    exception from network-free post-install gates and runtime.
+  ✅ docs/adr/0007-adapter-isolation-and-public-surface-build.md — reviewed; no
+    change required.
+  ✅ .github/workflows/ci.yml — reviewed; no change required; Bun 1.3.14 and the
+    frozen install are already isolated in an explicit step.
+  ✅ README.md, CLAUDE.md, bunfig.toml,
+    .github/instructions/use-bun.instructions.md,
+    .cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc, and
+    docs/adr/0010-bun-toolchain.md — reviewed; no conflicting Principle II
+    wording requires propagation.
 Deferred TODOs: none.
 Source of authority: docs/adr/0001, 0002, 0004, 0005, 0007, 0008, 0009, 0010.
 The ADRs are normative. If this file and an accepted ADR disagree, the ADR wins
@@ -46,18 +69,26 @@ code, diffable, and attributable via `git log`. (ADR-0001, ADR-0004)
 
 ### II. Clean Clone Builds Green
 
-A fresh clone with no credentials, no running services, and no network access
-MUST install, build, test, and lint successfully.
+A fresh clone MAY access an unauthenticated public package registry only during
+the frozen dependency-install step. That step MUST use Bun 1.3.14, the committed
+`bun.lock`, and the repository's `bunfig.toml` settings, including the isolated
+linker and `minimumReleaseAge`. After installation, build, typecheck, test, lint,
+packaging, smoke tests, and runtime behavior MUST require no credentials, no
+running services, and no network access.
 
 - This is a CI assertion (`clean-clone-builds`), not a guideline. A change that
-  makes the default build require a secret, a device, or a network call is a
-  defect regardless of its other merits.
-- Any integration that needs authenticated, corporate-device, or private access
-  to develop does not belong in this repository.
+  makes any post-install gate or runtime behavior require a secret, a device, a
+  service, or a network call is a defect regardless of its other merits.
+- The install exception is limited to `bun install --frozen-lockfile`. Private or
+  authenticated registries, tokens or other credentials, managed-device access,
+  and non-public dependency surfaces are forbidden.
+- Network-dependent tests and runtime behavior are forbidden. Dependencies and
+  integrations MUST use only publicly documented, publicly fetchable surfaces.
 
-Rationale: contributor onboarding, IP provenance, and offline use all depend on
-the build being self-contained; the constraint also mechanically enforces the
-boundary between this Apache-2.0 project and any employer-internal IP. (ADR-0007)
+Rationale: one deterministic public-registry fetch enables clean contributor
+onboarding, while post-install self-containment preserves reproducibility,
+offline use, IP provenance, and the mechanical boundary between this Apache-2.0
+project and any employer-internal IP. (ADR-0007, ADR-0010)
 
 ### III. Core Depends on No Adapter
 
@@ -173,4 +204,4 @@ governs and this file MUST be amended to match.
 - **Compliance.** PRs and reviews verify compliance with Principles I–V. Added
   complexity must be justified against the simpler alternative it displaces.
 
-**Version**: 1.0.1 | **Ratified**: 2026-07-18 | **Last Amended**: 2026-07-18
+**Version**: 1.0.2 | **Ratified**: 2026-07-18 | **Last Amended**: 2026-07-20

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,14 @@
 
 Decision memory for human- and agent-authored plans — machine-readable ADRs
 that are enforceable in CI and legible to agents, without leaving git.
-Status: early — phases 0–2 landed. `@adrkit/core` and `@adrkit/cli` (`lint`,
-`new`, `graph`, `explain`, `migrate --from madr`) exist, with `affects`
-resolution and MADR migration; the CI Action, evaluator, and MCP server are not
-yet built (see [`plan.md`](./plan.md)).
+Status: early — phases 0–4 landed and v0.1.0 is public. `@adrkit/core`,
+`@adrkit/evaluator`, and `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
+`check`, `migrate --from madr`, `evaluate`) are published on npm; the
+repository-backed CI Action is available at `mbeacom/adrkit/packages/ci@v0`.
+The read-only MCP server is scoped under `specs/006-mcp-server/`; its exact
+four-tool, local-only surface was ratified by the maintainer on 2026-07-20, so
+its 43-task graph is generated and critical/high artifact remediation is in
+progress before a fresh analysis and implementation (see [`plan.md`](./plan.md)).
 
 ## Toolchain
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,9 @@ Status: early — phases 0–4 landed and v0.1.0 is public. `@adrkit/core`,
 `@adrkit/evaluator`, and `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
 `check`, `migrate --from madr`, `evaluate`) are published on npm; the
 repository-backed CI Action is available at `mbeacom/adrkit/packages/ci@v0`.
-The read-only MCP server is scoped under `specs/006-mcp-server/`; its exact
-four-tool, local-only surface was ratified by the maintainer on 2026-07-20, so
-its 43-task graph is generated and critical/high artifact remediation is in
-progress before a fresh analysis and implementation (see [`plan.md`](./plan.md)).
+The read-only `@adrkit/mcp` server is implemented on PR #19 with exactly four
+local stdio tools; real-session dogfood and coordinated publication remain (see
+[`plan.md`](./plan.md)).
 
 ## Toolchain
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 ## Toolchain
 
-Bun (see [ADR-0010](docs/adr/0010-bun-toolchain.md)). Install it, then
-`bun install`. Bun is a **development** dependency only — nothing published by
-this project requires it, and every published artifact is smoke-tested under
-Node.
+Bun 1.3.14 (see [ADR-0010](docs/adr/0010-bun-toolchain.md)). Install it, then
+run `bun install --frozen-lockfile`. Bun is a **development** dependency only —
+nothing published by this project requires it, and every published artifact is
+smoke-tested under Node.
 
 `bunfig.toml` sets `linker = "isolated"`. Do not change it: the hoisted linker
 permits phantom dependencies, which would let the core import an adapter while
@@ -26,15 +26,25 @@ git commit -s -m "your message"
 These are enforced in CI. A PR that violates either will fail, and the fix is to
 change the code, not the check.
 
-**1. A clean clone must build with no credentials.**
+**1. A clean clone has one narrow network exception for dependency install.**
 
 ```
-git clone <repo> && cd adrkit && bun install && bun run build && bun test && bun run lint
+git clone <repo> && cd adrkit
+bun install --frozen-lockfile
+bun run typecheck && bun run build && bun test && bun run lint
 ```
 
-must pass with no tokens, no services, no network beyond the package registry.
-Contributions may not depend on private registries, authenticated APIs, or
-anything requiring a managed device. See
+The frozen install is the only step that may use the network, and it may contact
+only the unauthenticated public package registry. It must use Bun 1.3.14, the
+committed `bun.lock`, and the repository's `bunfig.toml` settings, including the
+isolated linker and `minimumReleaseAge`.
+
+After installation, build, typecheck, test, lint, packaging, smoke tests, and
+runtime behavior must require no credentials, no services, and no network
+access. Contributions may not use private or authenticated registries, registry
+tokens or other credentials, authenticated APIs, non-public dependency surfaces,
+network-dependent tests or runtime behavior, or anything requiring a managed
+device. See
 [ADR-0007](docs/adr/0007-adapter-isolation-and-public-surface-build.md).
 
 **2. The core depends on no adapter.**
@@ -93,4 +103,3 @@ bun install --frozen-lockfile   # restore your local (host) install afterward
 
 Then commit `packages/ci/dist`. Any change to `packages/ci/src` **or** `@adrkit/core`
 (which is bundled in) requires regenerating it.
-

--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@
 Architecture decision records that are machine-readable, enforceable in CI, and
 legible to agents — without leaving git.
 
-> Status: early, under active development. The schema, `@adrkit/core`,
-> `@adrkit/cli`, and the deterministic **Pass 0 evaluator** (`@adrkit/evaluator`)
-> are implemented — `adr lint`, `new`, `graph`, `explain`, `check`,
+> Status: early, under active development. **v0.1.0 is published** with the
+> schema, `@adrkit/core`, `@adrkit/cli`, and the deterministic **Pass 0
+> evaluator** (`@adrkit/evaluator`) implemented — `adr lint`, `new`, `graph`,
+> `explain`, `check`,
 > `migrate --from madr`, and `adr evaluate` all work, including `affects`
 > resolution, in-place MADR migration, and the offline eleven-rule Pass 0. Not yet
-> built: the later probabilistic passes (Passes 1–3) and the MCP server. See
-> [`plan.md`](./plan.md).
+> built: the later probabilistic passes (Passes 1–3) and the MCP server. The
+> read-only MCP surface is scoped under `specs/006-mcp-server/` and its exact
+> four-tool, local-only boundary was ratified on 2026-07-20. Its 43-task graph is
+> generated; critical/high artifact remediation and a clean analysis pass remain
+> before implementation. See [`plan.md`](./plan.md).
 
 ---
 
@@ -107,6 +111,29 @@ The pure library surfaces are independently installable:
 bun add @adrkit/core @adrkit/evaluator
 ```
 
+### MCP server (`@adrkit/mcp`)
+
+`@adrkit/mcp` ships a local, **read-only** [Model Context Protocol](https://modelcontextprotocol.io)
+server so an agent harness can retrieve decisions over stdio. It exposes exactly
+four tools — `search_decisions`, `get_decision`, `get_decision_context(files[])`,
+and `list_superseded` — and nothing else: no writes, no HTTP/auth, no model,
+embedding, or network access, and no persistent index. Run the `adrkit-mcp` bin,
+pointing it at the repository whose corpus it should answer for:
+
+```sh
+bunx @adrkit/mcp             # or: adrkit-mcp
+adrkit-mcp --cwd /path/to/repo --dir docs/adr
+```
+
+`--cwd` (env `ADRKIT_MCP_CWD`, default `process.cwd()`) must be a Git worktree
+root; `--dir` (env `ADRKIT_MCP_DIR`, default `docs/adr`) is resolved and contained
+within it. Flags win over environment variables. stdout carries only JSON-RPC
+protocol frames; all diagnostics go to stderr. Every call re-reads the corpus,
+the graveyard (`rejected`/`superseded`/`deprecated`) is included by default, and
+growing responses paginate through opaque, corpus-bound cursors. See
+[`packages/mcp/README.md`](packages/mcp/README.md) for the full tool contracts,
+limits, and cursor-restart rules.
+
 Published artifacts are ESM and require Node.js 22 or newer. Bun remains the
 project's development package manager and test/build runtime.
 
@@ -123,8 +150,8 @@ steps:
   - uses: mbeacom/adrkit/packages/ci@v0
 ```
 
-The npm packages and `v0` Action tag are created by the first `v0.1.0` release.
-Until then, source checkouts can run the CLI with `bun run adr`.
+The npm packages, immutable `v0.1.0` release, and moving `v0` Action tag are
+live. Source checkouts can also run the CLI with `bun run adr`.
 
 ## Design commitments
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ legible to agents — without leaving git.
 > evaluator** (`@adrkit/evaluator`) implemented — `adr lint`, `new`, `graph`,
 > `explain`, `check`,
 > `migrate --from madr`, and `adr evaluate` all work, including `affects`
-> resolution, in-place MADR migration, and the offline eleven-rule Pass 0. Not yet
-> built: the later probabilistic passes (Passes 1–3) and the MCP server. The
-> read-only MCP surface is scoped under `specs/006-mcp-server/` and its exact
-> four-tool, local-only boundary was ratified on 2026-07-20. Its 43-task graph is
-> generated; critical/high artifact remediation and a clean analysis pass remain
-> before implementation. See [`plan.md`](./plan.md).
+> resolution, in-place MADR migration, and the offline eleven-rule Pass 0. The
+> read-only `@adrkit/mcp` server is implemented on PR #19 with its exact
+> four-tool, local-only boundary; real-session dogfood and coordinated
+> publication remain. Not yet built: the later probabilistic passes (Passes
+> 1–3). See [`plan.md`](./plan.md).
 
 ---
 
@@ -113,7 +112,7 @@ bun add @adrkit/core @adrkit/evaluator
 
 ### MCP server (`@adrkit/mcp`)
 
-`@adrkit/mcp` ships a local, **read-only** [Model Context Protocol](https://modelcontextprotocol.io)
+`@adrkit/mcp` provides a local, **read-only** [Model Context Protocol](https://modelcontextprotocol.io)
 server so an agent harness can retrieve decisions over stdio. It exposes exactly
 four tools — `search_decisions`, `get_decision`, `get_decision_context(files[])`,
 and `list_superseded` — and nothing else: no writes, no HTTP/auth, no model,
@@ -188,8 +187,8 @@ consideration at all.
 Built with [Bun](https://bun.com) — see
 [ADR-0010](docs/adr/0010-bun-toolchain.md). **Bun is a development dependency
 only.** Nothing published by this project requires it: the CLI, the GitHub
-Action, and the MCP server are Node-targeted, and will be smoke-tested under
-Node 22 and 24 in CI once the publish pipeline lands (see [`plan.md`](./plan.md)).
+Action, and the MCP server are Node-targeted and smoke-tested under Node 22 and
+24 in CI (see [`plan.md`](./plan.md)).
 
 ## Contributing
 

--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,21 @@
         "@types/bun": "latest",
       },
     },
+    "packages/mcp": {
+      "name": "@adrkit/mcp",
+      "version": "0.1.0",
+      "bin": {
+        "adrkit-mcp": "./dist/bin.js",
+      },
+      "dependencies": {
+        "@adrkit/core": "workspace:*",
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "zod": "^4",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
   },
   "packages": {
     "@actions/core": ["@actions/core@1.11.1", "", { "dependencies": { "@actions/exec": "^1.1.1", "@actions/http-client": "^2.0.1" } }, "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A=="],
@@ -82,7 +97,13 @@
 
     "@adrkit/evaluator": ["@adrkit/evaluator@workspace:packages/evaluator"],
 
+    "@adrkit/mcp": ["@adrkit/mcp@workspace:packages/mcp"],
+
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@octokit/auth-token": ["@octokit/auth-token@4.0.0", "", {}, "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="],
 
@@ -112,21 +133,185 @@
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "before-after-hook": ["before-after-hook@2.2.3", "", {}, "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "deprecation": ["deprecation@2.3.1", "", {}, "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.0", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.30", "", {}, "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "jsonpath-rfc9535": ["jsonpath-rfc9535@1.3.0", "", {}, "sha512-3jFHya7oZ45aDxIIdx+/zQARahHXxFSMWBkcBUldfXpLS9VCXDJyTKt35kQfEXLqh0K3Ixw/9xFnvcDStaxh7Q=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
@@ -136,15 +321,27 @@
 
     "universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@12.6.0", "", { "dependencies": { "@octokit/openapi-types": "^20.0.0" } }, "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw=="],
 
     "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@12.6.0", "", { "dependencies": { "@octokit/openapi-types": "^20.0.0" } }, "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@20.0.0", "", {}, "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="],
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing adrkit
 
-adrkit distributes three public npm packages and one repository-backed GitHub
+adrkit distributes four public npm packages and one repository-backed GitHub
 Action:
 
 | Artifact | Distribution |
@@ -8,16 +8,27 @@ Action:
 | `@adrkit/core` | npm |
 | `@adrkit/evaluator` | npm |
 | `@adrkit/cli` (`adr`) | npm |
+| `@adrkit/mcp` (`adrkit-mcp`) | npm |
 | `packages/ci/action.yml` | Git tag (`v0.1.0`, moving `v0`) |
 
 `@adrkit/ci` stays private because GitHub executes the committed Action bundle
 directly from the referenced repository ref.
 
+The initial `v0.1.0` release is complete. All three npm packages now use GitHub
+Actions Trusted Publishing, traditional token publishing is disabled, and the
+`npm` environment contains no long-lived publish token.
+
 ## Release guarantees
 
-- All public package versions are identical.
+- All public package versions are identical. Introducing `@adrkit/mcp` as a
+  fourth public package therefore requires bumping `@adrkit/core`,
+  `@adrkit/evaluator`, and `@adrkit/cli` to the same version in the same
+  coordinated release; the actual next release number is a maintainer scheduling
+  choice made at release time.
 - The tag is exactly `v<package version>`.
-- Packages publish in dependency order: core, evaluator, CLI.
+- Packages publish in dependency order: core, evaluator, CLI, MCP (`@adrkit/mcp`
+  depends only on core, so it is appended last to preserve the list's
+  chronological order).
 - Bun 1.3.14 builds and packs the artifacts.
 - Packed manifests contain no `workspace:` protocols.
 - Tarballs include compiled ESM, declarations, README, LICENSE, and NOTICE.
@@ -37,15 +48,19 @@ From a clean checkout:
 ```sh
 bun install --frozen-lockfile
 bun run release:pack -- --tag v0.1.0
-bunx --package node@22 node .release/smoke/smoke.mjs "$PWD"
-bunx --package node@24 node .release/smoke/smoke.mjs "$PWD"
+# With Node 22 selected in your Node version manager:
+node .release/smoke/smoke.mjs "$PWD"
+# Switch the same shell to Node 24, then run:
+node .release/smoke/smoke.mjs "$PWD"
 bun run release:publish -- --dry-run
 ```
 
 The generated tarballs and manifest live under `.release/npm/` and are ignored
-by git.
+by git. The Node version manager is intentionally not prescribed; CI uses
+`actions/setup-node` for both supported versions. Do not substitute the npm
+`node` package through `bunx`: its executable resolution is platform-dependent.
 
-## One-time npm bootstrap
+## One-time npm bootstrap (completed for v0.1.0)
 
 The npm scope and packages must exist before Trusted Publishers can be attached.
 For the first release only:
@@ -71,8 +86,8 @@ For the first release only:
    - repository: `adrkit`
    - workflow filename: `release.yml`
    - environment: `npm`
-6. Delete the `NPM_TOKEN` environment secret. For maximum security, set each
-   package's publishing access to require 2FA and disallow tokens.
+6. Delete the `NPM_TOKEN` environment secret and set each package's publishing
+   access to require 2FA and disallow tokens.
 
 All later releases are tokenless.
 

--- a/docs/adr/0007-adapter-isolation-and-public-surface-build.md
+++ b/docs/adr/0007-adapter-isolation-and-public-surface-build.md
@@ -31,6 +31,7 @@ assertions:
       No package outside packages/adapters/** may depend on an adapter package,
       and no package may depend on a source requiring authenticated access.
     engine: custom
+    expression: core-has-no-adapter-deps
     input: source
     severity: error
   - id: clean-clone-builds
@@ -38,6 +39,7 @@ assertions:
       A clean clone with no credentials configured must install, build, test,
       and lint successfully.
     engine: custom
+    expression: clean-clone-builds
     input: source
     severity: error
 ---

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './schema/index.ts';
+export * from './schema/ref.ts';
 export * from './parse/frontmatter.ts';
 export * from './load/corpus.ts';
 export * from './validate/findings.ts';

--- a/packages/core/src/schema/ref.ts
+++ b/packages/core/src/schema/ref.ts
@@ -1,0 +1,26 @@
+/**
+ * @adrkit/core — ADR reference parsing.
+ *
+ * The single shared primitive for splitting an `AdrRef` string into its optional
+ * `log` qualifier and its bare `id`. Promoted from the private `parseRef` formerly
+ * duplicated in `packages/evaluator/src/rules/no-orphan-refs.ts`, and consumed by
+ * `@adrkit/mcp` to detect whether a caller-supplied ref is log-qualified.
+ *
+ * There is deliberately no inverse `formatAdrRef`: nothing re-serializes a
+ * `(log, id)` pair; every ref echoed to a caller reuses the original string verbatim.
+ */
+
+export interface ParsedAdrRef {
+  readonly id: string;
+  readonly log?: string;
+}
+
+// Splits on the first ':'. A leading ':' or no ':' at all is unqualified and
+// returns { id: ref } with `id` the untouched original string (never split in that
+// case); a qualified ref returns { log, id } split on the first colon. This is the
+// behavior- and object-shape-preserving promotion of no-orphan-refs.ts's private copy.
+export function parseAdrRef(ref: string): ParsedAdrRef {
+  const idx = ref.indexOf(':');
+  if (idx <= 0) return { id: ref };
+  return { log: ref.slice(0, idx), id: ref.slice(idx + 1) };
+}

--- a/packages/core/test/ref.test.ts
+++ b/packages/core/test/ref.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { parseAdrRef } from '@adrkit/core';
+
+// Behavior- and object-shape-preserving promotion of no-orphan-refs.ts's private
+// parseRef (contracts/core-projection.md §1). Split on the FIRST ':'; a leading
+// colon or no colon at all is unqualified and returns { id: ref } untouched.
+describe('parseAdrRef', () => {
+  test('an unqualified numeric ref returns { id } with no log key', () => {
+    expect(parseAdrRef('0042')).toEqual({ id: '0042' });
+    expect('log' in parseAdrRef('0042')).toBe(false);
+  });
+
+  test('a leading-colon ref is unqualified and keeps the original string, colon included', () => {
+    expect(parseAdrRef(':0042')).toEqual({ id: ':0042' });
+    expect('log' in parseAdrRef(':0042')).toBe(false);
+  });
+
+  test('a first-colon-qualified ref splits into { log, id }', () => {
+    expect(parseAdrRef('payments:0012')).toEqual({ log: 'payments', id: '0012' });
+  });
+
+  test('only the first colon splits; later colons stay in the id', () => {
+    expect(parseAdrRef('a:b:c')).toEqual({ log: 'a', id: 'b:c' });
+  });
+
+  test('a ULID id is preserved verbatim', () => {
+    const ulid = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+    expect(parseAdrRef(ulid)).toEqual({ id: ulid });
+  });
+});

--- a/packages/evaluator/src/rules/no-orphan-refs.ts
+++ b/packages/evaluator/src/rules/no-orphan-refs.ts
@@ -9,22 +9,12 @@
  */
 
 import type { Adr } from '@adrkit/core';
+import { parseAdrRef } from '@adrkit/core';
 import { aggregate, passResult, type SubResult } from './kernel.ts';
 import type { RuleContext } from './context.ts';
 import type { ReasonCode, RuleFinding, RuleResult } from '../types.ts';
 
 type RefField = 'supersedes' | 'relatesTo';
-
-interface Parsed {
-  readonly log?: string;
-  readonly id: string;
-}
-
-function parseRef(ref: string): Parsed {
-  const idx = ref.indexOf(':');
-  if (idx <= 0) return { id: ref };
-  return { log: ref.slice(0, idx), id: ref.slice(idx + 1) };
-}
 
 export function evaluateNoOrphanRefs(ctx: RuleContext): RuleResult {
   const resolutionLog = ctx.input.resolutionLog;
@@ -50,7 +40,7 @@ export function evaluateNoOrphanRefs(ctx: RuleContext): RuleResult {
   const subs: SubResult[] = [];
 
   function classify(ref: string): 'resolved' | 'dangling' | 'federated-absent' {
-    const parsed = parseRef(ref);
+    const parsed = parseAdrRef(ref);
     if (parsed.log === undefined || parsed.log === resolutionLog) {
       return localIds.has(parsed.id) ? 'resolved' : 'dangling';
     }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,99 @@
+# `@adrkit/mcp`
+
+A **local, read-only** [Model Context Protocol](https://modelcontextprotocol.io)
+server that exposes adrkit decision retrieval over stdio. It lets an agent harness
+ask "has this been decided?", "what governs these files?", and "what replaced this?"
+against one Git-backed ADR corpus — deterministically, offline, with no model,
+network, or write access.
+
+> Part of [adrkit](https://adrkit.dev). The corpus lives in git as one Markdown
+> file per decision with typed YAML frontmatter (`@adrkit/core`); this server only
+> reads it.
+
+## Install and run
+
+```sh
+bunx @adrkit/mcp                       # run the adrkit-mcp bin
+adrkit-mcp --cwd /path/to/repo --dir docs/adr
+```
+
+| Option | Env | Default | Meaning |
+|---|---|---|---|
+| `--cwd <path>` | `ADRKIT_MCP_CWD` | `process.cwd()` | Repository root; must canonicalize to a directory containing a readable `.git` entry (a normal clone or a linked-worktree `.git` file). |
+| `--dir <path>` | `ADRKIT_MCP_DIR` | `docs/adr` | ADR directory, resolved against `--cwd` and required to stay contained within it (realpath-checked, so a symlink escape is rejected). |
+
+Flags win over environment variables, which win over the defaults. An unusable
+configuration exits non-zero with a diagnostic on **stderr** (`2` for an
+unparseable flag, `1` for an invalid root/directory) and never starts a transport.
+**stdout is reserved for JSON-RPC protocol frames only.**
+
+## Library surface
+
+The package root exports only a sealed lifecycle factory. There is no way to reach
+the underlying SDK server, its registrations, or its transport:
+
+```ts
+import { createAdrkitMcpServer } from '@adrkit/mcp';
+
+const server = createAdrkitMcpServer({ cwd: process.cwd(), dir: 'docs/adr' });
+await server.start();   // validates the root, connects exactly one stdio transport
+// ... later:
+await server.close();
+```
+
+`createAdrkitMcpServer(options?)` performs no filesystem access at construction and
+returns a frozen, null-prototype handle with exactly `start()` and `close()`.
+
+## The four tools
+
+All four share fixed annotations (`readOnlyHint: true`, `destructiveHint: false`,
+`idempotentHint: true`, `openWorldHint: false`), a `corpusHealth`
+(`fingerprint`/`recordCount`/`excludedCount`) sibling on every substantive
+response, and a `findings` page carrying the corpus's own parse/validation findings.
+
+| Tool | Answers | Notable outcomes |
+|---|---|---|
+| `search_decisions` | Normalized literal substring search over id, title, tags, and body (graveyard included by default). Filters: `status`/`scope` (any-of), `tags` (all-of), ANDed. | `results` (empty is the same branch) |
+| `get_decision` | The complete typed frontmatter + body for one ref. | `found`, `not-found`, `ambiguous-local-id` (duplicate ids), `federated-log-unavailable` (a `log:id` ref is recognized, never resolved or substituted) |
+| `get_decision_context` | Governing / active-proposal / historical decisions for repo-relative `files[]`, via the corpus's own `affects` matchers. Paths are compared against patterns only — never opened. | `matches` (all three arrays; empty is the same branch) |
+| `list_superseded` | Every superseded record with its **direct** local replacement state. | `entries` with `resolved` / `dangling` / `ambiguous` (`candidateCount` only) / `federated-unavailable` targets |
+
+Relation refs (`supersedes`, `supersededBy`, `relatesTo`, `conflictsWith`) are
+surfaced verbatim and never expanded — follow them with a second `get_decision`
+call.
+
+## Limits
+
+`query` 1–256 code units (non-empty after trimming); `ref` 1–128; `files[]` 1–256
+entries of 1–1024 POSIX-only chars (no leading `/`, no `..`, no drive letter, no
+backslash); `status` ≤6, `scope` ≤3, `tags` ≤32 × ≤64 chars; result and findings
+pages default 20, max 100; a per-record ADR source cap of 64 KiB (oversized records
+are excluded and surfaced as a `record-too-large` finding, never truncated). Every
+input object is strict — an unknown field is rejected before any corpus access.
+
+## Pagination and cursor restart
+
+Every growing channel returns a `cursor` (`null` on the last page). Cursors are
+opaque, versioned, and bound to both the corpus fingerprint and the call's query
+shape. Reuse a returned cursor **only** with identical request parameters against
+an unchanged corpus; otherwise the response is a non-error `invalid-cursor` outcome
+(`corpus-changed`, `query-mismatch`, `wrong-channel`, `offset-out-of-range`,
+`cursor-not-applicable`, `version-unsupported`, or `decode-failed`) and you should
+restart the walk from no cursor. The primary-result and `findings` channels page
+independently.
+
+## Boundaries (out of scope by design)
+
+No fifth tool; no writes, proposals, or PR creation; no MCP prompts, resources,
+subscriptions, or sampling; no HTTP/SSE transport or authentication; no model,
+embedding, ranking, or network access; no persistent cache/index/database; no
+named-log federation or multi-repository aggregation; no transitive supersession
+traversal.
+
+## Toolchain
+
+Developed and tested with Bun; published artifacts are ESM targeting Node.js `>=22`
+and are verified on Node 22 and 24. Runtime dependencies are exactly `@adrkit/core`,
+`@modelcontextprotocol/sdk`, and `zod`.
+
+Apache-2.0.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@adrkit/mcp",
+  "version": "0.1.0",
+  "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "homepage": "https://adrkit.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mbeacom/adrkit.git",
+    "directory": "packages/mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/mbeacom/adrkit/issues"
+  },
+  "keywords": [
+    "adr",
+    "architecture-decision-records",
+    "mcp",
+    "model-context-protocol",
+    "governance"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "adrkit-mcp": "./dist/bin.js"
+  },
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && bun build ./src/index.ts ./src/bin.ts --target=node --outdir=dist --packages=external && tsc --project tsconfig.build.json && bun ../../scripts/normalize-dts-imports.ts dist && cp ../../LICENSE ../../NOTICE dist/ && chmod +x dist/bin.js",
+    "lint": "bun run typecheck",
+    "prepack": "bun run build",
+    "typecheck": "tsc --noEmit --customConditions bun --project ../../tsconfig.json"
+  },
+  "dependencies": {
+    "@adrkit/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "zod": "^4"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "src"
+  ]
+}

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+/**
+ * @adrkit/mcp — the `adrkit-mcp` stdio entrypoint.
+ *
+ * Never imported by anything except the compiled `bin` entry itself. Reserves
+ * stdout for protocol frames; all diagnostics go to stderr.
+ */
+
+import { isMainModule, main } from './main-module.ts';
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  process.exitCode = await main(process.argv.slice(2), process.env);
+}

--- a/packages/mcp/src/corpus/ordering.ts
+++ b/packages/mcp/src/corpus/ordering.ts
@@ -1,0 +1,41 @@
+/**
+ * @adrkit/mcp — the one locale-independent comparator and the canonical orderings
+ * every channel uses. Never `String.prototype.localeCompare` (research §R6).
+ */
+
+import type { Finding } from '@adrkit/core';
+
+/** The sole code-unit comparator: `a < b ? -1 : a > b ? 1 : 0` over UTF-16 units. */
+export function compareCodeUnits(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export interface OrderedSummary {
+  readonly id: string;
+  readonly sourcePath: string;
+}
+
+/** Canonical `(id, sourcePath)` ascending order; sourcePath is the unique tiebreak. */
+export function compareByIdThenPath(a: OrderedSummary, b: OrderedSummary): number {
+  return compareCodeUnits(a.id, b.id) || compareCodeUnits(a.sourcePath, b.sourcePath);
+}
+
+/** Canonical finding order using `sortFindings`' field tuple with the code-unit comparator. */
+export function compareFindings(a: Finding, b: Finding): number {
+  return (
+    compareCodeUnits(a.rule, b.rule) ||
+    compareCodeUnits(a.id ?? '', b.id ?? '') ||
+    compareCodeUnits(a.pattern ?? '', b.pattern ?? '') ||
+    compareCodeUnits(a.path ?? '', b.path ?? '') ||
+    compareCodeUnits(a.field ?? '', b.field ?? '') ||
+    compareCodeUnits(a.message, b.message)
+  );
+}
+
+export function sortFindingsCanonical(findings: readonly Finding[]): Finding[] {
+  return [...findings].sort(compareFindings);
+}
+
+export function sortByIdThenPath<T extends OrderedSummary>(items: readonly T[]): T[] {
+  return [...items].sort(compareByIdThenPath);
+}

--- a/packages/mcp/src/corpus/projection.ts
+++ b/packages/mcp/src/corpus/projection.ts
@@ -7,8 +7,7 @@
  * No cache, index, or database of any kind.
  */
 
-import { access, lstat, realpath, stat } from 'node:fs/promises';
-import { constants as FS } from 'node:fs';
+import { access, constants as FS, lstat, realpath, stat } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
 import { discoverAdrFiles, lintCorpus, normalizeDisplayPath, type Adr, type Finding } from '@adrkit/core';

--- a/packages/mcp/src/corpus/projection.ts
+++ b/packages/mcp/src/corpus/projection.ts
@@ -1,0 +1,300 @@
+/**
+ * @adrkit/mcp — the per-call, in-memory corpus projection (data-model.md §3, §8).
+ *
+ * Rebuilt from scratch on every tool call: fresh canonical-root validation, the
+ * pre-read 64 KiB size guard, `discoverAdrFiles` + `lintCorpus`, a local multi-valued
+ * `byId` index, immutable corpus findings, and a canonical SHA-256 fingerprint.
+ * No cache, index, or database of any kind.
+ */
+
+import { access, lstat, realpath, stat } from 'node:fs/promises';
+import { constants as FS } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { discoverAdrFiles, lintCorpus, normalizeDisplayPath, type Adr, type Finding } from '@adrkit/core';
+import { compareCodeUnits, sortFindingsCanonical } from './ordering.ts';
+
+export const MAX_SOURCE_BYTES = 64 * 1024;
+
+export type CorpusUnavailableReason =
+  | 'root-not-found'
+  | 'root-not-directory'
+  | 'root-not-readable'
+  | 'root-not-git'
+  | 'dir-not-found'
+  | 'dir-not-directory'
+  | 'dir-not-readable'
+  | 'dir-outside-root'
+  | 'corpus-changed-during-load';
+
+/** Typed rejection carrying one of the `CorpusUnavailableOutcome` reasons (data-model.md §5). */
+export class CorpusUnavailableError extends Error {
+  readonly reason: CorpusUnavailableReason;
+  constructor(reason: CorpusUnavailableReason) {
+    super(reason);
+    this.name = 'CorpusUnavailableError';
+    this.reason = reason;
+  }
+}
+
+export interface CorpusHealth {
+  readonly fingerprint: string;
+  readonly recordCount: number;
+  readonly excludedCount: number;
+}
+
+export interface CorpusProjection {
+  readonly records: readonly Adr[];
+  readonly byId: ReadonlyMap<string, readonly Adr[]>;
+  readonly corpusFindings: readonly Finding[];
+  readonly fingerprint: string;
+  readonly recordCount: number;
+  readonly excludedCount: number;
+}
+
+function fail(reason: CorpusUnavailableReason): never {
+  throw new CorpusUnavailableError(reason);
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error && typeof error === 'object' && 'code' in error ? String((error as { code: unknown }).code) : undefined;
+}
+
+/** Path-segment-safe containment on two ALREADY-canonical paths (never a string prefix). */
+function isContained(parent: string, child: string): boolean {
+  if (parent === child) return true;
+  const rel = relative(parent, child);
+  return rel !== '' && rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+}
+
+export interface ResolveCanonicalRootsOptions {
+  readonly cwd: string;
+  readonly dir: string;
+}
+
+export interface CanonicalRoots {
+  readonly canonicalCwd: string;
+  readonly canonicalDir: string;
+}
+
+/** The one canonicalization/containment routine both `start()` and every load call use. */
+export async function resolveCanonicalRoots(options: ResolveCanonicalRootsOptions): Promise<CanonicalRoots> {
+  let canonicalCwd: string;
+  try {
+    canonicalCwd = await realpath(options.cwd);
+  } catch (error) {
+    fail(errorCode(error) === 'ENOENT' ? 'root-not-found' : 'root-not-readable');
+  }
+
+  try {
+    const info = await stat(canonicalCwd);
+    if (!info.isDirectory()) fail('root-not-directory');
+  } catch (error) {
+    if (error instanceof CorpusUnavailableError) throw error;
+    fail(errorCode(error) === 'ENOENT' ? 'root-not-found' : 'root-not-readable');
+  }
+  try {
+    await access(canonicalCwd, FS.R_OK | FS.X_OK);
+  } catch {
+    fail('root-not-readable');
+  }
+
+  const gitEntry = resolve(canonicalCwd, '.git');
+  try {
+    await stat(gitEntry);
+    await access(gitEntry, FS.R_OK);
+  } catch {
+    fail('root-not-git');
+  }
+
+  const dirInput = isAbsolute(options.dir) ? options.dir : resolve(canonicalCwd, options.dir);
+  let canonicalDir: string;
+  try {
+    canonicalDir = await realpath(dirInput);
+  } catch (error) {
+    fail(errorCode(error) === 'ENOENT' ? 'dir-not-found' : 'dir-not-readable');
+  }
+
+  try {
+    const info = await stat(canonicalDir);
+    if (!info.isDirectory()) fail('dir-not-directory');
+  } catch (error) {
+    if (error instanceof CorpusUnavailableError) throw error;
+    fail(errorCode(error) === 'ENOENT' ? 'dir-not-found' : 'dir-not-readable');
+  }
+  try {
+    await access(canonicalDir, FS.R_OK | FS.X_OK);
+  } catch {
+    fail('dir-not-readable');
+  }
+
+  if (!isContained(canonicalCwd, canonicalDir)) fail('dir-outside-root');
+
+  return { canonicalCwd, canonicalDir };
+}
+
+export interface LoadCorpusProjectionOptions {
+  readonly configuredCwd: string;
+  readonly configuredDir: string;
+  readonly expectedCanonicalCwd: string;
+  readonly maxSourceBytes: number;
+}
+
+interface KeptCandidate {
+  readonly absolutePath: string;
+  readonly displayPath: string;
+  readonly identity: { dev: bigint; ino: bigint; size: bigint; mtimeNs: bigint };
+}
+
+function statError(displayPath: string): Finding {
+  return {
+    rule: 'record-stat-error',
+    severity: 'error',
+    path: displayPath,
+    message: 'ADR candidate could not be read to validate its size and was excluded from this response',
+  };
+}
+
+function tooLarge(displayPath: string): Finding {
+  return {
+    rule: 'record-too-large',
+    severity: 'error',
+    path: displayPath,
+    message: 'ADR source exceeds the 64 KiB maximum and was excluded from this response',
+  };
+}
+
+async function verifyRoots(options: LoadCorpusProjectionOptions): Promise<CanonicalRoots> {
+  const roots = await resolveCanonicalRoots({ cwd: options.configuredCwd, dir: options.configuredDir });
+  if (roots.canonicalCwd !== options.expectedCanonicalCwd) fail('root-not-found');
+  return roots;
+}
+
+function canonicalStringify(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalStringify).join(',')}]`;
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort(compareCodeUnits);
+    return `{${keys.map((key) => `${JSON.stringify(key)}:${canonicalStringify(record[key])}`).join(',')}}`;
+  }
+  return 'null';
+}
+
+function fingerprintOf(records: readonly Adr[], corpusFindings: readonly Finding[], recordCount: number, excludedCount: number): string {
+  const projection = {
+    records: records.map((record) => ({ sourcePath: record.path, frontmatter: record.frontmatter, body: record.body })),
+    corpusFindings,
+    corpusHealth: { recordCount, excludedCount },
+  };
+  return createHash('sha256').update(canonicalStringify(projection), 'utf8').digest('hex');
+}
+
+/** The one entry point every tool handler calls, fresh, at the start of its execution. */
+export async function loadCorpusProjection(options: LoadCorpusProjectionOptions): Promise<CorpusProjection> {
+  const roots = await verifyRoots(options);
+
+  let candidates: string[];
+  try {
+    candidates = await discoverAdrFiles(roots.canonicalDir, roots.canonicalCwd);
+  } catch (error) {
+    fail(errorCode(error) === 'ENOENT' ? 'dir-not-found' : 'dir-not-readable');
+  }
+
+  const preReadFindings: Finding[] = [];
+  const kept: KeptCandidate[] = [];
+
+  for (const candidate of candidates) {
+    const displayPath = normalizeDisplayPath(candidate, roots.canonicalCwd);
+    try {
+      const link = await lstat(candidate);
+      if (link.isSymbolicLink() || !link.isFile()) {
+        preReadFindings.push(statError(displayPath));
+        continue;
+      }
+      const real = await realpath(candidate);
+      if (!isContained(roots.canonicalDir, real)) {
+        preReadFindings.push(statError(displayPath));
+        continue;
+      }
+      const info = await stat(candidate, { bigint: true });
+      if (Number(info.size) > options.maxSourceBytes) {
+        preReadFindings.push(tooLarge(displayPath));
+        continue;
+      }
+      kept.push({
+        absolutePath: candidate,
+        displayPath,
+        identity: { dev: info.dev, ino: info.ino, size: info.size, mtimeNs: info.mtimeNs },
+      });
+    } catch {
+      preReadFindings.push(statError(displayPath));
+    }
+  }
+
+  // Never call lintCorpus with an empty paths array: expandRecordInputs would
+  // re-discover the whole directory and reinstate the excluded files (data-model.md §3.3).
+  let records: Adr[] = [];
+  let lintFindings: Finding[] = [];
+  if (kept.length > 0) {
+    const result = await lintCorpus({ paths: kept.map((k) => k.absolutePath), cwd: roots.canonicalCwd });
+    records = result.records;
+    lintFindings = result.findings;
+  }
+
+  // Post-load revalidation: roots plus every kept candidate's type, containment, and identity.
+  const postRoots = await verifyRoots(options);
+  if (postRoots.canonicalDir !== roots.canonicalDir) fail('corpus-changed-during-load');
+  for (const candidate of kept) {
+    try {
+      const link = await lstat(candidate.absolutePath);
+      if (link.isSymbolicLink() || !link.isFile()) fail('corpus-changed-during-load');
+      const real = await realpath(candidate.absolutePath);
+      if (!isContained(postRoots.canonicalDir, real)) fail('corpus-changed-during-load');
+      const info = await stat(candidate.absolutePath, { bigint: true });
+      if (Number(info.size) > options.maxSourceBytes) fail('corpus-changed-during-load');
+      if (
+        info.dev !== candidate.identity.dev ||
+        info.ino !== candidate.identity.ino ||
+        info.size !== candidate.identity.size ||
+        info.mtimeNs !== candidate.identity.mtimeNs
+      ) {
+        fail('corpus-changed-during-load');
+      }
+    } catch (error) {
+      if (error instanceof CorpusUnavailableError) throw error;
+      fail('corpus-changed-during-load');
+    }
+  }
+
+  const orderedRecords = [...records].sort(
+    (a, b) => compareCodeUnits(a.frontmatter.id, b.frontmatter.id) || compareCodeUnits(a.path, b.path),
+  );
+
+  const byId = new Map<string, Adr[]>();
+  for (const record of orderedRecords) {
+    const bucket = byId.get(record.frontmatter.id) ?? [];
+    bucket.push(record);
+    byId.set(record.frontmatter.id, bucket);
+  }
+  // Each bucket inherits `orderedRecords`' canonical (id, sourcePath) order already.
+
+  const corpusFindings = sortFindingsCanonical([...lintFindings, ...preReadFindings]);
+  const recordCount = orderedRecords.length;
+  const excludedCount = candidates.length - recordCount;
+  const fingerprint = fingerprintOf(orderedRecords, corpusFindings, recordCount, excludedCount);
+
+  return {
+    records: orderedRecords,
+    byId,
+    corpusFindings,
+    fingerprint,
+    recordCount,
+    excludedCount,
+  };
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,61 @@
+/**
+ * @adrkit/mcp — public entry point.
+ *
+ * Exports ONLY the sealed stdio lifecycle factory and its option/handle types.
+ * No SDK server, registration API, internal builder, transport, or test subpath is
+ * reachable from here. No side effects at import time; no filesystem access at
+ * construction time (data-model.md §8, contracts/tools.md §1).
+ */
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { buildRegisteredServer } from './server.ts';
+import { resolveCanonicalRoots, MAX_SOURCE_BYTES } from './corpus/projection.ts';
+import type { ToolConfig } from './tools/shared.ts';
+
+export interface AdrkitMcpServerOptions {
+  readonly cwd: string;
+  readonly dir: string;
+}
+
+export interface AdrkitMcpServerHandle {
+  start(): Promise<void>;
+  close(): Promise<void>;
+}
+
+/**
+ * The public stdio lifecycle factory. Performs NO filesystem access at construction;
+ * `start()` validates the configured root, builds the closure-private server, creates
+ * exactly one `StdioServerTransport`, and connects it. The concrete server, its
+ * registrations, and its transport remain unreachable to the caller.
+ */
+export function createAdrkitMcpServer(
+  options?: Partial<AdrkitMcpServerOptions>,
+): Readonly<AdrkitMcpServerHandle> {
+  const cwd = options?.cwd ?? process.cwd();
+  const dir = options?.dir ?? 'docs/adr';
+
+  let server: McpServer | undefined;
+
+  async function start(): Promise<void> {
+    const roots = await resolveCanonicalRoots({ cwd, dir });
+    const config: ToolConfig = {
+      configuredCwd: roots.canonicalCwd,
+      configuredDir: dir,
+      expectedCanonicalCwd: roots.canonicalCwd,
+      maxSourceBytes: MAX_SOURCE_BYTES,
+    };
+    server = buildRegisteredServer(config);
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+  }
+
+  async function close(): Promise<void> {
+    if (server) await server.close();
+  }
+
+  const handle = Object.create(null) as AdrkitMcpServerHandle;
+  handle.start = start;
+  handle.close = close;
+  return Object.freeze(handle);
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -9,6 +9,7 @@
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { resolve } from 'node:path';
 import { buildRegisteredServer } from './server.ts';
 import { resolveCanonicalRoots, MAX_SOURCE_BYTES } from './corpus/projection.ts';
 import type { ToolConfig } from './tools/shared.ts';
@@ -32,26 +33,60 @@ export interface AdrkitMcpServerHandle {
 export function createAdrkitMcpServer(
   options?: Partial<AdrkitMcpServerOptions>,
 ): Readonly<AdrkitMcpServerHandle> {
-  const cwd = options?.cwd ?? process.cwd();
+  const cwd = resolve(options?.cwd ?? process.cwd());
   const dir = options?.dir ?? 'docs/adr';
 
   let server: McpServer | undefined;
+  let startPromise: Promise<void> | undefined;
+  let closePromise: Promise<void> | undefined;
+  let closed = false;
 
-  async function start(): Promise<void> {
-    const roots = await resolveCanonicalRoots({ cwd, dir });
-    const config: ToolConfig = {
-      configuredCwd: roots.canonicalCwd,
-      configuredDir: dir,
-      expectedCanonicalCwd: roots.canonicalCwd,
-      maxSourceBytes: MAX_SOURCE_BYTES,
-    };
-    server = buildRegisteredServer(config);
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
+  function start(): Promise<void> {
+    if (closed) {
+      return Promise.reject(new Error('adrkit MCP server handle is closed'));
+    }
+    if (startPromise) return startPromise;
+
+    startPromise = (async () => {
+      let nextServer: McpServer | undefined;
+      try {
+        const roots = await resolveCanonicalRoots({ cwd, dir });
+        const config: ToolConfig = {
+          configuredCwd: cwd,
+          configuredDir: dir,
+          expectedCanonicalCwd: roots.canonicalCwd,
+          maxSourceBytes: MAX_SOURCE_BYTES,
+        };
+        nextServer = buildRegisteredServer(config);
+        server = nextServer;
+        await nextServer.connect(new StdioServerTransport());
+      } catch (error) {
+        server = undefined;
+        if (nextServer) {
+          try {
+            await nextServer.close();
+          } catch (closeError) {
+            startPromise = undefined;
+            throw new AggregateError([error, closeError], 'MCP server startup and cleanup failed');
+          }
+        }
+        startPromise = undefined;
+        throw error;
+      }
+    })();
+    return startPromise;
   }
 
-  async function close(): Promise<void> {
-    if (server) await server.close();
+  function close(): Promise<void> {
+    if (closePromise) return closePromise;
+    closed = true;
+    closePromise = (async () => {
+      if (startPromise) await startPromise;
+      const current = server;
+      server = undefined;
+      if (current) await current.close();
+    })();
+    return closePromise;
   }
 
   const handle = Object.create(null) as AdrkitMcpServerHandle;

--- a/packages/mcp/src/main-module.ts
+++ b/packages/mcp/src/main-module.ts
@@ -1,0 +1,72 @@
+/**
+ * @adrkit/mcp — CLI/startup helpers for the `adrkit-mcp` bin.
+ *
+ * The only place `process.argv`/`process.env` are read, the FR-036 startup check
+ * lives, and the `isMainModule()` guard is defined. A local helper mirroring
+ * `packages/cli/src/main-module.ts` (not imported from it). stdout is reserved for
+ * protocol frames; every diagnostic goes to stderr.
+ */
+
+import { existsSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+import { createAdrkitMcpServer } from './index.ts';
+import { resolveCanonicalRoots, CorpusUnavailableError } from './corpus/projection.ts';
+import { CORPUS_UNAVAILABLE_MESSAGES } from './tools/shared.ts';
+
+export function isMainModule(moduleUrl: string, argvPath: string | undefined): boolean {
+  if (!argvPath || !existsSync(argvPath)) return false;
+  return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvPath);
+}
+
+const USAGE = 'usage: adrkit-mcp [--cwd <path>] [--dir <path>]\n';
+
+function writeStderr(text: string): void {
+  process.stderr.write(text);
+}
+
+export async function main(
+  argv: string[],
+  env: Record<string, string | undefined>,
+): Promise<0 | 1 | 2> {
+  let values: { cwd?: string; dir?: string };
+  try {
+    ({ values } = parseArgs({
+      args: argv,
+      options: { cwd: { type: 'string' }, dir: { type: 'string' } },
+      strict: true,
+      allowPositionals: false,
+    }));
+  } catch (error) {
+    writeStderr(`${error instanceof Error ? error.message : String(error)}\n${USAGE}`);
+    return 2;
+  }
+
+  const cwd = values.cwd ?? env.ADRKIT_MCP_CWD ?? process.cwd();
+  const dir = values.dir ?? env.ADRKIT_MCP_DIR ?? 'docs/adr';
+
+  // Fail-fast startup check (FR-036): validate the configured root before any transport.
+  try {
+    await resolveCanonicalRoots({ cwd, dir });
+  } catch (error) {
+    if (error instanceof CorpusUnavailableError) {
+      writeStderr(`${CORPUS_UNAVAILABLE_MESSAGES[error.reason]}\n`);
+      return 1;
+    }
+    throw error;
+  }
+
+  const handle = createAdrkitMcpServer({ cwd, dir });
+
+  const shutdown = (): void => {
+    void handle.close().finally(() => process.exit(0));
+  };
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+  process.on('unhandledRejection', () => {
+    process.exitCode = 1;
+  });
+
+  await handle.start();
+  return 0;
+}

--- a/packages/mcp/src/main-module.ts
+++ b/packages/mcp/src/main-module.ts
@@ -25,6 +25,18 @@ function writeStderr(text: string): void {
   process.stderr.write(text);
 }
 
+export function reportUnhandledRejection(
+  reason: unknown,
+  write: (text: string) => void = writeStderr,
+  fail: () => void = () => {
+    process.exitCode = 1;
+  },
+): void {
+  const detail = reason instanceof Error ? reason.message : String(reason);
+  write(`adrkit-mcp: unhandled rejection: ${detail}\n`);
+  fail();
+}
+
 export async function main(
   argv: string[],
   env: Record<string, string | undefined>,
@@ -63,9 +75,7 @@ export async function main(
   };
   process.once('SIGINT', shutdown);
   process.once('SIGTERM', shutdown);
-  process.on('unhandledRejection', () => {
-    process.exitCode = 1;
-  });
+  process.on('unhandledRejection', (reason) => reportUnhandledRejection(reason));
 
   await handle.start();
   return 0;

--- a/packages/mcp/src/pagination/cursor.ts
+++ b/packages/mcp/src/pagination/cursor.ts
@@ -1,0 +1,162 @@
+/**
+ * @adrkit/mcp — opaque, versioned, query-bound pagination cursors and the
+ * query-shape hash (contracts/pagination-and-cursors.md).
+ */
+
+import { createHash } from 'node:crypto';
+
+export type CursorScope =
+  | 'search.results'
+  | 'search.findings'
+  | 'get_decision.candidates'
+  | 'get_decision.findings'
+  | 'context.results'
+  | 'context.findings'
+  | 'superseded.results'
+  | 'superseded.findings';
+
+export interface CursorPayloadV1 {
+  readonly v: 1;
+  readonly scope: CursorScope;
+  readonly fp: string;
+  readonly qh: string;
+  readonly offset: number;
+}
+
+export type InvalidCursorReason =
+  | 'decode-failed'
+  | 'version-unsupported'
+  | 'wrong-channel'
+  | 'corpus-changed'
+  | 'query-mismatch'
+  | 'cursor-not-applicable'
+  | 'offset-out-of-range';
+
+export interface Page<T> {
+  readonly items: readonly T[];
+  readonly cursor: string | null;
+}
+
+const CURSOR_KEYS = ['v', 'scope', 'fp', 'qh', 'offset'] as const;
+
+/** Fixed-field-order base64url(no-pad) UTF-8 JSON — byte-identical for identical payloads. */
+export function encodeCursor(payload: CursorPayloadV1): string {
+  const json =
+    `{"v":1,"scope":${JSON.stringify(payload.scope)},` +
+    `"fp":${JSON.stringify(payload.fp)},"qh":${JSON.stringify(payload.qh)},` +
+    `"offset":${payload.offset}}`;
+  return Buffer.from(json, 'utf8').toString('base64url');
+}
+
+/** SHA-256 hex over a fixed-order canonical JSON array of the hashed parameters. */
+export function queryShapeHash(parts: readonly unknown[]): string {
+  return createHash('sha256').update(JSON.stringify(parts)).digest('hex');
+}
+
+export interface VerifyCursorOptions {
+  readonly cursor: string;
+  readonly expectedScope: CursorScope;
+  readonly fp: string;
+  readonly qh: string;
+}
+
+export type VerifyCursorResult =
+  | { readonly ok: true; readonly offset: number }
+  | { readonly ok: false; readonly reason: InvalidCursorReason };
+
+function decodeStrict(
+  cursor: string,
+): { v: number; scope: string; fp: string; qh: string; offset: number } | undefined {
+  let text: string;
+  try {
+    text = Buffer.from(cursor, 'base64url').toString('utf8');
+  } catch {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+  const keys = Object.keys(parsed);
+  if (keys.length !== CURSOR_KEYS.length || !CURSOR_KEYS.every((k) => keys.includes(k))) return undefined;
+  const obj = parsed as Record<string, unknown>;
+  if (
+    typeof obj.v !== 'number' ||
+    typeof obj.scope !== 'string' ||
+    typeof obj.fp !== 'string' ||
+    typeof obj.qh !== 'string' ||
+    typeof obj.offset !== 'number' ||
+    !Number.isSafeInteger(obj.offset) ||
+    obj.offset < 1
+  ) {
+    return undefined;
+  }
+  return { v: obj.v, scope: obj.scope, fp: obj.fp, qh: obj.qh, offset: obj.offset };
+}
+
+/** Decode/verify steps 1-6 (pagination §2). */
+export function verifyCursor(options: VerifyCursorOptions): VerifyCursorResult {
+  const decoded = decodeStrict(options.cursor);
+  if (!decoded) return { ok: false, reason: 'decode-failed' };
+  if (decoded.v !== 1) return { ok: false, reason: 'version-unsupported' };
+  if (decoded.scope !== options.expectedScope) return { ok: false, reason: 'wrong-channel' };
+  if (decoded.fp !== options.fp) return { ok: false, reason: 'corpus-changed' };
+  if (decoded.qh !== options.qh) return { ok: false, reason: 'query-mismatch' };
+  return { ok: true, offset: decoded.offset };
+}
+
+export interface PaginateOptions<T> {
+  readonly items: readonly T[];
+  readonly cursor: string | undefined;
+  readonly limit: number;
+  readonly scope: CursorScope;
+  readonly fp: string;
+  readonly qh: string;
+}
+
+export type PaginateResult<T> =
+  | { readonly ok: true; readonly page: Page<T> }
+  | { readonly ok: false; readonly reason: InvalidCursorReason };
+
+/** Full applicable-channel pagination: verify (1-6), range-check (8), slice (9), mint. */
+export function paginate<T>(options: PaginateOptions<T>): PaginateResult<T> {
+  const { items, cursor, limit, scope, fp, qh } = options;
+  let offset = 0;
+  if (cursor !== undefined) {
+    const verified = verifyCursor({ cursor, expectedScope: scope, fp, qh });
+    if (!verified.ok) return { ok: false, reason: verified.reason };
+    offset = verified.offset;
+    if (offset >= items.length) return { ok: false, reason: 'offset-out-of-range' };
+  }
+  const slice = items.slice(offset, offset + limit);
+  const nextOffset = offset + slice.length;
+  const nextCursor = nextOffset < items.length ? encodeCursor({ v: 1, scope, fp, qh, offset: nextOffset }) : null;
+  return { ok: true, page: { items: slice, cursor: nextCursor } };
+}
+
+export interface InapplicablePrimaryOptions {
+  readonly cursor: string | undefined;
+  readonly scope: CursorScope;
+  readonly fp: string;
+  readonly qh: string;
+}
+
+export type InapplicablePrimaryResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: InvalidCursorReason };
+
+/** A primary cursor supplied against an outcome with no primary channel (step 7). */
+export function checkInapplicablePrimaryCursor(options: InapplicablePrimaryOptions): InapplicablePrimaryResult {
+  if (options.cursor === undefined) return { ok: true };
+  const verified = verifyCursor({
+    cursor: options.cursor,
+    expectedScope: options.scope,
+    fp: options.fp,
+    qh: options.qh,
+  });
+  if (!verified.ok) return { ok: false, reason: verified.reason };
+  return { ok: false, reason: 'cursor-not-applicable' };
+}

--- a/packages/mcp/src/search/normalize.ts
+++ b/packages/mcp/src/search/normalize.ts
@@ -1,0 +1,9 @@
+/**
+ * @adrkit/mcp — deterministic search normalization (research §R5).
+ *
+ * `normalize(s) = s.trim().normalize('NFKC').toLowerCase()` — engine-builtin,
+ * non-ICU, locale-independent. No stemming, fuzzy, weighting, or ranking.
+ */
+export function normalize(value: string): string {
+  return value.trim().normalize('NFKC').toLowerCase();
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,27 @@
+/**
+ * @adrkit/mcp — internal server assembly (package-internal, never publicly exported).
+ *
+ * Owns the concrete `McpServer`, its registration APIs, and the in-memory builder
+ * used only by in-process conformance tests. The public factory (`./index.ts`)
+ * exposes only the sealed lifecycle handle. This module is absent from
+ * `package.json#exports` and every public subpath.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerSearchDecisions } from './tools/search-decisions.ts';
+import { registerGetDecision } from './tools/get-decision.ts';
+import { registerGetDecisionContext } from './tools/get-decision-context.ts';
+import { registerListSuperseded } from './tools/list-superseded.ts';
+import type { ToolConfig } from './tools/shared.ts';
+
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.1.0' } as const;
+
+/** Package-internal: build the concrete server with exactly the four ratified tools. */
+export function buildRegisteredServer(config: ToolConfig): McpServer {
+  const server = new McpServer(SERVER_INFO);
+  registerSearchDecisions(server, config);
+  registerGetDecision(server, config);
+  registerGetDecisionContext(server, config);
+  registerListSuperseded(server, config);
+  return server;
+}

--- a/packages/mcp/src/tools/get-decision-context.ts
+++ b/packages/mcp/src/tools/get-decision-context.ts
@@ -1,0 +1,137 @@
+/**
+ * @adrkit/mcp — the `get_decision_context` tool (US2, contracts/tools.md §6).
+ *
+ * Reports governing, active-proposal, and historical records for logical file
+ * paths using the existing `resolveAffects` resolver, once per record, without ever
+ * reading a caller-supplied path. One canonical flat walk is paginated, then the
+ * page is partitioned by status.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { resolveAffects, type Adr, type Finding, type FiredMatcher } from '@adrkit/core';
+import { compareCodeUnits, sortFindingsCanonical } from '../corpus/ordering.ts';
+import { paginate, queryShapeHash } from '../pagination/cursor.ts';
+import {
+  ANNOTATIONS,
+  corpusHealthOf,
+  getDecisionContextInputSchema,
+  getDecisionContextOutputSchema,
+  invalidCursor,
+  loadProjection,
+  renderResponseText,
+  structuredResult,
+  toRelationRefs,
+  toSummary,
+  type ContextEntry,
+  type GetDecisionContextResult,
+  type ToolConfig,
+} from './shared.ts';
+
+interface GetDecisionContextArgs {
+  readonly files: string[];
+  readonly cursor?: string;
+  readonly limit: number;
+  readonly findingsCursor?: string;
+  readonly findingsLimit: number;
+}
+
+type Bucket = 'governing' | 'activeProposals' | 'history';
+
+function bucketFor(status: string): Bucket {
+  if (status === 'accepted') return 'governing';
+  if (status === 'draft' || status === 'proposed') return 'activeProposals';
+  return 'history';
+}
+
+function contextEntry(record: Adr, firedMatchers: readonly FiredMatcher[]): ContextEntry {
+  return { ...toSummary(record), firedMatchers, relations: toRelationRefs(record.frontmatter) };
+}
+
+export function registerGetDecisionContext(server: McpServer, config: ToolConfig): void {
+  server.registerTool(
+    'get_decision_context',
+    {
+      title: 'Get decision context for files',
+      description:
+        'Given repo-relative logical file paths, report which decisions govern them, which active proposals touch them, and which historical records once did — using the corpus\u2019s own affects matchers. The supplied paths are compared against patterns only; they are never opened or read.',
+      inputSchema: getDecisionContextInputSchema(),
+      outputSchema: getDecisionContextOutputSchema(),
+      annotations: ANNOTATIONS,
+    },
+    async (args) => {
+      const { files, cursor, limit, findingsCursor, findingsLimit } = args as GetDecisionContextArgs;
+
+      const loaded = await loadProjection(config);
+      if (!loaded.ok) {
+        return structuredResult(
+          loaded.outcome,
+          renderResponseText({ kind: 'corpus-unavailable', reason: loaded.outcome.reason }),
+          undefined,
+        );
+      }
+      const projection = loaded.projection;
+      const health = corpusHealthOf(projection);
+      const fp = projection.fingerprint;
+
+      const canonicalFiles = [...new Set(files)].sort(compareCodeUnits);
+      const primaryQh = queryShapeHash([canonicalFiles, limit]);
+      const findingsQh = queryShapeHash([canonicalFiles, findingsLimit]);
+
+      // Once per record, in canonical order. Derived findings are concatenated.
+      const flat: ContextEntry[] = [];
+      const derivedFindings: Finding[] = [];
+      for (const record of projection.records) {
+        const resolved = resolveAffects({ records: [record], changedFiles: files });
+        derivedFindings.push(...resolved.findings);
+        const match = resolved.matches[0];
+        if (match) flat.push(contextEntry(record, match.firedMatchers));
+      }
+
+      const responseFindings = sortFindingsCanonical([...projection.corpusFindings, ...derivedFindings]);
+
+      const primary = paginate({ items: flat, cursor, limit, scope: 'context.results', fp, qh: primaryQh });
+      if (!primary.ok) return invalid(primary.reason);
+      const findingsPage = paginate({
+        items: responseFindings,
+        cursor: findingsCursor,
+        limit: findingsLimit,
+        scope: 'context.findings',
+        fp,
+        qh: findingsQh,
+      });
+      if (!findingsPage.ok) return invalid(findingsPage.reason);
+
+      const governing: ContextEntry[] = [];
+      const activeProposals: ContextEntry[] = [];
+      const history: ContextEntry[] = [];
+      for (const entry of primary.page.items) {
+        const target = bucketFor(entry.status) === 'governing' ? governing : bucketFor(entry.status) === 'activeProposals' ? activeProposals : history;
+        target.push(entry);
+      }
+
+      const result: GetDecisionContextResult = {
+        outcome: 'matches',
+        governing,
+        activeProposals,
+        history,
+        cursor: primary.page.cursor,
+        findings: findingsPage.page,
+      };
+      return structuredResult(
+        result,
+        renderResponseText({
+          kind: 'matches',
+          governing: governing.length,
+          activeProposals: activeProposals.length,
+          history: history.length,
+          findings: findingsPage.page.items.length,
+        }),
+        health,
+      );
+
+      function invalid(reason: Parameters<typeof invalidCursor>[0]) {
+        return structuredResult(invalidCursor(reason), renderResponseText({ kind: 'invalid-cursor', reason }), health);
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/get-decision.ts
+++ b/packages/mcp/src/tools/get-decision.ts
@@ -1,0 +1,169 @@
+/**
+ * @adrkit/mcp — the `get_decision` tool (US1, contracts/tools.md §4).
+ *
+ * Fetches one within-limit decision by ref. `parseAdrRef` detects a log-qualified
+ * ref first (→ federated-log-unavailable, never a local substitute); a bare id is
+ * resolved through the fresh local `byId` bucket into found / not-found /
+ * ambiguous-local-id. Relation refs are surfaced verbatim, never expanded.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { parseAdrRef, type Adr } from '@adrkit/core';
+import { paginate, queryShapeHash, checkInapplicablePrimaryCursor } from '../pagination/cursor.ts';
+import {
+  ANNOTATIONS,
+  corpusHealthOf,
+  getDecisionInputSchema,
+  getDecisionOutputSchema,
+  invalidCursor,
+  loadProjection,
+  renderResponseText,
+  structuredResult,
+  toSummary,
+  type DecisionSummary,
+  type FullDecision,
+  type GetDecisionResult,
+  type ToolConfig,
+} from './shared.ts';
+
+interface GetDecisionArgs {
+  readonly ref: string;
+  readonly cursor?: string;
+  readonly limit: number;
+  readonly findingsCursor?: string;
+  readonly findingsLimit: number;
+}
+
+function fullDecision(record: Adr, ref: string): FullDecision {
+  return {
+    requestedRef: ref,
+    id: record.frontmatter.id,
+    title: record.frontmatter.title,
+    status: record.frontmatter.status,
+    sourcePath: record.path,
+    frontmatter: record.frontmatter,
+    body: record.body,
+  };
+}
+
+export function registerGetDecision(server: McpServer, config: ToolConfig): void {
+  server.registerTool(
+    'get_decision',
+    {
+      title: 'Get a decision by ref',
+      description:
+        'Fetch one architecture decision by its bare local id (e.g. "0042"). Returns the complete typed frontmatter and Markdown body, or an explicit not-found / ambiguous-local-id / federated-log-unavailable outcome. Relation refs are surfaced verbatim, never expanded.',
+      inputSchema: getDecisionInputSchema(),
+      outputSchema: getDecisionOutputSchema(),
+      annotations: ANNOTATIONS,
+    },
+    async (args) => {
+      const { ref, cursor, limit, findingsCursor, findingsLimit } = args as GetDecisionArgs;
+
+      const loaded = await loadProjection(config);
+      if (!loaded.ok) {
+        return structuredResult(
+          loaded.outcome,
+          renderResponseText({ kind: 'corpus-unavailable', reason: loaded.outcome.reason }),
+          undefined,
+        );
+      }
+      const projection = loaded.projection;
+      const health = corpusHealthOf(projection);
+      const fp = projection.fingerprint;
+      const responseFindings = projection.corpusFindings; // get_decision derives none.
+
+      // Findings channel (always applicable).
+      const findingsPage = paginate({
+        items: responseFindings,
+        cursor: findingsCursor,
+        limit: findingsLimit,
+        scope: 'get_decision.findings',
+        fp,
+        qh: queryShapeHash([findingsLimit]),
+      });
+
+      const parsed = parseAdrRef(ref);
+      const candidatesQh = queryShapeHash([ref, limit]);
+
+      // Log-qualified refs are federated-log-unavailable; byId is never consulted.
+      if (parsed.log !== undefined) {
+        const inapplicable = checkInapplicablePrimaryCursor({ cursor, scope: 'get_decision.candidates', fp, qh: candidatesQh });
+        if (!inapplicable.ok) return invalidResult(inapplicable.reason, health);
+        if (!findingsPage.ok) return invalidResult(findingsPage.reason, health);
+        const result: GetDecisionResult = {
+          outcome: 'federated-log-unavailable',
+          requestedRef: ref,
+          log: parsed.log,
+          id: parsed.id,
+          findings: findingsPage.page,
+        };
+        return structuredResult(
+          result,
+          renderResponseText({ kind: 'federated-log-unavailable', requestedRef: ref, findings: findingsPage.page.items.length }),
+          health,
+        );
+      }
+
+      const bucket = projection.byId.get(parsed.id) ?? [];
+
+      if (bucket.length > 1) {
+        const candidates: DecisionSummary[] = bucket.map(toSummary);
+        const primary = paginate({
+          items: candidates,
+          cursor,
+          limit,
+          scope: 'get_decision.candidates',
+          fp,
+          qh: candidatesQh,
+        });
+        if (!primary.ok) return invalidResult(primary.reason, health);
+        if (!findingsPage.ok) return invalidResult(findingsPage.reason, health);
+        const result: GetDecisionResult = {
+          outcome: 'ambiguous-local-id',
+          requestedRef: ref,
+          candidates: primary.page.items,
+          cursor: primary.page.cursor,
+          findings: findingsPage.page,
+        };
+        return structuredResult(
+          result,
+          renderResponseText({
+            kind: 'ambiguous-local-id',
+            candidatesLength: primary.page.items.length,
+            requestedRef: ref,
+            findings: findingsPage.page.items.length,
+          }),
+          health,
+        );
+      }
+
+      // found / not-found: the primary channel does not exist.
+      const inapplicable = checkInapplicablePrimaryCursor({ cursor, scope: 'get_decision.candidates', fp, qh: candidatesQh });
+      if (!inapplicable.ok) return invalidResult(inapplicable.reason, health);
+      if (!findingsPage.ok) return invalidResult(findingsPage.reason, health);
+
+      if (bucket.length === 1) {
+        const record = bucket[0] as Adr;
+        const result: GetDecisionResult = { outcome: 'found', decision: fullDecision(record, ref), findings: findingsPage.page };
+        return structuredResult(
+          result,
+          renderResponseText({ kind: 'found', id: record.frontmatter.id, findings: findingsPage.page.items.length }),
+          health,
+        );
+      }
+
+      const result: GetDecisionResult = { outcome: 'not-found', requestedRef: ref, findings: findingsPage.page };
+      return structuredResult(
+        result,
+        renderResponseText({ kind: 'not-found', requestedRef: ref, findings: findingsPage.page.items.length }),
+        health,
+      );
+
+      function invalidResult(reason: Parameters<typeof invalidCursor>[0], corpusHealth: ReturnType<typeof corpusHealthOf>) {
+        const outcome = invalidCursor(reason);
+        return structuredResult(outcome, renderResponseText({ kind: 'invalid-cursor', reason }), corpusHealth);
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/list-superseded.ts
+++ b/packages/mcp/src/tools/list-superseded.ts
@@ -1,0 +1,148 @@
+/**
+ * @adrkit/mcp — the `list_superseded` tool (US4, contracts/tools.md §7).
+ *
+ * Lists every superseded record with its DIRECT local replacement state, resolving
+ * only unqualified local targets through the fresh `byId` bucket. Never walks
+ * lineage, never embeds candidate arrays, and mints only the two specified derived
+ * finding templates.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { parseAdrRef, type Adr, type Finding } from '@adrkit/core';
+import { sortFindingsCanonical } from '../corpus/ordering.ts';
+import { paginate, queryShapeHash } from '../pagination/cursor.ts';
+import {
+  ANNOTATIONS,
+  corpusHealthOf,
+  invalidCursor,
+  loadProjection,
+  renderResponseText,
+  listSupersededInputSchema,
+  listSupersededOutputSchema,
+  structuredResult,
+  toSummary,
+  type ListSupersededResult,
+  type SupersededByState,
+  type SupersededEntry,
+  type ToolConfig,
+} from './shared.ts';
+
+interface ListSupersededArgs {
+  readonly cursor?: string;
+  readonly limit: number;
+  readonly findingsCursor?: string;
+  readonly findingsLimit: number;
+}
+
+interface ResolvedEntry {
+  readonly entry: SupersededEntry;
+  readonly derived: Finding | undefined;
+}
+
+function resolveEntry(record: Adr, byId: ReadonlyMap<string, readonly Adr[]>): ResolvedEntry {
+  // The schema invariant guarantees a superseded record has supersededBy.
+  const targetRef = record.frontmatter.supersededBy as string;
+  const parsed = parseAdrRef(targetRef);
+  const summary = toSummary(record);
+
+  if (parsed.log !== undefined) {
+    const supersededBy: SupersededByState = {
+      resolved: false,
+      targetRef,
+      reason: 'federated-unavailable',
+      log: parsed.log,
+      id: parsed.id,
+    };
+    const derived: Finding = {
+      rule: 'superseded-target-federated-unavailable',
+      severity: 'info',
+      id: record.frontmatter.id,
+      message: `supersededBy target "${targetRef}" is a log-qualified ref; named-log federation is not available in this phase`,
+    };
+    return { entry: { ...summary, supersededBy }, derived };
+  }
+
+  const bucket = byId.get(parsed.id) ?? [];
+  if (bucket.length === 1) {
+    return { entry: { ...summary, supersededBy: { resolved: true, target: toSummary(bucket[0] as Adr) } }, derived: undefined };
+  }
+  if (bucket.length === 0) {
+    return { entry: { ...summary, supersededBy: { resolved: false, targetRef, reason: 'dangling' } }, derived: undefined };
+  }
+  const supersededBy: SupersededByState = { resolved: false, targetRef, reason: 'ambiguous', candidateCount: bucket.length };
+  const derived: Finding = {
+    rule: 'superseded-target-ambiguous',
+    severity: 'warn',
+    id: record.frontmatter.id,
+    message: `supersededBy target "${targetRef}" resolves to ${bucket.length} local records; see get_decision("${targetRef}") for the full candidate list`,
+  };
+  return { entry: { ...summary, supersededBy }, derived };
+}
+
+export function registerListSuperseded(server: McpServer, config: ToolConfig): void {
+  server.registerTool(
+    'list_superseded',
+    {
+      title: 'List superseded decisions',
+      description:
+        'List every superseded decision with its direct local replacement state: resolved, dangling, ambiguous (candidateCount only), or federated-unavailable. Direct edges only \u2014 no transitive lineage, no embedded candidate arrays.',
+      inputSchema: listSupersededInputSchema(),
+      outputSchema: listSupersededOutputSchema(),
+      annotations: ANNOTATIONS,
+    },
+    async (args) => {
+      const { cursor, limit, findingsCursor, findingsLimit } = args as ListSupersededArgs;
+
+      const loaded = await loadProjection(config);
+      if (!loaded.ok) {
+        return structuredResult(
+          loaded.outcome,
+          renderResponseText({ kind: 'corpus-unavailable', reason: loaded.outcome.reason }),
+          undefined,
+        );
+      }
+      const projection = loaded.projection;
+      const health = corpusHealthOf(projection);
+      const fp = projection.fingerprint;
+
+      const entries: SupersededEntry[] = [];
+      const derivedFindings: Finding[] = [];
+      for (const record of projection.records) {
+        if (record.frontmatter.status !== 'superseded') continue;
+        const resolved = resolveEntry(record, projection.byId);
+        entries.push(resolved.entry);
+        if (resolved.derived) derivedFindings.push(resolved.derived);
+      }
+
+      const responseFindings = sortFindingsCanonical([...projection.corpusFindings, ...derivedFindings]);
+
+      const primary = paginate({ items: entries, cursor, limit, scope: 'superseded.results', fp, qh: queryShapeHash([limit]) });
+      if (!primary.ok) return invalid(primary.reason);
+      const findingsPage = paginate({
+        items: responseFindings,
+        cursor: findingsCursor,
+        limit: findingsLimit,
+        scope: 'superseded.findings',
+        fp,
+        qh: queryShapeHash([findingsLimit]),
+      });
+      if (!findingsPage.ok) return invalid(findingsPage.reason);
+
+      const result: ListSupersededResult = {
+        outcome: 'entries',
+        items: primary.page.items,
+        cursor: primary.page.cursor,
+        findings: findingsPage.page,
+      };
+      return structuredResult(
+        result,
+        renderResponseText({ kind: 'entries', itemsLength: primary.page.items.length, findings: findingsPage.page.items.length }),
+        health,
+      );
+
+      function invalid(reason: Parameters<typeof invalidCursor>[0]) {
+        return structuredResult(invalidCursor(reason), renderResponseText({ kind: 'invalid-cursor', reason }), health);
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/search-decisions.ts
+++ b/packages/mcp/src/tools/search-decisions.ts
@@ -1,0 +1,131 @@
+/**
+ * @adrkit/mcp — the `search_decisions` tool (US3, contracts/tools.md §5).
+ *
+ * Deterministic normalized literal substring search over id, title, tags, and
+ * body. Filters (status any-of, scope any-of, tags all-of, ANDed) apply before the
+ * normalizer. Graveyard records are included by default. Returns bounded summaries
+ * only — never a body, ranking score, or hidden index.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Adr } from '@adrkit/core';
+import { compareCodeUnits } from '../corpus/ordering.ts';
+import { normalize } from '../search/normalize.ts';
+import { paginate, queryShapeHash } from '../pagination/cursor.ts';
+import {
+  ANNOTATIONS,
+  corpusHealthOf,
+  invalidCursor,
+  loadProjection,
+  renderResponseText,
+  searchDecisionsInputSchema,
+  searchDecisionsOutputSchema,
+  structuredResult,
+  toSummary,
+  type SearchDecisionsResult,
+  type SearchMatch,
+  type ToolConfig,
+} from './shared.ts';
+
+interface SearchDecisionsArgs {
+  readonly query: string;
+  readonly status?: string[];
+  readonly tags?: string[];
+  readonly scope?: string[];
+  readonly cursor?: string;
+  readonly limit: number;
+  readonly findingsCursor?: string;
+  readonly findingsLimit: number;
+}
+
+const MATCHED_FIELD_ORDER = ['body', 'id', 'tag', 'title'] as const;
+type MatchedField = (typeof MATCHED_FIELD_ORDER)[number];
+
+function sortedUnique(values: readonly string[] | undefined): string[] {
+  return values ? [...new Set(values)].sort(compareCodeUnits) : [];
+}
+
+function passesFilters(record: Adr, status: string[] | undefined, scope: string[] | undefined, tags: string[] | undefined): boolean {
+  if (status && !status.includes(record.frontmatter.status)) return false;
+  if (scope && !scope.includes(record.frontmatter.scope)) return false;
+  if (tags && !tags.every((tag) => record.frontmatter.tags.includes(tag))) return false;
+  return true;
+}
+
+function matchedFields(record: Adr, needle: string): MatchedField[] {
+  const fields: MatchedField[] = [];
+  if (normalize(record.body).includes(needle)) fields.push('body');
+  if (normalize(record.frontmatter.id).includes(needle)) fields.push('id');
+  if (record.frontmatter.tags.some((tag) => normalize(tag).includes(needle))) fields.push('tag');
+  if (normalize(record.frontmatter.title).includes(needle)) fields.push('title');
+  return fields; // already in the fixed ['body','id','tag','title'] order
+}
+
+export function registerSearchDecisions(server: McpServer, config: ToolConfig): void {
+  server.registerTool(
+    'search_decisions',
+    {
+      title: 'Search decisions',
+      description:
+        'Search the decision corpus (including the graveyard by default) by deterministic normalized literal substring over id, title, tags, and Markdown body. Optional status/scope (any-of) and tags (all-of) filters are ANDed. Returns bounded summaries only \u2014 no ranking, no model, no body.',
+      inputSchema: searchDecisionsInputSchema(),
+      outputSchema: searchDecisionsOutputSchema(),
+      annotations: ANNOTATIONS,
+    },
+    async (args) => {
+      const { query, status, tags, scope, cursor, limit, findingsCursor, findingsLimit } = args as SearchDecisionsArgs;
+
+      const loaded = await loadProjection(config);
+      if (!loaded.ok) {
+        return structuredResult(
+          loaded.outcome,
+          renderResponseText({ kind: 'corpus-unavailable', reason: loaded.outcome.reason }),
+          undefined,
+        );
+      }
+      const projection = loaded.projection;
+      const health = corpusHealthOf(projection);
+      const fp = projection.fingerprint;
+
+      const needle = normalize(query);
+      const primaryQh = queryShapeHash([needle, sortedUnique(status), sortedUnique(tags), sortedUnique(scope), limit]);
+      const findingsQh = queryShapeHash([findingsLimit]);
+
+      const matches: SearchMatch[] = [];
+      for (const record of projection.records) {
+        if (!passesFilters(record, status, scope, tags)) continue;
+        const fields = matchedFields(record, needle);
+        if (fields.length === 0) continue;
+        matches.push({ ...toSummary(record), matchedFields: fields });
+      }
+
+      const primary = paginate({ items: matches, cursor, limit, scope: 'search.results', fp, qh: primaryQh });
+      if (!primary.ok) return invalid(primary.reason);
+      const findingsPage = paginate({
+        items: projection.corpusFindings,
+        cursor: findingsCursor,
+        limit: findingsLimit,
+        scope: 'search.findings',
+        fp,
+        qh: findingsQh,
+      });
+      if (!findingsPage.ok) return invalid(findingsPage.reason);
+
+      const result: SearchDecisionsResult = {
+        outcome: 'results',
+        items: primary.page.items,
+        cursor: primary.page.cursor,
+        findings: findingsPage.page,
+      };
+      return structuredResult(
+        result,
+        renderResponseText({ kind: 'results', itemsLength: primary.page.items.length, findings: findingsPage.page.items.length }),
+        health,
+      );
+
+      function invalid(reason: Parameters<typeof invalidCursor>[0]) {
+        return structuredResult(invalidCursor(reason), renderResponseText({ kind: 'invalid-cursor', reason }), health);
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/shared.ts
+++ b/packages/mcp/src/tools/shared.ts
@@ -1,0 +1,583 @@
+/**
+ * @adrkit/mcp — the shared tool contract: strict Zod input/output schemas, the
+ * fixed annotations, the deterministic text renderer (contracts/tools.md §2.1),
+ * and the wire shapes every tool returns. This is the ONE place limits, the text
+ * templates, and the envelope live.
+ */
+
+import { z } from 'zod';
+import { AdrFrontmatter, AdrRef, Status, Scope, type Finding, type FiredMatcher } from '@adrkit/core';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import {
+  loadCorpusProjection,
+  CorpusUnavailableError,
+  type CorpusHealth,
+  type CorpusProjection,
+  type CorpusUnavailableReason,
+} from '../corpus/projection.ts';
+import type { CursorScope, InvalidCursorReason, Page } from '../pagination/cursor.ts';
+
+export type { Finding, FiredMatcher } from '@adrkit/core';
+export type { CorpusHealth } from '../corpus/projection.ts';
+
+/* ------------------------------------------------------------------ *
+ * Fixed limits (contracts/tools.md §8)
+ * ------------------------------------------------------------------ */
+
+export const LIMITS = {
+  query: { min: 1, max: 256 },
+  ref: { min: 1, max: 128 },
+  status: { min: 1, max: 6 },
+  scope: { min: 1, max: 3 },
+  tags: { min: 1, max: 32 },
+  tag: { min: 1, max: 64 },
+  fileLength: { min: 1, max: 1024 },
+  files: { min: 1, max: 256 },
+  page: { min: 1, max: 100, default: 20 },
+  cursorBytes: 4 * 1024,
+  textCap: 512,
+} as const;
+
+/* ------------------------------------------------------------------ *
+ * Fixed annotations (contracts/tools.md §2)
+ * ------------------------------------------------------------------ */
+
+export const ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+} as const;
+
+/* ------------------------------------------------------------------ *
+ * Fixed message tables (contracts/tools.md §2.1)
+ * ------------------------------------------------------------------ */
+
+export const INVALID_CURSOR_MESSAGES: Record<InvalidCursorReason, string> = {
+  'decode-failed': 'Cursor could not be decoded.',
+  'version-unsupported': 'Cursor version is not supported.',
+  'wrong-channel': 'Cursor does not belong to this tool channel.',
+  'corpus-changed': 'Corpus changed after this cursor was issued.',
+  'query-mismatch': 'Cursor was issued for different request parameters.',
+  'cursor-not-applicable': 'Cursor does not apply to this outcome.',
+  'offset-out-of-range': 'Cursor offset is outside the current result set.',
+};
+
+export const CORPUS_UNAVAILABLE_MESSAGES: Record<CorpusUnavailableReason, string> = {
+  'root-not-found': 'Configured repository root was not found.',
+  'root-not-directory': 'Configured repository root is not a directory.',
+  'root-not-readable': 'Configured repository root is not readable.',
+  'root-not-git': 'Configured repository root is not a Git worktree.',
+  'dir-not-found': 'Configured ADR directory was not found.',
+  'dir-not-directory': 'Configured ADR directory is not a directory.',
+  'dir-not-readable': 'Configured ADR directory is not readable.',
+  'dir-outside-root': 'Configured ADR directory resolves outside the repository root.',
+  'corpus-changed-during-load': 'Corpus changed while it was being loaded; retry the call.',
+};
+
+const INVALID_CURSOR_REASONS = Object.keys(INVALID_CURSOR_MESSAGES) as [InvalidCursorReason, ...InvalidCursorReason[]];
+const CORPUS_UNAVAILABLE_REASONS = Object.keys(CORPUS_UNAVAILABLE_MESSAGES) as [
+  CorpusUnavailableReason,
+  ...CorpusUnavailableReason[],
+];
+
+/** `n === 1 ? one : many`. */
+export function plural(n: number, one: string, many: string): string {
+  return n === 1 ? one : many;
+}
+
+/** Immutable per-server config every tool handler reads to load its projection. */
+export interface ToolConfig {
+  readonly configuredCwd: string;
+  readonly configuredDir: string;
+  readonly expectedCanonicalCwd: string;
+  readonly maxSourceBytes: number;
+}
+
+/* ------------------------------------------------------------------ *
+ * Wire shapes (data-model.md §4, §6)
+ * ------------------------------------------------------------------ */
+
+export type StatusValue = z.infer<typeof Status>;
+export type ScopeValue = z.infer<typeof Scope>;
+
+export interface DecisionSummary {
+  readonly id: string;
+  readonly title: string;
+  readonly status: StatusValue;
+  readonly sourcePath: string;
+}
+
+export interface RelationRefs {
+  readonly supersedes: readonly string[];
+  readonly supersededBy: string | null;
+  readonly relatesTo: readonly string[];
+  readonly conflictsWith: readonly string[];
+}
+
+export interface FullDecision {
+  readonly requestedRef: string;
+  readonly id: string;
+  readonly title: string;
+  readonly status: StatusValue;
+  readonly sourcePath: string;
+  readonly frontmatter: z.infer<typeof AdrFrontmatter>;
+  readonly body: string;
+}
+
+export interface SearchMatch extends DecisionSummary {
+  readonly matchedFields: readonly ('id' | 'title' | 'tag' | 'body')[];
+}
+
+export interface ContextEntry extends DecisionSummary {
+  readonly firedMatchers: readonly FiredMatcher[];
+  readonly relations: RelationRefs;
+}
+
+export type SupersededByState =
+  | { readonly resolved: true; readonly target: DecisionSummary }
+  | { readonly resolved: false; readonly targetRef: string; readonly reason: 'dangling' }
+  | { readonly resolved: false; readonly targetRef: string; readonly reason: 'ambiguous'; readonly candidateCount: number }
+  | {
+      readonly resolved: false;
+      readonly targetRef: string;
+      readonly reason: 'federated-unavailable';
+      readonly log: string;
+      readonly id: string;
+    };
+
+export interface SupersededEntry extends DecisionSummary {
+  readonly supersededBy: SupersededByState;
+}
+
+export type FindingsPage = Page<Finding>;
+
+export interface InvalidCursorOutcome {
+  readonly outcome: 'invalid-cursor';
+  readonly reason: InvalidCursorReason;
+  readonly message: string;
+}
+
+export interface CorpusUnavailableOutcome {
+  readonly outcome: 'corpus-unavailable';
+  readonly reason: CorpusUnavailableReason;
+  readonly message: string;
+}
+
+export type SearchDecisionsResult =
+  | { outcome: 'results'; items: readonly SearchMatch[]; cursor: string | null; findings: FindingsPage }
+  | InvalidCursorOutcome
+  | CorpusUnavailableOutcome;
+
+export type GetDecisionResult =
+  | { outcome: 'found'; decision: FullDecision; findings: FindingsPage }
+  | { outcome: 'not-found'; requestedRef: string; findings: FindingsPage }
+  | {
+      outcome: 'ambiguous-local-id';
+      requestedRef: string;
+      candidates: readonly DecisionSummary[];
+      cursor: string | null;
+      findings: FindingsPage;
+    }
+  | { outcome: 'federated-log-unavailable'; requestedRef: string; log: string; id: string; findings: FindingsPage }
+  | InvalidCursorOutcome
+  | CorpusUnavailableOutcome;
+
+export type GetDecisionContextResult =
+  | {
+      outcome: 'matches';
+      governing: readonly ContextEntry[];
+      activeProposals: readonly ContextEntry[];
+      history: readonly ContextEntry[];
+      cursor: string | null;
+      findings: FindingsPage;
+    }
+  | InvalidCursorOutcome
+  | CorpusUnavailableOutcome;
+
+export type ListSupersededResult =
+  | { outcome: 'entries'; items: readonly SupersededEntry[]; cursor: string | null; findings: FindingsPage }
+  | InvalidCursorOutcome
+  | CorpusUnavailableOutcome;
+
+/* ------------------------------------------------------------------ *
+ * Deterministic text renderer (contracts/tools.md §2.1)
+ * ------------------------------------------------------------------ */
+
+export type TextSpec =
+  | { kind: 'results'; itemsLength: number; findings: number }
+  | { kind: 'found'; id: string; findings: number }
+  | { kind: 'not-found'; requestedRef: string; findings: number }
+  | { kind: 'ambiguous-local-id'; candidatesLength: number; requestedRef: string; findings: number }
+  | { kind: 'federated-log-unavailable'; requestedRef: string; findings: number }
+  | { kind: 'matches'; governing: number; activeProposals: number; history: number; findings: number }
+  | { kind: 'entries'; itemsLength: number; findings: number }
+  | { kind: 'invalid-cursor'; reason: InvalidCursorReason }
+  | { kind: 'corpus-unavailable'; reason: CorpusUnavailableReason };
+
+/** Cap a rendered string at 512 UTF-16 code units. */
+export function cap512(value: string): string {
+  return value.length > LIMITS.textCap ? value.slice(0, LIMITS.textCap) : value;
+}
+
+function findingsPhrase(findings: number): string {
+  return `${findings} ${plural(findings, 'finding', 'findings')} on this page.`;
+}
+
+export function renderResponseText(spec: TextSpec): string {
+  let text: string;
+  switch (spec.kind) {
+    case 'results':
+      text = `Returned ${spec.itemsLength} decision ${plural(spec.itemsLength, 'result', 'results')}; ${findingsPhrase(spec.findings)}`;
+      break;
+    case 'found':
+      text = `Found decision "${spec.id}"; ${findingsPhrase(spec.findings)}`;
+      break;
+    case 'not-found':
+      text = `No local decision matches "${spec.requestedRef}"; ${findingsPhrase(spec.findings)}`;
+      break;
+    case 'ambiguous-local-id':
+      text = `Returned ${spec.candidatesLength} ${plural(spec.candidatesLength, 'candidate', 'candidates')} for ambiguous local ref "${spec.requestedRef}"; ${findingsPhrase(spec.findings)}`;
+      break;
+    case 'federated-log-unavailable':
+      text = `Named-log federation is unavailable for "${spec.requestedRef}"; ${findingsPhrase(spec.findings)}`;
+      break;
+    case 'matches': {
+      const pageMatchCount = spec.governing + spec.activeProposals + spec.history;
+      text = `Returned ${pageMatchCount} context ${plural(pageMatchCount, 'match', 'matches')}: ${spec.governing} governing, ${spec.activeProposals} active ${plural(spec.activeProposals, 'proposal', 'proposals')}, ${spec.history} historical; ${findingsPhrase(spec.findings)}`;
+      break;
+    }
+    case 'entries':
+      text = `Returned ${spec.itemsLength} superseded decision ${plural(spec.itemsLength, 'entry', 'entries')}; ${findingsPhrase(spec.findings)}`;
+      break;
+    case 'invalid-cursor':
+      text = INVALID_CURSOR_MESSAGES[spec.reason];
+      break;
+    case 'corpus-unavailable':
+      text = CORPUS_UNAVAILABLE_MESSAGES[spec.reason];
+      break;
+  }
+  return cap512(text);
+}
+
+/* ------------------------------------------------------------------ *
+ * Schemas
+ * ------------------------------------------------------------------ */
+
+export type ToolInputSchema = z.ZodType;
+export type ToolOutputSchema = z.ZodRawShape;
+
+const uniqueArray = <T>(schema: z.ZodType<T>, min: number, max: number) =>
+  z
+    .array(schema)
+    .min(min)
+    .max(max)
+    .refine((values) => new Set(values.map((v) => JSON.stringify(v))).size === values.length, {
+      message: 'Items must be unique',
+    });
+
+function paginationShape(): z.ZodRawShape {
+  const cursor = z.string().max(LIMITS.cursorBytes).optional();
+  const limit = z.number().int().min(LIMITS.page.min).max(LIMITS.page.max).default(LIMITS.page.default);
+  return { cursor, limit, findingsCursor: cursor, findingsLimit: limit };
+}
+
+function isSafePosixPath(path: string): boolean {
+  if (path.includes('\\')) return false;
+  if (path.startsWith('/')) return false;
+  if (/^[a-zA-Z]:/.test(path)) return false;
+  if (path.split('/').includes('..')) return false;
+  return path.length > 0;
+}
+
+export function searchDecisionsInputSchema(): ToolInputSchema {
+  return z.strictObject({
+    query: z
+      .string()
+      .min(LIMITS.query.min)
+      .max(LIMITS.query.max)
+      .refine((q) => q.trim().length >= 1, { message: 'query must be non-empty after trimming' }),
+    status: uniqueArray(Status, LIMITS.status.min, LIMITS.status.max).optional(),
+    tags: uniqueArray(z.string().min(LIMITS.tag.min).max(LIMITS.tag.max), LIMITS.tags.min, LIMITS.tags.max).optional(),
+    scope: uniqueArray(Scope, LIMITS.scope.min, LIMITS.scope.max).optional(),
+    ...paginationShape(),
+  });
+}
+
+export function getDecisionInputSchema(): ToolInputSchema {
+  return z.strictObject({
+    ref: AdrRef.max(LIMITS.ref.max),
+    ...paginationShape(),
+  });
+}
+
+export function getDecisionContextInputSchema(): ToolInputSchema {
+  return z.strictObject({
+    files: z
+      .array(
+        z
+          .string()
+          .min(LIMITS.fileLength.min)
+          .max(LIMITS.fileLength.max)
+          .refine(isSafePosixPath, { message: 'files must be repo-relative POSIX paths' }),
+      )
+      .min(LIMITS.files.min)
+      .max(LIMITS.files.max),
+    ...paginationShape(),
+  });
+}
+
+export function listSupersededInputSchema(): ToolInputSchema {
+  return z.strictObject({ ...paginationShape() });
+}
+
+export function findingSchema(): z.ZodType {
+  return z.object({
+    rule: z.string(),
+    severity: z.enum(['error', 'warn', 'info']),
+    message: z.string(),
+    path: z.string().optional(),
+    id: z.string().optional(),
+    field: z.string().optional(),
+    pattern: z.string().optional(),
+  });
+}
+
+export function corpusHealthSchema(): z.ZodType {
+  return z.object({
+    fingerprint: z.string(),
+    recordCount: z.number().int(),
+    excludedCount: z.number().int(),
+  });
+}
+
+function findingsPageSchema(): z.ZodType {
+  return z.object({ items: z.array(findingSchema()), cursor: z.string().nullable() });
+}
+
+function decisionSummarySchema(): z.ZodType {
+  return z.object({ id: z.string(), title: z.string(), status: Status, sourcePath: z.string() });
+}
+
+function relationRefsSchema(): z.ZodType {
+  return z.object({
+    supersedes: z.array(z.string()),
+    supersededBy: z.string().nullable(),
+    relatesTo: z.array(z.string()),
+    conflictsWith: z.array(z.string()),
+  });
+}
+
+function invalidCursorSchema() {
+  return z.object({
+    outcome: z.literal('invalid-cursor'),
+    reason: z.enum(INVALID_CURSOR_REASONS),
+    message: z.string(),
+  });
+}
+
+function corpusUnavailableSchema() {
+  return z.object({
+    outcome: z.literal('corpus-unavailable'),
+    reason: z.enum(CORPUS_UNAVAILABLE_REASONS),
+    message: z.string(),
+  });
+}
+
+export function searchDecisionsOutputSchema(): ToolOutputSchema {
+  const searchMatch = z.object({
+    id: z.string(),
+    title: z.string(),
+    status: Status,
+    sourcePath: z.string(),
+    matchedFields: z.array(z.enum(['id', 'title', 'tag', 'body'])),
+  });
+  return {
+    corpusHealth: corpusHealthSchema().optional(),
+    result: z.discriminatedUnion('outcome', [
+      z.object({
+        outcome: z.literal('results'),
+        items: z.array(searchMatch),
+        cursor: z.string().nullable(),
+        findings: findingsPageSchema(),
+      }),
+      invalidCursorSchema(),
+      corpusUnavailableSchema(),
+    ]),
+  };
+}
+
+export function getDecisionOutputSchema(): ToolOutputSchema {
+  const fullDecision = z.object({
+    requestedRef: z.string(),
+    id: z.string(),
+    title: z.string(),
+    status: Status,
+    sourcePath: z.string(),
+    frontmatter: AdrFrontmatter,
+    body: z.string(),
+  });
+  return {
+    corpusHealth: corpusHealthSchema().optional(),
+    result: z.discriminatedUnion('outcome', [
+      z.object({ outcome: z.literal('found'), decision: fullDecision, findings: findingsPageSchema() }),
+      z.object({ outcome: z.literal('not-found'), requestedRef: z.string(), findings: findingsPageSchema() }),
+      z.object({
+        outcome: z.literal('ambiguous-local-id'),
+        requestedRef: z.string(),
+        candidates: z.array(decisionSummarySchema()),
+        cursor: z.string().nullable(),
+        findings: findingsPageSchema(),
+      }),
+      z.object({
+        outcome: z.literal('federated-log-unavailable'),
+        requestedRef: z.string(),
+        log: z.string(),
+        id: z.string(),
+        findings: findingsPageSchema(),
+      }),
+      invalidCursorSchema(),
+      corpusUnavailableSchema(),
+    ]),
+  };
+}
+
+export function getDecisionContextOutputSchema(): ToolOutputSchema {
+  const contextEntry = z.object({
+    id: z.string(),
+    title: z.string(),
+    status: Status,
+    sourcePath: z.string(),
+    firedMatchers: z.array(z.object({ type: z.string(), pattern: z.string() })),
+    relations: relationRefsSchema(),
+  });
+  return {
+    corpusHealth: corpusHealthSchema().optional(),
+    result: z.discriminatedUnion('outcome', [
+      z.object({
+        outcome: z.literal('matches'),
+        governing: z.array(contextEntry),
+        activeProposals: z.array(contextEntry),
+        history: z.array(contextEntry),
+        cursor: z.string().nullable(),
+        findings: findingsPageSchema(),
+      }),
+      invalidCursorSchema(),
+      corpusUnavailableSchema(),
+    ]),
+  };
+}
+
+export function listSupersededOutputSchema(): ToolOutputSchema {
+  const supersededBy = z.union([
+    z.object({ resolved: z.literal(true), target: decisionSummarySchema() }),
+    z.object({ resolved: z.literal(false), targetRef: z.string(), reason: z.literal('dangling') }),
+    z.object({
+      resolved: z.literal(false),
+      targetRef: z.string(),
+      reason: z.literal('ambiguous'),
+      candidateCount: z.number().int(),
+    }),
+    z.object({
+      resolved: z.literal(false),
+      targetRef: z.string(),
+      reason: z.literal('federated-unavailable'),
+      log: z.string(),
+      id: z.string(),
+    }),
+  ]);
+  const supersededEntry = z.object({
+    id: z.string(),
+    title: z.string(),
+    status: Status,
+    sourcePath: z.string(),
+    supersededBy,
+  });
+  return {
+    corpusHealth: corpusHealthSchema().optional(),
+    result: z.discriminatedUnion('outcome', [
+      z.object({
+        outcome: z.literal('entries'),
+        items: z.array(supersededEntry),
+        cursor: z.string().nullable(),
+        findings: findingsPageSchema(),
+      }),
+      invalidCursorSchema(),
+      corpusUnavailableSchema(),
+    ]),
+  };
+}
+
+/* ------------------------------------------------------------------ *
+ * CallToolResult builder
+ * ------------------------------------------------------------------ */
+
+export type StructuredResult = CallToolResult;
+
+export function structuredResult(
+  result: unknown,
+  text: string,
+  corpusHealth: CorpusHealth | undefined,
+): CallToolResult {
+  const structuredContent = corpusHealth === undefined ? { result } : { corpusHealth, result };
+  return { structuredContent, content: [{ type: 'text', text }] };
+}
+
+/* ------------------------------------------------------------------ *
+ * Handler runtime helpers
+ * ------------------------------------------------------------------ */
+
+export function corpusHealthOf(projection: CorpusProjection): CorpusHealth {
+  return {
+    fingerprint: projection.fingerprint,
+    recordCount: projection.recordCount,
+    excludedCount: projection.excludedCount,
+  };
+}
+
+export function invalidCursor(reason: InvalidCursorReason): InvalidCursorOutcome {
+  return { outcome: 'invalid-cursor', reason, message: INVALID_CURSOR_MESSAGES[reason] };
+}
+
+export function corpusUnavailable(reason: CorpusUnavailableReason): CorpusUnavailableOutcome {
+  return { outcome: 'corpus-unavailable', reason, message: CORPUS_UNAVAILABLE_MESSAGES[reason] };
+}
+
+export type LoadResult =
+  | { readonly ok: true; readonly projection: CorpusProjection }
+  | { readonly ok: false; readonly outcome: CorpusUnavailableOutcome };
+
+/** Load the fresh projection, mapping a typed `CorpusUnavailableError` to its outcome. */
+export async function loadProjection(config: ToolConfig): Promise<LoadResult> {
+  try {
+    const projection = await loadCorpusProjection({
+      configuredCwd: config.configuredCwd,
+      configuredDir: config.configuredDir,
+      expectedCanonicalCwd: config.expectedCanonicalCwd,
+      maxSourceBytes: config.maxSourceBytes,
+    });
+    return { ok: true, projection };
+  } catch (error) {
+    if (error instanceof CorpusUnavailableError) return { ok: false, outcome: corpusUnavailable(error.reason) };
+    throw error;
+  }
+}
+
+/** Every tool derives its DecisionSummary from an Adr record the same way. */
+export function toSummary(record: { frontmatter: { id: string; title: string; status: StatusValue }; path: string }): DecisionSummary {
+  return {
+    id: record.frontmatter.id,
+    title: record.frontmatter.title,
+    status: record.frontmatter.status,
+    sourcePath: record.path,
+  };
+}
+
+export function toRelationRefs(frontmatter: z.infer<typeof AdrFrontmatter>): RelationRefs {
+  return {
+    supersedes: frontmatter.supersedes,
+    supersededBy: frontmatter.supersededBy ?? null,
+    relatesTo: frontmatter.relatesTo,
+    conflictsWith: frontmatter.conflictsWith,
+  };
+}

--- a/packages/mcp/test/bin.test.ts
+++ b/packages/mcp/test/bin.test.ts
@@ -3,7 +3,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { main } from '../src/main-module.ts';
+import { main, reportUnhandledRejection } from '../src/main-module.ts';
 import { createRepo, repoFromFixture, type TempRepo } from './helpers.ts';
 
 const BIN_SRC = resolve(dirname(fileURLToPath(import.meta.url)), '../src/bin.ts');
@@ -99,6 +99,22 @@ describe('adrkit-mcp bin — startup validation and exit codes', () => {
     expect(code).toBe(1);
     expect(std.stderr).toContain('ADR directory');
     expect(std.stderr).not.toContain('Git worktree');
+  });
+
+  test('an unhandled rejection emits a stderr diagnostic and sets failure status', () => {
+    let diagnostic = '';
+    let failed = false;
+    reportUnhandledRejection(
+      new Error('background transport failed'),
+      (text) => {
+        diagnostic += text;
+      },
+      () => {
+        failed = true;
+      },
+    );
+    expect(diagnostic).toContain('unhandled rejection: background transport failed');
+    expect(failed).toBe(true);
   });
 });
 

--- a/packages/mcp/test/bin.test.ts
+++ b/packages/mcp/test/bin.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { main } from '../src/main-module.ts';
+import { createRepo, repoFromFixture, type TempRepo } from './helpers.ts';
+
+const BIN_SRC = resolve(dirname(fileURLToPath(import.meta.url)), '../src/bin.ts');
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+interface Captured {
+  stdout: string;
+  stderr: string;
+  restore(): void;
+}
+
+function captureStd(): Captured {
+  const captured: Captured = { stdout: '', stderr: '', restore() {} };
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    captured.stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    captured.stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  captured.restore = () => {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+  };
+  return captured;
+}
+
+async function runMain(argv: string[], env: Record<string, string | undefined> = {}): Promise<{ code: number; std: Captured }> {
+  const std = captureStd();
+  try {
+    const code = await main(argv, env);
+    return { code, std };
+  } finally {
+    std.restore();
+  }
+}
+
+describe('adrkit-mcp bin — startup validation and exit codes', () => {
+  test('an unknown flag exits 2 with stderr-only diagnostics', async () => {
+    const { code, std } = await runMain(['--nope']);
+    expect(code).toBe(2);
+    expect(std.stdout).toBe('');
+    expect(std.stderr.length).toBeGreaterThan(0);
+  });
+
+  test('a flag missing its value exits 2', async () => {
+    expect((await runMain(['--cwd'])).code).toBe(2);
+  });
+
+  test('an invalid root exits 1 with a stderr-only, path-free reason', async () => {
+    const { code, std } = await runMain(['--cwd', '/definitely/not/a/root', '--dir', 'docs/adr']);
+    expect(code).toBe(1);
+    expect(std.stdout).toBe('');
+    expect(std.stderr).toContain('repository root');
+  });
+
+  test('an invalid dir under a valid root exits 1 naming the directory problem', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    const { code, std } = await runMain(['--cwd', repo.root, '--dir', 'no-such-subdir']);
+    expect(code).toBe(1);
+    expect(std.stderr).toContain('ADR directory');
+  });
+
+  test('a flag --cwd beats ADRKIT_MCP_CWD (dir error proves the flag root was used)', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    const { code, std } = await runMain(['--cwd', repo.root, '--dir', 'no-such'], { ADRKIT_MCP_CWD: '/definitely/not/a/root' });
+    expect(code).toBe(1);
+    expect(std.stderr).toContain('ADR directory'); // not "repository root" — the flag cwd resolved fine
+  });
+
+  test('env vars are used when no flag is given', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    const { code, std } = await runMain([], { ADRKIT_MCP_CWD: repo.root, ADRKIT_MCP_DIR: 'no-such' });
+    expect(code).toBe(1);
+    expect(std.stderr).toContain('ADR directory');
+  });
+
+  test('a linked-worktree .git FILE is accepted as a root', async () => {
+    const repo = await createRepo({ gitFile: true });
+    cleanups.push(repo.cleanup);
+    // dir invalid so we fail fast without starting a server; a root-not-git error would prove rejection.
+    const { code, std } = await runMain(['--cwd', repo.root, '--dir', 'no-such']);
+    expect(code).toBe(1);
+    expect(std.stderr).toContain('ADR directory');
+    expect(std.stderr).not.toContain('Git worktree');
+  });
+});
+
+describe('adrkit-mcp bin — real stdio subprocess', () => {
+  async function spawnClient(repo: TempRepo): Promise<Client> {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [BIN_SRC, '--cwd', repo.root],
+    });
+    const client = new Client({ name: 'bin-test', version: '0.0.0' });
+    await client.connect(transport);
+    cleanups.push(() => client.close());
+    return client;
+  }
+
+  test('initialize / list / call / shutdown over real stdio', async () => {
+    const repo = await repoFromFixture('edge-corpus');
+    cleanups.push(repo.cleanup);
+    const client = await spawnClient(repo);
+    const list = await client.listTools();
+    expect(list.tools.map((t) => t.name).sort()).toEqual([
+      'get_decision',
+      'get_decision_context',
+      'list_superseded',
+      'search_decisions',
+    ]);
+    const call = await client.callTool({ name: 'list_superseded', arguments: {} });
+    expect((call.structuredContent as { result: { outcome: string } }).result.outcome).toBe('entries');
+  });
+
+  test('stdout is line-by-line JSON-RPC only, with zero non-protocol bytes', async () => {
+    const repo = await repoFromFixture('status-corpus');
+    cleanups.push(repo.cleanup);
+    const proc = Bun.spawn([process.execPath, BIN_SRC, '--cwd', repo.root], {
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const frames = [
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 't', version: '0' } } },
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+      { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'get_decision', arguments: { ref: '0001' } } },
+    ];
+    proc.stdin.write(frames.map((f) => `${JSON.stringify(f)}\n`).join(''));
+    await proc.stdin.end();
+    const out = await new Response(proc.stdout).text();
+    proc.kill();
+    await proc.exited;
+    const lines = out.split('\n').filter((line) => line.length > 0);
+    expect(lines.length).toBeGreaterThanOrEqual(3);
+    const ids = new Set<number>();
+    for (const line of lines) {
+      const message = JSON.parse(line); // throws if any non-JSON byte leaked to stdout
+      expect(message.jsonrpc).toBe('2.0');
+      if (typeof message.id === 'number') ids.add(message.id);
+    }
+    expect(ids.has(2)).toBe(true);
+    expect(ids.has(3)).toBe(true);
+  });
+});

--- a/packages/mcp/test/boundary.test.ts
+++ b/packages/mcp/test/boundary.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, writeFile, rm, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildRegisteredServer } from '../src/server.ts';
+import {
+  connectServer,
+  callTool,
+  resultOf,
+  repoFromFixture,
+  snapshotTree,
+  snapshotPaths,
+  diffSnapshots,
+  toolConfig,
+  type OpenServer,
+  type TempRepo,
+} from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+async function connectBuilt(repo: TempRepo): Promise<OpenServer> {
+  const server = buildRegisteredServer(await toolConfig(repo.root, repo.dir));
+  const harness = await connectServer(server);
+  cleanups.push(harness.close);
+  return harness;
+}
+
+describe('boundary — read-only, sandboxed, no arbitrary reads', () => {
+  test('no tool call mutates the sandbox tree or any parent/TMPDIR sentinel', async () => {
+    const repo = await repoFromFixture('status-corpus');
+    cleanups.push(repo.cleanup);
+    const parentSentinel = join(repo.root, '..', 'adrkit-parent-sentinel.txt');
+    await writeFile(parentSentinel, 'parent', 'utf8');
+    cleanups.push(() => rm(parentSentinel, { force: true }));
+    const tmpSentinelDir = await realpath(await mkdtemp(join(tmpdir(), 'adrkit-sentinel-')));
+    const tmpSentinel = join(tmpSentinelDir, 'sentinel.txt');
+    await writeFile(tmpSentinel, 'tmp', 'utf8');
+    cleanups.push(() => rm(tmpSentinelDir, { recursive: true, force: true }));
+
+    const sentinels = [parentSentinel, tmpSentinel, join(repo.root, '.git')];
+    const treeBefore = await snapshotTree(repo.root);
+    const sentBefore = await snapshotPaths(sentinels);
+
+    const { client } = await connectBuilt(repo);
+    await callTool(client, 'search_decisions', { query: 'the' });
+    await callTool(client, 'get_decision', { ref: '0001' });
+    await callTool(client, 'get_decision_context', { files: ['src/app.ts'] });
+    await callTool(client, 'list_superseded', {});
+
+    expect(diffSnapshots(treeBefore, await snapshotTree(repo.root))).toEqual([]);
+    expect(diffSnapshots(sentBefore, await snapshotPaths(sentinels))).toEqual([]);
+  });
+
+  test('adversarial inputs are rejected before any corpus access, mutating nothing', async () => {
+    const repo = await repoFromFixture('status-corpus');
+    cleanups.push(repo.cleanup);
+    const before = await snapshotTree(repo.root);
+    const { client } = await connectBuilt(repo);
+    const bad = [
+      ['get_decision_context', { files: ['../escape.md'] }],
+      ['get_decision_context', { files: ['/abs.md'] }],
+      ['get_decision_context', { files: ['docs\\adr\\x.md'] }],
+      ['search_decisions', { query: 'x', bogus: 1 }],
+      ['get_decision', { ref: 'x'.repeat(200) }],
+    ] as const;
+    for (const [name, args] of bad) {
+      const res = await callTool(client, name, args as Record<string, unknown>);
+      expect(res.isError).toBe(true);
+    }
+    expect(diffSnapshots(before, await snapshotTree(repo.root))).toEqual([]);
+  });
+
+  test('no successful response interpolates an absolute corpus path', async () => {
+    const repo = await repoFromFixture('status-corpus');
+    cleanups.push(repo.cleanup);
+    const { client } = await connectBuilt(repo);
+    for (const [name, args] of [
+      ['search_decisions', { query: 'the' }],
+      ['get_decision', { ref: '0001' }],
+      ['get_decision_context', { files: ['src/app.ts'] }],
+      ['list_superseded', {}],
+    ] as const) {
+      const res = await callTool(client, name, args as Record<string, unknown>);
+      expect(JSON.stringify(res)).not.toContain(repo.root);
+    }
+  });
+
+  test('each call fresh-reads the corpus: an edit between calls is visible', async () => {
+    const repo = await repoFromFixture('status-corpus');
+    cleanups.push(repo.cleanup);
+    const { client } = await connectBuilt(repo);
+    expect(resultOf(await callTool(client, 'get_decision', { ref: '0099' })).outcome).toBe('not-found');
+    await writeFile(
+      join(repo.adrDir, '0099-late-addition.md'),
+      '---\nschemaVersion: 0.1.0\nid: "0099"\ntitle: A late addition\nstatus: draft\ndate: 2026-06-01\n---\n\n# 0099\n',
+      'utf8',
+    );
+    expect(resultOf(await callTool(client, 'get_decision', { ref: '0099' })).outcome).toBe('found');
+  });
+
+  test('concurrent calls do not share mutable results or findings', async () => {
+    const repo = await repoFromFixture('edge-corpus');
+    cleanups.push(repo.cleanup);
+    const { client } = await connectBuilt(repo);
+    const [search, superseded] = await Promise.all([
+      callTool(client, 'search_decisions', { query: 'duplicate' }),
+      callTool(client, 'list_superseded', {}),
+    ]);
+    expect(resultOf(search).outcome).toBe('results');
+    expect(resultOf(superseded).outcome).toBe('entries');
+    // Distinct findings arrays, independently derived.
+    expect(resultOf(search).findings.items).not.toBe(resultOf(superseded).findings.items);
+  });
+});

--- a/packages/mcp/test/boundary.test.ts
+++ b/packages/mcp/test/boundary.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdtemp, writeFile, rm, realpath } from 'node:fs/promises';
+import { mkdir, mkdtemp, writeFile, rm, realpath } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { buildRegisteredServer } from '../src/server.ts';
 import {
   connectServer,
@@ -17,6 +20,9 @@ import {
 } from './helpers.ts';
 
 const cleanups: Array<() => Promise<void>> = [];
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PRELOAD = join(HERE, 'side-effect-denial-preload.mjs');
+const BIN_SRC = resolve(HERE, '../src/bin.ts');
 afterEach(async () => {
   for (const c of cleanups.splice(0)) await c();
 });
@@ -52,6 +58,53 @@ describe('boundary — read-only, sandboxed, no arbitrary reads', () => {
 
     expect(diffSnapshots(treeBefore, await snapshotTree(repo.root))).toEqual([]);
     expect(diffSnapshots(sentBefore, await snapshotPaths(sentinels))).toEqual([]);
+  });
+
+  test('real stdio corpus reads stay inside the configured root and preserve complete HOME/TMPDIR trees', async () => {
+    const repo = await repoFromFixture('status-corpus');
+    cleanups.push(repo.cleanup);
+    const environmentRoot = await mkdtemp(join(tmpdir(), 'adrkit-mcp-environment-'));
+    cleanups.push(() => rm(environmentRoot, { recursive: true, force: true }));
+    const home = join(environmentRoot, 'home');
+    const processTmp = join(environmentRoot, 'tmp');
+    await mkdir(home);
+    await mkdir(processTmp);
+    await writeFile(join(home, 'sentinel.txt'), 'home', 'utf8');
+    await writeFile(join(processTmp, 'sentinel.txt'), 'tmp', 'utf8');
+
+    const repoBefore = await snapshotTree(repo.root);
+    const homeBefore = await snapshotTree(home);
+    const tmpBefore = await snapshotTree(processTmp);
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ['--preload', PRELOAD, BIN_SRC, '--cwd', repo.root],
+      env: {
+        ...Object.fromEntries(
+          Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+        ),
+        HOME: home,
+        TMPDIR: processTmp,
+        BUN_RUNTIME_TRANSPILER_CACHE_PATH: '0',
+        ADRKIT_MCP_TEST_READ_ROOTS: JSON.stringify([repo.root]),
+      },
+    });
+    const client = new Client({ name: 'boundary-test', version: '0.0.0' });
+    await client.connect(transport);
+    cleanups.push(() => client.close());
+
+    for (const [name, args] of [
+      ['search_decisions', { query: 'the' }],
+      ['get_decision', { ref: '0001' }],
+      ['get_decision_context', { files: ['src/app.ts'] }],
+      ['list_superseded', {}],
+    ] as const) {
+      const response = await client.callTool({ name, arguments: args });
+      expect(response.isError).toBeFalsy();
+    }
+
+    expect(diffSnapshots(repoBefore, await snapshotTree(repo.root))).toEqual([]);
+    expect(diffSnapshots(homeBefore, await snapshotTree(home))).toEqual([]);
+    expect(diffSnapshots(tmpBefore, await snapshotTree(processTmp))).toEqual([]);
   });
 
   test('adversarial inputs are rejected before any corpus access, mutating nothing', async () => {

--- a/packages/mcp/test/cursor.test.ts
+++ b/packages/mcp/test/cursor.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  encodeCursor,
+  verifyCursor,
+  paginate,
+  checkInapplicablePrimaryCursor,
+  queryShapeHash,
+  type CursorScope,
+} from '../src/pagination/cursor.ts';
+import { walkChannel } from './helpers.ts';
+
+const FP = 'a'.repeat(64);
+const QH = 'b'.repeat(64);
+const ALL_SCOPES: CursorScope[] = [
+  'search.results',
+  'search.findings',
+  'get_decision.candidates',
+  'get_decision.findings',
+  'context.results',
+  'context.findings',
+  'superseded.results',
+  'superseded.findings',
+];
+
+function mint(scope: CursorScope, offset: number, fp = FP, qh = QH): string {
+  return encodeCursor({ v: 1, scope, fp, qh, offset });
+}
+
+function failReason(result: { ok: boolean } & Record<string, unknown>): unknown {
+  return result.ok ? 'ok' : result.reason;
+}
+
+describe('cursor wire format', () => {
+  test('encodes fixed-field-order base64url V1 with no padding or whitespace', () => {
+    const cursor = mint('search.results', 3);
+    expect(cursor).not.toContain('=');
+    const json = Buffer.from(cursor, 'base64url').toString('utf8');
+    expect(json).toBe(`{"v":1,"scope":"search.results","fp":"${FP}","qh":"${QH}","offset":3}`);
+  });
+
+  test('is deterministic for identical payloads', () => {
+    expect(mint('search.results', 3)).toBe(mint('search.results', 3));
+  });
+
+  test('round-trips through verifyCursor for all eight scopes', () => {
+    for (const scope of ALL_SCOPES) {
+      const result = verifyCursor({ cursor: mint(scope, 7), expectedScope: scope, fp: FP, qh: QH });
+      expect(result).toEqual({ ok: true, offset: 7 });
+    }
+  });
+});
+
+describe('verifyCursor decode/verify order', () => {
+  test('decode-failed on garbage', () => {
+    expect(verifyCursor({ cursor: '!!!not-base64!!!', expectedScope: 'search.results', fp: FP, qh: QH })).toEqual({
+      ok: false,
+      reason: 'decode-failed',
+    });
+  });
+
+  test('decode-failed on offset 0, negative, or non-safe', () => {
+    for (const offset of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 2]) {
+      const raw = Buffer.from(JSON.stringify({ v: 1, scope: 'search.results', fp: FP, qh: QH, offset })).toString(
+        'base64url',
+      );
+      expect(verifyCursor({ cursor: raw, expectedScope: 'search.results', fp: FP, qh: QH }).ok).toBe(false);
+    }
+  });
+
+  test('decode-failed on unknown keys / missing keys', () => {
+    const extra = Buffer.from(JSON.stringify({ v: 1, scope: 'search.results', fp: FP, qh: QH, offset: 1, x: 1 })).toString('base64url');
+    expect(failReason(verifyCursor({ cursor: extra, expectedScope: 'search.results', fp: FP, qh: QH }))).toBe('decode-failed');
+  });
+
+  test('version-unsupported for a future v', () => {
+    const raw = Buffer.from(JSON.stringify({ v: 2, scope: 'search.results', fp: FP, qh: QH, offset: 1 })).toString('base64url');
+    expect(failReason(verifyCursor({ cursor: raw, expectedScope: 'search.results', fp: FP, qh: QH }))).toBe(
+      'version-unsupported',
+    );
+  });
+
+  test('wrong-channel when scope differs from the input field', () => {
+    expect(failReason(verifyCursor({ cursor: mint('search.findings', 1), expectedScope: 'search.results', fp: FP, qh: QH }))).toBe(
+      'wrong-channel',
+    );
+    // a different tool's channel entirely
+    expect(failReason(verifyCursor({ cursor: mint('superseded.results', 1), expectedScope: 'search.results', fp: FP, qh: QH }))).toBe(
+      'wrong-channel',
+    );
+  });
+
+  test('corpus-changed when fp mismatches', () => {
+    expect(failReason(verifyCursor({ cursor: mint('search.results', 1, 'c'.repeat(64)), expectedScope: 'search.results', fp: FP, qh: QH }))).toBe(
+      'corpus-changed',
+    );
+  });
+
+  test('query-mismatch when qh mismatches', () => {
+    expect(failReason(verifyCursor({ cursor: mint('search.results', 1, FP, 'd'.repeat(64)), expectedScope: 'search.results', fp: FP, qh: QH }))).toBe(
+      'query-mismatch',
+    );
+  });
+
+  test('fp is checked before qh (corpus-changed wins when both differ)', () => {
+    const cursor = mint('search.results', 1, 'c'.repeat(64), 'd'.repeat(64));
+    expect(failReason(verifyCursor({ cursor, expectedScope: 'search.results', fp: FP, qh: QH }))).toBe('corpus-changed');
+  });
+});
+
+describe('paginate (applicable channel)', () => {
+  const items = [0, 1, 2, 3, 4];
+  const base = { scope: 'search.results' as const, fp: FP, qh: QH, limit: 2 };
+
+  test('first page (no cursor) mints a continuation cursor', () => {
+    const result = paginate({ items, cursor: undefined, ...base });
+    expect(result).toEqual({ ok: true, page: { items: [0, 1], cursor: expect.any(String) } });
+  });
+
+  test('a lossless walk returns every item exactly once', async () => {
+    const collected = await walkChannel<number>(async (cursor) => {
+      const result = paginate({ items, cursor, ...base });
+      if (!result.ok) throw new Error(result.reason);
+      return result.page;
+    });
+    expect(collected).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test('the final page has a null cursor', () => {
+    const result = paginate({ items, cursor: mint('search.results', 4), ...base });
+    expect(result.ok && result.page.cursor).toBeNull();
+    expect(result.ok && result.page.items).toEqual([4]);
+  });
+
+  test('offset-out-of-range when offset >= length', () => {
+    const result = paginate({ items, cursor: mint('search.results', 5), ...base });
+    expect(result).toEqual({ ok: false, reason: 'offset-out-of-range' });
+  });
+
+  test('an empty channel with no cursor is a single null-cursor page', () => {
+    const result = paginate({ items: [], cursor: undefined, ...base });
+    expect(result).toEqual({ ok: true, page: { items: [], cursor: null } });
+  });
+});
+
+describe('checkInapplicablePrimaryCursor (step 7)', () => {
+  test('a well-formed, correctly-scoped cursor with no channel is cursor-not-applicable', () => {
+    expect(
+      checkInapplicablePrimaryCursor({ cursor: mint('get_decision.candidates', 2), scope: 'get_decision.candidates', fp: FP, qh: QH }),
+    ).toEqual({ ok: false, reason: 'cursor-not-applicable' });
+  });
+
+  test('no cursor supplied is fine (nothing to resume)', () => {
+    expect(
+      checkInapplicablePrimaryCursor({ cursor: undefined, scope: 'get_decision.candidates', fp: FP, qh: QH }),
+    ).toEqual({ ok: true });
+  });
+
+  test('a cursor that fails an earlier step reports that earlier reason, not cursor-not-applicable', () => {
+    expect(
+      checkInapplicablePrimaryCursor({ cursor: mint('get_decision.candidates', 2, 'c'.repeat(64)), scope: 'get_decision.candidates', fp: FP, qh: QH }),
+    ).toEqual({ ok: false, reason: 'corpus-changed' });
+  });
+});
+
+describe('queryShapeHash', () => {
+  test('is a deterministic 64-hex digest', () => {
+    expect(queryShapeHash(['a', ['b'], 20])).toMatch(/^[0-9a-f]{64}$/);
+    expect(queryShapeHash(['a', ['b'], 20])).toBe(queryShapeHash(['a', ['b'], 20]));
+  });
+
+  test('changes when any hashed parameter changes', () => {
+    expect(queryShapeHash(['a', 20])).not.toBe(queryShapeHash(['a', 50]));
+  });
+});

--- a/packages/mcp/test/fingerprint.test.ts
+++ b/packages/mcp/test/fingerprint.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createRepo, writeRecords, toolConfig, type TempRepo } from './helpers.ts';
+import { loadCorpusProjection } from '../src/corpus/projection.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+async function fingerprintOf(repo: TempRepo): Promise<string> {
+  const projection = await loadCorpusProjection(await toolConfig(repo.root, repo.dir));
+  return projection.fingerprint;
+}
+
+async function repoWith(name: string, content: string): Promise<TempRepo> {
+  const repo = await createRepo();
+  cleanups.push(repo.cleanup);
+  await writeRecords(repo, { [name]: content });
+  return repo;
+}
+
+const ORDERED = `---
+schemaVersion: 0.1.0
+id: "0001"
+title: Same decision
+status: accepted
+date: 2026-01-01
+deciders:
+  - "@maintainer"
+tags:
+  - alpha
+  - beta
+---
+
+# Same decision
+
+Body text stays byte-for-byte.
+`;
+
+// Different YAML byte layout (key order, quoting, flow vs block) — SAME parsed frontmatter.
+const RESERIALIZED = `---
+date: 2026-01-01
+status: accepted
+title: "Same decision"
+id: "0001"
+schemaVersion: "0.1.0"
+deciders: ["@maintainer"]
+tags: [alpha, beta]
+---
+
+# Same decision
+
+Body text stays byte-for-byte.
+`;
+
+describe('corpus fingerprint (research §R6)', () => {
+  test('is byte-identical across two loads of an unchanged corpus', async () => {
+    const repo = await repoWith('0001-same-decision.md', ORDERED);
+    expect(await fingerprintOf(repo)).toBe(await fingerprintOf(repo));
+  });
+
+  test('is stable across a YAML-only reserialization that parses identically', async () => {
+    const a = await repoWith('0001-same-decision.md', ORDERED);
+    const b = await repoWith('0001-same-decision.md', RESERIALIZED);
+    expect(await fingerprintOf(a)).toBe(await fingerprintOf(b));
+  });
+
+  test('changes when the body changes', async () => {
+    const a = await repoWith('0001-same-decision.md', ORDERED);
+    const b = await repoWith('0001-same-decision.md', ORDERED.replace('byte-for-byte', 'DIFFERENT'));
+    expect(await fingerprintOf(a)).not.toBe(await fingerprintOf(b));
+  });
+
+  test('changes when the source path changes', async () => {
+    const a = await repoWith('0001-same-decision.md', ORDERED);
+    const b = await repoWith('0001-renamed-decision.md', ORDERED);
+    expect(await fingerprintOf(a)).not.toBe(await fingerprintOf(b));
+  });
+
+  test('changes when a parsed frontmatter field changes (tag order)', async () => {
+    const a = await repoWith('0001-same-decision.md', ORDERED);
+    const b = await repoWith('0001-same-decision.md', ORDERED.replace('  - alpha\n  - beta', '  - beta\n  - alpha'));
+    expect(await fingerprintOf(a)).not.toBe(await fingerprintOf(b));
+  });
+
+  test('changes when a corpus finding is added (a duplicate id)', async () => {
+    const a = await repoWith('0001-same-decision.md', ORDERED);
+    const b = await createRepo();
+    cleanups.push(b.cleanup);
+    await writeRecords(b, {
+      '0001-same-decision.md': ORDERED,
+      '0001-duplicate.md': ORDERED.replace('title: Same decision', 'title: Duplicate holder'),
+    });
+    expect(await fingerprintOf(a)).not.toBe(await fingerprintOf(b));
+  });
+});

--- a/packages/mcp/test/fixtures/README.md
+++ b/packages/mcp/test/fixtures/README.md
@@ -1,0 +1,53 @@
+# `@adrkit/mcp` offline test fixtures
+
+Every corpus here is a **local, offline, model-free, credential-free** set of ADR
+markdown files authored by hand for this package's tests. Nothing in this tree is
+fetched over a network, generated at test time, or copied from an external corpus.
+Dynamic scenarios that need a real repository shape (a `.git` entry, oversized
+sources, mid-load swaps, symlink escapes, linked worktrees) are built by
+`packages/mcp/test/helpers.ts` in disposable temporary directories, never committed
+here.
+
+## `status-corpus/` — one valid record per `Status`
+
+Six schema-valid records, exactly one per `Status` value, each carrying an
+`affects: [{ type: path, pattern: "src/**" }]` matcher so a single
+`get_decision_context` query for `src/…` partitions all six statuses across the
+three buckets:
+
+| id | status | bucket | notes |
+|----|--------|--------|-------|
+| `0001` | `accepted` | governing | has deciders; body contains the body-only token `pgvector` |
+| `0002` | `draft` | activeProposals | |
+| `0003` | `proposed` | activeProposals | |
+| `0004` | `rejected` | history | title names `MongoDB` (title-search fixture) |
+| `0005` | `superseded` | history | `supersededBy: "0001"` (resolves to an accepted target) |
+| `0006` | `deprecated` | history | |
+
+`lintCorpus` reports **six records, zero findings** for this corpus.
+
+## `edge-corpus/` — duplicate ids and every supersession target shape
+
+| id | status | purpose |
+|----|--------|---------|
+| `0010` (×2) | `accepted`, `proposed` | one id held by two files → `ambiguous-local-id` / `unique-id` finding |
+| `0015` | `accepted` | the unique, resolvable supersession target |
+| `0011` | `superseded` | `supersededBy: "0010"` → ambiguous target (`candidateCount: 2`) |
+| `0012` | `superseded` | `supersededBy: "0099"` → dangling target (+ core `dangling-supersededBy`) |
+| `0013` | `superseded` | `supersededBy: "payments:0020"` → log-qualified / federated target |
+| `0014` | `superseded` | `supersededBy: "0015"` → resolved unique target |
+
+`lintCorpus` reports **seven records** and the findings `unique-id` (×2 for `0010`)
+plus `dangling-supersededBy` for `0012` and `0013`.
+
+## `degraded-corpus/` — schema-invalid record beside inert-matcher records
+
+| id | status | purpose |
+|----|--------|---------|
+| `0030` | `accepted` | title `"ab"` is below the schema minimum → excluded from `records`, surfaced only as a finding |
+| `0031` | `accepted` | has an inert `package` matcher (`left-pad@^1`) → `affects-unresolvable` (info) when `get_decision_context` runs, with no dependency snapshot |
+| `0032` | `draft` | a plain valid neighbor that stays fully retrievable despite the invalid sibling |
+
+`lintCorpus` reports **two records** (`0031`, `0032`) and one exclusion finding for
+`0030`, proving a schema-invalid record degrades to a finding without removing any
+valid neighbor from tool results.

--- a/packages/mcp/test/fixtures/degraded-corpus/0030-schema-invalid.md
+++ b/packages/mcp/test/fixtures/degraded-corpus/0030-schema-invalid.md
@@ -1,0 +1,13 @@
+---
+schemaVersion: 0.1.0
+id: "0030"
+title: ab
+status: accepted
+date: 2026-03-01
+deciders:
+  - "@maintainer"
+---
+
+# Invalid record
+
+Title is too short so this fails schema validation and is excluded.

--- a/packages/mcp/test/fixtures/degraded-corpus/0031-inert-package-matcher.md
+++ b/packages/mcp/test/fixtures/degraded-corpus/0031-inert-package-matcher.md
@@ -1,0 +1,20 @@
+---
+schemaVersion: 0.1.0
+id: "0031"
+title: Record with an inert package matcher
+status: accepted
+date: 2026-03-02
+deciders:
+  - "@maintainer"
+tags:
+  - inert
+affects:
+  - type: path
+    pattern: "src/**"
+  - type: package
+    pattern: "left-pad@^1"
+---
+
+# Inert package matcher
+
+The package matcher is inert without a dependency snapshot.

--- a/packages/mcp/test/fixtures/degraded-corpus/0032-valid-neighbor.md
+++ b/packages/mcp/test/fixtures/degraded-corpus/0032-valid-neighbor.md
@@ -1,0 +1,16 @@
+---
+schemaVersion: 0.1.0
+id: "0032"
+title: A valid neighbor record
+status: draft
+date: 2026-03-03
+tags:
+  - neighbor
+affects:
+  - type: path
+    pattern: "src/**"
+---
+
+# Valid neighbor
+
+Remains fully usable even though a sibling is schema-invalid.

--- a/packages/mcp/test/fixtures/edge-corpus/0010-first-duplicate.md
+++ b/packages/mcp/test/fixtures/edge-corpus/0010-first-duplicate.md
@@ -1,0 +1,15 @@
+---
+schemaVersion: 0.1.0
+id: "0010"
+title: First duplicate holder of id 0010
+status: accepted
+date: 2026-02-01
+deciders:
+  - "@maintainer"
+tags:
+  - dup
+---
+
+# First duplicate
+
+First record sharing id 0010.

--- a/packages/mcp/test/fixtures/edge-corpus/0010-second-duplicate.md
+++ b/packages/mcp/test/fixtures/edge-corpus/0010-second-duplicate.md
@@ -1,0 +1,13 @@
+---
+schemaVersion: 0.1.0
+id: "0010"
+title: Second duplicate holder of id 0010
+status: proposed
+date: 2026-02-02
+tags:
+  - dup
+---
+
+# Second duplicate
+
+Second record sharing id 0010.

--- a/packages/mcp/test/fixtures/edge-corpus/0011-superseded-by-ambiguous.md
+++ b/packages/mcp/test/fixtures/edge-corpus/0011-superseded-by-ambiguous.md
@@ -1,0 +1,12 @@
+---
+schemaVersion: 0.1.0
+id: "0011"
+title: Superseded by an ambiguous target
+status: superseded
+date: 2026-02-03
+supersededBy: "0010"
+---
+
+# Superseded by ambiguous
+
+Points at duplicated id 0010.

--- a/packages/mcp/test/fixtures/edge-corpus/0012-superseded-by-dangling.md
+++ b/packages/mcp/test/fixtures/edge-corpus/0012-superseded-by-dangling.md
@@ -1,0 +1,12 @@
+---
+schemaVersion: 0.1.0
+id: "0012"
+title: Superseded by a dangling target
+status: superseded
+date: 2026-02-04
+supersededBy: "0099"
+---
+
+# Superseded by dangling
+
+Points at nonexistent id 0099.

--- a/packages/mcp/test/fixtures/edge-corpus/0013-superseded-by-federated.md
+++ b/packages/mcp/test/fixtures/edge-corpus/0013-superseded-by-federated.md
@@ -1,0 +1,12 @@
+---
+schemaVersion: 0.1.0
+id: "0013"
+title: Superseded by a federated target
+status: superseded
+date: 2026-02-06
+supersededBy: "payments:0020"
+---
+
+# Superseded by federated
+
+Points at a log-qualified ref.

--- a/packages/mcp/test/fixtures/edge-corpus/0014-superseded-by-resolved.md
+++ b/packages/mcp/test/fixtures/edge-corpus/0014-superseded-by-resolved.md
@@ -1,0 +1,12 @@
+---
+schemaVersion: 0.1.0
+id: "0014"
+title: Superseded by a resolved unique target
+status: superseded
+date: 2026-02-07
+supersededBy: "0015"
+---
+
+# Superseded by resolved
+
+Points at the unique id 0015.

--- a/packages/mcp/test/fixtures/edge-corpus/0015-replacement-target.md
+++ b/packages/mcp/test/fixtures/edge-corpus/0015-replacement-target.md
@@ -1,0 +1,15 @@
+---
+schemaVersion: 0.1.0
+id: "0015"
+title: Replacement target for supersession
+status: accepted
+date: 2026-02-05
+deciders:
+  - "@maintainer"
+tags:
+  - target
+---
+
+# Replacement target
+
+The unique replacement.

--- a/packages/mcp/test/fixtures/status-corpus/0001-adopt-postgres-for-the-index.md
+++ b/packages/mcp/test/fixtures/status-corpus/0001-adopt-postgres-for-the-index.md
@@ -1,0 +1,23 @@
+---
+schemaVersion: 0.1.0
+id: "0001"
+title: Adopt PostgreSQL for the index
+status: accepted
+date: 2026-01-01
+deciders:
+  - "@maintainer"
+tags:
+  - database
+  - storage
+scope: component
+affects:
+  - type: path
+    pattern: "src/**"
+relatesTo: []
+supersedes: []
+---
+
+# Adopt PostgreSQL for the index
+
+We will use Postgres as the durable index. The token pgvector appears only in
+this body and nowhere in any title, id, or tag.

--- a/packages/mcp/test/fixtures/status-corpus/0002-draft-a-caching-layer.md
+++ b/packages/mcp/test/fixtures/status-corpus/0002-draft-a-caching-layer.md
@@ -1,0 +1,17 @@
+---
+schemaVersion: 0.1.0
+id: "0002"
+title: Draft a caching layer
+status: draft
+date: 2026-01-02
+tags:
+  - cache
+scope: component
+affects:
+  - type: path
+    pattern: "src/**"
+---
+
+# Draft a caching layer
+
+A read-through cache draft.

--- a/packages/mcp/test/fixtures/status-corpus/0003-propose-a-message-queue.md
+++ b/packages/mcp/test/fixtures/status-corpus/0003-propose-a-message-queue.md
@@ -1,0 +1,17 @@
+---
+schemaVersion: 0.1.0
+id: "0003"
+title: Propose a message queue
+status: proposed
+date: 2026-01-03
+tags:
+  - queue
+scope: domain
+affects:
+  - type: path
+    pattern: "src/**"
+---
+
+# Propose a message queue
+
+Proposed asynchronous processing.

--- a/packages/mcp/test/fixtures/status-corpus/0004-reject-mongodb-for-primary-store.md
+++ b/packages/mcp/test/fixtures/status-corpus/0004-reject-mongodb-for-primary-store.md
@@ -1,0 +1,17 @@
+---
+schemaVersion: 0.1.0
+id: "0004"
+title: Reject MongoDB for the primary store
+status: rejected
+date: 2026-01-04
+tags:
+  - database
+scope: component
+affects:
+  - type: path
+    pattern: "src/**"
+---
+
+# Reject MongoDB for the primary store
+
+We tried this in the past and rejected it.

--- a/packages/mcp/test/fixtures/status-corpus/0005-use-the-legacy-auth-flow.md
+++ b/packages/mcp/test/fixtures/status-corpus/0005-use-the-legacy-auth-flow.md
@@ -1,0 +1,18 @@
+---
+schemaVersion: 0.1.0
+id: "0005"
+title: Use the legacy auth flow
+status: superseded
+date: 2026-01-05
+tags:
+  - auth
+scope: component
+supersededBy: "0001"
+affects:
+  - type: path
+    pattern: "src/**"
+---
+
+# Use the legacy auth flow
+
+Superseded by the index decision for demonstration.

--- a/packages/mcp/test/fixtures/status-corpus/0006-deprecate-the-old-api-gateway.md
+++ b/packages/mcp/test/fixtures/status-corpus/0006-deprecate-the-old-api-gateway.md
@@ -1,0 +1,17 @@
+---
+schemaVersion: 0.1.0
+id: "0006"
+title: Deprecate the old API gateway
+status: deprecated
+date: 2026-01-06
+tags:
+  - api
+scope: org
+affects:
+  - type: path
+    pattern: "src/**"
+---
+
+# Deprecate the old API gateway
+
+The old gateway is deprecated.

--- a/packages/mcp/test/get-decision-context-pagination.test.ts
+++ b/packages/mcp/test/get-decision-context-pagination.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { registerGetDecisionContext } from '../src/tools/get-decision-context.ts';
+import { registerGetDecision } from '../src/tools/get-decision.ts';
+import { encodeCursor, queryShapeHash } from '../src/pagination/cursor.ts';
+import { compareCodeUnits } from '../src/corpus/ordering.ts';
+import {
+  openTool,
+  callTool,
+  resultOf,
+  healthOf,
+  textOf,
+  walkChannel,
+  repoFromFixture,
+  toolConfig,
+  type TempRepo,
+} from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+async function open(repo: TempRepo) {
+  cleanups.push(repo.cleanup);
+  const harness = await openTool(registerGetDecisionContext, await toolConfig(repo.root, repo.dir));
+  cleanups.push(harness.close);
+  return harness;
+}
+
+const filesQh = (files: string[], limit: number) => queryShapeHash([[...new Set(files)].sort(compareCodeUnits), limit]);
+
+describe('get_decision_context — pagination and determinism', () => {
+  test('one flat canonical result walk, partitioned per page, returns every match once', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const collected = await walkChannel<{ id: string }>(async (cursor) => {
+      const result = resultOf(
+        await callTool(client, 'get_decision_context', { files: ['src/app.ts'], limit: 2, ...(cursor ? { cursor } : {}) }),
+      );
+      return { items: [...result.governing, ...result.activeProposals, ...result.history], cursor: result.cursor };
+    });
+    expect(collected.map((e) => e.id)).toEqual(['0001', '0002', '0003', '0004', '0005', '0006']);
+  });
+
+  test('files[] query binding is canonical and de-duplicated (order and dups do not matter)', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const first = resultOf(await callTool(client, 'get_decision_context', { files: ['src/app.ts', 'src/lib.ts'], limit: 2 }));
+    // Same set, different order + a duplicate: the returned cursor must still apply.
+    const next = resultOf(
+      await callTool(client, 'get_decision_context', { files: ['src/lib.ts', 'src/app.ts', 'src/app.ts'], limit: 2, cursor: first.cursor }),
+    );
+    expect(next.outcome).toBe('matches');
+  });
+
+  test('derived findings are NOT part of the fingerprint (context vs get_decision agree)', async () => {
+    const repo = await repoFromFixture('degraded-corpus');
+    cleanups.push(repo.cleanup);
+    const config = await toolConfig(repo.root, repo.dir);
+    const ctx = await openTool(registerGetDecisionContext, config);
+    cleanups.push(ctx.close);
+    const get = await openTool(registerGetDecision, config);
+    cleanups.push(get.close);
+
+    const ctxRes = await callTool(ctx.client, 'get_decision_context', { files: ['src/app.ts'] });
+    const getRes = await callTool(get.client, 'get_decision', { ref: '0032' });
+    // The context call has an extra derived affects-unresolvable finding get_decision lacks.
+    const ctxFindings = resultOf(ctxRes).findings.items.map((f: { rule: string }) => f.rule);
+    const getFindings = resultOf(getRes).findings.items.map((f: { rule: string }) => f.rule);
+    expect(ctxFindings).toContain('affects-unresolvable');
+    expect(getFindings).not.toContain('affects-unresolvable');
+    // Yet the fingerprint (which hashes corpus projection only) is identical.
+    expect(healthOf(ctxRes).fingerprint).toBe(healthOf(getRes).fingerprint);
+  });
+
+  test('the fingerprint is unchanged across two different files[] inputs', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const a = healthOf(await callTool(client, 'get_decision_context', { files: ['src/app.ts'] })).fingerprint;
+    const b = healthOf(await callTool(client, 'get_decision_context', { files: ['docs/readme.md'] })).fingerprint;
+    expect(a).toBe(b);
+  });
+
+  test('every applicable-channel cursor failure is reported with its fixed message', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const files = ['src/app.ts'];
+    const first = await callTool(client, 'get_decision_context', { files, limit: 2 });
+    const fp = healthOf(first).fingerprint;
+    const qh = filesQh(files, 2);
+    const cases: Array<[string, string]> = [
+      ['decode-failed', 'not-a-cursor'],
+      ['wrong-channel', encodeCursor({ v: 1, scope: 'search.results', fp, qh, offset: 1 })],
+      ['corpus-changed', encodeCursor({ v: 1, scope: 'context.results', fp: 'f'.repeat(64), qh, offset: 1 })],
+      ['query-mismatch', encodeCursor({ v: 1, scope: 'context.results', fp, qh: filesQh(['other.ts'], 2), offset: 1 })],
+      ['offset-out-of-range', encodeCursor({ v: 1, scope: 'context.results', fp, qh, offset: 6 })],
+    ];
+    for (const [reason, cursor] of cases) {
+      const result = resultOf(await callTool(client, 'get_decision_context', { files, limit: 2, cursor }));
+      expect(result.outcome).toBe('invalid-cursor');
+      expect(result.reason).toBe(reason);
+    }
+  });
+
+  test('text never interpolates a corpus path and stays within the 512 cap', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const res = await callTool(client, 'get_decision_context', { files: ['src/app.ts'] });
+    expect(textOf(res)).not.toContain('docs/adr');
+    expect(textOf(res).length).toBeLessThanOrEqual(512);
+  });
+});

--- a/packages/mcp/test/get-decision-context.test.ts
+++ b/packages/mcp/test/get-decision-context.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { rm } from 'node:fs/promises';
+import { registerGetDecisionContext } from '../src/tools/get-decision-context.ts';
+import {
+  openTool,
+  callTool,
+  resultOf,
+  healthOf,
+  textOf,
+  repoFromFixture,
+  createRepo,
+  writeRecords,
+  toolConfig,
+  type TempRepo,
+} from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+async function open(repo: TempRepo) {
+  cleanups.push(repo.cleanup);
+  const harness = await openTool(registerGetDecisionContext, await toolConfig(repo.root, repo.dir));
+  cleanups.push(harness.close);
+  return harness;
+}
+
+function record(id: string, status: string, affects: string): string {
+  return `---
+schemaVersion: 0.1.0
+id: "${id}"
+title: Context record ${id}
+status: ${status}
+date: 2026-04-01
+${status === 'accepted' ? 'deciders:\n  - "@m"\n' : ''}affects:
+${affects}
+---
+
+# ${id}
+`;
+}
+
+describe('get_decision_context — resolution and partitioning', () => {
+  test('partitions all six statuses across governing / activeProposals / history', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const res = await callTool(client, 'get_decision_context', { files: ['src/app.ts'] });
+    const result = resultOf(res);
+    expect(result.outcome).toBe('matches');
+    expect(result.governing.map((e: { id: string }) => e.id)).toEqual(['0001']);
+    expect(result.activeProposals.map((e: { id: string }) => e.id)).toEqual(['0002', '0003']);
+    expect(result.history.map((e: { id: string }) => e.id)).toEqual(['0004', '0005', '0006']);
+    expect(textOf(res)).toBe(
+      'Returned 6 context matches: 1 governing, 2 active proposals, 3 historical; 0 findings on this page.',
+    );
+  });
+
+  test('reports fired matchers and unexpanded relations on each entry', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const result = resultOf(await callTool(client, 'get_decision_context', { files: ['src/app.ts'] }));
+    const superseded = result.history.find((e: { id: string }) => e.id === '0005');
+    expect(superseded.firedMatchers).toEqual([{ type: 'path', pattern: 'src/**' }]);
+    expect(superseded.relations.supersededBy).toBe('0001');
+    expect(superseded.relations.supersedes).toEqual([]);
+  });
+
+  test('zero matches is still the matches branch with three empty arrays', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const res = await callTool(client, 'get_decision_context', { files: ['unrelated/elsewhere.txt'] });
+    const result = resultOf(res);
+    expect(result.outcome).toBe('matches');
+    expect([result.governing, result.activeProposals, result.history]).toEqual([[], [], []]);
+    expect(textOf(res)).toBe('Returned 0 context matches: 0 governing, 0 active proposals, 0 historical; 0 findings on this page.');
+  });
+
+  test('a repo-qualified matcher is inactive in this single-log phase', async () => {
+    const repo = await createRepo();
+    await writeRecords(repo, {
+      '0050-repo-qualified.md': record('0050', 'accepted', '  - type: path\n    pattern: "src/**"\n    repo: other'),
+    });
+    const { client } = await open(repo);
+    const result = resultOf(await callTool(client, 'get_decision_context', { files: ['src/app.ts'] }));
+    expect(result.governing).toEqual([]);
+  });
+
+  test('an inert package matcher surfaces an informational affects-unresolvable finding', async () => {
+    const { client } = await open(await repoFromFixture('degraded-corpus'));
+    const result = resultOf(await callTool(client, 'get_decision_context', { files: ['src/app.ts'] }));
+    const inert = result.findings.items.find((f: { rule: string }) => f.rule === 'affects-unresolvable');
+    expect(inert.severity).toBe('info');
+  });
+
+  test('files[] are never opened — a nonexistent path still resolves against patterns', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const result = resultOf(await callTool(client, 'get_decision_context', { files: ['src/does-not-exist.ts'] }));
+    expect(result.governing.map((e: { id: string }) => e.id)).toEqual(['0001']);
+  });
+
+  test('a corpus that cannot be loaded is corpus-unavailable', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    const config = await toolConfig(repo.root, repo.dir);
+    await rm(repo.adrDir, { recursive: true, force: true });
+    const harness = await openTool(registerGetDecisionContext, config);
+    cleanups.push(harness.close);
+    const res = await callTool(harness.client, 'get_decision_context', { files: ['src/app.ts'] });
+    expect(resultOf(res).outcome).toBe('corpus-unavailable');
+    expect(healthOf(res)).toBeUndefined();
+  });
+});

--- a/packages/mcp/test/get-decision-pagination.test.ts
+++ b/packages/mcp/test/get-decision-pagination.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { registerGetDecision } from '../src/tools/get-decision.ts';
+import { encodeCursor, queryShapeHash } from '../src/pagination/cursor.ts';
+import {
+  openTool,
+  callTool,
+  resultOf,
+  healthOf,
+  textOf,
+  walkChannel,
+  repoFromFixture,
+  toolConfig,
+  type TempRepo,
+  type OpenServer,
+} from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+async function open(repo: TempRepo): Promise<OpenServer> {
+  cleanups.push(repo.cleanup);
+  const harness = await openTool(registerGetDecision, await toolConfig(repo.root, repo.dir));
+  cleanups.push(harness.close);
+  return harness;
+}
+
+describe('get_decision — pagination and cursor contracts', () => {
+  test('a duplicate-id ambiguous walk returns every candidate exactly once, in canonical order', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const candidates = await walkChannel<{ sourcePath: string }>(async (cursor) => {
+      const result = resultOf(await callTool(client, 'get_decision', { ref: '0010', limit: 1, ...(cursor ? { cursor } : {}) }));
+      return { items: result.candidates, cursor: result.cursor };
+    });
+    expect(candidates.map((c) => c.sourcePath)).toEqual([
+      'docs/adr/0010-first-duplicate.md',
+      'docs/adr/0010-second-duplicate.md',
+    ]);
+  });
+
+  test('candidate and findings channels page independently', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const first = resultOf(await callTool(client, 'get_decision', { ref: '0010', limit: 1, findingsLimit: 1 }));
+    // Walk the candidate channel; the findings first page must stay put throughout.
+    let cursor: string | undefined = first.cursor ?? undefined;
+    while (cursor) {
+      const page = resultOf(await callTool(client, 'get_decision', { ref: '0010', limit: 1, findingsLimit: 1, cursor }));
+      expect(page.findings.items).toEqual(first.findings.items);
+      cursor = page.cursor ?? undefined;
+    }
+  });
+
+  test('the findings channel walks losslessly and independently of candidates', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const findings = await walkChannel<{ rule: string }>(async (findingsCursor) => {
+      const result = resultOf(
+        await callTool(client, 'get_decision', { ref: '0010', findingsLimit: 1, ...(findingsCursor ? { findingsCursor } : {}) }),
+      );
+      return { items: result.findings.items, cursor: result.findings.cursor };
+    });
+    expect(findings.length).toBe(4);
+    expect(findings.filter((f) => f.rule === 'unique-id')).toHaveLength(2);
+  });
+
+  test('a primary cursor supplied against a found outcome is cursor-not-applicable, never ignored', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const first = await callTool(client, 'get_decision', { ref: '0001' });
+    const fp = healthOf(first).fingerprint;
+    const cursor = encodeCursor({ v: 1, scope: 'get_decision.candidates', fp, qh: queryShapeHash(['0001', 20]), offset: 1 });
+    const res = await callTool(client, 'get_decision', { ref: '0001', cursor });
+    const result = resultOf(res);
+    expect(result.outcome).toBe('invalid-cursor');
+    expect(result.reason).toBe('cursor-not-applicable');
+    expect(textOf(res)).toBe('Cursor does not apply to this outcome.');
+    expect(healthOf(res).fingerprint).toBe(fp); // corpusHealth still present on invalid-cursor
+  });
+
+  test('every invalid-cursor reason is reachable with its fixed message', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const first = await callTool(client, 'get_decision', { ref: '0010', limit: 1 });
+    const fp = healthOf(first).fingerprint;
+    const qh = queryShapeHash(['0010', 1]);
+
+    const cases: Array<[string, string, string]> = [
+      ['decode-failed', 'Cursor could not be decoded.', 'not-a-cursor'],
+      ['version-unsupported', 'Cursor version is not supported.', Buffer.from(JSON.stringify({ v: 2, scope: 'get_decision.candidates', fp, qh, offset: 1 })).toString('base64url')],
+      ['wrong-channel', 'Cursor does not belong to this tool channel.', encodeCursor({ v: 1, scope: 'search.results', fp, qh, offset: 1 })],
+      ['corpus-changed', 'Corpus changed after this cursor was issued.', encodeCursor({ v: 1, scope: 'get_decision.candidates', fp: 'f'.repeat(64), qh, offset: 1 })],
+      ['query-mismatch', 'Cursor was issued for different request parameters.', encodeCursor({ v: 1, scope: 'get_decision.candidates', fp, qh: queryShapeHash(['9999', 1]), offset: 1 })],
+      ['offset-out-of-range', 'Cursor offset is outside the current result set.', encodeCursor({ v: 1, scope: 'get_decision.candidates', fp, qh, offset: 2 })],
+    ];
+    for (const [reason, message, cursor] of cases) {
+      const res = await callTool(client, 'get_decision', { ref: '0010', limit: 1, cursor });
+      const result = resultOf(res);
+      expect(result.outcome).toBe('invalid-cursor');
+      expect(result.reason).toBe(reason);
+      expect(textOf(res)).toBe(message);
+    }
+  });
+
+  test('responses carry schema-valid structured content and never interpolate a corpus path', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    for (const ref of ['0001', '9999', 'payments:0001']) {
+      const res = await callTool(client, 'get_decision', { ref });
+      expect(res.structuredContent).toBeDefined();
+      expect(textOf(res)).not.toContain('docs/adr');
+      expect(textOf(res).length).toBeLessThanOrEqual(512);
+    }
+  });
+
+  test('bounded strict inputs are rejected by the SDK before the handler runs', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const unknown = await callTool(client, 'get_decision', { ref: '0001', bogus: 1 });
+    expect(unknown.isError).toBe(true);
+    const overLong = await callTool(client, 'get_decision', { ref: 'x'.repeat(200) });
+    expect(overLong.isError).toBe(true);
+  });
+});

--- a/packages/mcp/test/get-decision.test.ts
+++ b/packages/mcp/test/get-decision.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { registerGetDecision } from '../src/tools/get-decision.ts';
+import {
+  openTool,
+  callTool,
+  resultOf,
+  healthOf,
+  textOf,
+  repoFromFixture,
+  createRepo,
+  toolConfig,
+  makeOversizedRecord,
+  type TempRepo,
+} from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+async function open(repo: TempRepo) {
+  cleanups.push(repo.cleanup);
+  const harness = await openTool(registerGetDecision, await toolConfig(repo.root, repo.dir));
+  cleanups.push(harness.close);
+  return harness;
+}
+
+describe('get_decision — full document and lookup branches', () => {
+  test('retrieves every one of the six statuses with complete typed frontmatter and body', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const expected: Record<string, string> = {
+      '0001': 'accepted',
+      '0002': 'draft',
+      '0003': 'proposed',
+      '0004': 'rejected',
+      '0005': 'superseded',
+      '0006': 'deprecated',
+    };
+    for (const [id, status] of Object.entries(expected)) {
+      const res = await callTool(client, 'get_decision', { ref: id });
+      const result = resultOf(res);
+      expect(result.outcome).toBe('found');
+      expect(result.decision.id).toBe(id);
+      expect(result.decision.status).toBe(status);
+      expect(result.decision.frontmatter.id).toBe(id);
+      expect(typeof result.decision.body).toBe('string');
+      expect(result.decision.body.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('returns a repo-relative POSIX source path, never absolute', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const result = resultOf(await callTool(client, 'get_decision', { ref: '0001' }));
+    expect(result.decision.sourcePath).toBe('docs/adr/0001-adopt-postgres-for-the-index.md');
+  });
+
+  test('leaves the four relation fields present and UNEXPANDED in frontmatter', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const result = resultOf(await callTool(client, 'get_decision', { ref: '0005' }));
+    expect(result.decision.frontmatter.supersededBy).toBe('0001');
+    expect(result.decision.frontmatter.supersedes).toEqual([]);
+    expect(result.decision.frontmatter.relatesTo).toEqual([]);
+    expect(result.decision.frontmatter.conflictsWith).toEqual([]);
+    // Unexpanded: no resolved target object is inlined anywhere.
+    expect(JSON.stringify(result)).not.toContain('Adopt PostgreSQL');
+  });
+
+  test('an absent id is not-found', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const res = await callTool(client, 'get_decision', { ref: '9999' });
+    const result = resultOf(res);
+    expect(result.outcome).toBe('not-found');
+    expect(result.requestedRef).toBe('9999');
+    expect(textOf(res)).toBe('No local decision matches "9999"; 0 findings on this page.');
+  });
+
+  test('an oversized source is not-found with the record-too-large finding present', async () => {
+    const repo = await repoFromFixture('status-corpus');
+    await writeFile(join(repo.adrDir, '0007-oversized.md'), makeOversizedRecord('0007'), 'utf8');
+    const { client } = await open(repo);
+    const res = await callTool(client, 'get_decision', { ref: '0007' });
+    const result = resultOf(res);
+    expect(result.outcome).toBe('not-found');
+    expect(result.findings.items.some((f: { rule: string }) => f.rule === 'record-too-large')).toBe(true);
+    expect(result.decision).toBeUndefined();
+  });
+
+  test('a duplicate local id is ambiguous with every candidate, distinguished by sourcePath', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const res = await callTool(client, 'get_decision', { ref: '0010' });
+    const result = resultOf(res);
+    expect(result.outcome).toBe('ambiguous-local-id');
+    expect(result.requestedRef).toBe('0010');
+    expect(result.candidates.map((c: { sourcePath: string }) => c.sourcePath)).toEqual([
+      'docs/adr/0010-first-duplicate.md',
+      'docs/adr/0010-second-duplicate.md',
+    ]);
+    expect(textOf(res)).toBe('Returned 2 candidates for ambiguous local ref "0010"; 4 findings on this page.');
+  });
+
+  test('a log-qualified ref returns federated-log-unavailable and never a same-id local substitute', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const res = await callTool(client, 'get_decision', { ref: 'payments:0001' });
+    const result = resultOf(res);
+    expect(result.outcome).toBe('federated-log-unavailable');
+    expect(result.log).toBe('payments');
+    expect(result.id).toBe('0001');
+    expect(result.decision).toBeUndefined();
+    expect(textOf(res)).toBe('Named-log federation is unavailable for "payments:0001"; 0 findings on this page.');
+  });
+
+  test('found text uses singular "finding" wording when the page has one finding', async () => {
+    const repo = await repoFromFixture('degraded-corpus');
+    const { client } = await open(repo);
+    const res = await callTool(client, 'get_decision', { ref: '0032' });
+    const result = resultOf(res);
+    expect(result.outcome).toBe('found');
+    // degraded-corpus carries exactly one corpus finding (the invalid 0030 record).
+    expect(result.findings.items).toHaveLength(1);
+    expect(textOf(res)).toBe('Found decision "0032"; 1 finding on this page.');
+  });
+
+  test('a corpus that cannot be loaded is corpus-unavailable with a fixed, path-free message', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    const config = await toolConfig(repo.root, repo.dir);
+    await rm(repo.adrDir, { recursive: true, force: true });
+    const harness = await openTool(registerGetDecision, config);
+    cleanups.push(harness.close);
+    const res = await callTool(harness.client, 'get_decision', { ref: '0001' });
+    const result = resultOf(res);
+    expect(result.outcome).toBe('corpus-unavailable');
+    expect(result.reason).toBe('dir-not-found');
+    expect(textOf(res)).toBe('Configured ADR directory was not found.');
+    expect(healthOf(res)).toBeUndefined();
+  });
+
+  test('every substantive branch carries corpusHealth', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const res = await callTool(client, 'get_decision', { ref: '0001' });
+    expect(healthOf(res).fingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/packages/mcp/test/helpers.ts
+++ b/packages/mcp/test/helpers.ts
@@ -1,0 +1,233 @@
+/**
+ * @adrkit/mcp — offline test helpers.
+ *
+ * Provides the in-memory SDK client harness (research §R1.4), disposable
+ * git-worktree corpora, complete-sandbox / parent-sentinel / HOME / TMPDIR
+ * snapshots, a cursor-walk driver, and response-schema accessors. Everything
+ * here is local, offline, model-free, and credential-free.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { createHash } from 'node:crypto';
+import { mkdtemp, mkdir, writeFile, readdir, readFile, rm, realpath, stat, cp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SERVER_INFO } from '../src/server.ts';
+import { MAX_SOURCE_BYTES } from '../src/corpus/projection.ts';
+import type { ToolConfig } from '../src/tools/shared.ts';
+
+export const FIXTURES_DIR = resolve(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+/* ------------------------------------------------------------------ *
+ * In-memory SDK harness
+ * ------------------------------------------------------------------ */
+
+export interface OpenServer {
+  readonly server: McpServer;
+  readonly client: Client;
+  close(): Promise<void>;
+}
+
+/** Connect an already-built McpServer to an in-process client. */
+export async function connectServer(server: McpServer): Promise<OpenServer> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'adrkit-mcp-test-client', version: '0.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return {
+    server,
+    client,
+    async close() {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+/** Build a fresh McpServer, apply `register`, and connect an in-process client. */
+export async function openServer(register: (server: McpServer) => void): Promise<OpenServer> {
+  const server = new McpServer(SERVER_INFO);
+  register(server);
+  return connectServer(server);
+}
+
+/** Convenience: register a single tool with `config` and connect a client. */
+export async function openTool(
+  register: (server: McpServer, config: ToolConfig) => void,
+  config: ToolConfig,
+): Promise<OpenServer> {
+  return openServer((server) => register(server, config));
+}
+
+export async function callTool(
+  client: Client,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<CallToolResult> {
+  return (await client.callTool({ name, arguments: args })) as CallToolResult;
+}
+
+// biome-ignore lint: test accessor
+export function resultOf(res: CallToolResult): any {
+  return (res.structuredContent as { result?: unknown } | undefined)?.result;
+}
+
+// biome-ignore lint: test accessor
+export function healthOf(res: CallToolResult): any {
+  return (res.structuredContent as { corpusHealth?: unknown } | undefined)?.corpusHealth;
+}
+
+export function textOf(res: CallToolResult): string {
+  const first = res.content?.[0];
+  return first && first.type === 'text' ? first.text : '';
+}
+
+/* ------------------------------------------------------------------ *
+ * Disposable git-worktree corpora
+ * ------------------------------------------------------------------ */
+
+export interface TempRepo {
+  readonly root: string; // realpath'd
+  readonly dir: string; // 'docs/adr' by default
+  readonly adrDir: string; // absolute path to the ADR directory
+  cleanup(): Promise<void>;
+}
+
+/** Create a disposable repo root with a `.git` directory and an empty ADR dir. */
+export async function createRepo(options: { dir?: string; gitFile?: boolean } = {}): Promise<TempRepo> {
+  const dir = options.dir ?? 'docs/adr';
+  const created = await mkdtemp(join(tmpdir(), 'adrkit-mcp-'));
+  const root = await realpath(created);
+  if (options.gitFile) {
+    await writeFile(join(root, '.git'), 'gitdir: /elsewhere/.git/worktrees/x\n', 'utf8');
+  } else {
+    await mkdir(join(root, '.git'), { recursive: true });
+  }
+  const adrDir = join(root, dir);
+  await mkdir(adrDir, { recursive: true });
+  return {
+    root,
+    dir,
+    adrDir,
+    async cleanup() {
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+/** Write named markdown files into a repo's ADR directory. */
+export async function writeRecords(repo: TempRepo, files: Record<string, string>): Promise<void> {
+  for (const [name, content] of Object.entries(files)) {
+    await writeFile(join(repo.adrDir, name), content, 'utf8');
+  }
+}
+
+/** Copy one committed fixture corpus into a fresh disposable repo's ADR directory. */
+export async function repoFromFixture(
+  fixtureName: 'status-corpus' | 'edge-corpus' | 'degraded-corpus',
+  options: { dir?: string; gitFile?: boolean } = {},
+): Promise<TempRepo> {
+  const repo = await createRepo(options);
+  const source = join(FIXTURES_DIR, fixtureName);
+  for (const entry of await readdir(source)) {
+    if (!entry.endsWith('.md')) continue;
+    await cp(join(source, entry), join(repo.adrDir, entry));
+  }
+  return repo;
+}
+
+/** Build a `ToolConfig` for a repo root, mirroring `resolveCanonicalRoots`' contract. */
+export async function toolConfig(root: string, dir = 'docs/adr'): Promise<ToolConfig> {
+  const canonicalCwd = await realpath(root);
+  return {
+    configuredCwd: canonicalCwd,
+    configuredDir: dir,
+    expectedCanonicalCwd: canonicalCwd,
+    maxSourceBytes: MAX_SOURCE_BYTES,
+  };
+}
+
+/* ------------------------------------------------------------------ *
+ * Filesystem snapshots (boundary / side-effect evidence)
+ * ------------------------------------------------------------------ */
+
+export type FsSnapshot = Map<string, string>;
+
+async function snapshotEntry(path: string): Promise<string> {
+  const info = await stat(path);
+  if (info.isDirectory()) return `dir:${(info.mode & 0o7777).toString(8)}`;
+  const bytes = await readFile(path);
+  const sha = createHash('sha256').update(bytes).digest('hex');
+  return `file:${info.size}:${(info.mode & 0o7777).toString(8)}:${sha}`;
+}
+
+/** Complete byte/mode snapshot of a directory tree. */
+export async function snapshotTree(root: string): Promise<FsSnapshot> {
+  const snapshot: FsSnapshot = new Map();
+  async function walk(dir: string, prefix: string): Promise<void> {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const abs = join(dir, entry.name);
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      snapshot.set(rel, await snapshotEntry(abs));
+      if (entry.isDirectory()) await walk(abs, rel);
+    }
+  }
+  await walk(root, '');
+  return snapshot;
+}
+
+/** Snapshot an explicit set of paths (parent sentinels, HOME, TMPDIR files). */
+export async function snapshotPaths(paths: readonly string[]): Promise<FsSnapshot> {
+  const snapshot: FsSnapshot = new Map();
+  for (const path of paths) {
+    try {
+      snapshot.set(path, await snapshotEntry(path));
+    } catch {
+      snapshot.set(path, 'absent');
+    }
+  }
+  return snapshot;
+}
+
+export function diffSnapshots(before: FsSnapshot, after: FsSnapshot): string[] {
+  const changes: string[] = [];
+  for (const [key, value] of before) {
+    if (after.get(key) !== value) changes.push(`changed:${key}`);
+  }
+  for (const key of after.keys()) {
+    if (!before.has(key)) changes.push(`added:${key}`);
+  }
+  return changes;
+}
+
+/* ------------------------------------------------------------------ *
+ * Cursor-walk driver
+ * ------------------------------------------------------------------ */
+
+export interface WalkPage<T> {
+  readonly items: readonly T[];
+  readonly cursor: string | null;
+}
+
+/** Drive a paginated channel to completion, collecting every item exactly once. */
+export async function walkChannel<T>(
+  step: (cursor: string | undefined) => Promise<WalkPage<T>>,
+): Promise<T[]> {
+  const all: T[] = [];
+  let cursor: string | undefined;
+  for (let guard = 0; guard < 10_000; guard += 1) {
+    const page = await step(cursor);
+    all.push(...page.items);
+    if (page.cursor == null) return all;
+    cursor = page.cursor;
+  }
+  throw new Error('walkChannel exceeded its page guard');
+}
+
+export function makeOversizedRecord(id: string, bytes = MAX_SOURCE_BYTES + 1): string {
+  const header = `---\nschemaVersion: 0.1.0\nid: "${id}"\ntitle: Oversized record ${id}\nstatus: draft\ndate: 2026-01-01\n---\n\n`;
+  return header + 'x'.repeat(Math.max(0, bytes - header.length));
+}

--- a/packages/mcp/test/helpers.ts
+++ b/packages/mcp/test/helpers.ts
@@ -143,7 +143,7 @@ export async function repoFromFixture(
 export async function toolConfig(root: string, dir = 'docs/adr'): Promise<ToolConfig> {
   const canonicalCwd = await realpath(root);
   return {
-    configuredCwd: canonicalCwd,
+    configuredCwd: root,
     configuredDir: dir,
     expectedCanonicalCwd: canonicalCwd,
     maxSourceBytes: MAX_SOURCE_BYTES,

--- a/packages/mcp/test/list-superseded-pagination.test.ts
+++ b/packages/mcp/test/list-superseded-pagination.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { registerListSuperseded } from '../src/tools/list-superseded.ts';
+import { registerGetDecision } from '../src/tools/get-decision.ts';
+import { encodeCursor, queryShapeHash } from '../src/pagination/cursor.ts';
+import {
+  openTool,
+  callTool,
+  resultOf,
+  healthOf,
+  textOf,
+  walkChannel,
+  repoFromFixture,
+  toolConfig,
+  type TempRepo,
+} from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+async function open(repo: TempRepo) {
+  cleanups.push(repo.cleanup);
+  const harness = await openTool(registerListSuperseded, await toolConfig(repo.root, repo.dir));
+  cleanups.push(harness.close);
+  return harness;
+}
+
+describe('list_superseded — ambiguity and pagination', () => {
+  test('a multi-page walk is lossless and canonical', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const entries = await walkChannel<{ id: string }>(async (cursor) => {
+      const result = resultOf(await callTool(client, 'list_superseded', { limit: 1, ...(cursor ? { cursor } : {}) }));
+      return { items: result.items, cursor: result.cursor };
+    });
+    expect(entries.map((e) => e.id)).toEqual(['0011', '0012', '0013', '0014']);
+  });
+
+  test('findings page independently and one warn finding is minted per ambiguous entry', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const findings = await walkChannel<{ rule: string }>(async (findingsCursor) => {
+      const result = resultOf(await callTool(client, 'list_superseded', { findingsLimit: 1, ...(findingsCursor ? { findingsCursor } : {}) }));
+      return { items: result.findings.items, cursor: result.findings.cursor };
+    });
+    expect(findings.filter((f) => f.rule === 'superseded-target-ambiguous')).toHaveLength(1);
+    expect(findings.length).toBe(6);
+  });
+
+  test('the ambiguous target is fully retrievable via a follow-up get_decision candidate walk', async () => {
+    const repo = await repoFromFixture('edge-corpus');
+    cleanups.push(repo.cleanup);
+    const config = await toolConfig(repo.root, repo.dir);
+    const superseded = await openTool(registerListSuperseded, config);
+    cleanups.push(superseded.close);
+    const get = await openTool(registerGetDecision, config);
+    cleanups.push(get.close);
+
+    const entry = resultOf(await callTool(superseded.client, 'list_superseded', {})).items.find(
+      (e: { id: string }) => e.id === '0011',
+    );
+    const targetRef = entry.supersededBy.targetRef as string;
+    const candidates = await walkChannel<{ sourcePath: string }>(async (cursor) => {
+      const result = resultOf(await callTool(get.client, 'get_decision', { ref: targetRef, limit: 1, ...(cursor ? { cursor } : {}) }));
+      return { items: result.candidates, cursor: result.cursor };
+    });
+    expect(candidates).toHaveLength(2);
+  });
+
+  test('every cursor failure branch is reachable with its fixed reason', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const fp = healthOf(await callTool(client, 'list_superseded', { limit: 1 })).fingerprint;
+    const qh = queryShapeHash([1]);
+    const cases: Array<[string, string]> = [
+      ['decode-failed', 'garbage'],
+      ['wrong-channel', encodeCursor({ v: 1, scope: 'search.results', fp, qh, offset: 1 })],
+      ['corpus-changed', encodeCursor({ v: 1, scope: 'superseded.results', fp: 'a'.repeat(64), qh, offset: 1 })],
+      ['query-mismatch', encodeCursor({ v: 1, scope: 'superseded.results', fp, qh: queryShapeHash([2]), offset: 1 })],
+      ['offset-out-of-range', encodeCursor({ v: 1, scope: 'superseded.results', fp, qh, offset: 4 })],
+    ];
+    for (const [reason, cursor] of cases) {
+      expect(resultOf(await callTool(client, 'list_superseded', { limit: 1, cursor })).reason).toBe(reason);
+    }
+  });
+
+  test('text never interpolates a corpus path and stays within the 512 cap', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const res = await callTool(client, 'list_superseded', {});
+    expect(textOf(res)).not.toContain('docs/adr');
+    expect(textOf(res).length).toBeLessThanOrEqual(512);
+  });
+});

--- a/packages/mcp/test/list-superseded.test.ts
+++ b/packages/mcp/test/list-superseded.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { rm } from 'node:fs/promises';
+import { registerListSuperseded } from '../src/tools/list-superseded.ts';
+import {
+  openTool,
+  callTool,
+  resultOf,
+  healthOf,
+  textOf,
+  repoFromFixture,
+  createRepo,
+  writeRecords,
+  toolConfig,
+  type TempRepo,
+} from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+async function open(repo: TempRepo) {
+  cleanups.push(repo.cleanup);
+  const harness = await openTool(registerListSuperseded, await toolConfig(repo.root, repo.dir));
+  cleanups.push(harness.close);
+  return harness;
+}
+
+function entryFor(result: { items: Array<{ id: string }> }, id: string) {
+  return result.items.find((e) => e.id === id) as any;
+}
+
+describe('list_superseded — direct edges', () => {
+  test('lists every superseded record with each direct target shape', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const res = await callTool(client, 'list_superseded', {});
+    const result = resultOf(res);
+    expect(result.outcome).toBe('entries');
+    expect(result.items.map((e: { id: string }) => e.id)).toEqual(['0011', '0012', '0013', '0014']);
+
+    expect(entryFor(result, '0014').supersededBy).toEqual({
+      resolved: true,
+      target: { id: '0015', title: 'Replacement target for supersession', status: 'accepted', sourcePath: 'docs/adr/0015-replacement-target.md' },
+    });
+    expect(entryFor(result, '0012').supersededBy).toEqual({ resolved: false, targetRef: '0099', reason: 'dangling' });
+    expect(entryFor(result, '0011').supersededBy).toEqual({ resolved: false, targetRef: '0010', reason: 'ambiguous', candidateCount: 2 });
+    expect(entryFor(result, '0013').supersededBy).toEqual({
+      resolved: false,
+      targetRef: 'payments:0020',
+      reason: 'federated-unavailable',
+      log: 'payments',
+      id: '0020',
+    });
+  });
+
+  test('an ambiguous entry carries candidateCount only, never a nested candidates array', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const entry = entryFor(resultOf(await callTool(client, 'list_superseded', {})), '0011');
+    expect('candidates' in entry.supersededBy).toBe(false);
+    expect(entry.supersededBy.candidateCount).toBe(2);
+  });
+
+  test('mints exactly the two derived finding templates and keeps the core dangling findings', async () => {
+    const { client } = await open(await repoFromFixture('edge-corpus'));
+    const findings = resultOf(await callTool(client, 'list_superseded', {})).findings.items as Array<{
+      rule: string;
+      severity: string;
+      id?: string;
+      message: string;
+    }>;
+    const ambiguous = findings.find((f) => f.rule === 'superseded-target-ambiguous');
+    expect(ambiguous).toEqual({
+      rule: 'superseded-target-ambiguous',
+      severity: 'warn',
+      id: '0011',
+      message: 'supersededBy target "0010" resolves to 2 local records; see get_decision("0010") for the full candidate list',
+    });
+    const federated = findings.find((f) => f.rule === 'superseded-target-federated-unavailable');
+    expect(federated).toEqual({
+      rule: 'superseded-target-federated-unavailable',
+      severity: 'info',
+      id: '0013',
+      message: 'supersededBy target "payments:0020" is a log-qualified ref; named-log federation is not available in this phase',
+    });
+    // Core's own dangling-supersededBy findings remain present alongside the derived ones.
+    expect(findings.some((f) => f.rule === 'dangling-supersededBy' && f.id === '0012')).toBe(true);
+  });
+
+  test('a resolved target reports its LIVE current status, not an assumed accepted', async () => {
+    const repo = await createRepo();
+    await writeRecords(repo, {
+      '0060-superseded.md': `---
+schemaVersion: 0.1.0
+id: "0060"
+title: Superseded record pointing at a deprecated target
+status: superseded
+date: 2026-05-01
+supersededBy: "0061"
+---
+
+# 0060
+`,
+      '0061-target.md': `---
+schemaVersion: 0.1.0
+id: "0061"
+title: A target that itself moved on to deprecated
+status: deprecated
+date: 2026-05-02
+---
+
+# 0061
+`,
+    });
+    const { client } = await open(repo);
+    const entry = entryFor(resultOf(await callTool(client, 'list_superseded', {})), '0060');
+    expect(entry.supersededBy).toEqual({
+      resolved: true,
+      target: { id: '0061', title: 'A target that itself moved on to deprecated', status: 'deprecated', sourcePath: 'docs/adr/0061-target.md' },
+    });
+  });
+
+  test('empty listing is the same entries branch', async () => {
+    const repo = await createRepo();
+    await writeRecords(repo, {
+      '0070-plain.md': `---\nschemaVersion: 0.1.0\nid: "0070"\ntitle: A plain accepted record\nstatus: accepted\ndate: 2026-05-05\ndeciders:\n  - "@m"\n---\n\n# 0070\n`,
+    });
+    const { client } = await open(repo);
+    const res = await callTool(client, 'list_superseded', {});
+    expect(resultOf(res).items).toEqual([]);
+    expect(textOf(res)).toBe('Returned 0 superseded decision entries; 0 findings on this page.');
+  });
+
+  test('exact entries text for one and many', async () => {
+    const single = await open(await repoFromFixture('status-corpus'));
+    expect(textOf(await callTool(single.client, 'list_superseded', {}))).toBe(
+      'Returned 1 superseded decision entry; 0 findings on this page.',
+    );
+    const many = await open(await repoFromFixture('edge-corpus'));
+    expect(textOf(await callTool(many.client, 'list_superseded', {}))).toBe(
+      'Returned 4 superseded decision entries; 6 findings on this page.',
+    );
+  });
+
+  test('a corpus that cannot be loaded is corpus-unavailable', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    const config = await toolConfig(repo.root, repo.dir);
+    await rm(repo.adrDir, { recursive: true, force: true });
+    const harness = await openTool(registerListSuperseded, config);
+    cleanups.push(harness.close);
+    const res = await callTool(harness.client, 'list_superseded', {});
+    expect(resultOf(res).outcome).toBe('corpus-unavailable');
+    expect(healthOf(res)).toBeUndefined();
+  });
+});

--- a/packages/mcp/test/ordering-normalize.test.ts
+++ b/packages/mcp/test/ordering-normalize.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import { compareCodeUnits, compareByIdThenPath, sortByIdThenPath, sortFindingsCanonical } from '../src/corpus/ordering.ts';
+import { normalize } from '../src/search/normalize.ts';
+import type { Finding } from '@adrkit/core';
+
+describe('code-unit comparator (never localeCompare)', () => {
+  test('orders by UTF-16 code unit', () => {
+    expect(compareCodeUnits('a', 'b')).toBe(-1);
+    expect(compareCodeUnits('b', 'a')).toBe(1);
+    expect(compareCodeUnits('a', 'a')).toBe(0);
+  });
+
+  test('uppercase sorts before lowercase (code-unit, not locale collation)', () => {
+    // localeCompare typically returns the OPPOSITE for 'B' vs 'a'; code-unit is fixed.
+    expect(compareCodeUnits('B', 'a')).toBe(-1);
+    expect('B'.localeCompare('a')).not.toBe(-1);
+  });
+
+  test('zero-padded numeric ids sort correctly under plain string order', () => {
+    expect(sortByIdThenPath([
+      { id: '0010', sourcePath: 'a' },
+      { id: '0002', sourcePath: 'a' },
+      { id: '0001', sourcePath: 'a' },
+    ]).map((x) => x.id)).toEqual(['0001', '0002', '0010']);
+  });
+});
+
+describe('canonical (id, sourcePath) order', () => {
+  test('id first, then sourcePath tiebreak', () => {
+    expect(compareByIdThenPath({ id: '0001', sourcePath: 'b.md' }, { id: '0001', sourcePath: 'a.md' })).toBe(1);
+    expect(compareByIdThenPath({ id: '0001', sourcePath: 'a.md' }, { id: '0002', sourcePath: 'a.md' })).toBe(-1);
+  });
+
+  test('sortByIdThenPath breaks ties within one id by sourcePath', () => {
+    const sorted = sortByIdThenPath([
+      { id: '0010', sourcePath: 'docs/adr/z.md' },
+      { id: '0010', sourcePath: 'docs/adr/a.md' },
+    ]);
+    expect(sorted.map((x) => x.sourcePath)).toEqual(['docs/adr/a.md', 'docs/adr/z.md']);
+  });
+});
+
+describe('canonical finding order (sortFindings tuple, code-unit compared)', () => {
+  test('orders by rule, then id, then pattern, then path, then field, then message', () => {
+    const findings: Finding[] = [
+      { rule: 'b', severity: 'info', message: 'm' },
+      { rule: 'a', severity: 'info', message: 'z', id: '2' },
+      { rule: 'a', severity: 'info', message: 'z', id: '1' },
+    ];
+    expect(sortFindingsCanonical(findings).map((f) => `${f.rule}/${f.id ?? ''}`)).toEqual(['a/1', 'a/2', 'b/']);
+  });
+});
+
+describe('search normalization: trim -> NFKC -> toLowerCase', () => {
+  test('trims incidental whitespace', () => {
+    expect(normalize('  Hello  ')).toBe('hello');
+  });
+
+  test('lowercases without locale sensitivity', () => {
+    expect(normalize('POSTGRES')).toBe('postgres');
+  });
+
+  test('applies NFKC compatibility folding (full-width forms)', () => {
+    expect(normalize('ＡＢＣ')).toBe('abc');
+    expect(normalize('ﬁ')).toBe('fi');
+  });
+
+  test('whitespace-only normalizes to empty (the input schema, not normalize, rejects it)', () => {
+    expect(normalize('   ')).toBe('');
+  });
+
+  test('order is trim then NFKC then lowercase', () => {
+    expect(normalize('  Ａ ')).toBe('a');
+  });
+});

--- a/packages/mcp/test/projection.test.ts
+++ b/packages/mcp/test/projection.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { loadCorpusProjection, CorpusUnavailableError, MAX_SOURCE_BYTES } from '../src/corpus/projection.ts';
+import { createRepo, repoFromFixture, toolConfig, makeOversizedRecord, type TempRepo } from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+function track(repo: TempRepo): TempRepo {
+  cleanups.push(repo.cleanup);
+  return repo;
+}
+
+async function load(repo: TempRepo, overrides: Partial<Awaited<ReturnType<typeof toolConfig>>> = {}) {
+  const config = { ...(await toolConfig(repo.root, repo.dir)), ...overrides };
+  return loadCorpusProjection(config);
+}
+
+async function reasonOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+    return 'resolved';
+  } catch (error) {
+    if (error instanceof CorpusUnavailableError) return error.reason;
+    throw error;
+  }
+}
+
+describe('loadCorpusProjection — stable load', () => {
+  test('loads all valid records with an id-keyed multi-value index', async () => {
+    const repo = track(await repoFromFixture('status-corpus'));
+    const projection = await load(repo);
+    expect(projection.records.map((r) => r.frontmatter.id)).toEqual(['0001', '0002', '0003', '0004', '0005', '0006']);
+    expect(projection.recordCount).toBe(6);
+    expect(projection.excludedCount).toBe(0);
+    expect(projection.byId.get('0001')?.length).toBe(1);
+    expect(projection.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('a pre-read oversized source is excluded with a record-too-large error finding', async () => {
+    const repo = track(await repoFromFixture('status-corpus'));
+    await writeFile(join(repo.adrDir, '0007-oversized.md'), makeOversizedRecord('0007'), 'utf8');
+    const projection = await load(repo);
+    expect(projection.records.some((r) => r.frontmatter.id === '0007')).toBe(false);
+    expect(projection.excludedCount).toBe(1);
+    const finding = projection.corpusFindings.find((f) => f.rule === 'record-too-large');
+    expect(finding?.severity).toBe('error');
+    expect(finding?.path).toBe('docs/adr/0007-oversized.md');
+    expect(finding?.id).toBeUndefined();
+  });
+
+  test('a corpus whose ONLY file is oversized yields zero records without lintCorpus re-discovery', async () => {
+    const repo = track(await createRepo());
+    await writeFile(join(repo.adrDir, '0100-oversized.md'), makeOversizedRecord('0100'), 'utf8');
+    const projection = await load(repo);
+    expect(projection.records).toHaveLength(0);
+    expect(projection.recordCount).toBe(0);
+    expect(projection.excludedCount).toBe(1);
+    expect(projection.corpusFindings.map((f) => f.rule)).toEqual(['record-too-large']);
+  });
+
+  test('a schema-invalid record is excluded but its valid neighbors remain', async () => {
+    const repo = track(await repoFromFixture('degraded-corpus'));
+    const projection = await load(repo);
+    expect(projection.records.map((r) => r.frontmatter.id).sort()).toEqual(['0031', '0032']);
+    expect(projection.excludedCount).toBe(1);
+    expect(projection.corpusFindings.some((f) => f.id === '0030')).toBe(true);
+  });
+
+  test('an invariant-flagged duplicate id keeps BOTH records and only adds a finding', async () => {
+    const repo = track(await repoFromFixture('edge-corpus'));
+    const projection = await load(repo);
+    expect(projection.byId.get('0010')?.length).toBe(2);
+    expect(projection.excludedCount).toBe(0);
+    expect(projection.corpusFindings.some((f) => f.rule === 'unique-id' && f.id === '0010')).toBe(true);
+  });
+
+  test('byId buckets are sorted (id, sourcePath) and expose every duplicate', async () => {
+    const repo = track(await repoFromFixture('edge-corpus'));
+    const projection = await load(repo);
+    const bucket = projection.byId.get('0010') ?? [];
+    expect(bucket.map((r) => r.path)).toEqual([
+      'docs/adr/0010-first-duplicate.md',
+      'docs/adr/0010-second-duplicate.md',
+    ]);
+  });
+
+  test('a changed canonical root (expected != fresh) rejects as corpus-unavailable', async () => {
+    const repo = track(await repoFromFixture('status-corpus'));
+    await expect(reasonOf(load(repo, { expectedCanonicalCwd: '/some/other/root' }))).resolves.not.toBe('resolved');
+  });
+
+  test('fresh reload sees an edit made between two calls', async () => {
+    const repo = track(await repoFromFixture('status-corpus'));
+    const before = await load(repo);
+    await writeFile(
+      join(repo.adrDir, '0002-draft-a-caching-layer.md'),
+      (await Bun.file(join(repo.adrDir, '0002-draft-a-caching-layer.md')).text()) + '\nExtra body line.\n',
+      'utf8',
+    );
+    const after = await load(repo);
+    expect(after.fingerprint).not.toBe(before.fingerprint);
+  });
+
+  test('concurrent calls return independent projection objects with equal content', async () => {
+    const repo = track(await repoFromFixture('status-corpus'));
+    const [a, b] = await Promise.all([load(repo), load(repo)]);
+    expect(a).not.toBe(b);
+    expect(a.records).not.toBe(b.records);
+    expect(a.fingerprint).toBe(b.fingerprint);
+  });
+
+  test('the guard cap matches the documented 64 KiB', () => {
+    expect(MAX_SOURCE_BYTES).toBe(65536);
+  });
+});

--- a/packages/mcp/test/projection.test.ts
+++ b/packages/mcp/test/projection.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { loadCorpusProjection, CorpusUnavailableError, MAX_SOURCE_BYTES } from '../src/corpus/projection.ts';
 import { createRepo, repoFromFixture, toolConfig, makeOversizedRecord, type TempRepo } from './helpers.ts';
@@ -91,6 +92,32 @@ describe('loadCorpusProjection — stable load', () => {
   test('a changed canonical root (expected != fresh) rejects as corpus-unavailable', async () => {
     const repo = track(await repoFromFixture('status-corpus'));
     await expect(reasonOf(load(repo, { expectedCanonicalCwd: '/some/other/root' }))).resolves.not.toBe('resolved');
+  });
+
+  test('a configured root symlink retargeted after startup is rejected', async () => {
+    const original = track(await repoFromFixture('status-corpus'));
+    const replacement = track(await repoFromFixture('status-corpus'));
+    const links = await mkdtemp(join(tmpdir(), 'adrkit-mcp-root-link-'));
+    cleanups.push(() => rm(links, { recursive: true, force: true }));
+    const configuredRoot = join(links, 'repo');
+    await symlink(original.root, configuredRoot);
+    const config = await toolConfig(configuredRoot, original.dir);
+    await rm(configuredRoot);
+    await symlink(replacement.root, configuredRoot);
+
+    await expect(reasonOf(loadCorpusProjection(config))).resolves.toBe('root-not-found');
+  });
+
+  test('a configured root symlink removed after startup is rejected', async () => {
+    const repo = track(await repoFromFixture('status-corpus'));
+    const links = await mkdtemp(join(tmpdir(), 'adrkit-mcp-root-link-'));
+    cleanups.push(() => rm(links, { recursive: true, force: true }));
+    const configuredRoot = join(links, 'repo');
+    await symlink(repo.root, configuredRoot);
+    const config = await toolConfig(configuredRoot, repo.dir);
+    await rm(configuredRoot);
+
+    await expect(reasonOf(loadCorpusProjection(config))).resolves.toBe('root-not-found');
   });
 
   test('fresh reload sees an edit made between two calls', async () => {

--- a/packages/mcp/test/roots.test.ts
+++ b/packages/mcp/test/roots.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm, symlink, writeFile, realpath, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveCanonicalRoots, CorpusUnavailableError } from '../src/corpus/projection.ts';
+import { createRepo } from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+async function outsideDir(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), 'adrkit-mcp-outside-'));
+  const real = await realpath(d);
+  cleanups.push(() => rm(real, { recursive: true, force: true }));
+  return real;
+}
+
+async function reasonOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+    return 'resolved';
+  } catch (error) {
+    if (error instanceof CorpusUnavailableError) return error.reason;
+    throw error;
+  }
+}
+
+describe('resolveCanonicalRoots', () => {
+  test('accepts an ordinary .git directory clone', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    const roots = await resolveCanonicalRoots({ cwd: repo.root, dir: repo.dir });
+    expect(roots.canonicalCwd).toBe(repo.root);
+    expect(roots.canonicalDir).toBe(join(repo.root, 'docs/adr'));
+  });
+
+  test('accepts a linked-worktree .git FILE (never parsed, only readable)', async () => {
+    const repo = await createRepo({ gitFile: true });
+    cleanups.push(repo.cleanup);
+    await expect(reasonOf(resolveCanonicalRoots({ cwd: repo.root, dir: repo.dir }))).resolves.toBe('resolved');
+  });
+
+  test('a missing root is root-not-found', async () => {
+    await expect(reasonOf(resolveCanonicalRoots({ cwd: '/no/such/adrkit/root', dir: 'docs/adr' }))).resolves.toBe(
+      'root-not-found',
+    );
+  });
+
+  test('a readable directory with no .git entry is root-not-git', async () => {
+    const bare = await outsideDir();
+    await mkdir(join(bare, 'docs/adr'), { recursive: true });
+    await expect(reasonOf(resolveCanonicalRoots({ cwd: bare, dir: 'docs/adr' }))).resolves.toBe('root-not-git');
+  });
+
+  test('a missing ADR directory is dir-not-found', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    await rm(repo.adrDir, { recursive: true, force: true });
+    await expect(reasonOf(resolveCanonicalRoots({ cwd: repo.root, dir: 'docs/adr' }))).resolves.toBe('dir-not-found');
+  });
+
+  test('an absolute --dir outside the root is dir-outside-root', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    const outside = await outsideDir();
+    await expect(reasonOf(resolveCanonicalRoots({ cwd: repo.root, dir: outside }))).resolves.toBe('dir-outside-root');
+  });
+
+  test('a ".." traversal --dir is dir-outside-root', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    await expect(reasonOf(resolveCanonicalRoots({ cwd: repo.root, dir: '../..' }))).resolves.toBe('dir-outside-root');
+  });
+
+  test('a string-prefix sibling directory does not count as contained', async () => {
+    const parent = await outsideDir();
+    const repoRoot = join(parent, 'repo');
+    const sibling = join(parent, 'repo-secrets');
+    await mkdir(join(repoRoot, '.git'), { recursive: true });
+    await mkdir(sibling, { recursive: true });
+    await expect(reasonOf(resolveCanonicalRoots({ cwd: repoRoot, dir: sibling }))).resolves.toBe('dir-outside-root');
+  });
+
+  test('a --dir that is a symlink escaping the root is dir-outside-root (realpath containment)', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    const outside = await outsideDir();
+    await rm(repo.adrDir, { recursive: true, force: true });
+    await mkdir(join(repo.root, 'docs'), { recursive: true });
+    await symlink(outside, join(repo.root, 'docs/adr'));
+    // The raw string 'docs/adr' contains no '..' yet resolves outside via the symlink.
+    await expect(reasonOf(resolveCanonicalRoots({ cwd: repo.root, dir: 'docs/adr' }))).resolves.toBe('dir-outside-root');
+  });
+
+  test('a --dir pointing at a file is dir-not-directory', async () => {
+    const repo = await createRepo();
+    cleanups.push(repo.cleanup);
+    await writeFile(join(repo.root, 'notadir.md'), 'x', 'utf8');
+    await expect(reasonOf(resolveCanonicalRoots({ cwd: repo.root, dir: 'notadir.md' }))).resolves.toBe(
+      'dir-not-directory',
+    );
+  });
+});

--- a/packages/mcp/test/search-decisions-pagination.test.ts
+++ b/packages/mcp/test/search-decisions-pagination.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { registerSearchDecisions } from '../src/tools/search-decisions.ts';
+import { encodeCursor, queryShapeHash } from '../src/pagination/cursor.ts';
+import { normalize } from '../src/search/normalize.ts';
+import {
+  openTool,
+  callTool,
+  resultOf,
+  healthOf,
+  walkChannel,
+  repoFromFixture,
+  toolConfig,
+  type TempRepo,
+} from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+async function open(repo: TempRepo) {
+  cleanups.push(repo.cleanup);
+  const harness = await openTool(registerSearchDecisions, await toolConfig(repo.root, repo.dir));
+  cleanups.push(harness.close);
+  return harness;
+}
+
+const resultsQh = (query: string, limit: number) => queryShapeHash([normalize(query), [], [], [], limit]);
+
+describe('search_decisions — determinism and pagination', () => {
+  test('results are in canonical (id, sourcePath) order, byte-identical across repeated calls', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const first = resultOf(await callTool(client, 'search_decisions', { query: 'the' }));
+    const second = resultOf(await callTool(client, 'search_decisions', { query: 'the' }));
+    expect(first.items.map((m: { id: string }) => m.id)).toEqual(['0001', '0004', '0005', '0006']);
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  test('a multi-page walk is lossless and returns every match exactly once', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const collected = await walkChannel<{ id: string }>(async (cursor) => {
+      const result = resultOf(await callTool(client, 'search_decisions', { query: 'the', limit: 1, ...(cursor ? { cursor } : {}) }));
+      return { items: result.items, cursor: result.cursor };
+    });
+    expect(collected.map((m) => m.id)).toEqual(['0001', '0004', '0005', '0006']);
+  });
+
+  test('a cursor bound to a different query is rejected as query-mismatch', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const first = await callTool(client, 'search_decisions', { query: 'the', limit: 1 });
+    const cursor = resultOf(first).cursor as string;
+    const res = await callTool(client, 'search_decisions', { query: 'legacy', limit: 1, cursor });
+    expect(resultOf(res).reason).toBe('query-mismatch');
+  });
+
+  test('a stale-corpus cursor (wrong fp) is corpus-changed', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const cursor = encodeCursor({ v: 1, scope: 'search.results', fp: 'f'.repeat(64), qh: resultsQh('the', 1), offset: 1 });
+    const res = await callTool(client, 'search_decisions', { query: 'the', limit: 1, cursor });
+    expect(resultOf(res).reason).toBe('corpus-changed');
+  });
+
+  test('a schema-invalid record degrades to a finding without suppressing valid matches', async () => {
+    const { client } = await open(await repoFromFixture('degraded-corpus'));
+    const result = resultOf(await callTool(client, 'search_decisions', { query: 'record' }));
+    // 0031 and 0032 titles contain "record"; the invalid 0030 is excluded from matches.
+    expect(result.items.map((m: { id: string }) => m.id).sort()).toEqual(['0031', '0032']);
+    expect(result.items.some((m: { id: string }) => m.id === '0030')).toBe(false);
+  });
+
+  test('result and findings cursors are independent', async () => {
+    const { client } = await open(await repoFromFixture('degraded-corpus'));
+    const first = resultOf(await callTool(client, 'search_decisions', { query: 'record', limit: 1, findingsLimit: 1 }));
+    expect(first.findings.items).toHaveLength(1);
+    // Walking results does not disturb the findings first page.
+    let cursor: string | undefined = first.cursor ?? undefined;
+    while (cursor) {
+      const page = resultOf(await callTool(client, 'search_decisions', { query: 'record', limit: 1, findingsLimit: 1, cursor }));
+      expect(page.findings.items).toEqual(first.findings.items);
+      cursor = page.cursor ?? undefined;
+    }
+  });
+
+  test('every cursor failure branch is reachable with its fixed reason', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const fp = healthOf(await callTool(client, 'search_decisions', { query: 'the', limit: 1 })).fingerprint;
+    const qh = resultsQh('the', 1);
+    const cases: Array<[string, string]> = [
+      ['decode-failed', 'garbage'],
+      ['wrong-channel', encodeCursor({ v: 1, scope: 'get_decision.candidates', fp, qh, offset: 1 })],
+      ['corpus-changed', encodeCursor({ v: 1, scope: 'search.results', fp: 'a'.repeat(64), qh, offset: 1 })],
+      ['query-mismatch', encodeCursor({ v: 1, scope: 'search.results', fp, qh: resultsQh('other', 1), offset: 1 })],
+      ['offset-out-of-range', encodeCursor({ v: 1, scope: 'search.results', fp, qh, offset: 4 })],
+    ];
+    for (const [reason, cursor] of cases) {
+      expect(resultOf(await callTool(client, 'search_decisions', { query: 'the', limit: 1, cursor })).reason).toBe(reason);
+    }
+  });
+});

--- a/packages/mcp/test/search-decisions.test.ts
+++ b/packages/mcp/test/search-decisions.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { registerSearchDecisions } from '../src/tools/search-decisions.ts';
+import { openTool, callTool, resultOf, textOf, repoFromFixture, toolConfig, type TempRepo } from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+async function open(repo: TempRepo) {
+  cleanups.push(repo.cleanup);
+  const harness = await openTool(registerSearchDecisions, await toolConfig(repo.root, repo.dir));
+  cleanups.push(harness.close);
+  return harness;
+}
+
+async function search(repo: TempRepo, args: Record<string, unknown>) {
+  const { client } = await open(repo);
+  return resultOf(await callTool(client, 'search_decisions', args));
+}
+
+function ids(result: { items: Array<{ id: string }> }): string[] {
+  return result.items.map((m) => m.id);
+}
+
+describe('search_decisions — matching', () => {
+  test('a body-only term matches only via the body field', async () => {
+    const result = await search(await repoFromFixture('status-corpus'), { query: 'pgvector' });
+    expect(ids(result)).toEqual(['0001']);
+    expect(result.items[0].matchedFields).toEqual(['body']);
+  });
+
+  test('a title term also matches the body (the H1 heading repeats the title), in canonical field order', async () => {
+    const result = await search(await repoFromFixture('status-corpus'), { query: 'mongodb' });
+    expect(ids(result)).toEqual(['0004']);
+    expect(result.items[0].matchedFields).toEqual(['body', 'title']);
+  });
+
+  test('a tag term matches via the tag field', async () => {
+    const result = await search(await repoFromFixture('status-corpus'), { query: 'storage' });
+    expect(ids(result)).toEqual(['0001']);
+    expect(result.items[0].matchedFields).toEqual(['tag']);
+  });
+
+  test('trim + NFKC + lowercase normalization applies to the query', async () => {
+    const result = await search(await repoFromFixture('status-corpus'), { query: '  ＰＯＳＴＧＲＥＳＱＬ  ' });
+    expect(ids(result)).toEqual(['0001']);
+  });
+
+  test('graveyard records are included by default', async () => {
+    const result = await search(await repoFromFixture('status-corpus'), { query: 'legacy' });
+    expect(ids(result)).toEqual(['0005']); // superseded record, no status filter supplied
+  });
+
+  test('empty results are the same results branch with items []', async () => {
+    const result = await search(await repoFromFixture('status-corpus'), { query: 'zzzznomatch' });
+    expect(result.outcome).toBe('results');
+    expect(result.items).toEqual([]);
+    expect(result.cursor).toBeNull();
+  });
+
+  test('summaries never include the body', async () => {
+    const result = await search(await repoFromFixture('status-corpus'), { query: 'the' });
+    expect('body' in result.items[0]).toBe(false);
+  });
+
+  test('status is any-of, tags is all-of, and categories are ANDed', async () => {
+    const repo = await repoFromFixture('status-corpus');
+    const { client } = await open(repo);
+    // any-of status: rejected only -> 0004
+    expect(ids(resultOf(await callTool(client, 'search_decisions', { query: 'the', status: ['rejected'] })))).toEqual(['0004']);
+    // all-of tags: [database, storage] -> only 0001 carries both
+    expect(ids(resultOf(await callTool(client, 'search_decisions', { query: 'the', tags: ['database', 'storage'] })))).toEqual(['0001']);
+    // ANDed: accepted AND tag storage -> 0001
+    expect(ids(resultOf(await callTool(client, 'search_decisions', { query: 'the', status: ['accepted'], tags: ['storage'] })))).toEqual(['0001']);
+    // scope any-of: org -> 0006
+    expect(ids(resultOf(await callTool(client, 'search_decisions', { query: 'the', scope: ['org'] })))).toEqual(['0006']);
+  });
+
+  test('a whitespace-only query is rejected before any corpus access', async () => {
+    const { client } = await open(await repoFromFixture('status-corpus'));
+    const res = await callTool(client, 'search_decisions', { query: '   ' });
+    expect(res.isError).toBe(true);
+  });
+
+  test('exact results text for zero, one, and many', async () => {
+    const repo = await repoFromFixture('status-corpus');
+    const { client } = await open(repo);
+    expect(textOf(await callTool(client, 'search_decisions', { query: 'zzzz' }))).toBe(
+      'Returned 0 decision results; 0 findings on this page.',
+    );
+    expect(textOf(await callTool(client, 'search_decisions', { query: 'pgvector' }))).toBe(
+      'Returned 1 decision result; 0 findings on this page.',
+    );
+    expect(textOf(await callTool(client, 'search_decisions', { query: 'the' }))).toBe(
+      'Returned 4 decision results; 0 findings on this page.',
+    );
+  });
+});

--- a/packages/mcp/test/shared-contracts.test.ts
+++ b/packages/mcp/test/shared-contracts.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  ANNOTATIONS,
+  LIMITS,
+  cap512,
+  plural,
+  renderResponseText,
+  searchDecisionsInputSchema,
+  getDecisionInputSchema,
+  getDecisionContextInputSchema,
+  listSupersededInputSchema,
+  searchDecisionsOutputSchema,
+  getDecisionOutputSchema,
+  getDecisionContextOutputSchema,
+  listSupersededOutputSchema,
+} from '../src/tools/shared.ts';
+
+describe('fixed annotations (contracts/tools.md §2)', () => {
+  test('every tool declares the same read-only, closed-world annotations', () => {
+    expect(ANNOTATIONS).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+  });
+});
+
+describe('deterministic text renderer (contracts/tools.md §2.1)', () => {
+  test('results: singular vs plural for items and findings', () => {
+    expect(renderResponseText({ kind: 'results', itemsLength: 2, findings: 1 })).toBe(
+      'Returned 2 decision results; 1 finding on this page.',
+    );
+    expect(renderResponseText({ kind: 'results', itemsLength: 1, findings: 0 })).toBe(
+      'Returned 1 decision result; 0 findings on this page.',
+    );
+  });
+
+  test('found interpolates the decision id', () => {
+    expect(renderResponseText({ kind: 'found', id: '0001', findings: 1 })).toBe(
+      'Found decision "0001"; 1 finding on this page.',
+    );
+  });
+
+  test('not-found interpolates the requested ref', () => {
+    expect(renderResponseText({ kind: 'not-found', requestedRef: '9999', findings: 0 })).toBe(
+      'No local decision matches "9999"; 0 findings on this page.',
+    );
+  });
+
+  test('ambiguous-local-id', () => {
+    expect(renderResponseText({ kind: 'ambiguous-local-id', candidatesLength: 2, requestedRef: '0010', findings: 3 })).toBe(
+      'Returned 2 candidates for ambiguous local ref "0010"; 3 findings on this page.',
+    );
+    expect(renderResponseText({ kind: 'ambiguous-local-id', candidatesLength: 1, requestedRef: '0010', findings: 1 })).toBe(
+      'Returned 1 candidate for ambiguous local ref "0010"; 1 finding on this page.',
+    );
+  });
+
+  test('federated-log-unavailable', () => {
+    expect(renderResponseText({ kind: 'federated-log-unavailable', requestedRef: 'payments:0012', findings: 0 })).toBe(
+      'Named-log federation is unavailable for "payments:0012"; 0 findings on this page.',
+    );
+  });
+
+  test('matches with pageMatchCount = governing + activeProposals + history', () => {
+    expect(renderResponseText({ kind: 'matches', governing: 1, activeProposals: 2, history: 3, findings: 0 })).toBe(
+      'Returned 6 context matches: 1 governing, 2 active proposals, 3 historical; 0 findings on this page.',
+    );
+    expect(renderResponseText({ kind: 'matches', governing: 1, activeProposals: 1, history: 0, findings: 1 })).toBe(
+      'Returned 2 context matches: 1 governing, 1 active proposal, 0 historical; 1 finding on this page.',
+    );
+  });
+
+  test('entries singular/plural', () => {
+    expect(renderResponseText({ kind: 'entries', itemsLength: 1, findings: 0 })).toBe(
+      'Returned 1 superseded decision entry; 0 findings on this page.',
+    );
+    expect(renderResponseText({ kind: 'entries', itemsLength: 3, findings: 2 })).toBe(
+      'Returned 3 superseded decision entries; 2 findings on this page.',
+    );
+  });
+
+  test('fixed invalid-cursor and corpus-unavailable messages', () => {
+    expect(renderResponseText({ kind: 'invalid-cursor', reason: 'offset-out-of-range' })).toBe(
+      'Cursor offset is outside the current result set.',
+    );
+    expect(renderResponseText({ kind: 'corpus-unavailable', reason: 'root-not-git' })).toBe(
+      'Configured repository root is not a Git worktree.',
+    );
+  });
+
+  test('every rendered string is capped at 512 UTF-16 code units', () => {
+    const longRef = 'x'.repeat(1000);
+    expect(renderResponseText({ kind: 'not-found', requestedRef: longRef, findings: 0 }).length).toBeLessThanOrEqual(512);
+    expect(cap512('y'.repeat(1000)).length).toBe(512);
+    expect(cap512('short')).toBe('short');
+  });
+
+  test('plural helper', () => {
+    expect(plural(1, 'a', 'b')).toBe('a');
+    expect(plural(0, 'a', 'b')).toBe('b');
+    expect(plural(2, 'a', 'b')).toBe('b');
+  });
+});
+
+describe('strict, bounded input schemas (contracts/tools.md §8)', () => {
+  test('search_decisions: query bounds, trim-non-empty, filters, strict', () => {
+    const schema = searchDecisionsInputSchema();
+    expect(schema.safeParse({ query: 'postgres' }).success).toBe(true);
+    expect(schema.safeParse({ query: '' }).success).toBe(false);
+    expect(schema.safeParse({ query: '   ' }).success).toBe(false);
+    expect(schema.safeParse({ query: 'x'.repeat(257) }).success).toBe(false);
+    expect(schema.safeParse({ query: 'x', bogus: 1 }).success).toBe(false);
+    expect(schema.safeParse({ query: 'x', status: [] }).success).toBe(false);
+    expect(schema.safeParse({ query: 'x', status: ['accepted', 'draft'] }).success).toBe(true);
+    expect(schema.safeParse({ query: 'x', status: ['bogus'] }).success).toBe(false);
+    expect(schema.safeParse({ query: 'x', tags: Array.from({ length: 33 }, (_, i) => `t${i}`) }).success).toBe(false);
+    expect(schema.safeParse({ query: 'x', tags: ['a'.repeat(65)] }).success).toBe(false);
+    expect(schema.safeParse({ query: 'x', limit: 0 }).success).toBe(false);
+    expect(schema.safeParse({ query: 'x', limit: 101 }).success).toBe(false);
+  });
+
+  test('get_decision: ref bounds and strict', () => {
+    const schema = getDecisionInputSchema();
+    expect(schema.safeParse({ ref: '0001' }).success).toBe(true);
+    expect(schema.safeParse({ ref: 'payments:0012' }).success).toBe(true);
+    expect(schema.safeParse({ ref: '' }).success).toBe(false);
+    expect(schema.safeParse({ ref: 'x'.repeat(129) }).success).toBe(false);
+    expect(schema.safeParse({ ref: 'not a ref!' }).success).toBe(false);
+    expect(schema.safeParse({}).success).toBe(false);
+    expect(schema.safeParse({ ref: '0001', bogus: 1 }).success).toBe(false);
+  });
+
+  test('get_decision_context: files path rules (POSIX only), counts, strict', () => {
+    const schema = getDecisionContextInputSchema();
+    expect(schema.safeParse({ files: ['docs/adr/0001.md'] }).success).toBe(true);
+    expect(schema.safeParse({ files: [] }).success).toBe(false);
+    expect(schema.safeParse({ files: ['/abs/x.md'] }).success).toBe(false);
+    expect(schema.safeParse({ files: ['../escape.md'] }).success).toBe(false);
+    expect(schema.safeParse({ files: ['a/../b.md'] }).success).toBe(false);
+    expect(schema.safeParse({ files: ['C:\\win.md'] }).success).toBe(false);
+    expect(schema.safeParse({ files: ['docs\\adr\\0001.md'] }).success).toBe(false);
+    expect(schema.safeParse({ files: [''] }).success).toBe(false);
+    expect(schema.safeParse({ files: ['x'.repeat(1025)] }).success).toBe(false);
+    expect(schema.safeParse({ files: Array.from({ length: 257 }, (_, i) => `f${i}.md`) }).success).toBe(false);
+  });
+
+  test('list_superseded: pagination only, strict', () => {
+    const schema = listSupersededInputSchema();
+    expect(schema.safeParse({}).success).toBe(true);
+    expect(schema.safeParse({ limit: 20, findingsLimit: 20 }).success).toBe(true);
+    expect(schema.safeParse({ status: ['accepted'] }).success).toBe(false);
+    expect(schema.safeParse({ cursor: 'x'.repeat(LIMITS.cursorBytes + 1) }).success).toBe(false);
+  });
+});
+
+describe('root-object output schemas with a nested discriminated union', () => {
+  for (const [name, builder] of [
+    ['search_decisions', searchDecisionsOutputSchema],
+    ['get_decision', getDecisionOutputSchema],
+    ['get_decision_context', getDecisionContextOutputSchema],
+    ['list_superseded', listSupersededOutputSchema],
+  ] as const) {
+    test(`${name} output raw shape has corpusHealth + result (union nested under result)`, () => {
+      const shape = builder();
+      expect(Object.keys(shape).sort()).toEqual(['corpusHealth', 'result']);
+    });
+  }
+});

--- a/packages/mcp/test/side-effect-denial-preload.mjs
+++ b/packages/mcp/test/side-effect-denial-preload.mjs
@@ -15,6 +15,8 @@
 import { createRequire } from 'node:module';
 import * as nodeModule from 'node:module';
 import { constants as FS } from 'node:fs';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 
@@ -44,6 +46,53 @@ function denyAll(target, names, prefix) {
         throw new SideEffectDenied(`${prefix}.${name}`);
       };
     }
+  }
+  syncEsm();
+}
+
+// ---- optional read boundary -------------------------------------------------
+const READ_ROOTS = (() => {
+  const encoded = process.env.ADRKIT_MCP_TEST_READ_ROOTS;
+  if (!encoded) return [];
+  try {
+    const roots = JSON.parse(encoded);
+    return Array.isArray(roots) ? roots.map((root) => resolve(String(root))) : [];
+  } catch {
+    throw new Error('ADRKIT_MCP_TEST_READ_ROOTS must be a JSON array');
+  }
+})();
+
+function pathString(path) {
+  if (typeof path === 'number') return undefined;
+  if (path instanceof URL) return fileURLToPath(path);
+  if (Buffer.isBuffer(path)) return path.toString();
+  return String(path);
+}
+
+function isWithin(root, candidate) {
+  const rel = relative(root, candidate);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}
+
+function assertReadAllowed(api, path) {
+  if (READ_ROOTS.length === 0) return;
+  const raw = pathString(path);
+  if (raw === undefined) return;
+  const candidate = resolve(raw);
+  if (!READ_ROOTS.some((root) => isWithin(root, candidate))) {
+    throw new SideEffectDenied(`${api}:out-of-root`);
+  }
+}
+
+function guardPathReads(target, names, prefix) {
+  if (!target || READ_ROOTS.length === 0) return;
+  for (const name of names) {
+    const original = target[name];
+    if (typeof original !== 'function') continue;
+    target[name] = function guardedRead(path, ...rest) {
+      assertReadAllowed(`${prefix}.${name}`, path);
+      return original.call(this, path, ...rest);
+    };
   }
   syncEsm();
 }
@@ -101,6 +150,15 @@ const FS_MUTATORS = [
 function patchFs() {
   const fs = require('node:fs');
   denyAll(fs, FS_MUTATORS, 'fs');
+  guardPathReads(
+    fs,
+    [
+      'access', 'accessSync', 'existsSync', 'lstat', 'lstatSync', 'stat', 'statSync',
+      'realpath', 'realpathSync', 'readFile', 'readFileSync', 'readdir', 'readdirSync',
+      'opendir', 'opendirSync', 'createReadStream',
+    ],
+    'fs',
+  );
 
   // Write-capable open only; a read open is allowed but its handle is not writable.
   for (const openName of ['open', 'openSync']) {
@@ -108,6 +166,7 @@ function patchFs() {
     if (typeof original === 'function') {
       fs[openName] = function guardedOpen(path, flags, ...rest) {
         if (flagPermitsWrite(flags)) throw new SideEffectDenied(`fs.${openName}`);
+        assertReadAllowed(`fs.${openName}`, path);
         return original.call(this, path, flags, ...rest);
       };
     }
@@ -124,10 +183,16 @@ function patchFs() {
     ],
     'fs/promises',
   );
+  guardPathReads(
+    fsp,
+    ['access', 'lstat', 'stat', 'realpath', 'readFile', 'readdir', 'opendir'],
+    'fs/promises',
+  );
   const originalOpen = fsp.open;
   if (typeof originalOpen === 'function') {
     fsp.open = async function guardedOpen(path, flags, ...rest) {
       if (flagPermitsWrite(flags)) throw new SideEffectDenied('fs/promises.open');
+      assertReadAllowed('fs/promises.open', path);
       return guardFileHandle(await originalOpen.call(this, path, flags, ...rest));
     };
   }
@@ -191,8 +256,8 @@ function patchNetwork() {
 // NOTE: `Bun.file(...).writer()` and `Bun.file(...).delete()` are deliberately NOT
 // patched at runtime: `Bun.file()`/its `writer()` back the runtime's OWN stdout/stderr
 // WriteStreams, so wrapping them breaks the very stdio channel this server speaks on.
-// Per research §R10 they are covered by import-discipline (this package's source never
-// imports or references them), which check-deps and the static import audit enforce,
+// Per research §R10 they are covered by import discipline (this package's source never
+// imports or references them), which check-deps and the static source audit enforce,
 // not by a runtime patch that has no safe injection point. `Bun.write`/`Bun.spawn`/
 // `Bun.spawnSync` DO have safe patch points and are trapped here.
 function patchBun() {

--- a/packages/mcp/test/side-effect-denial-preload.mjs
+++ b/packages/mcp/test/side-effect-denial-preload.mjs
@@ -1,0 +1,219 @@
+/**
+ * @adrkit/mcp — side-effect-denial preload (contracts/tools.md §10.1, research §R10).
+ *
+ * Loaded via `node --import ./side-effect-denial-preload.mjs` (or `bun --preload`).
+ * Patches — through `createRequire` plus `syncBuiltinESMExports()` so ESM imports of a
+ * builtin observe the patched function, never a stale facade — every enumerated
+ * filesystem-mutation, write-capable open, returned-FileHandle, child-process,
+ * cluster, worker, dlopen, and network/listen entry point to fail closed. Read-only
+ * filesystem APIs are deliberately left intact so the server can still load its corpus.
+ *
+ * Passing is BOUNDED executed-path evidence only — it does not prove the absence of raw
+ * native syscalls or of future, unenumerated runtime APIs.
+ */
+
+import { createRequire } from 'node:module';
+import * as nodeModule from 'node:module';
+import { constants as FS } from 'node:fs';
+
+const require = createRequire(import.meta.url);
+
+export class SideEffectDenied extends Error {
+  constructor(api) {
+    super(`side-effect denied: ${api}`);
+    this.name = 'SideEffectDenied';
+    this.api = api;
+  }
+}
+
+function syncEsm() {
+  if (typeof nodeModule.syncBuiltinESMExports === 'function') {
+    try {
+      nodeModule.syncBuiltinESMExports();
+    } catch {
+      /* best-effort; a no-op when no ESM facade exists yet */
+    }
+  }
+}
+
+function denyAll(target, names, prefix) {
+  if (!target) return;
+  for (const name of names) {
+    if (typeof target[name] === 'function' || name in target) {
+      target[name] = function denied() {
+        throw new SideEffectDenied(`${prefix}.${name}`);
+      };
+    }
+  }
+  syncEsm();
+}
+
+// ---- write-capable open flag decoding -------------------------------------
+function flagPermitsWrite(flags) {
+  if (flags === undefined || flags === null) return false; // defaults to 'r'
+  if (typeof flags === 'string') return /[wa+]/.test(flags);
+  if (typeof flags === 'number') {
+    const mask = FS.O_WRONLY | FS.O_RDWR | FS.O_APPEND | FS.O_CREAT | FS.O_TRUNC;
+    return (flags & mask) !== 0;
+  }
+  return true; // unknown flag shape → fail closed
+}
+
+const FILE_HANDLE_MUTATORS = [
+  'write',
+  'writev',
+  'writeFile',
+  'appendFile',
+  'truncate',
+  'createWriteStream',
+  'chmod',
+  'chown',
+  'utimes',
+  'sync',
+  'datasync',
+];
+
+function guardFileHandle(handle) {
+  for (const name of FILE_HANDLE_MUTATORS) {
+    if (typeof handle?.[name] === 'function') {
+      handle[name] = function denied() {
+        throw new SideEffectDenied(`FileHandle.${name}`);
+      };
+    }
+  }
+  return handle;
+}
+
+// ---- filesystem mutation ---------------------------------------------------
+const FS_MUTATORS = [
+  'write', 'writeSync', 'writev', 'writevSync',
+  'writeFile', 'writeFileSync', 'appendFile', 'appendFileSync',
+  'createWriteStream', 'truncate', 'truncateSync', 'ftruncate', 'ftruncateSync',
+  'rename', 'renameSync', 'copyFile', 'copyFileSync', 'cp', 'cpSync',
+  'unlink', 'unlinkSync', 'rm', 'rmSync', 'rmdir', 'rmdirSync',
+  'mkdir', 'mkdirSync', 'mkdtemp', 'mkdtempSync', 'link', 'linkSync',
+  'symlink', 'symlinkSync', 'chmod', 'chmodSync', 'fchmod', 'fchmodSync',
+  'lchmod', 'lchmodSync', 'chown', 'chownSync', 'fchown', 'fchownSync',
+  'lchown', 'lchownSync', 'utimes', 'utimesSync', 'futimes', 'futimesSync',
+  'lutimes', 'lutimesSync',
+];
+
+function patchFs() {
+  const fs = require('node:fs');
+  denyAll(fs, FS_MUTATORS, 'fs');
+
+  // Write-capable open only; a read open is allowed but its handle is not writable.
+  for (const openName of ['open', 'openSync']) {
+    const original = fs[openName];
+    if (typeof original === 'function') {
+      fs[openName] = function guardedOpen(path, flags, ...rest) {
+        if (flagPermitsWrite(flags)) throw new SideEffectDenied(`fs.${openName}`);
+        return original.call(this, path, flags, ...rest);
+      };
+    }
+  }
+  syncEsm();
+
+  const fsp = require('node:fs/promises');
+  denyAll(
+    fsp,
+    [
+      'writeFile', 'appendFile', 'truncate', 'rename', 'copyFile', 'cp', 'unlink', 'rm',
+      'rmdir', 'mkdir', 'mkdtemp', 'link', 'symlink', 'chmod', 'lchmod', 'chown', 'lchown',
+      'utimes', 'lutimes',
+    ],
+    'fs/promises',
+  );
+  const originalOpen = fsp.open;
+  if (typeof originalOpen === 'function') {
+    fsp.open = async function guardedOpen(path, flags, ...rest) {
+      if (flagPermitsWrite(flags)) throw new SideEffectDenied('fs/promises.open');
+      return guardFileHandle(await originalOpen.call(this, path, flags, ...rest));
+    };
+  }
+  syncEsm();
+}
+
+// ---- process / runtime escape ---------------------------------------------
+function patchProcessEscape() {
+  const cp = require('node:child_process');
+  denyAll(
+    cp,
+    ['spawn', 'spawnSync', 'exec', 'execSync', 'execFile', 'execFileSync', 'fork'],
+    'child_process',
+  );
+
+  const cluster = require('node:cluster');
+  denyAll(cluster, ['fork'], 'cluster');
+
+  const worker = require('node:worker_threads');
+  if (worker && typeof worker.Worker === 'function') {
+    worker.Worker = class DeniedWorker {
+      constructor() {
+        throw new SideEffectDenied('worker_threads.Worker');
+      }
+    };
+    syncEsm();
+  }
+
+  if (typeof process.dlopen === 'function') {
+    process.dlopen = function denied() {
+      throw new SideEffectDenied('process.dlopen');
+    };
+  }
+}
+
+// ---- network / listen ------------------------------------------------------
+function patchNetwork() {
+  globalThis.fetch = function denied() {
+    throw new SideEffectDenied('fetch');
+  };
+
+  const net = require('node:net');
+  denyAll(net, ['connect', 'createConnection'], 'net');
+  if (net?.Server?.prototype && typeof net.Server.prototype.listen === 'function') {
+    net.Server.prototype.listen = function denied() {
+      throw new SideEffectDenied('net.Server.listen');
+    };
+  }
+
+  const http = require('node:http');
+  denyAll(http, ['request', 'get'], 'http');
+  const https = require('node:https');
+  denyAll(https, ['request', 'get'], 'https');
+
+  const dgram = require('node:dgram');
+  denyAll(dgram, ['createSocket'], 'dgram');
+  syncEsm();
+}
+
+// ---- Bun companion ---------------------------------------------------------
+// NOTE: `Bun.file(...).writer()` and `Bun.file(...).delete()` are deliberately NOT
+// patched at runtime: `Bun.file()`/its `writer()` back the runtime's OWN stdout/stderr
+// WriteStreams, so wrapping them breaks the very stdio channel this server speaks on.
+// Per research §R10 they are covered by import-discipline (this package's source never
+// imports or references them), which check-deps and the static import audit enforce,
+// not by a runtime patch that has no safe injection point. `Bun.write`/`Bun.spawn`/
+// `Bun.spawnSync` DO have safe patch points and are trapped here.
+function patchBun() {
+  if (typeof globalThis.Bun === 'undefined') return;
+  const bun = globalThis.Bun;
+  try {
+    bun.write = function denied() {
+      throw new SideEffectDenied('Bun.write');
+    };
+    bun.spawn = function denied() {
+      throw new SideEffectDenied('Bun.spawn');
+    };
+    bun.spawnSync = function denied() {
+      throw new SideEffectDenied('Bun.spawnSync');
+    };
+  } catch {
+    /* Bun globals may be read-only in some builds; the Node traps remain authoritative. */
+  }
+}
+
+patchFs();
+patchProcessEscape();
+patchNetwork();
+patchBun();

--- a/packages/mcp/test/side-effect-denial.test.ts
+++ b/packages/mcp/test/side-effect-denial.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, writeFile, rm, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { repoFromFixture, snapshotTree, diffSnapshots, type TempRepo } from './helpers.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PRELOAD = join(HERE, 'side-effect-denial-preload.mjs');
+const BIN_SRC = resolve(HERE, '../src/bin.ts');
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+const DRIVER = `
+import { writeFile, readFile, rm, mkdir, open } from 'node:fs/promises';
+import { execSync, spawn } from 'node:child_process';
+import http from 'node:http';
+import net from 'node:net';
+import dgram from 'node:dgram';
+import worker from 'node:worker_threads';
+
+const results = {};
+async function check(name, fn) {
+  try { await fn(); results[name] = 'NOT-DENIED'; }
+  catch (e) { results[name] = e && e.name === 'SideEffectDenied' ? 'denied' : ('other:' + (e && e.name)); }
+}
+
+await check('static.writeFile', () => writeFile('/tmp/adrkit-should-not-exist', 'x'));
+await check('dynamic.writeFile', async () => { const m = await import('node:fs/promises'); return m.writeFile('/tmp/x', 'y'); });
+await check('alias.writeFile', () => { const w = writeFile; return w('/tmp/x', 'y'); });
+await check('fs/promises.rm', () => rm('/tmp/x'));
+await check('fs/promises.mkdir', () => mkdir('/tmp/x'));
+await check('fs/promises.open(write)', () => open('/tmp/x', 'w'));
+await check('fs.writeFileSync', async () => { const fs = await import('node:fs'); return fs.writeFileSync('/tmp/x', 'y'); });
+await check('fs.openSync(write)', async () => { const fs = await import('node:fs'); return fs.openSync('/tmp/x', 'w'); });
+await check('child_process.execSync', () => execSync('true'));
+await check('child_process.spawn', () => spawn('true'));
+await check('fetch', () => fetch('http://127.0.0.1:1/'));
+await check('http.request', () => http.request('http://127.0.0.1:1/'));
+await check('net.connect', () => net.connect(1, '127.0.0.1'));
+await check('dgram.createSocket', () => dgram.createSocket('udp4'));
+await check('worker_threads.Worker', () => new worker.Worker('/tmp/x.js'));
+await check('process.dlopen', () => process.dlopen({ exports: {} }, '/tmp/x.node'));
+
+// A read-only API must still work — the preload never touches reads.
+let readOk = false;
+try { await readFile(process.argv[1]); readOk = true; } catch {}
+results['read.readFile'] = readOk ? 'ok' : 'BROKEN';
+
+process.stdout.write(JSON.stringify(results));
+`;
+
+describe('side-effect denial — the preload fails closed on the enumerated inventory (Node)', () => {
+  test('every enumerated mutation / spawn / network entry point throws, reads still work', async () => {
+    const dir = await realpath(await mkdtemp(join(tmpdir(), 'adrkit-denial-')));
+    cleanups.push(() => rm(dir, { recursive: true, force: true }));
+    const driverPath = join(dir, 'driver.mjs');
+    await writeFile(driverPath, DRIVER, 'utf8');
+
+    const proc = Bun.spawn(['node', '--import', PRELOAD, driverPath], { stdout: 'pipe', stderr: 'pipe' });
+    const out = await new Response(proc.stdout).text();
+    const err = await new Response(proc.stderr).text();
+    await proc.exited;
+    expect(err).toBe('');
+    const results = JSON.parse(out) as Record<string, string>;
+
+    for (const [name, verdict] of Object.entries(results)) {
+      if (name === 'read.readFile') {
+        expect(verdict).toBe('ok');
+      } else {
+        expect([name, verdict]).toEqual([name, 'denied']);
+      }
+    }
+  });
+});
+
+describe('side-effect denial — all four tools run clean under the trap (Bun)', () => {
+  async function spawnUnderTrap(repo: TempRepo): Promise<Client> {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ['--preload', PRELOAD, BIN_SRC, '--cwd', repo.root],
+    });
+    const client = new Client({ name: 'denial-test', version: '0.0.0' });
+    await client.connect(transport);
+    cleanups.push(() => client.close());
+    return client;
+  }
+
+  test('startup and every tool call complete with no denied API and no sandbox mutation', async () => {
+    const repo = await repoFromFixture('edge-corpus');
+    cleanups.push(repo.cleanup);
+    const before = await snapshotTree(repo.root);
+    const client = await spawnUnderTrap(repo);
+
+    const calls = [
+      ['search_decisions', { query: 'duplicate' }],
+      ['get_decision', { ref: '0010' }],
+      ['get_decision_context', { files: ['src/app.ts'] }],
+      ['list_superseded', {}],
+    ] as const;
+    for (const [name, args] of calls) {
+      const res = await client.callTool({ name, arguments: args as Record<string, unknown> });
+      expect(res.isError).toBeFalsy();
+    }
+
+    expect(diffSnapshots(before, await snapshotTree(repo.root))).toEqual([]);
+  });
+});

--- a/packages/mcp/test/side-effect-denial.test.ts
+++ b/packages/mcp/test/side-effect-denial.test.ts
@@ -1,15 +1,17 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdtemp, writeFile, rm, realpath } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, writeFile, rm, realpath } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, extname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import * as ts from 'typescript';
 import { repoFromFixture, snapshotTree, diffSnapshots, type TempRepo } from './helpers.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PRELOAD = join(HERE, 'side-effect-denial-preload.mjs');
 const BIN_SRC = resolve(HERE, '../src/bin.ts');
+const CORE_SRC = resolve(HERE, '../../core/src');
 
 const cleanups: Array<() => Promise<void>> = [];
 afterEach(async () => {
@@ -17,7 +19,7 @@ afterEach(async () => {
 });
 
 const DRIVER = `
-import { writeFile, readFile, rm, mkdir, open } from 'node:fs/promises';
+import { writeFile, readFile, stat, rm, mkdir, open } from 'node:fs/promises';
 import { execSync, spawn } from 'node:child_process';
 import http from 'node:http';
 import net from 'node:net';
@@ -46,6 +48,8 @@ await check('net.connect', () => net.connect(1, '127.0.0.1'));
 await check('dgram.createSocket', () => dgram.createSocket('udp4'));
 await check('worker_threads.Worker', () => new worker.Worker('/tmp/x.js'));
 await check('process.dlopen', () => process.dlopen({ exports: {} }, '/tmp/x.node'));
+await check('read.outside-readFile', () => readFile('/etc/hosts'));
+await check('read.outside-stat', () => stat('/etc/hosts'));
 
 // A read-only API must still work — the preload never touches reads.
 let readOk = false;
@@ -55,6 +59,65 @@ results['read.readFile'] = readOk ? 'ok' : 'BROKEN';
 process.stdout.write(JSON.stringify(results));
 `;
 
+const BUN_READ_DRIVER = `
+import { access, lstat, readFile, readdir, realpath, stat } from 'node:fs/promises';
+
+const results = {};
+async function check(name, fn) {
+  try { await fn(); results[name] = 'allowed'; }
+  catch (e) { results[name] = e && e.name === 'SideEffectDenied' ? 'denied' : ('other:' + (e && e.name)); }
+}
+
+for (const [name, fn] of [
+  ['inside.access', () => access(process.argv[1])],
+  ['inside.lstat', () => lstat(process.argv[1])],
+  ['inside.readFile', () => readFile(process.argv[1])],
+  ['inside.readdir', () => readdir(process.argv[2])],
+  ['inside.realpath', () => realpath(process.argv[1])],
+  ['inside.stat', () => stat(process.argv[1])],
+  ['outside.access', () => access('/etc/hosts')],
+  ['outside.lstat', () => lstat('/etc/hosts')],
+  ['outside.readFile', () => readFile('/etc/hosts')],
+  ['outside.readdir', () => readdir('/etc')],
+  ['outside.realpath', () => realpath('/etc/hosts')],
+  ['outside.stat', () => stat('/etc/hosts')],
+]) {
+  await check(name, fn);
+}
+process.stdout.write(JSON.stringify(results));
+`;
+
+function auditProductionSource(file: string, source: string): string[] {
+  const findings = new Set<string>();
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const allowsSyncFs = file.endsWith('/main-module.ts');
+
+  function visit(node: ts.Node): void {
+    if (ts.isIdentifier(node)) {
+      if (node.text === 'Bun') findings.add('Bun runtime API');
+      if (node.text === 'globalThis') findings.add('global runtime access');
+      if (node.text === 'require' || node.text === 'createRequire') {
+        findings.add('dynamic module loader');
+      }
+    }
+    if (node.kind === ts.SyntaxKind.ImportKeyword) {
+      findings.add('dynamic import');
+    }
+    if (ts.isStringLiteralLike(node)) {
+      if (node.text === 'Bun' || node.text === 'bun' || node.text.startsWith('bun:')) {
+        findings.add('Bun runtime/module access');
+      }
+      if (!allowsSyncFs && (node.text === 'fs' || node.text === 'node:fs')) {
+        findings.add('Bun-untrapped synchronous filesystem module');
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return [...findings].sort();
+}
+
 describe('side-effect denial — the preload fails closed on the enumerated inventory (Node)', () => {
   test('every enumerated mutation / spawn / network entry point throws, reads still work', async () => {
     const dir = await realpath(await mkdtemp(join(tmpdir(), 'adrkit-denial-')));
@@ -62,7 +125,14 @@ describe('side-effect denial — the preload fails closed on the enumerated inve
     const driverPath = join(dir, 'driver.mjs');
     await writeFile(driverPath, DRIVER, 'utf8');
 
-    const proc = Bun.spawn(['node', '--import', PRELOAD, driverPath], { stdout: 'pipe', stderr: 'pipe' });
+    const proc = Bun.spawn(['node', '--import', PRELOAD, driverPath], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...process.env,
+        ADRKIT_MCP_TEST_READ_ROOTS: JSON.stringify([dir]),
+      },
+    });
     const out = await new Response(proc.stdout).text();
     const err = await new Response(proc.stderr).text();
     await proc.exited;
@@ -76,6 +146,86 @@ describe('side-effect denial — the preload fails closed on the enumerated inve
         expect([name, verdict]).toEqual([name, 'denied']);
       }
     }
+  });
+});
+
+describe('side-effect denial — Bun-only escape paths are statically absent', () => {
+  test('production sources contain no Bun mutation, process, or shell entry point', async () => {
+    const files: string[] = [];
+    async function collect(dir: string): Promise<void> {
+      for (const entry of await readdir(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) await collect(path);
+        else if (['.ts', '.js', '.mjs', '.cjs'].includes(extname(entry.name))) files.push(path);
+      }
+    }
+    await collect(resolve(HERE, '../src'));
+    await collect(CORE_SRC);
+
+    const findings: string[] = [];
+    for (const file of files) {
+      const source = await readFile(file, 'utf8');
+      for (const finding of auditProductionSource(file, source)) {
+        findings.push(`${file}: ${finding}`);
+      }
+    }
+    expect(findings).toEqual([]);
+  });
+
+  test('the AST audit rejects representative Bun, module-loader, and sync-fs escapes', () => {
+    for (const source of [
+      'Bun.file(path).writer()',
+      'const file = Bun.file(resolve(path)); file.delete()',
+      'Bun.write(path, bytes)',
+      'Bun.spawn(["cmd"])',
+      'Bun.spawnSync(["cmd"])',
+      'Bun.$`echo escaped`',
+      'const { $ } = Bun; $`echo escaped`',
+      'import { $ } from "bun"',
+      'await import("bun")',
+      'require("bun")',
+      'await import("node:fs")',
+      'import fs from "fs"',
+      'const load = createRequire(import.meta.url)',
+      'globalThis["Bun"].file(path).writer()',
+      'import { Database } from "bun:sqlite"',
+    ]) {
+      expect(auditProductionSource('/src/tool.ts', source).length).toBeGreaterThan(0);
+    }
+  });
+
+  test('the Bun preload denies the async read/stat APIs used by corpus loading outside allowed roots', async () => {
+    const dir = await realpath(await mkdtemp(join(tmpdir(), 'adrkit-bun-read-boundary-')));
+    cleanups.push(() => rm(dir, { recursive: true, force: true }));
+    const driverPath = join(dir, 'driver.ts');
+    await writeFile(driverPath, BUN_READ_DRIVER, 'utf8');
+    const proc = Bun.spawn([process.execPath, '--preload', PRELOAD, driverPath, dir], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...process.env,
+        BUN_RUNTIME_TRANSPILER_CACHE_PATH: '0',
+        ADRKIT_MCP_TEST_READ_ROOTS: JSON.stringify([dir]),
+      },
+    });
+    const out = await new Response(proc.stdout).text();
+    const err = await new Response(proc.stderr).text();
+    const code = await proc.exited;
+    expect([code, err]).toEqual([0, '']);
+    expect(JSON.parse(out)).toEqual({
+      'inside.access': 'allowed',
+      'inside.lstat': 'allowed',
+      'inside.readFile': 'allowed',
+      'inside.readdir': 'allowed',
+      'inside.realpath': 'allowed',
+      'inside.stat': 'allowed',
+      'outside.access': 'denied',
+      'outside.lstat': 'denied',
+      'outside.readFile': 'denied',
+      'outside.readdir': 'denied',
+      'outside.realpath': 'denied',
+      'outside.stat': 'denied',
+    });
   });
 });
 

--- a/packages/mcp/test/surface.test.ts
+++ b/packages/mcp/test/surface.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createAdrkitMcpServer } from '../src/index.ts';
+import { buildRegisteredServer } from '../src/server.ts';
+import { connectServer, repoFromFixture, toolConfig, type TempRepo } from './helpers.ts';
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const c of cleanups.splice(0)) await c();
+});
+
+const FOUR_TOOLS = ['get_decision', 'get_decision_context', 'list_superseded', 'search_decisions'];
+
+describe('public surface — sealed lifecycle handle', () => {
+  test('createAdrkitMcpServer does no construction-time I/O and returns a frozen null-prototype handle', () => {
+    // A bogus, nonexistent root does NOT throw at construction — proving no fs access here.
+    const handle = createAdrkitMcpServer({ cwd: '/definitely/not/a/real/adrkit/root', dir: 'docs/adr' });
+    expect(Object.getPrototypeOf(handle)).toBeNull();
+    expect(Object.isFrozen(handle)).toBe(true);
+    expect(Object.getOwnPropertyNames(handle).sort()).toEqual(['close', 'start']);
+    expect(Object.getOwnPropertySymbols(handle)).toEqual([]);
+    expect(typeof handle.start).toBe('function');
+    expect(typeof handle.close).toBe('function');
+    // No SDK server, transport, registration API, or internal builder is reachable.
+    expect((handle as Record<string, unknown>).server).toBeUndefined();
+    expect((handle as Record<string, unknown>).connect).toBeUndefined();
+  });
+
+  test('start() takes no argument (a caller cannot inject a transport)', () => {
+    const handle = createAdrkitMcpServer();
+    expect(handle.start.length).toBe(0);
+    expect(handle.close.length).toBe(0);
+  });
+});
+
+describe('internal builder — exactly four tools, no other capability', () => {
+  async function connectBuilt(repo: TempRepo) {
+    cleanups.push(repo.cleanup);
+    const server = buildRegisteredServer(await toolConfig(repo.root, repo.dir));
+    const harness = await connectServer(server);
+    cleanups.push(harness.close);
+    return harness;
+  }
+
+  test('tools/list exposes exactly the four named tools with root-object output schemas and fixed annotations', async () => {
+    const { client } = await connectBuilt(await repoFromFixture('status-corpus'));
+    const list = await client.listTools();
+    expect(list.tools.map((t) => t.name).sort()).toEqual(FOUR_TOOLS);
+    for (const tool of list.tools) {
+      expect(tool.outputSchema?.type).toBe('object');
+      expect(tool.annotations).toMatchObject({
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+    }
+  });
+
+  test('the server declares tools capability but NOT prompts, resources, or subscriptions', async () => {
+    const { client } = await connectBuilt(await repoFromFixture('status-corpus'));
+    const caps = client.getServerCapabilities();
+    expect(caps?.tools).toBeDefined();
+    expect(caps?.prompts).toBeUndefined();
+    expect(caps?.resources).toBeUndefined();
+  });
+
+  test('listing prompts or resources fails — no such capability is registered', async () => {
+    const { client } = await connectBuilt(await repoFromFixture('status-corpus'));
+    await expect(client.listPrompts()).rejects.toThrow();
+    await expect(client.listResources()).rejects.toThrow();
+  });
+});

--- a/packages/mcp/test/surface.test.ts
+++ b/packages/mcp/test/surface.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
+import { resolve } from 'node:path';
 import { createAdrkitMcpServer } from '../src/index.ts';
 import { buildRegisteredServer } from '../src/server.ts';
+import * as projection from '../src/corpus/projection.ts';
 import { connectServer, repoFromFixture, toolConfig, type TempRepo } from './helpers.ts';
 
 const cleanups: Array<() => Promise<void>> = [];
@@ -29,6 +31,47 @@ describe('public surface — sealed lifecycle handle', () => {
     const handle = createAdrkitMcpServer();
     expect(handle.start.length).toBe(0);
     expect(handle.close.length).toBe(0);
+  });
+
+  test('concurrent start() calls share one in-flight startup', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const rootSpy = spyOn(projection, 'resolveCanonicalRoots').mockImplementation(async () => {
+      await gate;
+      throw new Error('controlled startup failure');
+    });
+    const handle = createAdrkitMcpServer({ cwd: '/not-read-by-this-test' });
+
+    const first = handle.start();
+    const second = handle.start();
+    expect(rootSpy).toHaveBeenCalledTimes(1);
+    release();
+    await expect(first).rejects.toThrow('controlled startup failure');
+    await expect(second).rejects.toThrow('controlled startup failure');
+    rootSpy.mockRestore();
+  });
+
+  test('a relative configured root is captured as an absolute lexical path', async () => {
+    let observedCwd: string | undefined;
+    const rootSpy = spyOn(projection, 'resolveCanonicalRoots').mockImplementation(async (options) => {
+      observedCwd = options.cwd;
+      throw new Error('controlled startup failure');
+    });
+    try {
+      const handle = createAdrkitMcpServer({ cwd: '.' });
+      await expect(handle.start()).rejects.toThrow('controlled startup failure');
+      expect(observedCwd).toBe(resolve('.'));
+    } finally {
+      rootSpy.mockRestore();
+    }
+  });
+
+  test('a closed handle cannot be started', async () => {
+    const handle = createAdrkitMcpServer();
+    await handle.close();
+    await expect(handle.start()).rejects.toThrow('server handle is closed');
   });
 });
 

--- a/packages/mcp/tsconfig.build.json
+++ b/packages/mcp/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/plan.md
+++ b/plan.md
@@ -30,7 +30,7 @@ sync.
 | 2 — Migration | `specs/003-migration/` | landed (PR #7 merged) |
 | 3 — CI surface | `specs/004-ci-surface/` | landed (PR #12 merged) |
 | 4 — Deterministic evaluator | `specs/005-deterministic-evaluator/` | landed (PR #14 merged) |
-| 5 — MCP server | `specs/006-mcp-server/` | scope ratified; tasks and analysis next |
+| 5 — MCP server | `specs/006-mcp-server/` | implementation complete (PR #19) |
 
 Advance **scoping** (spec → plan → tasks) of the next phase is explicitly permitted
 and encouraged, so a design is review-ready when its turn comes; **implementation** of
@@ -56,8 +56,9 @@ assertions gained explicit symbolic expressions, the rerun exited 0 with all
 eleven ordered rules, two honest warnings, the unregistered custom engine
 reported inert, and deterministic routing to `@mbeacom`. The maintainer
 explicitly ratified Phase 5's exact four-tool, local-only, read-only scope on
-2026-07-20. Both implementation preconditions are therefore cleared; task
-generation and cross-artifact analysis are next.
+2026-07-20. Fresh cross-artifact analysis then passed without critical, high,
+or medium findings, all 43 tasks were implemented, and the complete change is
+recorded in PR #19.
 
 The "real user" a rung requires is satisfied by **maintainer dogfooding** — the ladder
 already says "even if that user is only you". For rung 2 specifically, the required
@@ -91,8 +92,9 @@ T00A). Rung 3 is also **met**: the `@adrkit/ci` Action ran twice on the separate
 12-record `adrkit-t018-dogfood` repository, selected exactly two governing ADRs, and
 updated one comment in place using only the default token (Phase 3 T018). Rung 5 is
 **met** by the landed Pass 0 evaluator and the ADR-0007 maintainer dogfood above.
-Rung 4 is the next delivery target: its MCP design is scoped and independently
-reviewed, but no implementation exists yet.
+Rung 4 is the next delivery target: its MCP implementation is complete on PR
+#19, but a real MCP-compatible session must still exercise it before the rung is
+met.
 
 ## Binding constraints
 
@@ -202,7 +204,7 @@ Exit criteria:
   configured at all. If it isn't, the rubric passes are being asked to carry
   weight they shouldn't.
 
-### Phase 5 — MCP server (rung 4)
+### Phase 5 — MCP server (rung 4, implemented; dogfood pending)
 
 Deliverables: `@adrkit/mcp`, read tools only.
 
@@ -211,10 +213,9 @@ Scope: exactly `search_decisions`, `get_decision`,
 stdio. No writes, fifth tool, prompts, resources, HTTP transport, authentication,
 model, network access, persistent cache, database, or named-log federation.
 Detailed design lives in `specs/006-mcp-server/`. The maintainer explicitly
-ratified this exact scope on 2026-07-20. The 43-task graph is generated; a fresh
-analysis found one critical and five high-severity artifact defects, now under
-remediation. Implementation remains blocked until the rerun has no blocking or
-high-severity finding.
+ratified this exact scope on 2026-07-20. Fresh analysis passed after artifact
+remediation, all 43 tasks are complete, and PR #19 contains the implementation.
+Merge plus a real MCP-compatible dogfood session remain before rung 4 is met.
 
 Exit criteria:
 

--- a/plan.md
+++ b/plan.md
@@ -30,7 +30,7 @@ sync.
 | 2 — Migration | `specs/003-migration/` | landed (PR #7 merged) |
 | 3 — CI surface | `specs/004-ci-surface/` | landed (PR #12 merged) |
 | 4 — Deterministic evaluator | `specs/005-deterministic-evaluator/` | landed (PR #14 merged) |
-| 5 — MCP server | _(unopened)_ | queued |
+| 5 — MCP server | `specs/006-mcp-server/` | scope ratified; tasks and analysis next |
 
 Advance **scoping** (spec → plan → tasks) of the next phase is explicitly permitted
 and encouraged, so a design is review-ready when its turn comes; **implementation** of
@@ -46,6 +46,18 @@ Phase 4's implementation gate is **cleared**. Phase 3 T018 was completed on
 [PR](https://github.com/mbeacom/adrkit-t018-dogfood/pull/1), a selective comment naming
 only ADRs 0001 and 0002, and a second default-token-only run updating the same
 [comment](https://github.com/mbeacom/adrkit-t018-dogfood/pull/1#issuecomment-5017253372).
+
+Phase 5's lower-phase real-user gate is also **cleared**. The maintainer ran
+`adr evaluate` against the genuine, then-`proposed` ADR-0007 with the complete
+tracked-file inventory and an active-human identity snapshot. The first run
+found a real `assertions-compile.no-source` defect while still proving the
+`one-way-door` trigger and routing to `@mbeacom`; after the two custom
+assertions gained explicit symbolic expressions, the rerun exited 0 with all
+eleven ordered rules, two honest warnings, the unregistered custom engine
+reported inert, and deterministic routing to `@mbeacom`. The maintainer
+explicitly ratified Phase 5's exact four-tool, local-only, read-only scope on
+2026-07-20. Both implementation preconditions are therefore cleared; task
+generation and cross-artifact analysis are next.
 
 The "real user" a rung requires is satisfied by **maintainer dogfooding** — the ladder
 already says "even if that user is only you". For rung 2 specifically, the required
@@ -77,7 +89,10 @@ Spec-kit realization note above). For rung 2, that dogfood is the maintainer run
 subset of the real [adr/madr](https://github.com/adr/madr) corpus offline (Phase 3
 T00A). Rung 3 is also **met**: the `@adrkit/ci` Action ran twice on the separate
 12-record `adrkit-t018-dogfood` repository, selected exactly two governing ADRs, and
-updated one comment in place using only the default token (Phase 3 T018).
+updated one comment in place using only the default token (Phase 3 T018). Rung 5 is
+**met** by the landed Pass 0 evaluator and the ADR-0007 maintainer dogfood above.
+Rung 4 is the next delivery target: its MCP design is scoped and independently
+reviewed, but no implementation exists yet.
 
 ## Binding constraints
 
@@ -117,8 +132,7 @@ Named explicitly so the orchestrator doesn't helpfully build them:
 
 Deliverables: `schema/` published, `@adrkit/core` parsing and validating, `@adrkit/cli`
 with `new`, `lint`, `graph`, and the CI workflow (`.github/workflows/ci.yml`)
-carrying the three gate assertions. **The workflow file does not exist yet** —
-`MANIFEST.md` references it as though it does; creating it is part of this phase.
+carrying the three gate assertions.
 
 Exit criteria:
 
@@ -175,7 +189,7 @@ Exit criteria:
   lists everything, the `affects` matchers or the comment are wrong.
 - Runs with no credentials beyond the default token.
 
-### Phase 4 — Deterministic evaluator (rung 5, partial)
+### Phase 4 — Deterministic evaluator (rung 5, landed)
 
 Deliverables: Pass 0 from `docs/EVALUATOR_RUBRIC.md`. **No model calls.**
 
@@ -191,6 +205,16 @@ Exit criteria:
 ### Phase 5 — MCP server (rung 4)
 
 Deliverables: `@adrkit/mcp`, read tools only.
+
+Scope: exactly `search_decisions`, `get_decision`,
+`get_decision_context(files[])`, and `list_superseded` over one local corpus via
+stdio. No writes, fifth tool, prompts, resources, HTTP transport, authentication,
+model, network access, persistent cache, database, or named-log federation.
+Detailed design lives in `specs/006-mcp-server/`. The maintainer explicitly
+ratified this exact scope on 2026-07-20. The 43-task graph is generated; a fresh
+analysis found one critical and five high-severity artifact defects, now under
+remediation. Implementation remains blocked until the rerun has no blocking or
+high-severity finding.
 
 Exit criteria:
 

--- a/scripts/check-deps.test.ts
+++ b/scripts/check-deps.test.ts
@@ -233,3 +233,100 @@ describe('evaluator dependency boundary (Phase 4)', () => {
     expect(outside.map((v) => v.dependency).sort()).toEqual(['fast-glob', 'undici']);
   });
 });
+
+describe('mcp dependency boundary (Phase 5)', () => {
+  test('allows exactly core, the pinned SDK, and zod, plus @types/bun in dev', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(
+      join(root, 'packages/mcp/package.json'),
+      JSON.stringify(
+        {
+          name: '@adrkit/mcp',
+          version: '0.1.0',
+          dependencies: { '@adrkit/core': 'workspace:*', '@modelcontextprotocol/sdk': '1.29.0', zod: '^4' },
+          devDependencies: { '@types/bun': 'latest' },
+        },
+        null,
+        2,
+      ),
+    );
+    await expect(checkDependencyRules(root)).resolves.toEqual({ ok: true, violations: [] });
+  });
+
+  test('rejects an adapter, network/auth/model/embedding/db/cache lib, native addon, or worker helper', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(
+      join(root, 'packages/adapters/example/package.json'),
+      JSON.stringify({ name: '@adrkit/adapter-example', version: '0.1.0' }, null, 2),
+    );
+    await writeText(
+      join(root, 'packages/mcp/package.json'),
+      JSON.stringify(
+        {
+          name: '@adrkit/mcp',
+          version: '0.1.0',
+          dependencies: {
+            '@adrkit/core': 'workspace:*',
+            '@modelcontextprotocol/sdk': '1.29.0',
+            zod: '^4',
+            '@adrkit/adapter-example': 'workspace:*',
+            undici: '^6',
+            jose: '^5',
+            openai: '^4',
+            '@xenova/transformers': '^2',
+            pg: '^8',
+            ioredis: '^5',
+            'node-gyp': '^10',
+            piscina: '^4',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const result = await checkDependencyRules(root);
+    expect(result.ok).toBe(false);
+    const outside = result.violations
+      .filter((v) => v.reason.includes('outside its allowed public surface'))
+      .map((v) => v.dependency)
+      .sort();
+    expect(outside).toEqual(['@adrkit/adapter-example', '@xenova/transformers', 'ioredis', 'jose', 'node-gyp', 'openai', 'pg', 'piscina', 'undici']);
+    expect(result.violations.some((v) => v.reason === 'non-adapter workspace depends on an adapter package')).toBe(true);
+  });
+
+  test('rejects an undeclared SDK subpath package masquerading as the SDK', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(
+      join(root, 'packages/mcp/package.json'),
+      JSON.stringify(
+        {
+          name: '@adrkit/mcp',
+          version: '0.1.0',
+          dependencies: { '@adrkit/core': 'workspace:*', '@modelcontextprotocol/sdk': '1.29.0', zod: '^4', '@modelcontextprotocol/server-everything': '^1' },
+        },
+        null,
+        2,
+      ),
+    );
+    const result = await checkDependencyRules(root);
+    expect(result.ok).toBe(false);
+    expect(result.violations.map((v) => v.dependency)).toContain('@modelcontextprotocol/server-everything');
+  });
+
+  test('rejects the GitHub toolkit reaching the mcp surface', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(
+      join(root, 'packages/mcp/package.json'),
+      JSON.stringify(
+        { name: '@adrkit/mcp', version: '0.1.0', dependencies: { '@adrkit/core': 'workspace:*', '@modelcontextprotocol/sdk': '1.29.0', zod: '^4', '@actions/github': '^6' } },
+        null,
+        2,
+      ),
+    );
+    const result = await checkDependencyRules(root);
+    expect(result.ok).toBe(false);
+    expect(result.violations.map((v) => v.reason)).toContain(
+      'GitHub Action toolkit must stay confined to @adrkit/ci and never reach core/schema/cli',
+    );
+  });
+});

--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -123,6 +123,18 @@ function allowedDependenciesFor(packageName: string): Record<DependencySection, 
     };
   }
 
+  if (packageName === '@adrkit/mcp') {
+    // The MCP server surface may depend on core, the pinned Model Context Protocol
+    // SDK, and zod only — never an adapter, GitHub toolkit, network/auth/model/
+    // embedding/database/cache client, native addon, or worker helper (R2/R10).
+    return {
+      dependencies: new Set(['@adrkit/core', '@modelcontextprotocol/sdk', 'zod']),
+      devDependencies: new Set(['@types/bun']),
+      peerDependencies: new Set(),
+      optionalDependencies: new Set(),
+    };
+  }
+
   if (packageName === CI_SURFACE_PACKAGE) {
     // The first-party CI surface may depend on core and the public GitHub Action
     // toolkit only — never an adapter (enforced separately below).

--- a/scripts/release-pack.test.ts
+++ b/scripts/release-pack.test.ts
@@ -68,3 +68,50 @@ describe('release package validation', () => {
     ).toThrow('must resolve @adrkit/core to 0.1.0');
   });
 });
+
+describe('release package validation — @adrkit/mcp (Phase 5)', () => {
+  test('@adrkit/mcp is the fourth public release package with a packed bin and dist/bin.js', () => {
+    expect(RELEASE_PACKAGES.map((p) => p.name)).toEqual([
+      '@adrkit/core',
+      '@adrkit/evaluator',
+      '@adrkit/cli',
+      '@adrkit/mcp',
+    ]);
+    const mcp = RELEASE_PACKAGES.find((p) => p.name === '@adrkit/mcp');
+    expect(mcp).toBeDefined();
+    expect(mcp?.directory).toBe('packages/mcp');
+    expect(mcp?.workspaceDependencies).toEqual(['@adrkit/core']);
+    expect(mcp?.expectedFiles).toContain('dist/bin.js');
+    expect(mcp?.expectedFiles).toContain('dist/index.js');
+    expect(mcp?.expectedFiles).toContain('dist/index.d.ts');
+    expect(mcp?.expectedFiles).toContain('src/index.ts');
+    // No internal test/builder export leaks into the packed file list.
+    expect(mcp?.expectedFiles).not.toContain('dist/server.js');
+  });
+
+  test('all four public manifests must share one identical stable SemVer', () => {
+    const aligned = new Map(
+      RELEASE_PACKAGES.map((d) => [d.name, sourceManifest(d.name, d.directory)]),
+    );
+    expect(validateSourceManifests(aligned, 'v0.1.0')).toBe('0.1.0');
+
+    const drifted = new Map(
+      RELEASE_PACKAGES.map((d) => [
+        d.name,
+        sourceManifest(d.name, d.directory, d.name === '@adrkit/mcp' ? '0.2.0' : '0.1.0'),
+      ]),
+    );
+    expect(() => validateSourceManifests(drifted)).toThrow('versions must match');
+  });
+
+  test('a leaked workspace protocol in the packed @adrkit/mcp manifest is rejected', () => {
+    const mcp = RELEASE_PACKAGES.find((p) => p.name === '@adrkit/mcp')!;
+    expect(() =>
+      validatePackedManifest(
+        mcp,
+        { name: '@adrkit/mcp', version: '0.1.0', dependencies: { '@adrkit/core': 'workspace:*' } },
+        '0.1.0',
+      ),
+    ).toThrow('leaked workspace protocols');
+  });
+});

--- a/scripts/release-pack.ts
+++ b/scripts/release-pack.ts
@@ -84,6 +84,21 @@ export const RELEASE_PACKAGES: readonly ReleasePackageDefinition[] = [
     ],
     workspaceDependencies: ['@adrkit/core', '@adrkit/evaluator'],
   },
+  {
+    name: '@adrkit/mcp',
+    directory: 'packages/mcp',
+    expectedFiles: [
+      'README.md',
+      'dist/LICENSE',
+      'dist/NOTICE',
+      'dist/bin.js',
+      'dist/index.d.ts',
+      'dist/index.js',
+      'package.json',
+      'src/index.ts',
+    ],
+    workspaceDependencies: ['@adrkit/core'],
+  },
 ] as const;
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -235,17 +250,80 @@ async function prepareSmokeProject(outputDir: string, artifacts: readonly Releas
   await Bun.write(
     join(smokeDir, 'smoke.mjs'),
     `import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import * as core from '@adrkit/core';
 import * as cli from '@adrkit/cli';
 import * as evaluator from '@adrkit/evaluator';
+import * as mcp from '@adrkit/mcp';
 
 if (typeof core.lintCorpus !== 'function') throw new Error('Installed @adrkit/core is missing lintCorpus');
 if (typeof cli.main !== 'function') throw new Error('Installed @adrkit/cli is missing main');
 if (typeof evaluator.evaluatePass0 !== 'function') throw new Error('Installed @adrkit/evaluator is missing evaluatePass0');
+if (typeof mcp.createAdrkitMcpServer !== 'function') throw new Error('Installed @adrkit/mcp is missing createAdrkitMcpServer');
 
 const repoRoot = process.argv[2];
 if (!repoRoot) throw new Error('Expected repository root argument');
+
+// The public @adrkit/mcp surface is only the sealed lifecycle handle.
+const handle = mcp.createAdrkitMcpServer({ cwd: repoRoot, dir: 'docs/adr' });
+if (Object.getPrototypeOf(handle) !== null) throw new Error('Installed MCP handle must be a null-prototype object');
+if (!Object.isFrozen(handle)) throw new Error('Installed MCP handle must be frozen');
+if (JSON.stringify(Object.getOwnPropertyNames(handle).sort()) !== JSON.stringify(['close', 'start'])) {
+  throw new Error('Installed MCP handle must expose exactly start and close');
+}
+if (mcp.buildRegisteredServer !== undefined) throw new Error('Installed @adrkit/mcp must not export its internal builder');
+
+async function runMcpStdio(bin, cwd) {
+  const proc = spawn(bin, ['--cwd', cwd], { stdio: ['pipe', 'pipe', 'inherit'] });
+  const messages = new Map();
+  const wanted = [2, 3, 4, 5, 6];
+  let buffer = '';
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('MCP stdio smoke timed out')), 20000);
+    proc.on('error', reject);
+    proc.stdout.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      let index;
+      while ((index = buffer.indexOf('\\n')) >= 0) {
+        const line = buffer.slice(0, index);
+        buffer = buffer.slice(index + 1);
+        if (!line.trim()) continue;
+        const message = JSON.parse(line);
+        if (message.jsonrpc !== '2.0') throw new Error('MCP bin emitted a non-JSON-RPC stdout line');
+        if (typeof message.id === 'number') messages.set(message.id, message);
+        if (wanted.every((id) => messages.has(id))) {
+          clearTimeout(timer);
+          resolve();
+        }
+      }
+    });
+    const frames = [
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'smoke', version: '0' } } },
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+      { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'search_decisions', arguments: { query: 'git' } } },
+      { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'get_decision', arguments: { ref: '0001' } } },
+      { jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'get_decision_context', arguments: { files: ['README.md'] } } },
+      { jsonrpc: '2.0', id: 6, method: 'tools/call', params: { name: 'list_superseded', arguments: {} } },
+    ];
+    proc.stdin.write(frames.map((f) => JSON.stringify(f) + '\\n').join(''));
+  });
+  proc.stdin.end();
+  proc.kill();
+  const list = messages.get(2);
+  const names = (list?.result?.tools ?? []).map((t) => t.name).sort();
+  const expected = ['get_decision', 'get_decision_context', 'list_superseded', 'search_decisions'];
+  if (JSON.stringify(names) !== JSON.stringify(expected)) throw new Error('Installed adrkit-mcp did not list the four tools: ' + names);
+  for (const id of [3, 4, 5, 6]) {
+    const outcome = messages.get(id)?.result?.structuredContent?.result?.outcome;
+    if (!outcome) throw new Error('Installed adrkit-mcp tool call ' + id + ' did not return a structured outcome');
+  }
+}
+
+const mcpBin = join(import.meta.dirname, 'node_modules', '.bin', process.platform === 'win32' ? 'adrkit-mcp.cmd' : 'adrkit-mcp');
+await runMcpStdio(mcpBin, repoRoot);
+
 const bin = join(import.meta.dirname, 'node_modules', '.bin', process.platform === 'win32' ? 'adr.cmd' : 'adr');
 const lint = spawnSync(bin, ['lint', join(repoRoot, 'docs/adr')], { cwd: repoRoot, encoding: 'utf8' });
 if (lint.stdout) process.stdout.write(lint.stdout);
@@ -316,6 +394,9 @@ export async function packRelease(args = Bun.argv.slice(2)): Promise<ReleaseMani
     validatePackedManifest(definition, packedManifest, version);
     if (definition.name === '@adrkit/cli') {
       assert(packedManifest.bin?.adr === './dist/index.js', 'Packed CLI must expose the adr binary');
+    }
+    if (definition.name === '@adrkit/mcp') {
+      assert(packedManifest.bin?.['adrkit-mcp'] === './dist/bin.js', 'Packed MCP must expose the adrkit-mcp binary');
     }
     artifacts.push({
       name: definition.name,

--- a/scripts/smoke-node.mjs
+++ b/scripts/smoke-node.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawnSync, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
@@ -33,6 +33,89 @@ const evaluator = await import(evaluatorUrl.href);
 if (typeof evaluator.evaluatePass0 !== 'function') {
   throw new Error('Expected built @adrkit/evaluator to export evaluatePass0');
 }
+
+// The built @adrkit/mcp public surface is only the sealed lifecycle handle.
+const mcpUrl = new URL('../packages/mcp/dist/index.js', import.meta.url);
+if (!existsSync(fileURLToPath(mcpUrl))) {
+  throw new Error('Expected packages/mcp/dist/index.js to exist; run bun run build first');
+}
+const mcp = await import(mcpUrl.href);
+if (typeof mcp.createAdrkitMcpServer !== 'function') {
+  throw new Error('Expected built @adrkit/mcp to export createAdrkitMcpServer');
+}
+if (mcp.buildRegisteredServer !== undefined) {
+  throw new Error('Built @adrkit/mcp must not export its internal builder');
+}
+const mcpHandle = mcp.createAdrkitMcpServer({ cwd: repoRoot, dir: 'docs/adr' });
+if (Object.getPrototypeOf(mcpHandle) !== null) {
+  throw new Error('Built MCP handle must be a null-prototype object');
+}
+if (!Object.isFrozen(mcpHandle)) {
+  throw new Error('Built MCP handle must be frozen');
+}
+if (JSON.stringify(Object.getOwnPropertyNames(mcpHandle).sort()) !== JSON.stringify(['close', 'start'])) {
+  throw new Error('Built MCP handle must expose exactly start and close');
+}
+
+// Run the built bin under Node with the side-effect-denial preload, over real stdio,
+// against this repository's own docs/adr corpus; every stdout line must be JSON-RPC.
+const mcpBinPath = fileURLToPath(new URL('../packages/mcp/dist/bin.js', import.meta.url));
+const mcpPreloadPath = fileURLToPath(new URL('../packages/mcp/test/side-effect-denial-preload.mjs', import.meta.url));
+
+async function runBuiltMcpStdio() {
+  const proc = spawn(process.execPath, ['--import', mcpPreloadPath, mcpBinPath, '--cwd', repoRoot], {
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
+  const messages = new Map();
+  const wanted = [2, 3, 4, 5, 6];
+  let buffer = '';
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Built MCP stdio smoke timed out')), 20000);
+    proc.on('error', reject);
+    proc.stdout.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      let index;
+      while ((index = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, index);
+        buffer = buffer.slice(index + 1);
+        if (!line.trim()) continue;
+        const message = JSON.parse(line);
+        if (message.jsonrpc !== '2.0') {
+          reject(new Error('Built adrkit-mcp emitted a non-JSON-RPC stdout line'));
+          return;
+        }
+        if (typeof message.id === 'number') messages.set(message.id, message);
+        if (wanted.every((id) => messages.has(id))) {
+          clearTimeout(timer);
+          resolve();
+        }
+      }
+    });
+    const frames = [
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'smoke', version: '0' } } },
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+      { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'search_decisions', arguments: { query: 'git' } } },
+      { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'get_decision', arguments: { ref: '0001' } } },
+      { jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'get_decision_context', arguments: { files: ['README.md'] } } },
+      { jsonrpc: '2.0', id: 6, method: 'tools/call', params: { name: 'list_superseded', arguments: {} } },
+    ];
+    proc.stdin.write(frames.map((f) => JSON.stringify(f) + '\n').join(''));
+  });
+  proc.stdin.end();
+  proc.kill();
+  const names = (messages.get(2)?.result?.tools ?? []).map((t) => t.name).sort();
+  const expected = ['get_decision', 'get_decision_context', 'list_superseded', 'search_decisions'];
+  if (JSON.stringify(names) !== JSON.stringify(expected)) {
+    throw new Error(`Built adrkit-mcp did not list the four tools: ${names}`);
+  }
+  for (const id of [3, 4, 5, 6]) {
+    const outcome = messages.get(id)?.result?.structuredContent?.result?.outcome;
+    if (!outcome) throw new Error(`Built adrkit-mcp tool call ${id} did not return a structured outcome`);
+  }
+}
+
+await runBuiltMcpStdio();
 
 const cli = spawnSync(process.execPath, [cliPath, 'lint', 'docs/adr'], {
   cwd: repoRoot,
@@ -92,5 +175,5 @@ if (!action.stdout.includes('not a pull_request event')) {
   throw new Error('Expected the Action bundle to no-op outside a pull_request event');
 }
 
-console.log('smoke-node: built core import, evaluator import, CLI lint, offline `adr evaluate`, and Action bundle passed');
+console.log('smoke-node: built core import, evaluator import, MCP sealed handle + stdio tools, CLI lint, offline `adr evaluate`, and Action bundle passed');
 

--- a/specs/006-mcp-server/checklists/requirements.md
+++ b/specs/006-mcp-server/checklists/requirements.md
@@ -43,8 +43,8 @@
   rules inert (no trusted custom engine registered), `one-way-door` proven, target
   resolved to `@mbeacom`. No model/network/clock/write occurred. This is the real-user
   evidence the outcome ladder requires and, together with maintainer scope ratification
-  of this spec, clears Phase 5 implementation — this document performs the scoping step
-  only.
+  of this spec, cleared Phase 5 implementation. The subsequent implementation completed
+  all 43 tasks in PR #19.
 - **Scope is the four named read tools only.** `search_decisions`, `get_decision`,
   `get_decision_context(files[])`, `list_superseded` — no fifth tool, no write/mutation/
   PR-creation tool, no MCP prompts/resources/subscriptions/sampling, no model call or
@@ -203,6 +203,6 @@
   acceptance criteria. It does not select a specific data structure, algorithm, file
   layout, or library beyond what those ADRs already require, which is the property this
   checklist item is actually protecting.
-- **This spec changes no implementation code and commits nothing.** It is the
-  completed scoping step. The 43-task implementation graph is generated; current artifact
-  remediation and a clean cross-artifact analysis pass precede implementation.
+- **This checklist remains the completed scoping-quality record.** Subsequent
+  artifact remediation passed fresh cross-artifact analysis with no critical,
+  high, or medium finding; all 43 implementation tasks are complete in PR #19.

--- a/specs/006-mcp-server/checklists/requirements.md
+++ b/specs/006-mcp-server/checklists/requirements.md
@@ -1,0 +1,208 @@
+# Specification Quality Checklist: MCP Server (Read-Only Retrieval) — Phase 5
+
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2026-07-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **Phase 4 real-user gate evidence recorded 2026-07-20**, immediately before this
+  specification. The maintainer ran `adr evaluate` on genuine, then-`proposed` ADR-0007
+  with the full tracked-file inventory and an identity snapshot naming an active human
+  (`@mbeacom`) on the evaluation date. First run: real `assertions-compile.no-source`
+  error on the two `engine: custom` assertions, while still proving `one-way-door` and
+  routing to `@mbeacom` via `deciders`. Fix: declared the two symbolic custom-expression
+  sources (`core-has-no-adapter-deps`, `clean-clone-builds`). Rerun: exit `0`,
+  `outcome: ok`, exactly eleven ordered rules, two honest `warn` findings
+  (`packages/adapters/**` zero targets; overlap with accepted ADR-0010), custom-engine
+  rules inert (no trusted custom engine registered), `one-way-door` proven, target
+  resolved to `@mbeacom`. No model/network/clock/write occurred. This is the real-user
+  evidence the outcome ladder requires and, together with maintainer scope ratification
+  of this spec, clears Phase 5 implementation — this document performs the scoping step
+  only.
+- **Scope is the four named read tools only.** `search_decisions`, `get_decision`,
+  `get_decision_context(files[])`, `list_superseded` — no fifth tool, no write/mutation/
+  PR-creation tool, no MCP prompts/resources/subscriptions/sampling, no model call or
+  embedding, matching `plan.md`'s Phase 5 exit criteria exactly (FR-001–FR-004).
+- **Local stdio transport, no auth, no stdout logging.** No network listener, no
+  HTTP/SSE/remote transport, no authentication (nothing to authenticate against), and
+  stdout is reserved exclusively for MCP protocol frames — any log output, if present,
+  goes elsewhere (FR-005–FR-007).
+- **The public package surface is sealed.** The root factory returns a frozen
+  null-prototype handle with exactly `start()` and `close()`, no symbols, and no
+  caller-supplied transport. The SDK server, registrations, transport, and in-memory test
+  builder remain package-internal and absent from package exports (FR-003, FR-005).
+- **Human-readable content is exact and bounded rather than merely "concise."** Every
+  substantive outcome and every cursor/corpus-unavailable reason uses the literal template
+  in `contracts/tools.md` §2.1, including fixed singular/plural rules, never interpolates
+  paths or unbounded corpus text, and is at most 512 UTF-16 code units (FR-005, SC-007).
+- **`get_decision` returns the complete document, never frontmatter alone, and never an
+  absolute path.** Canonical identity, full typed frontmatter, repo-relative source path,
+  and complete Markdown body on every successful response. Declared relation refs remain
+  in the typed frontmatter but are never resolved or inlined; the caller follows them
+  with a further `get_decision` call. ADR sources above the fixed maximum are excluded
+  with a structured `record-too-large` finding rather than truncated (FR-012, FR-017,
+  FR-023, FR-024).
+- **`search_decisions` matches the Markdown body, not only id/title/tags, with a fixed,
+  documented normalization contract and no ranking heuristic.** Query and searchable
+  fields are trimmed and case-folded by the same locale-independent rule; a query that is
+  empty after trimming is rejected as an input-contract error before any corpus access,
+  never silently treated as an empty-string query that would otherwise match every
+  record; a match is a normalized literal substring; results are bounded summaries with
+  matched-field indicators, ordered by canonical `(id, sourcePath)` identity using a
+  fixed, locale-independent code-unit comparator — never a relevance score, embedding,
+  fuzzy match, or locale-sensitive collation (FR-025–FR-028). `status`/`scope` filters
+  are any-of (a record matches if its own value is any one listed); `tags` is all-of (a
+  record matches only if it carries every listed tag, up to 32 tags of at most 64
+  characters each); the three filter categories are ANDed together. There is no `log`
+  filter: this phase has no log dimension to filter by.
+- **The graveyard is included by default; named-log federation is deferred completely,
+  not partially designed.** `rejected` and `superseded` (and `deprecated`) records are
+  searchable and fetchable by default. This phase serves exactly one local corpus —
+  `@adrkit/core` never populates a record's `log` field and this server's discovery is
+  non-recursive — so identity is a record's bare `id` alone, held in one multi-valued
+  local index that never keeps a single arbitrary representative. An unqualified id
+  resolving to more than one local record returns an explicit `ambiguous-local-id`
+  candidate list (distinguished by `sourcePath`) rather than a silent first match; a
+  log-qualified ref is recognized only far enough to return an explicit
+  `federated-log-unavailable` result — never resolved, stripped, or substituted with a
+  same-id local record (FR-020–FR-022, FR-034, FR-035, ADR-0002).
+- **`get_decision_context(files[])` reuses core `affects` resolution unchanged, never
+  reads file content, and never omits in-flight work.** `files[]` entries are validated
+  as repo-relative logical paths (rejecting absolute paths, `..` traversal, drive
+  letters, any backslash character, and empty strings — the contract is POSIX separators
+  only) and compared only against already-loaded `affects` patterns — never used to
+  open, read, or `stat` a filesystem path. Results are three structurally
+  separate collections — `governing` (`accepted`), `activeProposals`
+  (`draft`/`proposed`), and `history` (`rejected`/`superseded`/`deprecated`) — covering
+  all six statuses, never merged; each summary lists the record's declared relation refs
+  (including `conflictsWith`) without expanding them (FR-029–FR-033, ADR-0009).
+- **`list_superseded` reports direct `supersededBy` edges only, resolved locally,
+  never picking a target silently, and never inlining an unbounded candidate list;
+  transitive lineage is explicitly out of scope for this phase.** An unqualified target
+  used by exactly one local record resolves; one used by more than one local record
+  surfaces a deterministic `superseded-target-ambiguous` finding naming the target id and
+  a `candidateCount` — never every candidate's path/title inline, with the complete
+  candidate list separately obtainable via a follow-up `get_decision` call on the same
+  target id; a log-qualified target surfaces an informational federated-unavailable
+  finding; a wholly dangling target surfaces via the corpus's own existing finding — none
+  fabricated, none silently dropped (FR-034).
+- **A tool's `findings` channel is corpus findings plus that call's own derived
+  findings — two distinct sources, composed fresh per call, never a mutated shared
+  value.** The corpus projection's own findings (a schema-invalid record, a
+  pre-read-guard exclusion — both severity `error`, since the corpus is genuinely
+  incomplete even though the call proceeds) are what the corpus fingerprint hashes; a
+  tool-derived finding (`get_decision_context`'s per-record `affects` findings,
+  `list_superseded`'s minted ambiguity/federation findings) is deterministic from the
+  corpus plus that call's own inputs and is merged in afterward, outside the hash — the
+  fingerprint together with the per-channel query-shape hash is what a derived-findings
+  cursor is actually bound to, not the fingerprint alone. A corpus invariant
+  (`unique-id`, a dangling reference) never removes a schema-valid record from the
+  corpus this server answers from; it only adds a finding about it.
+- **Deterministic ordering and lossless pagination, with every supplied cursor always
+  checked.** Any result set that can grow
+  (search matches, decision-context matches, superseded listing, or findings) is ordered
+  canonically, bounded, and cursor-paginated with no gap/duplicate across a full walk,
+  using one fixed, locale-independent code-unit comparator `@adrkit/mcp` defines itself —
+  never `@adrkit/core`'s own `localeCompare`-based finding order, reused only as an input
+  to be re-sorted. Decision context uses one canonical walk partitioned per page into its
+  three status collections rather than separate collection cursors. A cursor is a plain,
+  reversible, base64url-encoded value — opaque by MCP protocol convention, never by
+  confidentiality or tamper-proofing — and is always decoded and strictly verified,
+  whether or not this call's own outcome turns out to need pagination at all: a primary
+  cursor presented against a call whose resolved outcome has no primary channel to apply
+  it to is reported as `invalid-cursor`/`cursor-not-applicable`, not silently ignored,
+  and an in-range-looking offset that no longer indexes inside the freshly recomputed
+  channel is `offset-out-of-range` — this is a correctness/staleness binding, not an
+  authentication or security mechanism. Repeated identical calls against an unchanged
+  corpus return byte-identical ordered results (FR-012, FR-018, FR-019, FR-027).
+- **Three never-conflated response shapes.** Every tool distinguishes a usage/
+  input-contract error, a well-formed empty/not-found result, and a corpus finding
+  encountered while otherwise answering the call — a single bad record or missing
+  `affects` backing source never blocks the rest of the corpus and is always surfaced in
+  structured content, never silently dropped and never text-only (FR-015, FR-016,
+  FR-032).
+- **No hidden index, cache, database, or runtime network access; configuration is
+  startup-only and every corpus load revalidates observable filesystem state.** Startup
+  stores configured root/dir strings plus the expected canonical root. Before and after
+  each core load, the server re-realpaths the root, confirms it still equals that expected
+  root and has readable `.git`, and re-realpaths/validates the ADR directory with
+  path-segment-safe containment. Each candidate is `lstat`-checked as a non-symlink regular
+  file, realpath-checked for containment, then compared before/after by bigint
+  `dev`/`ino`/`size`/`mtimeNs`; any observed change discards the whole provisional
+  projection as `corpus-unavailable` without returning changed-path data. Deterministic
+  tests inject root, directory, type, size, symlink, containment, and identity swaps at
+  every checkpoint. Portable Node path calls do not provide an atomic hostile-filesystem
+  snapshot, so the requirements do not claim detection of a transient swap that occurs and
+  reverts entirely between checkpoints (FR-002, FR-008–FR-011, FR-032, FR-035–FR-036,
+  SC-005, ADR-0001, ADR-0004, ADR-0009).
+- **Toolchain boundary matches the existing adapter-isolation gate, and its proof is
+  honestly scoped.** `@adrkit/mcp` depends only on `@adrkit/core`; core never depends on
+  `@adrkit/mcp`; a clean clone may contact only the unauthenticated public registry for
+  `bun install --frozen-lockfile`, after which build/typecheck/test/lint/package/smoke and
+  runtime execute with networking disabled and no credentials/services; the published
+  artifact targets Node `>=22`, Bun for development only (FR-037–FR-040, ADR-0007,
+  ADR-0010). The allow-list proves declared direct dependencies only. Import discipline,
+  exact Node/Bun denial hooks for filesystem mutation/write-capable opens/FileHandles,
+  subprocesses, cluster, workers, `process.dlopen`, network/listen paths, and Bun
+  write/delete/writer/spawn/shell paths, plus complete sandbox/parent-sentinel/`HOME`/
+  `TMPDIR` snapshots provide separate bounded evidence. Passing proves only that enumerated
+  JavaScript-level APIs were not invoked on exercised paths, not that raw native syscalls
+  or future unenumerated APIs are impossible (SC-005, SC-012, SC-013).
+- **Assumptions A1–A9** capture ADR-consistent, non-one-way-door defaults: exactly one
+  local corpus per server instance, with named-log and multi-repository federation
+  deferred completely — not partially designed with a vestigial log field kept "ready"
+  — because `@adrkit/core` never populates a record's `log` and this server's discovery
+  is non-recursive (A1); search as fixed, deterministic normalized literal matching with
+  no open ranking question — only the specific case-folding primitive is left, portably,
+  to the plan stage (A2); `list_superseded` scoped to direct, locally-resolved edges by
+  deliberate choice, not left open (A3); plus first-party non-adapter package placement,
+  current-stable (beta v2, not alpha) MCP SDK context, subprocess launch model,
+  stdout-reserved logging and the Bun-dev/Node-publish toolchain split (A4–A8).
+  Distribution/package/smoke/docs wiring is a Phase 5 deliverable; actual publication,
+  tag creation, release-number choice, and `scripts/release-publish.ts` changes are deferred
+  (A9).
+- **Open Questions for Maintainer Review now holds no unresolved item.** Search
+  ranking, transitive-supersession scope, `conflictsWith` visibility, and
+  log-identity semantics are fixed to conservative defaults directly in the
+  Functional Requirements and Assumptions (FR-021, FR-022, FR-026, FR-027,
+  FR-033, FR-034, FR-035; A1–A3). The maintainer explicitly ratified the exact
+  four-tool boundary and exclusions on 2026-07-20, satisfying SC-016.
+- **"No implementation details" means no implementation choices invented by this spec,
+  not zero technical constraint.** This spec correctly cites ADR- and MCP-protocol-
+  mandated constraints already governing the project — Bun for development / Node for
+  the published artifact (ADR-0010), the Model Context Protocol's own stdio transport and
+  `@modelcontextprotocol/sdk` shape, and Zod-compatible strict schemas (ADR-0002's
+  "schema is the contract") — as boundary conditions (FR-037–FR-040, A5, A8), because
+  those constraints were ratified before this document and are load-bearing for its
+  acceptance criteria. It does not select a specific data structure, algorithm, file
+  layout, or library beyond what those ADRs already require, which is the property this
+  checklist item is actually protecting.
+- **This spec changes no implementation code and commits nothing.** It is the
+  completed scoping step. The 43-task implementation graph is generated; current artifact
+  remediation and a clean cross-artifact analysis pass precede implementation.

--- a/specs/006-mcp-server/contracts/core-projection.md
+++ b/specs/006-mcp-server/contracts/core-projection.md
@@ -1,0 +1,141 @@
+# Contract: `@adrkit/core`/`@adrkit/evaluator` additive projection surface
+
+**Feature**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md) |
+**Research**: [../research.md](../research.md) §R3 | **Data model**:
+[../data-model.md](../data-model.md) §§1–3 | **Date**: 2026-07-20
+
+This contract defines the **entire** change this feature requires outside
+`packages/mcp/`: one new `@adrkit/core` file, one new `@adrkit/core` export line, and
+one existing `@adrkit/evaluator` file migrated (behavior-preservingly) to call that new
+export instead of its own private, duplicated copy. It also defines the boundary between
+what stays in `@adrkit/core` (because it is genuinely shared, previously-duplicated
+parsing logic with a second real caller today) and what stays entirely inside
+`@adrkit/mcp` (because it is a policy or an indexing detail specific to one consumer). It
+exists as a separate contract from contracts/tools.md because it governs the **library
+boundary** between packages, not tool behavior over the wire.
+
+This contract promotes exactly **one** function — `parseAdrRef` — because it is the only
+one with a real, today caller (`no-orphan-refs.ts`'s private copy) and a real, planned
+second caller (`@adrkit/mcp`'s `get_decision`/`list_superseded`). There is no
+`formatAdrRef`: nothing in this feature's planned production call sites ever needs to
+re-serialize a `(log, id)` pair back into a `log:id` string — every place this design
+echoes a ref back to a caller (`requestedRef`, a `targetRef`) simply reuses the caller's
+own original input string verbatim, never reconstructs one from parsed parts. Adding an
+inverse function with no production caller would be speculative surface this contract's
+"smallest change that satisfies the task" posture rejects.
+
+---
+
+## 1. What changes in `@adrkit/core`, and in `@adrkit/evaluator`
+
+**One new file**: `packages/core/src/schema/ref.ts`.
+
+```ts
+export interface ParsedAdrRef {
+  readonly id: string;
+  readonly log?: string;
+}
+
+export function parseAdrRef(ref: string): ParsedAdrRef {
+  const idx = ref.indexOf(':');
+  if (idx <= 0) return { id: ref };
+  return { log: ref.slice(0, idx), id: ref.slice(idx + 1) };
+}
+```
+
+`parseAdrRef` is **specified to preserve the exact observable behavior and object shape**
+of the private `parseRef` formerly shipped in `packages/evaluator/src/rules/no-orphan-refs.ts`
+(identical `indexOf`/`idx <= 0` logic: an unqualified ref, or one with a **leading**
+colon, returns `{ id: ref }` — `id` is the untouched original string, colon included when
+present, because it was never split; a qualified ref returns `{ log, id }`, split on the
+first colon) — this is a promotion of already-proven logic to one shared, exported,
+tested location, not a behavior change or a reinterpretation of the grammar. "Byte-identical"
+is deliberately not the claim made here: the promoted function is behavior- and
+object-shape-preserving for every input, which is the property that actually matters (the
+two implementations produce the same return value for the same input and agree on which
+keys are present), not that the two source files were ever literally byte-for-byte the
+same text.
+
+**One new export line** in `packages/core/src/index.ts`:
+
+```ts
+export * from './schema/ref.ts';   // ADDED — sits alongside the existing 13 lines, none of which change
+```
+
+**One migrated caller, in the same change — not deferred**:
+`packages/evaluator/src/rules/no-orphan-refs.ts`'s private `parseRef` function is
+**removed**, and its one call site is replaced with an import of `parseAdrRef` from
+`@adrkit/core` (already a direct dependency of `@adrkit/evaluator` — no new dependency).
+Because the two functions are specified to be behavior- and object-shape-preserving for
+every input, this is a safe substitution: `no-orphan-refs.ts`'s own existing test suite is
+expected to pass unchanged, with no new or updated assertions required to prove the
+migration correct beyond "the suite still passes." This migration is included **in this
+same change** — not deferred to "a separate, optional follow-up" — because the
+duplication this promotion exists to close already has a second, real caller today
+(`no-orphan-refs.ts`); promoting the logic to a shared export while leaving that caller's
+own private copy in place would recreate the exact duplication the promotion is meant to
+close, just with an unused third copy sitting beside it.
+
+**Future changes this promotion enables, stated precisely so its cost is not
+understated**: adding a second real caller inside `@adrkit/mcp` (`get_decision`,
+`list_superseded` — contracts/tools.md §§4, 7) later requires exactly: one import line
+per call site, and zero changes to `ref.ts` itself or to `no-orphan-refs.ts`. No further
+`@adrkit/core` surface is anticipated by this feature.
+
+**Nothing else changes.** `packages/core/src/load/corpus.ts` (`loadCorpus`, `Corpus`,
+`byId`, `discoverAdrFiles`, `expandRecordInputs`, `parseAdrFile`,
+`normalizeDisplayPath`), `packages/core/src/validate/*.ts` (`lintCorpus` and every
+validation rule, including `unique-id` and the dangling-reference checks), every other
+`@adrkit/evaluator` rule module, `packages/core/src/graph/build.ts`,
+`packages/core/src/affects/*.ts`, and `packages/core/src/check/index.ts` are
+**byte-for-byte unmodified**. `packages/core/package.json`'s and
+`packages/evaluator/package.json`'s `dependencies` are unmodified — `ref.ts` uses no
+dependency at all, and `no-orphan-refs.ts`'s migration adds no new import target beyond
+`@adrkit/core`, which it already imports from.
+
+## 2. What deliberately stays out of `@adrkit/core`
+
+| Concept | Why it is `@adrkit/mcp`-only, not a core export |
+|---|---|
+| The local, multi-valued `id` index (`byId: Map<string, readonly Adr[]>`) | Builds directly off `Adr.frontmatter.id` — no string parsing involved, so there is no shared *parser* to deduplicate. A six-line loop over `lintCorpus()`'s own output, specific to how `@adrkit/mcp` needs to answer "zero/one/many" — not a general-purpose corpus concern any other consumer has asked for, and deliberately **not** log-qualified: this phase has no `log` dimension to index by at all (`@adrkit/core` never populates `Adr.log`), so there is nothing log-shaped to promote either. |
+| The 64 KiB source-size guard, stable-load verification, and their `record-too-large`/`record-stat-error`/`corpus-changed-during-load` outcomes | Product policy of this one feature (FR-012), not a property of `@adrkit/core`'s loading contract. Adding it to `lintCorpus` would silently change `adr lint`/`graph`/`check` for every existing consumer. It runs on top of the already-exported `discoverAdrFiles`: pre-stat candidates, call `lintCorpus` only on initial survivors, then post-stat those survivors and reject the provisional projection if identity/size changed (data-model.md §3.3). No new core surface is needed. |
+| The corpus fingerprint (research §R6) | Specific to this feature's pagination-staleness design; no other consumer has a cursor to bind it to. Computed by `@adrkit/mcp` over the **parsed wire projection** it already builds for other reasons (the records, the findings, the two health counts) — never over raw file bytes — so it needs no new core surface to get at that data; it is a pure, additional CPU pass over structures `@adrkit/mcp` already holds. |
+| The locale-independent code-unit comparator (research §R6) | A one-line, self-contained function (`a < b ? -1 : a > b ? 1 : 0`) with no dependency and no reason to live anywhere but beside its one caller; promoting a five-token function to a shared export would be the wrong kind of "shared logic" this contract's §1 promotion is reserved for. |
+| Any output/wire shape (`DecisionSummary`, `FullDecision`, the four tools' result unions, `federated-log-unavailable`, `ambiguous-local-id`) | Entirely presentation-layer concerns of one MCP server; `@adrkit/core` has and needs no concept of "search match," "candidate list," or "federated-log-unavailable" — the last of these is a decision about how *one tool* responds to a grammar `@adrkit/core` already validates, not a new core capability. |
+
+## 3. Verification this contract implies
+
+- **Unmodified existing behavior, everywhere except the one migrated call site**:
+  `git diff` against `packages/core/src/**` (excluding the one new `ref.ts` file and the
+  one new export line) is empty after this feature lands. `git diff` against
+  `packages/evaluator/src/**` shows exactly one file changed
+  (`rules/no-orphan-refs.ts`), and that diff is limited to replacing the private
+  `parseRef` definition and its one call site with an import of `parseAdrRef` — no other
+  line changes. `adr lint`/`graph`/`explain`/`check`/`evaluate`, `@adrkit/ci`, and every
+  `@adrkit/evaluator` rule **other than** `no-orphan-refs` are unaffected without needing
+  to be re-run against different behavior, only re-run to confirm they still pass
+  unchanged; `no-orphan-refs.ts`'s own test suite must still pass unchanged, which is the
+  direct evidence the migration preserved behavior and object shape.
+- **`core-has-no-adapter-deps` / clean-clone**: `ref.ts` adds no dependency, so
+  `scripts/check-deps.ts`'s existing `@adrkit/core` allow-list needs no change at all —
+  the new file is pure TypeScript with no imports beyond nothing. `@adrkit/evaluator`'s
+  allow-list entry likewise needs no change: `no-orphan-refs.ts` already imports from
+  `@adrkit/core`, and the migration adds no new package to its import graph.
+- **`schema:emit` byte-clean**: `ref.ts` does not touch `AdrFrontmatter` or any other
+  Zod schema value; `bun run schema:emit && git diff --exit-code schema/adr.schema.json`
+  reports no diff.
+- **Unit coverage for the new file**: deep-equality assertions on `parseAdrRef`'s return
+  value for the two shapes the grammar actually produces — an unqualified ref (e.g.
+  `"0042"`) and a leading-colon ref (e.g. `":0042"`) each assert `toEqual({ id: ref })`
+  (the whole original string, colon included when present, since neither case is ever
+  split); a qualified ref (e.g. `"payments:0012"`) asserts
+  `toEqual({ log: 'payments', id: '0012' })`. There is deliberately **no** format/
+  round-trip test (e.g. no assertion of the shape `format(parse(ref)) === ref`), because
+  no such inverse function exists in this design (see the note above §1) — a round-trip
+  test would be asserting behavior of a function this contract does not add. A small,
+  fast, `@adrkit/core`-local test, independent of anything in `@adrkit/mcp`.
+- **Unit coverage for the migration**: `no-orphan-refs.ts`'s existing fixture set
+  (resolved/dangling/federated-log-absent refs) continues to pass with zero fixture
+  changes required — the migration's entire correctness claim is "nothing observable
+  moved," and an unchanged test suite passing unchanged is exactly the evidence for that
+  claim, not a weaker substitute for it.

--- a/specs/006-mcp-server/contracts/pagination-and-cursors.md
+++ b/specs/006-mcp-server/contracts/pagination-and-cursors.md
@@ -1,0 +1,236 @@
+# Contract: pagination, cursors, and the corpus fingerprint
+
+**Feature**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md) |
+**Research**: [../research.md](../research.md) §R6 | **Data model**:
+[../data-model.md](../data-model.md) §5 | **Date**: 2026-07-20
+
+This contract is the single, shared specification every one of the four tools' growing
+channels implements identically. It exists as its own file because the binding design
+direction requires it to be precise and uniform across tools, and repeating it four
+times in contracts/tools.md would risk the four copies drifting from each other.
+
+---
+
+## 1. Why an opaque, versioned, query-bound cursor (not a raw offset)
+
+FR-018/FR-019 require: every growing response channel paginates; walking a cursor to
+completion returns every item exactly once, in stable canonical order, with no gap or
+duplicate; and — per the binding design direction — a corpus change between pages must
+**fail explicitly**, never silently gap or duplicate. A bare integer offset satisfies
+none of "opaque" (nothing marks it as a token the caller should not interpret or
+construct by hand — MCP's own pagination convention, research §R6), "query-bound"
+(nothing stops reusing page 3 of query A as page 3 of query B), or "corpus-change-safe"
+(an offset into a corpus that has since gained or lost records points at the wrong item,
+silently). This contract's cursor is the minimal structure that closes all three gaps at
+once.
+
+**What "opaque" does and does not mean here, stated precisely.** Base64url is a plain,
+public, reversible encoding, not a cryptographic one — it carries **zero** confidentiality
+or integrity guarantee. "Opaque" is used in the same sense MCP's own list-pagination
+convention uses it (research §R6): a caller is not *meant* to construct, parse, or
+persist a cursor across sessions, and this design never asks a caller to. It is not a
+claim that a caller *cannot* — anyone who reads this document can compute a `qh` (§4) and
+hand-assemble a plausible-looking cursor with no help from this server at all. Nothing in
+this design relies on that being hard. What actually makes a hand-constructed, edited, or
+replayed cursor safe is the strict decode/verify sequence in §2: every check runs whether
+the cursor arrived from this server's own last response or from anywhere else, and any
+mismatch — at any step — is rejected as `invalid-cursor`, never silently accepted or
+silently reinterpreted. This is a **correctness/staleness** binding (does this cursor
+still describe *this* call, against *this* corpus, at *this* offset), not an
+authentication or security boundary: there is no secret to protect, and a cursor that
+passes every check can, at most, hand the caller an in-range offset into their own
+already-authorized, read-only view of the same corpus they could otherwise page through
+one item at a time — it can never widen access, skip validation, or reach a different
+corpus.
+
+## 2. Wire format
+
+A cursor is a **string**, always: base64url (`RFC 4648 §5`, no padding) of the UTF-8
+JSON encoding of exactly this shape, with fields in this literal, fixed order (so two
+calls that mint "the same" cursor produce byte-identical strings — required for
+determinism tests, e.g. SC-014's spirit extended to cursor minting):
+
+```ts
+interface CursorPayloadV1 {
+  readonly v: 1;
+  readonly scope: CursorScope;   // see §3 — which tool+channel+field this cursor belongs to
+  readonly fp: string;            // 64-char lowercase hex SHA-256 — CorpusHealth.fingerprint at mint time
+  readonly qh: string;            // 64-char lowercase hex SHA-256 — hash of this call's binding parameters (§4)
+  readonly offset: number;        // positive safe integer; index into that call's deterministic sorted array
+}
+```
+
+`offset` is a **positive** (never zero, never negative) safe integer
+(`Number.isSafeInteger(offset) && offset >= 1`). Zero is never minted: the first page of
+any channel is always fetched with **no** cursor supplied for that channel at all (there
+is nothing to resume yet), and every cursor this server mints for a *next* page carries
+`offset = <previous offset (or 0 for an implicit first page)> + <that page's item
+count>`, which is at least `limit`'s own minimum of `1` — so a genuine, server-minted
+cursor's `offset` is always `>= 1`. A decoded `offset` of `0`, or a negative or non-safe
+value, therefore fails decoding outright (`reason: 'decode-failed'`) as a value this
+build never produces and never accepts.
+
+Encoded size is on the order of 150–250 bytes — comfortably inside the 4 KiB input-
+schema cap (research §R11), which exists purely as defensive headroom against a
+caller-supplied garbage string, not because a legitimate cursor is ever close to it.
+
+**Every supplied cursor is validated — never silently skipped.** A caller that supplies a
+`cursor` or `findingsCursor` value always has it decoded and verified through the full
+sequence below, regardless of what this call's own substantive outcome turns out to be.
+This phase never reasons "the outcome this call resolved to has no pagination, so the
+cursor the caller happened to send doesn't matter" — a cursor that cannot apply to this
+call's actual outcome is itself a distinct, reported failure (`reason:
+'cursor-not-applicable'`, step 7 below), not a silently ignored input. See §5 for exactly
+when a primary cursor is applicable and when it is not.
+
+**Decode/verify order** (every step's failure produces the shared, non-error
+`InvalidCursorOutcome` — data-model.md §5 — with the named `reason`, never a silent
+fallback and never a thrown exception):
+
+1. Base64url-decode. Failure → `reason: 'decode-failed'`.
+2. `JSON.parse` the decoded bytes as `CursorPayloadV1`, strictly (unknown keys,
+   wrong types, a missing required key, or an `offset` that is not a positive safe
+   integer are all decode failures, not partial acceptance). Failure →
+   `reason: 'decode-failed'`.
+3. Check `v === 1` (the only version this build understands). Mismatch →
+   `reason: 'version-unsupported'`.
+4. Check `scope` equals the scope expected for **the specific input field this cursor
+   value arrived in**, for **this specific tool** (§3) — a `search.findings`-scoped
+   cursor supplied in `search_decisions`'s `cursor` field (not `findingsCursor`), or any
+   cursor scoped to a different tool's channel entirely, is rejected here, even though it
+   decoded fine. Mismatch → `reason: 'wrong-channel'`.
+5. Check `fp` equals this call's freshly computed `CorpusHealth.fingerprint`. Mismatch →
+   `reason: 'corpus-changed'`.
+6. Check `qh` equals this call's freshly computed query-shape hash (§4). Mismatch →
+   `reason: 'query-mismatch'`.
+7. **(Primary cursor only.)** Check that this call's freshly recomputed, resolved
+   substantive outcome actually has a paginated primary channel for this cursor's scope
+   to apply to. Every tool's *findings* channel exists on every substantive outcome, so
+   this step never rejects a `findingsCursor` (§5). A tool's *primary* channel does not
+   always exist — concretely, `get_decision`'s `found`, `not-found`, and
+   `federated-log-unavailable` outcomes carry no `candidates` array at all. A `cursor`
+   presented against a call that resolves to one of those has passed every check above
+   (it may even be a genuine echo of a cursor this server minted for a *different*,
+   currently-ambiguous ref against the same corpus) yet still names a channel that, for
+   *this* ref, does not exist. Mismatch → `reason: 'cursor-not-applicable'`.
+8. Recompute the channel's deterministic sorted array fresh for this call, and check
+   `offset < array.length`. A corpus that matches `fp` and a query-shape that matches
+   `qh` together pin down that array's contents exactly (§6), so this can only fail when
+   the offset itself was never validly issued against this exact array — e.g. a
+   hand-constructed or truncated-then-replayed value. Mismatch →
+   `reason: 'offset-out-of-range'`.
+9. Only now is `offset` used, as a plain array index into that recomputed array.
+
+Steps 5 and 6 are independent and both checked (in that order, so a corpus change is
+reported as `corpus-changed` even if the query-shape also happens to differ) — a cursor
+can be simultaneously stale *and* bound to a different query, and the more actionable
+diagnosis (the corpus moved) is reported first. Steps 7 and 8 are checked only after 3–6
+all pass, because both require already knowing this call's resolved, concrete outcome and
+its freshly recomputed channel array — there is nothing to check "channel exists" or
+"offset in range" against until the corpus and query are confirmed unchanged.
+
+## 3. `CursorScope`, and which input field each scope is valid in
+
+```ts
+type CursorScope =
+  | 'search.results'        // search_decisions.cursor
+  | 'search.findings'        // search_decisions.findingsCursor
+  | 'get_decision.candidates' // get_decision.cursor
+  | 'get_decision.findings'   // get_decision.findingsCursor
+  | 'context.results'         // get_decision_context.cursor
+  | 'context.findings'        // get_decision_context.findingsCursor
+  | 'superseded.results'      // list_superseded.cursor
+  | 'superseded.findings';    // list_superseded.findingsCursor
+```
+
+Each tool mints cursors with exactly the two scopes named in its own row above and
+rejects (`wrong-channel`) any other scope value presented in either of its two cursor
+input fields — including a scope that belongs to a **different tool's** channel
+(e.g. a `superseded.results` cursor presented to `search_decisions`). This closes the
+"presented in the wrong field" gap precisely, not just "the wrong tool."
+
+## 4. The query-shape hash (`qh`)
+
+SHA-256, hex-encoded, over a fixed-order canonical JSON array of exactly the parameters
+that determine **membership and order** of the channel being paginated — deliberately
+excluding the cursor/offset itself (which is what the hash exists to protect, not
+something it can include) and, for the primary-result hash, excluding the
+findings-channel's own parameters (and vice versa), because the two channels page
+independently (§5) and must not invalidate each other's cursor on an unrelated change.
+
+| Tool / channel | Hashed parameters, in this order |
+|---|---|
+| `search_decisions` results | normalized `query` (already validated non-empty after `trim()`, §4 below refers to the same normalization research §R5 defines), sorted unique `status[]` (or `[]` for "all six" — any-of semantics: a record matches if its own `status` is any listed value), sorted unique `tags[]` (all-of semantics: a record matches only if it carries every listed tag — hashed anyway, because a caller changing *which* tags are required between pages, even without changing the count, must invalidate the cursor exactly like any other filter change), sorted unique `scope[]` (any-of semantics, same reasoning as `status`), `limit` |
+| `search_decisions` findings | `findingsLimit` only — findings are never filtered by the search's own `query`/`status`/`tags`/`scope`, so only the page size can invalidate a findings cursor for this tool |
+| `get_decision` candidates | `requestedRef` (the raw ref that resolved `ambiguous-local-id` — always unqualified, since a qualified ref never reaches this branch), `limit` |
+| `get_decision` findings | `findingsLimit` only — `get_decision` derives no findings from `ref`; its findings channel is exactly the corpus findings already bound by `fp`, so binding this cursor to `ref` would reject otherwise-valid continuation calls without protecting membership or order |
+| `get_decision_context` results | canonical-sorted, de-duplicated `files[]`, `limit` |
+| `get_decision_context` findings | canonical-sorted, de-duplicated `files[]`, `findingsLimit` — this channel's derived findings (e.g. `affects-unresolvable`) are a deterministic function of the corpus (covered by `fp`) and `files[]` (covered here), so no separate hash input is needed to bind them (data-model.md §3.5) |
+| `list_superseded` results | `limit` only (no filters exist for this tool) |
+| `list_superseded` findings | `findingsLimit` only — this channel's derived findings (`superseded-target-ambiguous`, `superseded-target-federated-unavailable`) are a deterministic function of the corpus alone (covered by `fp`), since this tool takes no filter input to hash |
+
+Every string compared or sorted while computing `qh` — and while building the canonical
+JSON that `qh` itself is hashed over — uses `@adrkit/mcp`'s own fixed, locale-independent
+code-unit comparator (research §R6), never `String.prototype.localeCompare`, so this
+hash cannot vary between two otherwise-identical processes purely because of a runtime
+locale difference. There is no `log` parameter anywhere in this table: this phase has no
+log dimension to filter or hash by (spec.md FR-021).
+
+Changing any hashed parameter between calls (including simply passing a different
+`limit`) is, by design, a `query-mismatch` on the next page — resuming a walk started
+with `limit: 20` using `limit: 50` is exactly the kind of silent-reinterpretation this
+contract exists to prevent, per the binding design direction's "query-bound" requirement.
+
+## 5. How the primary-result cursor and the findings cursor coexist
+
+Every tool's input carries **two** independent cursor/limit pairs — `cursor`/`limit` for
+its primary substantive channel, and `findingsCursor`/`findingsLimit` for the findings
+channel (data-model.md §7) — both minted against the **same** `fp` (corpus fingerprint)
+but **different** `scope` values and **different** `qh` hashes (§4), and each tracking
+its **own** `offset` into its **own** independently-sorted array. Concretely:
+
+- A caller walking only the results channel to completion (repeatedly supplying the
+  returned `result.cursor` until it is `null`) never needs to look at `findings` or
+  supply `findingsCursor` at all — the findings channel simply always returns its first
+  page (or, if `findings.items` is short enough to fit in one page, its only page)
+  on every one of those calls, independent of how far into the results the caller has
+  walked.
+- A caller walking only the findings channel to completion behaves symmetrically.
+- A caller walking both simultaneously supplies both cursors on each call; each is
+  decoded/verified/applied completely independently (§2) — a `wrong-channel`,
+  `query-mismatch`, `cursor-not-applicable`, or `offset-out-of-range` failure on one does
+  not affect the other, and the response's `outcome` becomes `invalid-cursor` for
+  whichever one first failed verification. **If both are supplied and both are invalid in
+  the same call, the primary-result cursor's failure is reported** (the response's
+  `outcome` can only be one discriminant per call) — deterministically, always the
+  primary cursor's specific failure `reason`, never the findings cursor's, and never a
+  coin-flip between them; a caller correcting the primary cursor and retrying will then
+  see the findings cursor's own specific failure reason on the next call, never both
+  silently discarded.
+- **Every supplied cursor is validated — never silently ignored because the outcome
+  turned out to be non-paginated.** A `findingsCursor` is always decoded and verified
+  (§2 steps 1–6, 8–9), because every substantive outcome from every tool carries a
+  findings page — step 7 (channel-exists) never rejects a findings cursor. A primary
+  `cursor` is likewise always decoded and verified through steps 1–6; step 7 then asks
+  specifically whether *this call's* resolved outcome has a primary channel for that
+  cursor's scope to apply to. For `search_decisions`/`get_decision_context`/
+  `list_superseded`, every substantive outcome (`results`/`matches`/`entries`, even when
+  empty) has one, so step 7 never rejects their primary cursor either. `get_decision` is
+  the one tool whose primary channel is outcome-dependent: only its `ambiguous-local-id`
+  outcome has a `candidates` array. A `cursor` supplied on a `get_decision` call that
+  resolves to `found`, `not-found`, or `federated-log-unavailable` therefore fails step 7
+  with `reason: 'cursor-not-applicable'` — reported, not swallowed — even though the
+  cursor may otherwise be perfectly well-formed and even correctly scoped/fingerprinted
+  (e.g. a genuine cursor from a *different*, still-ambiguous ref queried earlier against
+  the same, unchanged corpus).
+
+## 6. Determinism this contract guarantees (ties to SC-008, SC-014)
+
+Given an unchanged corpus and identical call parameters: minting a cursor, decoding it
+on the next call, and slicing its channel's freshly recomputed sorted array at `offset`
+reproduces byte-identical results to a single, unpaginated walk of the same array —
+because the fingerprint check (§2 step 5) guarantees the array is byte-identical to the
+one the offset was issued against, not merely "probably the same," and the
+range check (§2 step 8) guarantees that offset still indexes inside it. Walking every
+page of every channel to completion therefore returns every item exactly once, with no
+gap and no duplicate, in the same canonical order a non-paginated call would produce.

--- a/specs/006-mcp-server/contracts/tools.md
+++ b/specs/006-mcp-server/contracts/tools.md
@@ -1,0 +1,608 @@
+# Contract: the four tools (`@adrkit/mcp`)
+
+**Feature**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md) |
+**Research**: [../research.md](../research.md) | **Data model**:
+[../data-model.md](../data-model.md) | **Pagination**:
+[pagination-and-cursors.md](./pagination-and-cursors.md) | **Date**: 2026-07-20
+
+This contract defines the behavioral surface of `search_decisions`, `get_decision`,
+`get_decision_context`, and `list_superseded`: the library/bin split, the shared
+envelope and annotations every tool uses identically, the canonical ordering rule, the
+error/output-schema reconciliation this design relies on, each tool's precise semantics,
+the fixed limits, and startup behavior. Shapes are the conceptual types from
+[data-model.md](../data-model.md); FR-numbers refer to [../spec.md](../spec.md).
+
+---
+
+## 1. Library surface (`@adrkit/mcp`)
+
+```ts
+interface AdrkitMcpServerHandle {
+  start(): Promise<void>;
+  close(): Promise<void>;
+}
+
+// packages/mcp/src/index.ts — the public stdio lifecycle factory. No side effects
+// at import time; no filesystem access at construction time (data-model.md §8).
+function createAdrkitMcpServer(
+  options?: Partial<AdrkitMcpServerOptions>,
+): Readonly<AdrkitMcpServerHandle>;
+
+// packages/mcp/src/bin.ts — the dedicated stdio entrypoint. Only file with a
+// process.argv/process.env read, the FR-036 startup check, and a top-level
+// isMainModule() guard (mirroring packages/cli/src/main-module.ts's own pattern —
+// not imported from there; a five-line, local, non-domain helper, not a core export).
+// Never imported by anything except the compiled `bin` entry itself.
+async function main(argv: string[], env: Record<string, string | undefined>): Promise<0 | 1 | 2>;
+```
+
+The returned handle is a frozen, null-prototype object with exactly the own string
+properties `start` and `close` and no symbol properties. The concrete SDK `McpServer`,
+its low-level `.server`, registration APIs, and its transport remain closure-private.
+`start()` accepts no argument, performs the startup validation in §9, creates exactly
+one `StdioServerTransport`, and connects it; it cannot be redirected to an HTTP,
+in-memory, or caller-supplied transport. `close()` closes that private server.
+
+The closure-private server registers **exactly** `search_decisions`,
+`get_decision`, `get_decision_context`, and `list_superseded` (FR-001), and
+**nothing else** — no `registerResource`, no `registerPrompt`, no sampling call,
+no subscription handler (FR-003). A package-internal builder returns the concrete
+server only for in-memory conformance tests. It is absent from `package.json#exports`
+and every public subpath. Every handler calls `loadCorpusProjection`
+(data-model.md §3) itself, fresh, on every invocation (FR-010).
+
+## 2. Shared envelope, annotations, and canonical ordering
+
+Every tool's `outputSchema` raw shape is:
+
+```ts
+{ corpusHealth: CorpusHealth.optional(), result: <Tool>Result }   // registerTool raw shape — never a bare union at the schema root (research §R1.1)
+```
+
+Every tool's annotations are identical and fixed:
+
+```ts
+{ readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }
+```
+
+— `readOnlyHint`/`destructiveHint`/`idempotentHint` together are the accurate,
+literal statement that no call ever creates, edits, deletes, or has any side effect
+(FR-002); `openWorldHint: false` is the accurate statement that this server's domain of
+interaction is exactly the one configured corpus, never anything beyond it (FR-008,
+FR-014) — the "closed-world" property the spec's checklist calls out by name.
+
+### 2.1 Deterministic text channel
+
+Every server-authored response contains exactly one text-content item. The renderer
+uses `plural(n, one, many)`, defined as `n === 1 ? one : many`, and the following
+exact templates; `{findings}` is the current findings page's `items.length`, not a
+corpus-wide total:
+
+| Outcome | Exact text |
+|---|---|
+| `results` | `Returned {items.length} decision {plural(items.length, "result", "results")}; {findings} {plural(findings, "finding", "findings")} on this page.` |
+| `found` | `Found decision "{decision.id}"; {findings} {plural(findings, "finding", "findings")} on this page.` |
+| `not-found` | `No local decision matches "{requestedRef}"; {findings} {plural(findings, "finding", "findings")} on this page.` |
+| `ambiguous-local-id` | `Returned {candidates.length} {plural(candidates.length, "candidate", "candidates")} for ambiguous local ref "{requestedRef}"; {findings} {plural(findings, "finding", "findings")} on this page.` |
+| `federated-log-unavailable` | `Named-log federation is unavailable for "{requestedRef}"; {findings} {plural(findings, "finding", "findings")} on this page.` |
+| `matches` | `Returned {pageMatchCount} context {plural(pageMatchCount, "match", "matches")}: {governing.length} governing, {activeProposals.length} active {plural(activeProposals.length, "proposal", "proposals")}, {history.length} historical; {findings} {plural(findings, "finding", "findings")} on this page.` |
+| `entries` | `Returned {items.length} superseded decision {plural(items.length, "entry", "entries")}; {findings} {plural(findings, "finding", "findings")} on this page.` |
+
+`pageMatchCount` is exactly `governing.length + activeProposals.length +
+history.length`. Invalid-cursor messages are fixed:
+
+| Reason | Exact message and text |
+|---|---|
+| `decode-failed` | `Cursor could not be decoded.` |
+| `version-unsupported` | `Cursor version is not supported.` |
+| `wrong-channel` | `Cursor does not belong to this tool channel.` |
+| `corpus-changed` | `Corpus changed after this cursor was issued.` |
+| `query-mismatch` | `Cursor was issued for different request parameters.` |
+| `cursor-not-applicable` | `Cursor does not apply to this outcome.` |
+| `offset-out-of-range` | `Cursor offset is outside the current result set.` |
+
+Corpus-unavailable messages are likewise fixed and interpolate no path:
+
+| Reason | Exact message and text |
+|---|---|
+| `root-not-found` | `Configured repository root was not found.` |
+| `root-not-directory` | `Configured repository root is not a directory.` |
+| `root-not-readable` | `Configured repository root is not readable.` |
+| `root-not-git` | `Configured repository root is not a Git worktree.` |
+| `dir-not-found` | `Configured ADR directory was not found.` |
+| `dir-not-directory` | `Configured ADR directory is not a directory.` |
+| `dir-not-readable` | `Configured ADR directory is not readable.` |
+| `dir-outside-root` | `Configured ADR directory resolves outside the repository root.` |
+| `corpus-changed-during-load` | `Corpus changed while it was being loaded; retry the call.` |
+
+Every rendered string is capped at 512 UTF-16 code units. The only interpolated
+strings are schema-bounded ids/refs; corpus paths and messages are never interpolated.
+
+**Canonical order, used identically everywhere a list of `DecisionSummary`-shaped items
+is produced** (FR-018, FR-027): ascending by `(id, sourcePath)` — `id` compared as a
+plain string with `@adrkit/mcp`'s own fixed, locale-independent code-unit comparator
+(`a < b ? -1 : a > b ? 1 : 0` over UTF-16 code units — never
+`String.prototype.localeCompare`, whose result can vary by runtime locale; matching the
+schema's own id grammar, zero-padded numeric ids and ULIDs both sort correctly under
+plain string ordering), then `sourcePath` as a final, always-unique tiebreak. Never a
+relevance score, a weight, or any other heuristic (FR-004, FR-026). This is the *one*
+comparator `@adrkit/mcp` implements; every tool's primary channel is ordered by it. Every
+tool's `findings` channel is **also** ordered by this same comparator, using the same
+field-priority tuple `@adrkit/core`'s own `sortFindings` already uses (`rule`, `id`,
+`pattern`, `path`, `field`, `message`).
+
+**What a tool's `findings` channel actually contains — corpus findings plus this call's
+own derived findings, never the other way around (data-model.md §3.5).**
+`CorpusProjection.corpusFindings` is `lintCorpus()`'s own findings plus the pre-read
+guard's own findings, re-sorted by `@adrkit/mcp`'s comparator — and nothing else.
+`@adrkit/mcp` re-sorts with its own comparator rather than reusing `sortFindings()`
+directly, because that function compares with `localeCompare`, which is locale-sensitive
+and therefore not the deterministic, environment-independent order this design's cursor
+and fingerprint guarantees depend on (research §R6); `lintCorpus()`'s own
+`localeCompare`-ordered findings array is accepted as **input** and then re-sorted,
+never returned in its original order. Each tool handler builds its own
+`responseFindings` by concatenating `corpusFindings` with whatever findings that
+*specific call* deterministically derives on top of it (§6 for `get_decision_context`,
+§7 for `list_superseded`; `search_decisions` and `get_decision` derive none), then
+re-sorts the combined array with the same comparator before the findings-channel cursor
+paginates it. `CorpusProjection` is a `readonly` value read by every tool in the same
+call — it is **never mutated** to accumulate a tool's own derived findings; each handler
+computes its own `responseFindings` locally and returns it, leaving the shared
+projection untouched for any other code that reads it during the same call.
+
+## 3. Error / output-schema reconciliation — the practical rule (research §R1.2)
+
+1. A call whose arguments fail the declared `inputSchema` — including every
+   `.refine()`-encoded semantic check (`files[]` path-traversal/absolute/drive-letter/
+   empty, `query`/`ref`/cursor length bounds, array-count bounds) — never reaches this
+   server's own handler code at all. The SDK returns `{ isError: true, content: [{
+   type: 'text', text: '...' }] }` itself, before any corpus access (FR-012, FR-030).
+   This satisfies FR-015 case (a) for every violation expressible as an input-shape
+   constraint.
+2. Every other anticipated, name-able condition — an ambiguous or log-qualified id, an
+   empty result, zero context matches, an invalid/mismatched/stale cursor, an
+   unavailable corpus at call time — is a **non-error** branch of the tool's own
+   `outcome` discriminated union, fully validated by the SDK's output-schema check
+   (never `isError`). This is FR-015 cases (a)-as-a-substantive-answer and (b), always
+   structured, always distinguishable by `result.outcome` alone.
+3. Corpus findings (FR-016) ride the `findings` field of whichever substantive branch
+   fired — never a separate error, never text-only. This is FR-015 case (c).
+4. `isError: true` is otherwise reserved for a genuinely unanticipated internal
+   exception. Even then, the SDK's own catch-all guarantees a well-formed
+   `CallToolResult` reaches the caller — never a raw, unhandled exception (SC-005).
+
+## 4. `get_decision`
+
+**Input**: `GetDecisionInput` (data-model.md §7) — `ref` (required, always, even on a
+continuation call; 1–128 chars; validated by ADR-0002's `AdrRef` grammar so a caller can
+pass a ref copied verbatim from another response's relation fields), optional
+`cursor`/`limit` (`ambiguous-local-id` candidates page, only meaningful when this call's
+outcome resolves to `ambiguous-local-id` — see step 7 below for what happens when it is
+supplied but this call resolves to anything else), optional
+`findingsCursor`/`findingsLimit` (always meaningful — every outcome carries a
+`findings` page).
+
+**Resolution** (FR-021, FR-022, US1 AC1–AC7):
+
+1. `loadCorpusProjection` (data-model.md §3, §8). If it reports the corpus itself is
+   unavailable, return `CorpusUnavailableOutcome` immediately.
+2. `parseAdrRef(ref)` (contracts/core-projection.md §1).
+3. If `parsed.log` is **defined** — the ref is log-qualified — return
+   `federated-log-unavailable` (`requestedRef: ref`, `log: parsed.log`, `id:
+   parsed.id`) immediately, **without** consulting `byId` at all. This phase serves
+   exactly one local corpus and never attempts a local lookup with a qualified ref,
+   never strips the qualifier and retries unqualified, and never substitutes a same-id
+   local record for it (FR-021, US1 AC5) — regardless of whether `byId.get(parsed.id)`
+   would otherwise have resolved unambiguously.
+4. If `parsed.log` is **undefined** — a bare local id — look up `byId.get(parsed.id)`:
+   - Bucket absent/empty → `not-found` (`requestedRef: ref`).
+   - Bucket length 1 → `found`, using that one record.
+   - Bucket length \>1 → `ambiguous-local-id`, with `requestedRef: ref` and `candidates`
+     built from every record in the bucket as a `DecisionSummary` (distinguished by
+     `sourcePath`, since no log qualifier exists to distinguish them by), canonically
+     ordered and paginated (§2, pagination contract). This bucket length can only exceed
+     1 when the corpus already has a `unique-id` error finding for that id (§3 of
+     data-model.md); this phase offers no way to disambiguate further — the caller's
+     actionable next step is fixing the corpus, not retrying with a different input.
+5. On `found`, build `FullDecision` (data-model.md §4) directly from the resolved
+   `Adr`: `requestedRef` is the raw input `ref` (identical to `id` here, since only an
+   unqualified ref reaches this branch); `frontmatter` is that record's own
+   `AdrFrontmatter` object, reused verbatim (no field picked or omitted) — this is the
+   mechanism for FR-023/FR-024: every declared `supersedes`/`supersededBy`/`relatesTo`/
+   `conflictsWith` ref is present because it is simply part of `frontmatter`, and none of
+   them is resolved, fetched, or inlined, because nothing in this step touches any
+   *other* record.
+6. `findings`: the full `responseFindings` — here, exactly `CorpusProjection
+   .corpusFindings`, since `get_decision` derives no findings of its own (§2) — paginated
+   independently (pagination contract §5). This tool does not filter findings to only the
+   resolved record; a caller fetching one decision still learns the corpus has, say, one
+   schema-invalid file elsewhere.
+7. **If a `cursor` was supplied and this call's outcome is *not* `ambiguous-local-id`**
+   (i.e. it resolved to `found`, `not-found`, or `federated-log-unavailable`): the
+   supplied `cursor` is still decoded and verified through every step that does not
+   require a `candidates` array to exist (contracts/pagination-and-cursors.md §2, steps
+   1–6) — if it fails any of those on its own merits (bad encoding, wrong version, wrong
+   scope, stale fingerprint, mismatched `requestedRef`/`limit`), that specific reason is
+   reported. If it passes all of those, the response is `invalid-cursor` /
+   `cursor-not-applicable`, because there is no `candidates` channel for this outcome to
+   apply it to — the cursor is never silently ignored in favor of returning `found`/
+   `not-found`/`federated-log-unavailable` as if no `cursor` had been supplied.
+
+**Oversized source (US1 AC8, SC-001)**: if `ref` resolves to a record the pre-read size
+guard (data-model.md §3.3) already excluded before `lintCorpus` ever ran, the lookup
+behaves exactly as if that record did not exist — `not-found` — and the
+`record-too-large` finding for that path is present in `findings`, so the caller can
+distinguish "genuinely absent" from "present but excluded" by reading the findings
+channel, never by a fabricated partial `found`.
+
+If a candidate changes between the pre-load metadata check and the post-load verification,
+the call instead returns `corpus-unavailable` / `corpus-changed-during-load`; no
+provisional decision or finding page from that inconsistent read is returned.
+
+## 5. `search_decisions`
+
+**Input**: `SearchDecisionsInput` (data-model.md §7).
+
+**Query validation, before matching runs (FR-026, research §R5)**: `query` must be
+`1`–`256` raw UTF-16 code units, **and** non-empty after `query.trim()` — a
+whitespace-only `query` is rejected as an input-contract error (FR-015 case (a)) before
+any corpus access, never silently normalized to an empty-string query that would
+otherwise match every record via `''.includes('')`-style substring containment.
+
+**Filter semantics — any-of within `status`/`scope`, all-of within `tags`, ANDed across
+categories (contracts/tools.md §8 for the size limits)**:
+
+- `status` (1–6 unique values when present, omitted entirely = all six, FR-020): **any-of** — a record matches
+  this filter if its own `status` is any one of the listed values.
+- `scope` (1–3 unique values when present): **any-of** — a record matches this filter if its own
+  `scope` is any one of the listed values.
+- `tags` (1–32 unique slugs when present, each 1–64 chars): **all-of** — a record matches this filter
+  only if its own `tags` array contains *every* listed value, not merely one of them.
+- Across categories, the three filters are **ANDed**: a record must satisfy every
+  supplied category's own condition to remain a candidate at all; omitting a category
+  entirely means "no constraint from that category," never "match nothing." A record
+  failing any one supplied category is excluded before the query is ever tested against
+  it (never partially matched).
+
+**Matching** (FR-025–FR-028, US3):
+
+1. `loadCorpusProjection`.
+2. Normalize the query: `normalize(query)` (research §R5, already validated non-empty
+   after `trim()` above). If `status`/`tags`/`scope` filters are present, apply them
+   first per the semantics above.
+3. For each remaining record, in canonical order, test whether
+   `normalize(candidateField)` contains `normalize(query)` as a substring, independently
+   for each of: the record's `id`, `title`, each `tag` (any one matching is sufficient),
+   and `body`. A record matches iff **at least one** field matches; `matchedFields`
+   lists **every** field that independently matched (FR-028), sorted
+   `['body','id','tag','title']` (alphabetical, using `@adrkit/mcp`'s own code-unit
+   comparator — a fixed, arbitrary but deterministic order, since no field is
+   privileged over another).
+4. Matching records become `SearchMatch` (data-model.md §6), canonically ordered,
+   paginated (§2, pagination contract).
+
+**Default graveyard inclusion** (FR-020, US3 AC1): omitting `status` matches all six
+values; a caller must explicitly narrow with `status` to exclude any of them — there is
+no way to *opt out* of seeing `rejected`/`superseded`/`deprecated` records other than
+naming the statuses to include.
+
+**No match** (US3 AC7): the same `'results'` branch, `items: []`, `cursor: null` — not a
+distinct outcome and not an error.
+
+## 6. `get_decision_context`
+
+**Input**: `GetDecisionContextInput` (data-model.md §7) — `files[]` (1–256 entries,
+each a validated repo-relative logical path: 1–1024 chars, no leading `/`, no `..`
+segment, no drive letter, and **no backslash anywhere in the string** — the contract is
+POSIX separators only (FR-030), so a path using `\` as a separator, or containing one as
+any other character, is rejected identically to an absolute or traversal path, before
+any matcher evaluation).
+
+**Resolution** (FR-029–FR-033, US2):
+
+1. `loadCorpusProjection`. (`files[]` entries are never opened, read, or `stat`'d —
+   FR-009 — they are compared only against `affects` patterns already loaded from the
+   corpus, by `resolveAffects`.)
+2. For each record in `CorpusProjection.records`, in canonical order, call
+   `resolveAffects({ records: [record], changedFiles: files })` **once per record**
+   (research §R4) — never one batched call across the whole corpus.
+3. A record with at least one fired matcher becomes a `ContextEntry` (data-model.md §6)
+   and is assigned to exactly one of three buckets by its own `status`: `accepted` →
+   `governing`; `draft`/`proposed` → `activeProposals`; `rejected`/`superseded`/
+   `deprecated` → `history` (FR-031). Every one of the six `Status` values is reachable
+   through exactly one bucket; none is structurally excluded.
+4. Findings from every per-record `resolveAffects` call (e.g. `affects-unresolvable` for
+   a `package` matcher with no lockfile snapshot — FR-032, ADR-0009) are this tool's
+   **derived** findings (§2, data-model.md §3.5): concatenated across all per-record
+   calls, then merged with `CorpusProjection.corpusFindings` into this call's own
+   `responseFindings`, re-sorted canonically, and only then does the findings-channel
+   cursor apply — `CorpusProjection` itself is read, never mutated, by this step.
+5. **One canonical walk, partitioned per page**: all matching records across all three
+   buckets are combined into one canonically-ordered flat list *before* pagination; the
+   primary-channel cursor's `offset` indexes into that flat list; only the page sliced
+   from it is partitioned into `governing`/`activeProposals`/`history` for the response
+   (FR-019, data-model.md §6). There is no independent per-bucket cursor.
+
+**Zero matches** (US2 AC7): the same `'matches'` branch, all three arrays empty — not an
+error.
+
+## 7. `list_superseded`
+
+**Input**: `ListSupersededInput` (data-model.md §7) — pagination only, no filters
+(FR-034's scope is unconditional).
+
+**Resolution** (FR-034, US4):
+
+1. `loadCorpusProjection`.
+2. Every record with `status === 'superseded'` becomes a `SupersededEntry`
+   (data-model.md §6), in canonical order. The schema's own invariant
+   (`superseded-requires-supersededBy`) guarantees `frontmatter.supersededBy` is always
+   present on such a record; resolve it with `parseAdrRef` (the same primitive
+   `get_decision` uses) followed by a **local-only** lookup:
+   - `parsed.log` is **defined** (the target is a log-qualified ref) → unresolved:
+     `{ resolved: false, targetRef, reason: 'federated-unavailable', log: parsed.log,
+     id: parsed.id }`. One additional, fixed-template `superseded-target-federated
+     -unavailable` finding (severity `info`) is minted for this entry — `{ rule:
+     'superseded-target-federated-unavailable', severity: 'info', id: <this record's own
+     id>, message: 'supersededBy target "<targetRef>" is a log-qualified ref; named-log
+     federation is not available in this phase' }`, with `<targetRef>` the only
+     interpolated value (itself bounded — an `AdrRef`-shaped string transitively bounded
+     by the 64 KiB per-record source cap, data-model.md §3.5) — this phase serves exactly
+     one local corpus and never resolves, strips, or substitutes a qualified target
+     (FR-021, FR-034). This is a **derived** finding (§2, data-model.md §3.5): it is
+     merged into this call's own `responseFindings` alongside `CorpusProjection
+     .corpusFindings`, never written back into the shared projection. Note it coexists
+     with, and does not replace or suppress, `@adrkit/core`'s own unmodified
+     `dangling-supersededBy` finding for the same field, already present in
+     `corpusFindings` — that check has no concept of a `log:` qualifier either
+     (contracts/core-projection.md §2) and will already have flagged the same raw string
+     as a plain dangling reference; both findings are legitimate and both remain present.
+   - `parsed.log` is **undefined** → look up `byId.get(parsed.id)`:
+     - Bucket length 1 → `{ resolved: true, target: DecisionSummary }` of the resolved
+       record (id, title, **current** status — not assumed to still be `accepted`; a
+       target can itself have moved on, e.g. to `deprecated`, and this tool reports its
+       live status).
+     - Bucket absent/empty → unresolved: `{ resolved: false, targetRef, reason:
+       'dangling' }` — a target that should have failed corpus validation upstream;
+       `@adrkit/core`'s own existing `dangling-supersededBy` finding is already present
+       in `CorpusProjection.corpusFindings` (no duplicate finding is minted here), never
+       fabricated, never silently dropped from the listing (US4 AC3).
+     - Bucket length \>1 → unresolved: `{ resolved: false, targetRef, reason:
+       'ambiguous', candidateCount: number }` — **not** an embedded `candidates[]` array
+       (FR-034). One additional, fixed-template, compact `superseded-target-ambiguous`
+       finding (severity `warn`) is minted for this entry — `{ rule:
+       'superseded-target-ambiguous', severity: 'warn', id: <this record's own id>,
+       message: 'supersededBy target "<targetRef>" resolves to <candidateCount> local
+       records; see get_decision("<targetRef>") for the full candidate list' }`, naming
+       the target id and the count, never enumerating every candidate's path/title
+       inline — a candidate is never picked silently, this bucket length can only exceed
+       1 when the corpus already has a `unique-id` error finding for that id, and the
+       **complete** candidate list remains obtainable, already paginated, via a separate
+       `get_decision(targetRef)` call, which resolves that same bucket as its own
+       `ambiguous-local-id` outcome (§4) — this design deliberately reuses that existing,
+       already-bounded channel rather than nesting a second, unbounded list inside one
+       page item of this tool's own response. This finding, too, is a **derived** finding
+       merged into `responseFindings`, never written back into `CorpusProjection`.
+3. This tool reports **direct edges only** — it never walks `target.supersedes` further
+   to build a transitive chain (FR-034, explicitly Out of Scope).
+
+**No superseded records** (US4 AC2): the same `'entries'` branch, `items: []` — not an
+error.
+
+## 8. Fixed limits
+
+| Limit | Value | Enforced by |
+|---|---|---|
+| `query` length | 1–256 raw UTF-16 code units; non-empty after `trim()` | `search_decisions` input schema |
+| `status[]` count | 1–6 unique entries when present, omitted entirely = all six | `search_decisions` input schema; any-of semantics (§5) |
+| `scope[]` count | 1–3 unique entries when present | `search_decisions` input schema; any-of semantics (§5) |
+| `tags[]` count | 1–32 unique entries when present | `search_decisions` input schema; all-of semantics (§5) |
+| `tags[i]` length | 1–64 chars | `search_decisions` input schema |
+| path length (`files[i]`) | 1–1024 chars | `get_decision_context` input schema (`.refine()`); rejects a leading `/`, a `..` segment, a drive letter, and **any backslash**, not only a Windows-style absolute path — the contract is POSIX separators only (§6) |
+| `files[]` count | 1–256 | `get_decision_context` input schema |
+| `ref` length | 1–128 chars | `get_decision` input schema |
+| result page size | default 20, max 100 | every tool's `limit` input field |
+| findings page size | default 20, max 100 | every tool's `findingsLimit` input field |
+| cursor `offset` | positive safe integer (`>= 1`); rejected if `>= channel.length` on recomputation | contracts/pagination-and-cursors.md §2 |
+| ADR source max | 64 KiB | the pre-read guard (data-model.md §3.3); excluded records surface `record-too-large` (severity `error`), never truncated. This one cap bounds a record's entire source-derived footprint — frontmatter and body together — so it transitively bounds every summary field, full-document field, and finding-message field derived from that record (data-model.md §3.5); it is not a second, separate byte budget from pagination, which bounds item counts only. |
+| cursor max | 4 KiB | every `cursor`/`findingsCursor` input field |
+
+Every input object is a **strict** Zod object — an unknown or extra field is rejected
+before any corpus access, for every tool, with no exception. Rationale for each value is
+in [../research.md](../research.md) §R11; none was adjusted from the binding design
+direction's own starting point for the limits it specified (the `tags[]` count/length
+limits are new in this pass, closing a gap an earlier draft left unbounded).
+
+## 9. Startup behavior (FR-035, FR-036)
+
+`src/bin.ts`'s `main()`, before ever constructing a server or connecting a transport:
+
+1. Resolves `cwd`/`dir` from `--cwd`/`--dir` flags, falling back to
+   `ADRKIT_MCP_CWD`/`ADRKIT_MCP_DIR` env vars, falling back to `process.cwd()`/
+   `'docs/adr'` (research §R7).
+2. Canonicalizes `cwd` with `fs.realpath` and checks the **canonical** path is a
+   readable directory that contains a readable `.git` entry directly beneath it — a
+   directory (an ordinary clone) or a file (a linked worktree's `.git` pointer file; its
+   contents are never parsed, only its existence and readability checked) — via
+   `fs.access`/`fs.stat`, with **no `git` executable invocation of any kind** (research
+   §R7). Any failure here means `cwd` is not the configured repository root this server
+   requires; the resulting `canonicalCwd` is held for the remaining lifetime of this
+   process (data-model.md §8).
+3. Resolves `dir` against `canonicalCwd`, canonicalizes it with `fs.realpath`, and
+   checks the **canonical** `dir` is a readable directory that is path-segment-safely
+   contained within `canonicalCwd` (`path.relative(canonicalCwd, canonicalDir)` is empty
+   or does not begin with a `..` segment — never a plain string-prefix test). An absolute
+   `--dir` that does not fall under `cwd`, a `--dir` that escapes `cwd` via a `..`
+   traversal segment, and a `--dir` that is or resolves through a **symlink** landing
+   outside `cwd` all fail this check identically to a missing directory — realpath-based
+   containment closes the symlink case a purely lexical check cannot (research §R7).
+4. Any failure in steps 2–3 prints an actionable, specific message to **`stderr`**
+   (never `stdout` — FR-007), naming the precise `CorpusUnavailableOutcome`-shaped reason
+   (data-model.md §5) that failed, and exits **`1`**. An unparseable/unknown flag exits
+   **`2`**, mirroring `@adrkit/cli`'s own `usage()` exit-code convention.
+5. Only on success does it call `createAdrkitMcpServer({ cwd: canonicalCwd, dir })` and
+   invoke the handle's zero-argument `start()`. Neither the bin nor any public caller can
+   supply a transport.
+
+This eager, once-only check is a fail-fast **startup UX nicety**, not the only line of
+defense: it is distinct from, and does not replace, the per-call
+`CorpusUnavailableOutcome` (data-model.md §5) branch every tool can still return if an
+observable root, ADR-directory, or candidate condition changes after startup. That later
+failure is a normal tool-call outcome, not a process exit, because the server is already
+connected and mid-session. `loadCorpusProjection` re-realpaths the configured root fresh
+on **every** call, verifies it still equals the startup `canonicalCwd`, and rechecks its
+readable `.git`; it then re-realpaths the configured `dir`, validates segment-safe
+containment/readability, and repeats both root and directory checks after the core load.
+Each discovered candidate is also `lstat`-checked as a non-symlink regular file,
+realpath-contained, and bigint-`stat` checked before the core load; candidate
+type/realpath and `dev`/`ino`/`size`/nanosecond-`mtime` are checked again afterward. Any
+observed change discards the complete provisional projection as
+`corpus-changed-during-load` without returning changed-path data.
+
+These portable Node `>=22` checks are consistency checkpoints, not an atomic
+open-beneath/no-follow guarantee. They do not claim to detect a hostile swap that occurs
+and reverts entirely between checkpoints while the path-based core read is in progress.
+
+## 10. Non-goals (contract boundaries)
+
+- No fifth tool, no write/mutation/PR-creation tool (FR-001, FR-002).
+- No `registerResource`, `registerPrompt`, subscription, or sampling call (FR-003).
+- No model call, embedding, or ranking of any kind (FR-004).
+- No HTTP/SSE transport, no authentication (FR-005, FR-006).
+- No named-log or multi-repository federation. A log-qualified `ref`/`supersededBy`
+  target is recognized only far enough to answer `federated-log-unavailable`
+  (`get_decision`) or an unresolved, informational entry (`list_superseded`) — never
+  resolved, stripped, or substituted (FR-021, FR-022, FR-034).
+- No persistent cache, index, or database across calls (FR-010).
+- No transitive supersession walk (`list_superseded` is direct edges only — §7).
+- No expansion of `supersedes`/`supersededBy`/`relatesTo`/`conflictsWith` refs into
+  fetched records by `get_decision_context` (FR-033) — they are surfaced, never walked.
+
+### 10.1 Exact side-effect-denial inventory
+
+The conformance harness MUST deny the following JavaScript-level entry points. For Node
+filesystem methods, callback, sync, and `node:fs/promises` forms are included where the
+runtime provides them:
+
+- filesystem content/mutation: `write`, `writev`, `writeFile`, `appendFile`,
+  `createWriteStream`, `truncate`, `ftruncate`, `rename`, `copyFile`, `cp`, `unlink`,
+  `rm`, `rmdir`, `mkdir`, `mkdtemp`, `link`, `symlink`, `chmod`, `fchmod`, `lchmod`,
+  `chown`, `fchown`, `lchown`, `utimes`, `futimes`, and `lutimes`;
+- write-capable open: `open`, `openSync`, and `promises.open` whenever numeric or string
+  flags permit write, append, create, truncate, or update;
+- returned `FileHandle`: `write`, `writev`, `writeFile`, `appendFile`, `truncate`,
+  `createWriteStream`, `chmod`, `chown`, `utimes`, `sync`, and `datasync`;
+- process/runtime escape: all sync and async `node:child_process`
+  spawn/exec/execFile/fork forms, `cluster.fork`, `new worker_threads.Worker`, and
+  `process.dlopen`;
+- network/listen: global `fetch` plus net/http/https/dgram
+  connect/request/get/socket/listen entry points;
+- Bun: `Bun.write`, `Bun.file(...).writer()`, `Bun.file(...).delete()`, `Bun.spawn`,
+  `Bun.spawnSync`, and Bun shell imports/member use (statically rejected where no reliable
+  runtime patch point exists).
+
+Coverage fixtures MUST exercise static and dynamic imports, destructured aliases,
+pre-captured references, numeric/string open flags, and returned FileHandles before the
+real startup/four-tool run. Passing is bounded executed-path evidence only; it does not
+prove the absence of raw native syscalls or future unenumerated runtime APIs. Complete
+disposable-sandbox, parent-sentinel, `HOME`, and `TMPDIR` snapshots remain a separate
+required line of evidence.
+
+## 11. Conformance tests this contract implies (offline only; no model, no network)
+
+- Every one of US1–US5's acceptance scenarios, as fixture cases against the
+  package-internal registered-server builder driven through
+  `InMemoryTransport.createLinkedPair()` (research §R1.4). The builder is never
+  publicly exported.
+- A real stdio-subprocess byte-capture test proving zero non-protocol `stdout` bytes
+  (research §R8), against both `src/bin.ts` (Bun) and the built `dist/bin.js` (Node
+  22/24 smoke — research §R10).
+- A side-effect-denial preload harness test (research §R10) proving, as executed-path,
+  defense-in-depth evidence — not a formal proof against every conceivable channel —
+  that the enumerated network, filesystem-mutation, subprocess, worker, native-addon,
+  and Bun-shell entry points are never invoked while the stdio server starts and all
+  four tools are each called at least once. The test retains an independent full-sandbox,
+  parent-sentinel, `HOME`, and `TMPDIR` snapshot.
+- The five adversarial-input fixtures from US5 AC1–AC4 (path traversal, absolute path,
+  unknown extra field, oversized `query`/`files[]`), each asserted to produce
+  `isError: true` with no filesystem read outside the configured root and no attempted
+  network call.
+- A duplicate-local-id fixture (two records sharing one `id`, spanning more than one
+  page) proving `get_decision`'s `ambiguous-local-id` candidate cursor returns every true
+  candidate exactly once, distinguished by `sourcePath`, and never a silently chosen
+  record (SC-003).
+- A log-qualified-ref fixture proving `get_decision` returns `federated-log-unavailable`
+  naming the requested log and id — for both a colliding and a non-colliding id — never a
+  local substitute and never the qualifier silently stripped (SC-003).
+- A `superseded` record whose `supersededBy` targets an id used by more than one local
+  record, proving `list_superseded` reports that entry unresolved with a deterministic,
+  fixed-template `superseded-target-ambiguous` finding naming the target id and
+  `candidateCount` (never every candidate's path/title inline, and never one picked
+  silently), and proving a follow-up `get_decision(targetRef)` call independently returns
+  that same bucket as its own paginated `ambiguous-local-id` outcome.
+- A `superseded` record whose `supersededBy` is a log-qualified ref, proving
+  `list_superseded` reports that entry unresolved as federated-unavailable with an
+  informational, fixed-template finding, alongside (not replacing) `@adrkit/core`'s own
+  unmodified `dangling-supersededBy` finding for the same field.
+- A fixture proving a tool's `findings` channel is `corpusFindings` plus that call's own
+  derived findings, never the reverse: two `get_decision_context` calls against the same
+  corpus with different `files[]` (one triggering an inert `affects-unresolvable` match,
+  one not) produce different `findings` pages while `corpusHealth.fingerprint` stays
+  identical across both calls — proving the derived finding is not, and does not need to
+  be, part of the hashed corpus projection (data-model.md §3.5).
+- A startup fixture with a `--cwd` that is a readable directory but contains no `.git`
+  entry, proving the bin exits `1` with an actionable stderr message and never starts a
+  transport; a companion fixture with a linked-worktree-style `.git` **file** (not a
+  directory) proving startup succeeds; a fixture with an absolute or `..`-escaping
+  `--dir` outside the validated `--cwd`, proving the same `1`-exit rejection. A **symlink**
+  fixture proving the same rejection when `--dir` is (or resolves through) a symlink that
+  lands outside the canonical `--cwd`, even though the raw, uncanonicalized string
+  contains no literal `..` — proving containment is checked on the `fs.realpath`'d paths,
+  not the lexical input strings (research §R7).
+- Deterministic root, directory, and candidate-file swap fixtures injected at every
+  explicit validation checkpoint, proving the call returns `corpus-unavailable` and no
+  response includes data from an observed changed path. The test explicitly does not
+  claim universal atomic protection against an unscheduled transient swap between
+  checkpoints.
+- A fixture where the pre-read size guard (data-model.md §3.3) excludes **every**
+  discovered candidate file (e.g. a one-file corpus whose only file is oversized),
+  proving the implementation does not call `lintCorpus({ paths: [] })` — which would
+  silently re-discover and re-include the excluded file — and instead returns zero
+  records with only the guard's own, `error`-severity finding present.
+- A fixture proving both `record-stat-error` and `record-too-large` are severity
+  `error` (not `warn`), and that the call carrying either still succeeds with every
+  other, valid record usable — severity communicates "the corpus has a real gap," not
+  "this call failed."
+- Cursor round-trip fixtures: mint → decode on the next call → identical page; each of
+  the seven `InvalidCursorOutcome` reasons independently triggered — `decode-failed`
+  (tampered payload), `version-unsupported` (future `v`), `wrong-channel` (wrong-field/
+  wrong-tool scope), `corpus-changed` (mutated corpus), `query-mismatch` (changed query
+  parameter), `cursor-not-applicable` (a primary `cursor` supplied against a
+  `get_decision` call that resolves to `found`/`not-found`/`federated-log-unavailable`
+  this time), and `offset-out-of-range` (a hand-constructed or truncated-then-replayed
+  cursor whose `offset` is at or past the freshly recomputed channel's length).
+- A whitespace-only `query` fixture (e.g. `"   "`) proving `search_decisions` rejects it
+  as an input-contract error before any corpus access, rather than normalizing it to an
+  empty-string query that would otherwise match every record (research §R5).
+- A `tags[]` fixture at the 32-entry/64-char boundary proving the limit is enforced by
+  the input schema, and a fixture proving `tags` filtering is all-of (a record with only
+  some of the listed tags does not match) while `status`/`scope` filtering is any-of (a
+  record matches if its own single value is any one of the listed values), and that all
+  three categories are ANDed together.
+- A `files[]` entry containing a backslash (e.g. `docs\adr\0001.md`, with no leading `/`
+  and no `..` segment) proving it is rejected identically to an absolute or
+  drive-qualified path — the contract is POSIX separators only, not merely "no Windows
+  drive letter."
+- A fixture proving two repeated calls with an unchanged corpus produce a byte-identical
+  fingerprint, and a fixture proving a frontmatter re-serialization that changes only
+  YAML byte layout (key order, quoting) without changing the parsed result leaves the
+  fingerprint unchanged, while any change to a record's `body` changes it (research §R6).
+- A schema-invalid record fixture proving `search_decisions`/`get_decision_context`
+  still answer correctly for every other record, with the invalid one surfaced only as a
+  finding (SC-009); a companion fixture proving a corpus-invariant finding (`unique-id`,
+  a dangling reference) never removes the flagged record from any tool's results — only
+  the finding is added, the record itself remains fully present and retrievable
+  (data-model.md §3.3).
+- An oversized-source fixture proving `record-too-large` exclusion end to end
+  (SC-001), including that `get_decision` on that exact id reports `not-found` with the
+  finding present, not a partial body.

--- a/specs/006-mcp-server/data-model.md
+++ b/specs/006-mcp-server/data-model.md
@@ -1,0 +1,761 @@
+# Data Model: MCP Server (Read-Only Retrieval) — Phase 5
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) |
+**Research**: [research.md](./research.md) | **Contracts**:
+[contracts/core-projection.md](./contracts/core-projection.md),
+[contracts/pagination-and-cursors.md](./contracts/pagination-and-cursors.md),
+[contracts/tools.md](./contracts/tools.md) | **Date**: 2026-07-20
+
+These are **conceptual, TypeScript-like shapes** to fix vocabulary and boundaries for
+the plan — not implementation code, and not authoritative over whatever the committed
+Zod schemas ultimately are. Where a shape already exists in `@adrkit/core`, it is
+**reused by reference**, never redefined. Where research.md §R3 proposes a small,
+additive `@adrkit/core` export, it is marked *(new — additive core export)*. Everything
+else lives only in `@adrkit/mcp` and is marked *(new — `@adrkit/mcp`, runtime only)*;
+none of it is persisted, cached, or added to the committed schema (`schema/
+adr.schema.json` is untouched by this feature — Principle V).
+
+---
+
+## 1. Reused core types (unchanged)
+
+```ts
+// packages/core/src/schema/adr.schema.ts — reused verbatim, zero changes.
+type Adr = { frontmatter: AdrFrontmatter; body: string; path: string; log?: string };
+type AdrFrontmatter; // the full typed frontmatter: id, title, status, date, deciders[],
+                      // tags[], scope, domain?, reversibility, blastRadius,
+                      // supersedes[], supersededBy?, relatesTo[], conflictsWith[],
+                      // affects[], assertions[], provenance?, review?, evaluation?,
+                      // externalRefs[], complianceControls[], reviewBy?
+type Status;          // 'draft'|'proposed'|'accepted'|'rejected'|'superseded'|'deprecated'
+type Scope;            // 'component'|'domain'|'org'
+type AffectsType;      // 'path'|'entity'|'package'|'resource'|'api'|'data'
+type AffectsMatcher;   // { type: AffectsType; pattern: string; repo?: string; negate?: boolean }
+type AdrRef;           // Zod validator for `0042` or `payments:0012` (regex only — no parser)
+
+// packages/core/src/validate/findings.ts — reused verbatim.
+type FindingSeverity = 'error' | 'warn' | 'info';
+type Finding = { rule: string; severity: FindingSeverity; message: string;
+                  path?: string; id?: string; field?: string; pattern?: string };
+
+// packages/core/src/validate/index.ts — reused verbatim; the ONLY loader @adrkit/mcp calls.
+interface LintCorpusResult { checked: number; findings: Finding[]; records: Adr[] }
+function lintCorpus(options: { dir?: string; paths?: string[]; cwd?: string }): Promise<LintCorpusResult>;
+
+// packages/core/src/affects/index.ts — reused verbatim; called once per record (research §R4).
+interface ResolveAffectsInput { records: readonly Adr[]; changedFiles: readonly string[];
+                                 snapshots?: ResolutionSnapshots; log?: string }
+interface FiredMatcher { type: string; pattern: string }
+interface AffectsMatch { recordId: string; firedMatchers: FiredMatcher[] }
+interface ResolveAffectsResult { matches: AffectsMatch[]; findings: Finding[] }
+function resolveAffects(input: ResolveAffectsInput): ResolveAffectsResult;
+```
+
+`@adrkit/mcp` never imports from `packages/core/src/load/corpus.ts`'s `loadCorpus`/
+`Corpus`/`byId` — those remain exported, unmodified, and unused by this feature
+(research §R3).
+
+---
+
+## 2. New additive core export, plus one migrated caller (research §R3)
+
+```ts
+// packages/core/src/schema/ref.ts — NEW FILE. One export.
+
+interface ParsedAdrRef {
+  readonly id: string;
+  readonly log?: string;   // absent when the ref carries no "log:" prefix
+}
+
+/** Splits on the first ':'. A leading ':' or no ':' at all is unqualified — returns
+ *  { id: ref } with `id` the untouched original string (never split in that case).
+ *  Identical observable behavior and object shape to the private `parseRef` formerly
+ *  duplicated in packages/evaluator/src/rules/no-orphan-refs.ts, promoted to one shared
+ *  location. @adrkit/mcp uses this to detect WHETHER a caller-supplied ref is
+ *  log-qualified — never to build or consult a log-aware index, since this phase has
+ *  none (§3). There is no inverse `formatAdrRef`: no planned call site ever
+ *  re-serializes a `(log, id)` pair — every ref this design echoes back to a caller
+ *  (`requestedRef`, a `targetRef`) is the caller's or the frontmatter's own original
+ *  string, reused verbatim, never reconstructed from parsed parts (contracts/
+ *  core-projection.md §1). */
+function parseAdrRef(ref: string): ParsedAdrRef;
+```
+
+Re-exported from `packages/core/src/index.ts` via one additional `export * from
+'./schema/ref.ts';` line. **`packages/evaluator/src/rules/no-orphan-refs.ts` is migrated,
+behavior- and object-shape-preservingly, to import `parseAdrRef` in place of its own
+private copy** (contracts/core-projection.md §1) — this is the entire change outside
+`@adrkit/mcp`: one new core file, one new core export line, one migrated evaluator
+import. No behavior changes anywhere, and no dependency changes.
+
+---
+
+## 3. `@adrkit/mcp`'s corpus projection *(new — runtime only, `packages/mcp/src/corpus/`)*
+
+This is the layer that turns core's exported discovery primitive plus one fresh
+`lintCorpus()` result into everything the four tools need: the pre-read size guard, a
+local index, and the corpus fingerprint/health summary. It is rebuilt from scratch on
+**every** tool call (FR-010) — there is no cross-call cache of any kind, not even an
+in-memory one, because "every call reloads the current configured corpus" is
+load-bearing, not an optimization detail to relax later. Every field of
+`CorpusProjection` below is `readonly`, and nothing in this design ever mutates one after
+it is built (§3.5) — a fresh, independent `CorpusProjection` value is what "every call
+reloads" produces, never a shared object two calls both hold a reference to.
+
+```ts
+/** The complete, per-call, in-memory projection every tool reads from. Built once per
+ *  tool call by `loadCorpusProjection()`; never retained across calls, never mutated
+ *  after it is returned (§3.5). */
+interface CorpusProjection {
+  /** Every within-limit, schema-valid record `lintCorpus()` returned for the
+   *  within-limit paths this call fed it (§3.3) — never a record whose source exceeded
+   *  the size guard, because that source was never handed to `lintCorpus` at all.
+   *  Sorted canonically by `(id, sourcePath)` (§3.1). A duplicate-id or dangling-ref
+   *  record is still schema-valid and therefore still present here — corpus invariants
+   *  (§3.3) never remove a record from this array, only add a finding about it. */
+  readonly records: readonly Adr[];
+
+  /** LOCAL id → every record in `records` sharing that id, sorted `(id, sourcePath)`.
+   *  Bucket length is exactly what FR-022's three-way outcome reads: absent/empty is
+   *  "not found," length 1 is unambiguous, length >1 is `ambiguous-local-id` — the full
+   *  bucket becomes the candidate list, never a single arbitrary representative (§3.2).
+   *  There is no per-log or canonical-log-qualified key anywhere: this phase has no
+   *  `log` dimension to index by (research §R3; spec.md Assumption A1). */
+  readonly byId: ReadonlyMap<string, readonly Adr[]>;
+
+  /** **Corpus** findings only: `lintCorpus()`'s own findings for the within-limit paths,
+   *  PLUS one finding per pre-read guard exclusion (§3.3) — re-sorted by `@adrkit/mcp`'s
+   *  own locale-independent code-unit comparator (research §R6), never left in
+   *  `lintCorpus`'s own `localeCompare`-based order. This is deliberately **not** "the
+   *  complete findings set for this call": it excludes any finding a specific tool
+   *  handler derives on top of the projection (an inert `affects` matcher, an ambiguous
+   *  or federated-unavailable `supersededBy` target) — those are computed per tool call,
+   *  from this projection plus that call's own substantive inputs, and merged in by the
+   *  handler itself, never added here (§3.5). */
+  readonly corpusFindings: readonly Finding[];
+
+  /** SHA-256 over the canonical-JSON wire projection (research §R6) — exactly `records`,
+   *  `corpusFindings`, and `corpusHealth` (recordCount + excludedCount) below. Never a
+   *  hash of any raw file's bytes, and never a hash of any tool-derived finding — a
+   *  tool's per-call `responseFindings` (§3.5) is deliberately outside the hashed value,
+   *  because it is a pure, deterministic function of this projection plus that call's own
+   *  inputs, which the cursor's `qh` (contracts/pagination-and-cursors.md §4) already
+   *  covers separately; see §3.5 for why the pair `(fingerprint, qh)` together, not the
+   *  fingerprint alone, is what makes a derived-findings cursor safe. */
+  readonly fingerprint: string;
+
+  /** `records.length` — valid, in-limit, loaded. */
+  readonly recordCount: number;
+
+  /** `discoveredCandidateCount - records.length` — every discovered candidate path
+   *  (`discoverAdrFiles`'s own filtered universe) that contributed zero records to
+   *  `records`, because it was excluded by the pre-read stat/size guard (§3.3), because
+   *  reading or parsing it failed, or because its frontmatter failed schema/contract
+   *  validation. This is exact **only** over those three causes: a corpus-invariant
+   *  finding (`unique-id`, a dangling `supersedes`/`relatesTo`/`conflictsWith` reference)
+   *  never removes a record from `records` (see the `records` field above), so it is
+   *  never counted here, and this subtraction does not need to enumerate which finding
+   *  rule caused which exclusion among the three causes that do count. */
+  readonly excludedCount: number;
+}
+
+/** The one entry point every tool handler calls, exactly once, at the start of its
+ *  own execution. Pure with respect to its OWN inputs (cwd, dir, maxSourceBytes) in
+ *  the sense of ADR-0009's "no hidden state" posture, but not pure end-to-end — it
+ *  performs the filesystem read `discoverAdrFiles()`/`lintCorpus()` themselves perform,
+ *  plus its own canonical-root re-check (§8) ahead of that; "every call reloads"
+ *  requires exactly this, not a cached snapshot. Rejects (throws a typed,
+ *  caught-by-the-caller error, carrying one of the `CorpusUnavailableOutcome` reasons —
+ *  §5) when the canonical-root re-check or the ADR directory itself cannot be discovered
+ *  — the tool-level `CorpusUnavailableOutcome` branch is built from that rejection,
+ *  never fabricated as an empty-but-successful projection. */
+function loadCorpusProjection(options: {
+  readonly configuredCwd: string;      // immutable startup input; re-realpath'd and revalidated on THIS call (§8)
+  readonly configuredDir: string;      // immutable startup input; re-realpath'd and revalidated on THIS call (§8)
+  readonly expectedCanonicalCwd: string; // canonical root established by start(); a changed resolution invalidates the call
+  readonly maxSourceBytes: number;     // fixed at 64 KiB by contracts/tools.md §8; a parameter here so the cap is never silently pushed into @adrkit/core (research §R3)
+}): Promise<CorpusProjection>;
+```
+
+### 3.1 Local identity and ordering
+
+A record's identity in this phase is its bare `id` alone (FR-021) — there is no `log`
+dimension anywhere in this index, because `@adrkit/core` never populates `Adr.log` and
+this server's own discovery is non-recursive over one directory (research §R3). Every
+ordered channel — `records`, each `byId` bucket, `corpusFindings`, every tool's
+`responseFindings` (§3.5), `matchedFields` arrays, and the canonical-JSON key sort
+feeding the fingerprint — uses the **one** comparator `@adrkit/mcp` defines: a fixed,
+locale-independent code-unit comparison (`a < b ? -1 : a > b ? 1 : 0`), never
+`String.prototype.localeCompare` (contracts/tools.md §2; research §R6). The canonical
+record order is `(id, sourcePath)` ascending, `sourcePath` acting as the always-unique
+tiebreak within one `id` bucket.
+
+### 3.2 The three-way unqualified-id outcome (FR-022)
+
+Given a bare id, `byId.get(id)`:
+
+| `byId.get(id)` | Outcome |
+|---|---|
+| `undefined` (or an empty bucket — never actually constructed) | not found |
+| exactly one entry | that record, unambiguously |
+| more than one entry | `ambiguous-local-id` — the full bucket, sorted `(id, sourcePath)`, becomes the candidate list (contracts/tools.md §2), paginated like any other growing channel; this always coincides with a pre-existing `unique-id` error finding already present in `corpusFindings` (§3), because that is the only way this bucket can exceed length 1 |
+
+A **log-qualified** ref (`parseAdrRef` returns a defined `log`) is never looked up
+against `byId` at all — there is no canonical-log-qualified map to consult. It is instead
+a distinct, non-error `federated-log-unavailable` outcome naming the requested log and
+id (FR-021, FR-022, US1 AC5) — the qualifier is recognized only far enough to answer that
+outcome, never stripped, and never satisfied by a same-id entry from `byId`.
+
+### 3.3 The pre-read size guard (research §R3; not a core change)
+
+Ordering matters: this guard runs **before** `lintCorpus`, so a source that is already
+oversized when inspected is never handed to core's unbounded `readFile` path. It also
+runs strictly **after** fresh root and ADR-directory realpath, readability, git-root,
+and containment checks (§8). Candidate type, canonical containment, and bigint identity
+are checked before and after the path-based core load. A candidate involved in any
+observed change is never included in a response from that call.
+
+1. Call `resolveCanonicalRoots` (§8) from the immutable configured `cwd`/`dir`, require
+   the fresh `canonicalCwd` to equal `expectedCanonicalCwd`, and retain the fresh
+   `canonicalDir`. Any root/directory failure or changed canonical-root resolution makes
+   the whole projection unavailable.
+2. Call core's already-exported `discoverAdrFiles(canonicalDir, canonicalCwd)`. If it
+   rejects, the whole projection is unavailable — this becomes the tool-level
+   `CorpusUnavailableOutcome` (§5), never a per-file finding.
+3. For each discovered candidate absolute path, call `lstat()` and reject a symlink or
+   non-regular file; call `realpath()` and require path-segment-safe containment within
+   `canonicalDir`; then call `stat(path, { bigint: true })` and retain the identity tuple
+   (`dev`, `ino`, `size`, and nanosecond-resolution `mtimeNs`) for step 5:
+   - The `stat()` call itself fails (e.g. a permission error, or a file deleted in a
+     race between discovery and this step) → one finding, `path` set to
+     `normalizeDisplayPath(candidate, canonicalCwd)` (core's own exported helper — the
+     identical value `lintCorpus` would have produced), **no `id`** (the file was never
+     parsed): `{ rule: 'record-stat-error', severity: 'error', path, message: 'ADR
+     candidate could not be read to validate its size and was excluded from this
+     response' }` — a fixed-string message with no interpolated, unbounded content.
+     `error`, not `warn`: the corpus this call answers from is
+     now genuinely incomplete (a candidate that should have been checked could not be),
+     even though the call itself still proceeds and every other, valid record remains
+     usable — severity communicates "the corpus has a real gap," not "this call failed."
+     The candidate is excluded from the next step.
+   - The file's byte size exceeds `maxSourceBytes` (64 KiB) → one finding, same `path`
+     convention, **no `id`**: `{ rule: 'record-too-large', severity: 'error', path,
+     message: 'ADR source exceeds the 64 KiB maximum and was excluded from this
+     response' }` — likewise `error`, for the identical reason: the corpus is missing a
+     record it should contain, not merely advisory. Excluded from the next step — never
+     truncated, never included as a partial body (FR-012, US1 AC8, SC-001).
+   - Otherwise, the candidate's absolute path and identity tuple are kept.
+4. If at least one candidate was kept, call `lintCorpus({ paths: keptPaths, cwd:
+   canonicalCwd })` — **never** with an empty array. `lintCorpus`'s own
+   `expandRecordInputs` treats an empty `paths` array identically to "no `paths`
+   supplied" and falls back to re-discovering the **entire** ADR directory via
+   `discoverAdrFiles(dir, cwd)` again — which would silently reintroduce every file step
+   2 just excluded, defeating the guard for the specific edge case where every discovered
+   candidate is excluded. `@adrkit/mcp` therefore special-cases `keptPaths.length === 0`:
+   it skips calling `lintCorpus` entirely and treats the projection as zero records with
+   only the pre-read guard's own findings from step 2 — this is the one place the "call
+   `lintCorpus` unchanged" rule (research §R3) is deliberately not "just call it with
+   whatever paths remain," because doing so would reopen exactly the hole this guard
+   exists to close.
+5. After `lintCorpus` returns, repeat step 1 and require the same fresh
+   `canonicalCwd`/`canonicalDir`; then repeat each candidate's `lstat`, `realpath`
+   containment, and bigint `stat`. If any root, directory, or candidate is unavailable,
+   changes type or canonical path, exceeds `maxSourceBytes`, or no longer has the same
+   (`dev`, `ino`, `size`, `mtimeNs`) tuple captured in step 3, discard the entire
+   provisional projection and return `corpus-unavailable` /
+   `corpus-changed-during-load`. The caller can retry from a fresh call. This does not
+   claim that a transient hostile swap was never read; it guarantees that no record from
+   an **observed** changed, escaping, non-regular, or now-oversized candidate is returned
+   or fingerprinted as a stable result.
+6. Only after step 5 succeeds are `lintCorpus`'s returned `records[]` accepted as
+   `CorpusProjection.records` (stable and within-limit at both checks — this includes any record
+   `lintCorpus`'s own corpus-invariant checks flagged with a `unique-id` or
+   dangling-reference finding, since those checks never remove a record from
+   `records[]`, only add a finding about it; see §3 above). Its `findings[]` — corpus
+   findings only, never a tool-derived finding, which does not exist yet at this point in
+   the call — are concatenated with step 2's pre-read findings, then re-sorted by
+   `@adrkit/mcp`'s own comparator (§3.1) to produce `CorpusProjection.corpusFindings`.
+
+This is a consistency and containment check, not a lock, atomic snapshot, or uniform
+cross-platform open-beneath/no-follow guarantee. It detects changes visible at the
+explicit validation checkpoints. Portable Node `>=22` path APIs cannot prove that a
+transient hostile swap did not occur and revert entirely between checks while core's
+path-based read was in progress; that unscheduled case is explicitly outside this
+phase's guarantee.
+
+### 3.4 Corpus fingerprint and health
+
+`CorpusHealth` — surfaced on every tool response as the sibling of `result` (contracts/
+tools.md §1), present on every branch except `corpus-unavailable` (where it cannot be
+computed at all) — is exactly `{ fingerprint, recordCount, excludedCount }`, the last
+three fields of `CorpusProjection` above, computed as described there (research §R6 for
+the fingerprint algorithm itself).
+
+### 3.5 Corpus findings vs. a tool's per-call response findings
+
+`CorpusProjection.corpusFindings` (§3) is **not** what any tool returns on its own
+`findings` channel. Each of the four tool handlers builds its own, call-specific
+`responseFindings` by concatenating `corpusFindings` with whatever findings **that
+handler itself** deterministically derives for **this** call, then re-sorting the
+combined array with `@adrkit/mcp`'s own comparator (§3.1) before the findings-channel
+cursor (contracts/pagination-and-cursors.md) paginates it. `CorpusProjection` itself is
+never mutated to hold a tool's derived findings — it is a plain, `readonly` value shared
+by reference within one call, not an accumulator:
+
+| Tool | Derived findings it adds on top of `corpusFindings` |
+|---|---|
+| `search_decisions` | none |
+| `get_decision` | none |
+| `get_decision_context` | the findings returned by each per-record `resolveAffects` call (e.g. `affects-unresolvable` — FR-032, research §R4) |
+| `list_superseded` | one `superseded-target-ambiguous` finding per ambiguous entry, one `superseded-target-federated-unavailable` finding per federated-unavailable entry (§6) |
+
+`affects`-resolution findings are intentionally context-tool findings: the other three
+tools do not run `resolveAffects`, so their findings channels do not claim to diagnose
+matcher execution. A caller that needs matcher health uses `get_decision_context`;
+searching or fetching a document reports corpus parse/validation health only.
+
+**Why `(fingerprint, qh)` together, not the fingerprint alone, make a derived-findings
+cursor safe.** `CorpusProjection.fingerprint` pins down `records`/`corpusFindings`/
+`corpusHealth` exactly (§3.4) — it says nothing about a specific tool call's own
+substantive inputs. The cursor's `qh` (contracts/pagination-and-cursors.md §4) covers
+exactly those inputs for the channel being paginated — `files[]` for
+`get_decision_context`, nothing beyond page size for `list_superseded`, which takes no
+filter input. Because each tool's derived findings are a **pure, deterministic**
+function of `(CorpusProjection, that call's own substantive inputs)` — `resolveAffects`
+is pure given `records` and `files`; `list_superseded`'s ambiguity/federation
+findings are pure given `records`/`byId` alone — an unchanged `fingerprint` **and** an
+unchanged `qh` together already guarantee the derived findings are the same array they
+were the last time both matched, with no need to fold them into the hashed
+`CorpusProjection` itself. Folding them in anyway would be redundant, and would also be
+wrong for `list_superseded`'s findings-channel `qh` specifically, which intentionally
+hashes nothing but `findingsLimit` (page size) — if derived findings were part of the
+hashed projection, this document's claim that only the corpus's own fingerprint (never a
+separate parameter) governs that channel's staleness would no longer hold.
+
+This replaces an earlier draft's imprecise framing that the fingerprint (or
+`CorpusProjection.findings`, since renamed `corpusFindings`) was "the complete findings
+set for this call" or that it changed for "every" tool-derived finding — neither claim
+was ever true for `get_decision_context`'s per-record `resolveAffects` findings or
+`list_superseded`'s minted findings, both of which depend on that call's own inputs, not
+on the corpus alone, and neither of which the fingerprint has ever hashed.
+
+**Source-derived content stays bounded, transitively, without a second budget.** The
+64 KiB pre-read cap (§3.3) bounds a loaded record's entire source-derived footprint —
+frontmatter *and* body together, since both come from the one capped file — and
+therefore transitively bounds every artifact derived from that record: its
+`DecisionSummary` (§4, a handful of already-schema-bounded fields — e.g. `title` is
+`AdrFrontmatter`'s own `min(3).max(120)`), its `FullDecision` (§4, the same frontmatter
+and body verbatim, never truncated further), and any finding message that quotes one of
+its fields (§6, §7 of contracts/tools.md). This is one cap doing its one job, not two
+overlapping budgets. **Pagination is a separate, item-count bound, not a byte-size
+one**: `limit`/`findingsLimit` (§7) bound how many summaries or findings a page contains,
+never an exact serialized-byte ceiling for the page as a whole — a page's total size is
+therefore the product of a bounded item count and a per-item size that is itself bounded
+(directly by a field's own schema limit, or transitively by the 64 KiB source cap), not a
+number this design promises to keep under some single fixed byte figure.
+
+---
+
+## 4. Decision summaries and the full document
+
+```ts
+/** The bounded, partial projection used everywhere a full document would be unbounded
+ *  or unnecessary — search results, candidate sets, decision-context entries, and
+ *  superseded listings all embed this as their common base (FR-028, FR-031, FR-022,
+ *  Key Entities: "Decision-record summary"). No `log` or `ref` field: this phase's
+ *  identity is the bare local `id` alone (§3.1), and a "canonical ref" would just
+ *  duplicate `id` with no qualifier ever attached to it. */
+interface DecisionSummary {
+  readonly id: string;           // record.frontmatter.id, bare, local
+  readonly title: string;
+  readonly status: Status;
+  readonly sourcePath: string;   // repo-relative, POSIX-separator (FR-017) — never absolute; the field that distinguishes candidates sharing one id (§3.2)
+}
+
+/** Declared relation refs, verbatim and UNEXPANDED (FR-024, FR-033). Every array is the
+ *  record's own frontmatter array, unmodified; `supersededBy` mirrors the schema's own
+ *  optionality (present only when status is 'superseded'). These ref strings may
+ *  themselves be log-qualified (ADR-0002's grammar); this shape never resolves them —
+ *  that is `get_decision`'s/`list_superseded`'s job on a follow-up call, not this one's. */
+interface RelationRefs {
+  readonly supersedes: readonly string[];
+  readonly supersededBy: string | null;
+  readonly relatesTo: readonly string[];
+  readonly conflictsWith: readonly string[];
+}
+
+/** The full document `get_decision` returns on success (FR-023). `frontmatter` reuses
+ *  @adrkit/core's own `AdrFrontmatter` Zod value directly as a nested schema (verified
+ *  safe to nest under a discriminated-union variant despite its `.refine()` cross-field
+ *  checks — research §R1.1) — never a hand-redefined subset of its fields. Echoes
+ *  `requestedRef` (the caller's raw input, always unqualified here — a qualified ref
+ *  never reaches this variant, see §6) alongside the resolved local `id`; no `log`
+ *  field, because none exists to report. */
+interface FullDecision {
+  readonly requestedRef: string;
+  readonly id: string;
+  readonly title: string;
+  readonly status: Status;
+  readonly sourcePath: string;
+  readonly frontmatter: AdrFrontmatter;  // reused core schema, nested verbatim — full typed frontmatter, incl. RelationRefs' fields in their original shape
+  readonly body: string;                 // complete Markdown body, never truncated (FR-023)
+}
+```
+
+`FullDecision` does not separately repeat `RelationRefs` — the caller already has every
+relation field inside `frontmatter` verbatim (FR-024: "return those refs as part of the
+complete typed frontmatter"). `RelationRefs` as its own named shape exists only for
+`ContextEntry` (§6), where a **summary** — not the full frontmatter — needs to carry the
+relation fields explicitly (FR-033).
+
+---
+
+## 5. Findings and pagination *(new — runtime only; full wire format in
+contracts/pagination-and-cursors.md)*
+
+```ts
+/** Identical shape wherever a growing channel appears — result pages, findings pages,
+ *  candidate pages — parameterized only by item type. */
+interface Page<T> {
+  readonly items: readonly T[];
+  readonly cursor: string | null;   // null ⇔ this is the last page
+}
+
+type FindingsPage = Page<Finding>;   // Finding reused verbatim from @adrkit/core (§1)
+
+/** The opaque cursor payload before base64url-encoding (contracts/pagination-and-
+ *  cursors.md §1-§2). Never exposed to a caller in this decoded form. */
+interface CursorPayloadV1 {
+  readonly v: 1;
+  readonly scope: CursorScope;        // e.g. 'search.results' | 'search.findings' — which channel/field this cursor is valid in
+  readonly fp: string;                 // CorpusHealth.fingerprint at mint time
+  readonly qh: string;                 // hash of this call's normalized query-shape parameters
+  readonly offset: number;             // positive safe integer (>= 1) index into that call's deterministic sorted array — 0 is never minted (contracts/pagination-and-cursors.md §2)
+}
+
+type CursorScope =
+  | 'search.results' | 'search.findings'
+  | 'get_decision.candidates' | 'get_decision.findings'
+  | 'context.results' | 'context.findings'
+  | 'superseded.results' | 'superseded.findings';
+
+/** The shared, non-error, fully schema-validated branch every tool's output union
+ *  includes for a cursor that fails to decode, fails its version check, arrives in the
+ *  wrong input field, no longer matches the live corpus/query, does not apply to this
+ *  call's actual resolved outcome, or indexes past the end of its freshly recomputed
+ *  channel (contracts/pagination-and-cursors.md §2). Every supplied cursor is always
+ *  decoded and checked through this full sequence — there is no outcome for which a
+ *  supplied cursor is silently accepted without being validated (contracts/
+ *  pagination-and-cursors.md §1, §5). This is a correctness/staleness signal, never an
+ *  authentication or security failure. */
+interface InvalidCursorOutcome {
+  readonly outcome: 'invalid-cursor';
+  readonly reason: 'decode-failed' | 'version-unsupported' | 'wrong-channel'
+                  | 'query-mismatch' | 'corpus-changed' | 'cursor-not-applicable'
+                  | 'offset-out-of-range';
+  readonly message: string;
+}
+
+/** The shared, non-error branch for a corpus that cannot be loaded AT CALL TIME
+ *  (distinct from the bin's own startup-time check, contracts/tools.md §9; Edge Cases:
+ *  "corpus-wide load failure"). The `root-*` reasons describe the configured `cwd` — in
+ *  practice already ruled out when the public handle's `start()` succeeds, but still
+ *  reachable if the root disappears or changes afterward. The `dir-*` reasons describe
+ *  the configured ADR directory, re-validated fresh on **every** call (§3.3, §8). */
+interface CorpusUnavailableOutcome {
+  readonly outcome: 'corpus-unavailable';
+  readonly reason: 'root-not-found' | 'root-not-directory' | 'root-not-readable'
+                  | 'root-not-git'
+                  | 'dir-not-found' | 'dir-not-directory' | 'dir-not-readable'
+                  | 'dir-outside-root' | 'corpus-changed-during-load';
+  readonly message: string;
+}
+```
+
+---
+
+## 6. Per-tool outcome shapes
+
+Every tool's `outputSchema` raw shape is `{ corpusHealth: CorpusHealth.optional(),
+result: <Tool>Result }`, where `<Tool>Result` is a Zod discriminated union nested under
+`result` (never at the schema root — research §R1.1). `corpusHealth` is present on every
+branch except `corpus-unavailable`, where it cannot be computed at all.
+
+Every **substantive** branch below (`results`, `found`/`not-found`/`ambiguous-local-id`/
+`federated-log-unavailable`, `matches`, `entries`) carries its own `findings:
+FindingsPage` field — the wire name callers see. Its contents are that call's
+`responseFindings` (§3.5): `CorpusProjection.corpusFindings` plus whatever this specific
+tool call deterministically derived on top of it (none, for `search_decisions`/
+`get_decision`), re-sorted canonically, then paginated. `InvalidCursorOutcome` and
+`CorpusUnavailableOutcome` deliberately carry **no** `findings` field at all — neither is
+a substantive answer about the corpus's content; one reports a cursor problem, the other
+reports the corpus could not be loaded well enough to compute anything, including
+findings, for this call.
+
+```ts
+// search_decisions
+type SearchDecisionsResult =
+  | { outcome: 'results'; items: readonly SearchMatch[]; cursor: string | null; findings: FindingsPage }
+  | InvalidCursorOutcome
+  | CorpusUnavailableOutcome;
+
+interface SearchMatch extends DecisionSummary {
+  readonly matchedFields: readonly ('id' | 'title' | 'tag' | 'body')[]; // non-empty, sorted, every field that independently matched (FR-028); no 'ref' — the searchable surface is local id, title, tags, body only (FR-025)
+}
+// Empty result set is the SAME 'results' branch with items: [] (US3 AC7) — not a
+// separate discriminant; "explicit empty result... same shape as a non-empty response."
+
+// get_decision
+type GetDecisionResult =
+  | { outcome: 'found'; decision: FullDecision; findings: FindingsPage }
+  | { outcome: 'not-found'; requestedRef: string; findings: FindingsPage }
+  | { outcome: 'ambiguous-local-id'; requestedRef: string; candidates: readonly DecisionSummary[]; cursor: string | null; findings: FindingsPage }
+  | { outcome: 'federated-log-unavailable'; requestedRef: string; log: string; id: string; findings: FindingsPage }
+  | InvalidCursorOutcome
+  | CorpusUnavailableOutcome;
+// `federated-log-unavailable` fires whenever `parseAdrRef(ref).log` is defined — this
+// phase never attempts a local lookup with a qualified ref, never strips the qualifier,
+// and never substitutes a same-id local record (FR-021, FR-022, US1 AC5). `id` here is
+// `parseAdrRef(ref).id` — the unqualified part of the requested ref, for the caller's
+// convenience — not a claim that a local record with that id exists.
+// Only `ambiguous-local-id` carries a primary `candidates`/`cursor` pair; a `cursor`
+// supplied against a call resolving to any of the other three outcomes is not silently
+// ignored — it is decoded and, having no channel to apply to, rejected as
+// `invalid-cursor` / `cursor-not-applicable` (contracts/pagination-and-cursors.md §2, §5).
+
+
+// get_decision_context
+type GetDecisionContextResult =
+  | { outcome: 'matches'; governing: readonly ContextEntry[]; activeProposals: readonly ContextEntry[];
+      history: readonly ContextEntry[]; cursor: string | null; findings: FindingsPage }
+  | InvalidCursorOutcome
+  | CorpusUnavailableOutcome;
+// `findings` here is `responseFindings` (§3.5): `corpusFindings` plus every per-record
+// `resolveAffects` call's own findings for this call's `files[]` (e.g.
+// `affects-unresolvable` — FR-032, research §R4), concatenated and re-sorted — never a
+// mutation of `CorpusProjection.corpusFindings` itself.
+
+interface ContextEntry extends DecisionSummary {
+  readonly firedMatchers: readonly FiredMatcher[];   // reused core shape (§1) — which matcher(s) fired, verbatim
+  readonly relations: RelationRefs;                   // declared refs, unexpanded (FR-033)
+}
+// "Zero matches" is the SAME 'matches' branch with all three arrays empty (US2 AC7) —
+// not an error and not a fourth discriminant.
+
+// list_superseded
+type ListSupersededResult =
+  | { outcome: 'entries'; items: readonly SupersededEntry[]; cursor: string | null; findings: FindingsPage }
+  | InvalidCursorOutcome
+  | CorpusUnavailableOutcome;
+// `findings` here is `responseFindings` (§3.5): `corpusFindings` plus one
+// `superseded-target-ambiguous`/`superseded-target-federated-unavailable` finding per
+// entry that needs one (below), concatenated and re-sorted.
+
+interface SupersededEntry extends DecisionSummary {
+  readonly supersededBy:
+    // Resolves only against an UNQUALIFIED local target with exactly one match (FR-034).
+    | { readonly resolved: true; readonly target: DecisionSummary }
+    // Unqualified target, zero local matches — a dangling reference that should have
+    // failed corpus validation upstream; the corpus's own existing `dangling-supersededBy`
+    // finding is already present in `corpusFindings` (§3), so no duplicate finding is
+    // minted here.
+    | { readonly resolved: false; readonly targetRef: string; readonly reason: 'dangling' }
+    // Unqualified target, MORE THAN ONE local match — never picked silently, but the
+    // full candidate list is NOT embedded here: an entry carries only `candidateCount`
+    // (a small integer), never an unbounded, per-entry `candidates[]` array (FR-034,
+    // contracts/tools.md §7). One compact `superseded-target-ambiguous` finding
+    // (severity 'warn'), naming `targetRef` and `candidateCount`, is minted for this
+    // entry (§3.5) — never one finding per candidate. The complete candidate list
+    // remains obtainable, already paginated, via a separate `get_decision(targetRef)`
+    // call, which returns that same bucket as its own `ambiguous-local-id` outcome (§6
+    // above) — this design deliberately reuses that existing, already-bounded channel
+    // instead of inventing a second, nested pagination scheme for a list nested inside
+    // a list.
+    | { readonly resolved: false; readonly targetRef: string; readonly reason: 'ambiguous'; readonly candidateCount: number }
+    // Target is a log-qualified ref — never resolved, stripped, or substituted; a
+    // `superseded-target-federated-unavailable` finding (severity 'info') is minted for
+    // this entry (§3.5), alongside (not replacing) whatever `dangling-supersededBy`
+    // finding @adrkit/core's own unmodified, log-unaware invariant check already
+    // produced for the same field, since that check has no concept of a qualifier either
+    // (research §R3).
+    | { readonly resolved: false; readonly targetRef: string; readonly reason: 'federated-unavailable'; readonly log: string; readonly id: string };
+}
+```
+
+**Every `SupersededEntry` is a small, fixed-shape object.** None of its four
+`supersededBy` variants embeds an array whose length depends on corpus content — the
+`'ambiguous'` variant's `candidateCount` is a bounded integer, not the candidates
+themselves. Combined with the per-record 64 KiB source cap that already bounds every
+other field on this shape (transitively — §3.5), a `list_superseded` page's total size is
+therefore the product of a bounded item count (`limit`, §7) and a genuinely bounded
+per-item size, never a page that could balloon because one entry happened to be
+ambiguous among many candidates.
+
+**One canonical result walk, partitioned per page (`get_decision_context`, FR-019,
+FR-031)**: the flat, canonically-sorted list of every matching record (governing +
+activeProposals + history combined) is paginated as **one** sequence — the cursor's
+`offset` indexes into that single flat list — and only *after* slicing one page from it
+does the handler partition that page's entries into the three named arrays by status.
+There is one `cursor` for the whole union, never one per bucket (contracts/tools.md §6).
+
+---
+
+## 7. Input shapes (summary; exact Zod shapes in contracts/tools.md)
+
+Every input object is a **strict** Zod object (`z.strictObject`/`.strict()`) — an unknown
+or extra field is rejected before any corpus access, for every tool, with no exception
+(FR-012). Every tool shares two pagination-input fields beyond its own substantive
+arguments: `cursor?: string` (max 4 KiB, primary channel) and `findingsCursor?: string`
+(max 4 KiB, findings channel), each paired with its own `limit?`/`findingsLimit?` (int,
+1–100, default 20). **A supplied cursor is always decoded and validated**, never silently
+skipped because this call's outcome turns out to be a non-paginated singleton — a primary
+`cursor` presented against an outcome with no primary channel to resume (e.g.
+`get_decision` resolving to `found`) is decoded, then rejected as `invalid-cursor` /
+`cursor-not-applicable` (contracts/pagination-and-cursors.md §2, §5); it is never merely
+ignored.
+
+```ts
+interface SearchDecisionsInput {
+  readonly query: string;            // 1–256 raw UTF-16 code units; MUST be non-empty after trim() — a whitespace-only query is rejected as an input-contract error before any corpus access (US3, FR-026), not silently normalized to an empty-string match-everything query; trim/NFKC/lowercase-normalized (research §R5) before matching
+  readonly status?: readonly Status[];   // 1–6 unique entries; omitted = all six (FR-020); ANY-OF — a record matches if its own status is any one of the listed values
+  readonly tags?: readonly string[];     // 1–32 unique slugs when present, each 1–64 chars; ALL-OF — a record matches only if it carries every listed tag (contracts/tools.md §8)
+  readonly scope?: readonly Scope[];     // 1–3 unique entries; ANY-OF, same reasoning as `status`
+  readonly cursor?: string; readonly limit?: number;
+  readonly findingsCursor?: string; readonly findingsLimit?: number;
+  // No `log` filter — this phase has no log dimension to filter by (FR-021, FR-025).
+  // `status`/`tags`/`scope` are ANDed across categories — a record must satisfy every
+  // supplied category's own condition (any-of within status/scope; all-of within tags);
+  // omitting a category always means "no constraint from that category," never "match
+  // nothing" (contracts/tools.md §5).
+}
+
+interface GetDecisionInput {
+  readonly ref: string;              // bare id or log:id (ADR-0002's AdrRef grammar), 1–128 chars; always required, even on a continuation call (contracts/tools.md §4). A qualified ref never resolves locally — see GetDecisionResult's federated-log-unavailable branch (§6).
+  readonly cursor?: string; readonly limit?: number;         // ambiguous-local-id candidates page, only meaningful when ambiguous
+  readonly findingsCursor?: string; readonly findingsLimit?: number;
+}
+
+interface GetDecisionContextInput {
+  readonly files: readonly string[];   // 1–256 entries, each a validated repo-relative logical path (1–1024 chars; no leading '/', no '..' segment, no drive letter, no backslash, non-empty) — enforced by input-schema .refine(), never read/opened/stat'd (FR-009, FR-030). The backslash rejection is not merely "no Windows drive letter": ANY backslash anywhere in the string is rejected, because the contract is POSIX separators only (contracts/tools.md §6) — a path using `\` as a separator, or containing one as a literal (escaped) character, is equally out of contract for a logical path this design only ever compares against forward-slash `affects` patterns.
+  readonly cursor?: string; readonly limit?: number;
+  readonly findingsCursor?: string; readonly findingsLimit?: number;
+}
+
+interface ListSupersededInput {
+  readonly cursor?: string; readonly limit?: number;
+  readonly findingsCursor?: string; readonly findingsLimit?: number;
+  // No status/log/tags/scope filter — FR-034's scope is unconditional over every
+  // superseded record; adding filters here would be unrequested surface area.
+}
+```
+
+---
+
+## 8. Server configuration *(new — runtime only)*
+
+```ts
+/** Startup-only; immutable for the process lifetime; no tool input can override any
+ *  field of it (FR-035). No log-identity, named-log, or backing-snapshot field exists —
+ *  this phase has none of those. */
+interface AdrkitMcpServerOptions {
+  readonly cwd: string;    // default process.cwd(); --cwd / ADRKIT_MCP_CWD (research §R7); MUST canonicalize (realpath) to a readable directory containing a readable direct .git entry (directory, or file for a linked worktree)
+  readonly dir: string;    // default 'docs/adr'; --dir / ADRKIT_MCP_DIR, resolved against cwd; MUST canonicalize (realpath) to a readable directory whose canonical path equals or is contained within the canonical cwd
+}
+
+/** The one canonicalization/containment routine both the public handle's `start()`
+ *  (fail-fast) and `loadCorpusProjection` (before and after every core load — §3.3)
+ *  call. Never shells out to `git`; every check uses portable filesystem APIs. */
+function resolveCanonicalRoots(options: {
+  readonly cwd: string;
+  readonly dir: string;
+}): Promise<{ readonly canonicalCwd: string; readonly canonicalDir: string }>;   // rejects with a typed CorpusUnavailableOutcome-shaped reason on any failure
+```
+
+**Realpath, not lexical, containment — this is the actual gap being closed.** A `..`-free,
+non-absolute `--dir` string can still resolve, once symlinks are followed, to a location
+outside the repository — e.g. `docs/adr` is a symlink into `/etc`, or an intermediate
+path segment is. Checking the raw, uncanonicalized strings (as an earlier draft did) only
+catches a **lexical** escape (a literal `..` segment or a leading `/`); it does nothing
+against a **symlinked** escape, where every character of the string looks perfectly
+contained. This design therefore canonicalizes both `cwd` and `dir` with `fs.realpath`
+(which resolves every symlink in the path, including in intermediate segments) before
+checking anything else, and it checks containment on the two **canonical** paths, never
+the two original ones.
+
+**The containment check itself is path-segment-safe, not a string prefix.** Given
+`canonicalCwd` and `canonicalDir`, compute `rel = path.relative(canonicalCwd,
+canonicalDir)` and reject unless `rel` is empty, or is a relative path whose first
+segment is not `..` (equivalently: `rel !== '..' && !rel.startsWith('..' + path.sep) &&
+!path.isAbsolute(rel)`). A naive `canonicalDir.startsWith(canonicalCwd)` check is
+deliberately **not** used: it would wrongly accept a sibling directory that merely shares
+a string prefix (`/repo` vs. `/repo-secrets`), which `path.relative` + a segment-aware
+check does not.
+
+**Startup establishes an expected root; every call revalidates it.**
+`createAdrkitMcpServer` performs no filesystem access at construction. Its
+zero-argument `start()` realpaths and validates the configured `cwd` and `dir` before
+constructing the private SDK server or connecting stdio, retaining the immutable
+configured strings and the resulting `expectedCanonicalCwd`. Every tool call then
+realpaths and validates both configured paths before and after core loading and requires
+the fresh canonical root to equal that expected value. The root's direct readable `.git`
+entry is rechecked each time; `dir` is rechecked for readability and segment-safe
+containment in the fresh root. This is per-instance state only, never a process-wide
+cache, and it does not retain corpus records or findings.
+
+**Failure produces `corpus-unavailable` with a precise reason** (§5) — `root-not-found`/
+`root-not-directory`/`root-not-readable`/`root-not-git` for a `cwd` problem, `dir-
+not-found`/`dir-not-directory`/`dir-not-readable`/`dir-outside-root` for a `dir` problem
+The per-candidate checks in §3.3 are additional and mandatory even though
+`discoverAdrFiles` currently filters by `Dirent.isFile()`: discovery and later reads are
+separate path operations. Each candidate is therefore `lstat`-checked as a regular
+non-symlink, realpath-contained in the fresh canonical ADR directory, and bigint-identity
+checked before and after the core load. Every reported `sourcePath` or finding path is
+still normalized relative to the fresh canonical `cwd` (FR-017).
+
+`createAdrkitMcpServer(options?: Partial<AdrkitMcpServerOptions>):
+Readonly<AdrkitMcpServerHandle>` (contracts/tools.md §1) applies the same defaults as the
+bin and returns a frozen null-prototype object with exactly zero-argument `start` and
+`close` methods. The concrete SDK server, registration APIs, low-level server, and
+transport are closure-private; `start()` performs validation and creates exactly one
+`StdioServerTransport`. A package-internal builder exposes the concrete registered server
+only to in-memory tests and is absent from every public export map.
+
+---
+
+## 9. Entity relationships (summary)
+
+```
+AdrkitMcpServerOptions (startup input: cwd, dir)
+        │
+        ▼
+resolveCanonicalRoots (§8)
+        ├─ cwd  → realpath'd + validated ONCE per server instance, then held  →  canonicalCwd (or: corpus-unavailable, root-*)
+        └─ dir  → realpath'd + containment-checked AGAINST canonicalCwd, FRESH on every call below  →  canonicalDir (or: corpus-unavailable, dir-*)
+        │
+        ▼
+loadCorpusProjection(canonicalCwd, dir, maxSourceBytes)   — called fresh, every tool call; re-runs the dir half of resolveCanonicalRoots first, every time (§3.3, §8)
+        │
+        ├─ discoverAdrFiles(canonicalDir, canonicalCwd)  (@adrkit/core, unmodified)  →  candidate paths, already isFile()-filtered (or: corpus-unavailable, dir-*)
+        │        │
+        │        └─ pre-read size guard (§3.3, @adrkit/mcp-only)  →  stat() each candidate; excludes oversized/unstattable paths BEFORE parsing; adds record-too-large / record-stat-error findings, severity error (no id — never parsed)
+        │
+        ├─ lintCorpus({ paths: keptPaths, cwd: canonicalCwd })  (@adrkit/core, unmodified; skipped entirely if keptPaths is empty — §3.3)  →  Adr[] + Finding[]  (a duplicate-id/dangling-ref record is still schema-valid and stays in Adr[]; only its finding is added)
+        │
+        ├─ byId  (§3.1–§3.2)   — LOCAL id → readonly Adr[], built from Adr.frontmatter.id alone; never a single arbitrary representative
+        ├─ corpusFindings      (lintCorpus findings + pre-read guard findings ONLY, re-sorted by @adrkit/mcp's own code-unit comparator — never core's localeCompare-based order; never a tool-derived finding — §3.5)
+        └─ fingerprint         (§3.4, research §R6 — canonical JSON over records+corpusFindings+corpusHealth counts, never raw file bytes, never a tool-derived finding)
+
+CorpusProjection (readonly; never mutated — §3.5)
+        │
+        ├─ search_decisions     → SearchMatch[]         (normalized literal match over id/title/tags/body, §R5; canonical (id, sourcePath) order; responseFindings = corpusFindings, no derived findings)
+        ├─ get_decision          → FullDecision | not-found | ambiguous-local-id candidates | federated-log-unavailable   (parseAdrRef detects qualification first; byId only for the unqualified case, §3.2; responseFindings = corpusFindings, no derived findings)
+        ├─ get_decision_context  → resolveAffects() per record, no `log` (research §R4) → ContextEntry[] partitioned into governing/activeProposals/history; responseFindings = corpusFindings + this call's own resolveAffects findings (§3.5)
+        └─ list_superseded       → SupersededEntry[]     (every 'superseded' record; supersededBy resolved via byId when unqualified — resolved / dangling / ambiguous [candidateCount, not candidates[]] / federated-unavailable; responseFindings = corpusFindings + one compact finding per ambiguous/federated-unavailable entry — §3.5)
+
+Every growing channel above is sliced into a Page<T> by an independent CursorPayloadV1
+(§5) bound to CorpusProjection.fingerprint and a per-call query-shape hash — every
+supplied cursor is decoded and verified (never silently skipped), and a primary cursor
+that names a channel this call's actual outcome does not have fails as
+`cursor-not-applicable` rather than being ignored (contracts/pagination-and-cursors.md
+§2, §5).
+```

--- a/specs/006-mcp-server/plan.md
+++ b/specs/006-mcp-server/plan.md
@@ -1,8 +1,7 @@
 # Implementation Plan: MCP Server (Read-Only Retrieval) — Phase 5
 
-**Feature directory**: `006-mcp-server` (scoped in place — **no git branch is created or
-switched** by this work; the header note in `spec.md` already establishes this and
-nothing here changes it) | **Date**: 2026-07-20 | **Spec**: [spec.md](./spec.md)
+**Feature directory**: `006-mcp-server` | **Implementation branch**:
+`feat/phase-5-mcp-server` | **Date**: 2026-07-20 | **Spec**: [spec.md](./spec.md)
 
 **Input**: Feature specification from `specs/006-mcp-server/spec.md` (Functional
 Requirements FR-001–FR-040, Success Criteria SC-001–SC-016, Assumptions A1–A9).
@@ -33,10 +32,9 @@ I–V.
 >
 > **✅ SC-016 satisfied 2026-07-20.** The maintainer explicitly ratified the exact
 > four-tool, local-only, read-only boundary and its exclusions. Both governance
-> preconditions are now closed. The 43-task graph is generated. Fresh analysis found
-> one critical and five high-severity artifact defects; this revision remediates those
-> contracts and tasks, and implementation remains blocked until a fresh analysis reports
-> no blocking or high-severity finding.
+> preconditions are closed. Fresh analysis passed after artifact remediation with no
+> critical, high, or medium finding. All 43 tasks are complete and the implementation is
+> complete in PR #19.
 
 ## Summary
 
@@ -107,10 +105,9 @@ harness plus import discipline can observe and bound, no authentication, no pers
 cache/index/database, and no absolute filesystem path in any response (FR-001–FR-011,
 FR-017).
 
-This plan was produced during the advance-scoping step root `plan.md` permits.
-SC-016 was explicitly ratified on 2026-07-20, and `tasks.md` has since been
-generated. These artifacts do not themselves constitute implementation; the
-current cross-artifact findings must be resolved before implementation begins.
+This plan originated during the advance-scoping step root `plan.md` permits.
+SC-016 was explicitly ratified on 2026-07-20, fresh cross-artifact analysis
+passed after remediation, and every task in `tasks.md` is now implemented.
 
 ## Technical Context
 

--- a/specs/006-mcp-server/plan.md
+++ b/specs/006-mcp-server/plan.md
@@ -1,0 +1,311 @@
+# Implementation Plan: MCP Server (Read-Only Retrieval) — Phase 5
+
+**Feature directory**: `006-mcp-server` (scoped in place — **no git branch is created or
+switched** by this work; the header note in `spec.md` already establishes this and
+nothing here changes it) | **Date**: 2026-07-20 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/006-mcp-server/spec.md` (Functional
+Requirements FR-001–FR-040, Success Criteria SC-001–SC-016, Assumptions A1–A9).
+**Normative sources** (ADRs win on conflict): [ADR-0001](../../docs/adr/0001-record-architecture-decisions-in-git.md)
+(git is truth; every consumer, including this server, is a reader),
+[ADR-0002](../../docs/adr/0002-typed-frontmatter-as-madr-superset.md) (the typed schema,
+`Status`, the log-qualified `AdrRef` grammar, the four relation-ref fields),
+[ADR-0004](../../docs/adr/0004-git-is-source-of-truth-database-is-an-index.md) (git is
+truth; the database is a derived, optional index; names "the MCP retrieval tools" as a
+reader, never a second writer), [ADR-0007](../../docs/adr/0007-adapter-isolation-and-public-surface-build.md)
+(adapter isolation; clean-clone build; **completed dogfood evidence recorded below**),
+[ADR-0009](../../docs/adr/0009-affects-resolution-and-catalog-binding.md) (pure
+`affects` resolution this server reuses unchanged), [ADR-0010](../../docs/adr/0010-bun-toolchain.md)
+(Bun for development; Node-targeted published artifact; names the MCP server explicitly
+as launched under Node by third-party harnesses), and
+[`.specify/memory/constitution.md`](../../.specify/memory/constitution.md) Principles
+I–V.
+
+> **✅ Phase 4 real-user gate evidence — already recorded, not re-litigated here.**
+> `spec.md`'s header callout records the maintainer's `adr evaluate` run against the
+> genuine, then-`proposed` ADR-0007 on 2026-07-20: a real `assertions-compile.no-source`
+> failure on first run, a one-line fix (declaring the two symbolic custom-expression
+> sources), and a clean rerun (`outcome: ok`, eleven ordered rules, two honest `warn`
+> findings, `one-way-door` proven, routed to `@mbeacom`). This plan treats that evidence
+> as **satisfied and closed** — it is the outcome-ladder rung-5 (project Phase 4)
+> real-user precondition this rung-4 (project Phase 5) feature's implementation gate
+> depends on, per `plan.md`'s (root) outcome-ladder rule.
+>
+> **✅ SC-016 satisfied 2026-07-20.** The maintainer explicitly ratified the exact
+> four-tool, local-only, read-only boundary and its exclusions. Both governance
+> preconditions are now closed. The 43-task graph is generated. Fresh analysis found
+> one critical and five high-severity artifact defects; this revision remediates those
+> contracts and tasks, and implementation remains blocked until a fresh analysis reports
+> no blocking or high-severity finding.
+
+## Summary
+
+Build `@adrkit/mcp`: a local, stdio-only, read-only Model Context Protocol server
+exposing **exactly four tools** — `search_decisions`, `get_decision`,
+`get_decision_context`, `list_superseded` — over the same `@adrkit/core` parsing,
+validation, graph, and `affects`-resolution primitives the CLI and CI surface already
+use, plus one small, additive `@adrkit/core` export (`parseAdrRef` only — research §R3)
+— used to detect whether a caller-supplied `ref` carries a `log:` qualifier, not to
+build any log-aware index — together with a migration of
+`packages/evaluator/src/rules/no-orphan-refs.ts` to import that export instead of its own
+private, duplicated copy, preserving that rule's exact observable behavior and result
+shape. This is the entire `@adrkit/core` change: one new file, one new export line, and
+one existing file migrated to call it; no existing behavior changes anywhere in
+`@adrkit/core` or `@adrkit/evaluator`, and no dependency changes. The server depends on
+the stable, current `@modelcontextprotocol/sdk` at **exact `1.29.0`** (verified against
+first-party sources and empirically against the pinned package itself — research
+§§R0–R1; v2 is a separate, beta, split-package line, not this phase's dependency). This
+phase serves exactly one local corpus and defers named-log/multi-repository federation
+completely — `@adrkit/core` never populates a record's `log` field and this server's
+discovery is non-recursive, so there is nothing to index or search by log; local
+identity is a record's bare `id`, alone. The configured corpus root and ADR directory
+are both realpath-canonicalized before use — the root once per server instance, the ADR
+directory freshly on every corpus load — and checked for path-segment-safe containment,
+not a lexical `..`/prefix check, so a symlinked directory that escapes the repository
+cannot be trusted, whether the symlink existed at startup or was swapped in afterward
+(research §R7; data-model.md §8). Every tool call reloads the configured corpus fresh via
+`@adrkit/core`'s existing `lintCorpus()` — never `loadCorpus()`/`Corpus`/`byId`, which
+remain untouched and unused — preceded by a **pre-read** 64 KiB size guard (every
+candidate file `discoverAdrFiles` finds is `stat`'d, and only paths within-limit at that
+check are passed to `lintCorpus`; a second metadata/cap check after loading rejects the
+whole provisional projection as `corpus-changed-during-load` if any candidate changed,
+so a changing or now-oversized record is never returned as stable; both guard-produced
+findings are severity `error`, since the corpus is genuinely incomplete even though the
+call still proceeds), a local,
+multi-valued `id` index (never a single arbitrary representative when more than one
+record shares an id), and a corpus fingerprint over exactly the **corpus projection** —
+a canonical JSON serialization of the in-limit records, `@adrkit/mcp`'s own corpus
+findings (never a tool-derived finding — see below), and the two corpus-health counts,
+never a hash of raw candidate-file bytes — all ordered with one fixed, locale-independent
+code-unit comparator `@adrkit/mcp` defines itself (never reusing `@adrkit/core`'s own
+`localeCompare`-based finding order), entirely inside `@adrkit/mcp` (data-model.md §3).
+Each tool handler builds its own response findings by concatenating that shared corpus
+projection's findings with whatever it deterministically derives for its own call (a
+per-record `resolveAffects` finding for `get_decision_context`; a compact
+`superseded-target-ambiguous`/`-federated-unavailable` finding per affected entry for
+`list_superseded`; nothing for the other two tools), re-sorting canonically before
+paginating — the shared projection itself is read-only and is never mutated to accumulate
+a tool's own derived findings (data-model.md §3.5). Every response is a strict, versioned,
+discriminated-union output shape (verified empirically to be the one pattern the SDK's
+own output-schema validation actually supports — research §R1.1) that distinguishes a
+usage/input-contract problem, a well-formed empty/`ambiguous-local-id`/`not-found`/
+`federated-log-unavailable` result, and a corpus finding, never conflating them
+(FR-015). Every growing channel — search matches, ambiguous-local-id candidates,
+decision-context matches, findings — is cursor-paginated with a base64url-encoded,
+versioned, corpus-fingerprint-and-query-bound cursor (research §R6; contracts/pagination-and-cursors.md);
+"opaque" here is an MCP-protocol convention about caller intent, not a confidentiality or
+tamper-proofing claim — every supplied cursor is always decoded and strictly verified
+(never silently skipped because a call's outcome happens to need no pagination), and a
+corpus change, a parameter change, an inapplicable channel, or an out-of-range offset
+between pages each fails explicitly, as a distinct `invalid-cursor` reason, rather than
+silently gapping or duplicating. `list_superseded`'s per-entry ambiguity never embeds an
+unbounded candidate list inside a page item — an ambiguous entry carries only a
+`candidateCount`; the full candidate list remains available, already paginated, via a
+follow-up `get_decision` call. No write tool, no MCP prompts/resources/subscriptions/
+sampling, no model call, no network access beyond what a defense-in-depth runtime
+harness plus import discipline can observe and bound, no authentication, no persistent
+cache/index/database, and no absolute filesystem path in any response (FR-001–FR-011,
+FR-017).
+
+This plan was produced during the advance-scoping step root `plan.md` permits.
+SC-016 was explicitly ratified on 2026-07-20, and `tasks.md` has since been
+generated. These artifacts do not themselves constitute implementation; the
+current cross-artifact findings must be resolved before implementation begins.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ESNext), developed and tested with **Bun** (pinned
+`1.3.14`, matching this project's existing pin — `packageManager` in root
+`package.json` and every prior feature's plan). Published artifact targets Node
+**`>=22`** (ADR-0010), smoke-tested under Node 22 and 24 (matching the existing
+`node-smoke-built-artifacts` CI job's matrix).
+
+**Primary Dependencies**: `@adrkit/mcp` depends on **`@adrkit/core` (`workspace:*`)**,
+**`@modelcontextprotocol/sdk` (exact `1.29.0`)**, and **`zod` (`^4`**, matching the rest
+of the workspace)** — nothing else. It imports only the SDK's `server/mcp.js`,
+`server/stdio.js`, and `inMemory.js` subpaths in production code (`client/index.js` is
+test-only); the SDK's own HTTP/OAuth transport dependency tree (`express`, `hono`,
+`jose`, `cors`, `ajv`, etc.) is installed transitively but never imported or executed by
+this package's code (research §R2). No adapter dependency, ever (Principle III;
+ADR-0007's `core-has-no-adapter-deps`, extended to this package exactly as it already
+extends to `@adrkit/evaluator`).
+
+**Storage**: **None.** No database, no persistent cache, no on-disk index. Every tool
+call reads the configured corpus directly via `@adrkit/core`'s `lintCorpus()`, fresh,
+for that call (FR-010; ADR-0004: git is truth, any index is derived and never required).
+
+**Testing**: `bun test`. Three lines of evidence (research §R8, §R10): (1) in-process, via
+`InMemoryTransport.createLinkedPair()` driving the SDK's own `Client` against a
+package-internal registered-server builder absent from public exports — the primary
+surface for every discriminated-outcome branch, cursor/fingerprint edge case, and
+adversarial-input fixture; (2) a real stdio-subprocess
+byte-capture test (both under Bun against `src/bin.ts`, and under Node 22/24 against the
+built `dist/bin.js` in the existing Node-smoke pipeline) proving `stdout` carries only
+well-formed JSON-RPC frames; (3) dedicated side-effect-denial preloads/tests
+(`packages/mcp/test/side-effect-denial-preload.mjs`) that throw on the enumerated
+network, filesystem-mutation, subprocess, worker, native-addon, and Bun-shell entry
+points, loaded while starting the same stdio subprocess and calling all four tools at
+least once, with independent full-sandbox/parent-sentinel/`HOME`/`TMPDIR` snapshots.
+This is executed-path defense-in-depth evidence, complementing (never substituting for)
+the declared-dependency and import-discipline checks (research §R10; FR-002, FR-011,
+SC-005, SC-013).
+
+**Target Platform**: a local subprocess, launched by an MCP-compatible agent harness
+over stdio (A6). The frozen Bun install may use only the unauthenticated public package
+registry; every post-install gate and runtime path is network-disabled and uses only the
+configured corpus on disk (Principle II).
+
+**Project Type**: Bun-workspace monorepo — adds a first-party **`packages/mcp/`**
+surface package (peer of `@adrkit/cli`/`@adrkit/ci`/`@adrkit/evaluator`, not an adapter
+— research §R2), one small, additive `@adrkit/core` export, and one behavior-preserving
+`@adrkit/evaluator` migration to use it (contracts/core-projection.md); reuses
+`@adrkit/core`'s existing parser, schema validator, corpus invariants, graph builder, and
+`affects` resolver verbatim — no second implementation of any of them (FR-029, FR-037).
+
+**Performance Goals**: no numeric SLO is specified by `spec.md`; the operative property
+is *cost*, not *latency* — every call's cost is linear in corpus size (one full
+`lintCorpus()` read) plus, for `get_decision_context`, `O(files.length × records)`
+`resolveAffects` calls (research §R4, deliberately chosen over a single ambiguous
+batched call). No model call means no token cost and no external-latency variance to
+budget for (ADR-0005's short-circuit posture, extended to this phase's "no model at
+all").
+
+**Constraints**: every call rereads the corpus — no caching layer may be added later
+without first revisiting FR-010, which this plan treats as load-bearing, not an
+optimization to relax; the size guard, canonical index, and fingerprint stay entirely
+inside `@adrkit/mcp` and never modify `@adrkit/core`'s observable behavior for any
+existing consumer (contracts/core-projection.md §3); every output schema's root stays an
+object per the MCP `Tool.outputSchema` requirement, which rules out a bare top-level
+discriminated union (research §R1.1 — verified, not assumed) and fixes the `{
+corpusHealth, result }` envelope shape used identically by all four tools.
+
+**Scale/Scope**: this project's own corpus size (tens of records today, plausibly low
+thousands for an adopting organization) — no scale target beyond "the same corpus sizes
+`@adrkit/core`'s other consumers already handle," since this server adds no new storage
+tier and performs no aggregation beyond one linear pass per call.
+
+## Constitution Check (pre-design gate)
+
+*GATE: evaluated **before** Phase 1 design below. No violations — Complexity Tracking is
+intentionally empty. The SC-016 maintainer-ratification callout above is an
+**outcome-ladder/governance precondition on implementation**, not a Principle I–V
+design violation, exactly as the equivalent T018 gate was treated in feature 005's plan.*
+
+| Principle | Pre-design assessment |
+|---|---|
+| **I. Git is the source of truth** | PASS (planned) — all four tools are read-only; none creates, edits, deletes, or proposes a change to any record, any other file, or any git ref (FR-002). No database is read or required (FR-010; ADR-0004 already names "the MCP retrieval tools" as a reader). |
+| **II. Clean clone builds green** | PASS (planned) — Constitution v1.0.2 permits only `bun install --frozen-lockfile` to use the unauthenticated public registry. `@adrkit/mcp`'s exact-pinned SDK is public, MIT-licensed, and zero-advisory as checked 2026-07-20; after installation, build/typecheck/test/lint/packaging/smoke/runtime run with networking disabled, no credential, and no service (FR-005/FR-006/FR-011/FR-039; research §R0/§R2/§R10). |
+| **III. Core depends on no adapter** | PASS (planned) — `@adrkit/mcp` is a first-party **surface** package (peer of `@adrkit/cli`/`@adrkit/ci`/`@adrkit/evaluator`), not `packages/adapters/*` and not core, following the exact precedent `@adrkit/evaluator` already established for a surface package depending on one additional vetted, deterministic, network-free public library beyond `zod`/`yaml` (research §R2). `@adrkit/core` never depends on `@adrkit/mcp` (FR-038) — the one new core export (`parseAdrRef`) and its one migrated caller (`@adrkit/evaluator`'s `no-orphan-refs.ts`) add no new dependency to either package at all. |
+| **IV. Deterministic before probabilistic** | PASS (planned) — no model, embedding, sampling, or ranking of any kind, anywhere in this phase (FR-004). Search is deterministic normalized literal matching (FR-025/FR-026, research §R5); every result set is canonically ordered, never by relevance (FR-018/FR-027). A matcher with no backing snapshot resolves inert with an informational finding, exactly as `@adrkit/core`'s existing `resolveAffects` already does — no new degradation semantics are invented (FR-032; ADR-0009). |
+| **V. The schema is the contract** | PASS (planned) — no schema change; `schema/adr.schema.json` is untouched (`schema:emit` byte-clean). `get_decision` returns `@adrkit/core`'s own `AdrFrontmatter` object reused verbatim, never a hand-redefined subset (data-model.md §4). Every tool's strict, versioned, discriminated output schema (FR-012) was verified empirically against the actual SDK before being finalized (research §R1.1), not assumed to work. |
+
+**Result**: PASS. Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-mcp-server/
+├── spec.md                              # Feature spec (binding; FR-001–FR-040, SC-001–SC-016, A1–A9)
+├── plan.md                              # This file
+├── research.md                          # R0–R11: SDK version/API (empirically verified), core loading gap, resolveAffects reuse,
+│                                         #   search normalization, cursor/fingerprint design, CLI conventions, stdio safety,
+│                                         #   why prompts/resources/HTTP/auth/indexing are excluded, distribution wiring, limits
+├── data-model.md                        # Reused core types, the one additive core export, the corpus projection, canonical
+│                                         #   identity, pagination/cursor shapes, per-tool input/output shapes, server config
+├── contracts/
+│   ├── core-projection.md               # The ENTIRE @adrkit/core + @adrkit/evaluator change: one new core file, one new core export line, one evaluator file migrated (behavior-preserving)
+│   ├── pagination-and-cursors.md        # The one shared cursor/fingerprint wire format every tool implements identically
+│   └── tools.md                         # Library/bin split, shared envelope+annotations, canonical order, error/output-schema
+│                                         #   reconciliation, per-tool resolution semantics, fixed limits, startup behavior
+├── checklists/
+│   └── requirements.md                  # Spec quality checklist (done)
+└── tasks.md                             # Generated after SC-016 ratification; current Phase 5 implementation worklist
+```
+
+### Source Code (repository root — extends merged Phases 0–4; additive only)
+
+```text
+packages/core/src/
+└── schema/
+    └── ref.ts                           # NEW FILE — parseAdrRef(ref); detects a ref's optional "log:" qualifier only — no log-aware index anywhere, no inverse formatter (contracts/core-projection.md §1); zero new dependency
+    (packages/core/src/index.ts gains exactly one new `export * from './schema/ref.ts';` line)
+
+packages/evaluator/src/rules/
+└── no-orphan-refs.ts                   # MIGRATED, behavior- and object-shape-preserving — imports parseAdrRef from @adrkit/core in place of its own private copy (contracts/core-projection.md §1); no behavior change, no dependency change
+(no other file under packages/core/src/** or packages/evaluator/src/** changes)
+
+packages/mcp/                            # NEW first-party surface package @adrkit/mcp (peer of cli/ci/evaluator)
+├── package.json                         # deps: @adrkit/core workspace:* + @modelcontextprotocol/sdk (exact 1.29.0) + zod ^4 (T001; research §R0/§R2)
+├── tsconfig.json
+├── tsconfig.build.json
+├── src/
+│   ├── index.ts                         # PUBLIC: createAdrkitMcpServer(options?) returns only a frozen null-prototype start/close handle; SDK server/registration/transport closure-private (data-model.md §8)
+│   ├── server.ts                        # INTERNAL: builds the concrete four-tool SDK server for the public handle and in-memory tests; absent from package exports
+│   ├── bin.ts                           # dedicated stdio entrypoint: argv/env parsing, invokes handle.start(); no caller-supplied transport (contracts/tools.md §§1,9)
+│   ├── main-module.ts                   # tiny, local isMainModule() guard mirroring packages/cli/src/main-module.ts's own pattern — not a core export, not shared
+│   ├── corpus/
+│   │   ├── projection.ts                # loadCorpusProjection(): revalidates root/dir, lstat+realpath+bigint-stat checks candidates before/after lintCorpus({ paths: withinLimitPaths, cwd }), rejects observed swaps, then builds byId/corpusFindings/fingerprint (data-model.md §§3, 3.5, 8)
+│   │   └── ordering.ts                  # the ONE canonical (id, sourcePath) comparator, using @adrkit/mcp's own locale-independent code-unit comparison (never core's localeCompare-based sortFindings order) — every tool/channel and the findings channel uses it (contracts/tools.md §2)
+│   ├── pagination/
+│   │   └── cursor.ts                    # CursorPayloadV1 encode/decode/verify, query-shape hashing (contracts/pagination-and-cursors.md)
+│   ├── search/
+│   │   └── normalize.ts                 # trim → NFKC → toLowerCase() pipeline (research §R5) — the one normalization function every searchable field and the query both call
+│   └── tools/
+│       ├── search-decisions.ts          # registerTool('search_decisions', ...) — FR-025–FR-028
+│       ├── get-decision.ts              # registerTool('get_decision', ...) — FR-021–FR-024; uses parseAdrRef from @adrkit/core to detect a log-qualified ref (→ federated-log-unavailable) vs. an unqualified local id (→ byId lookup)
+│       ├── get-decision-context.ts      # registerTool('get_decision_context', ...) — FR-029–FR-033; calls resolveAffects() once per record (research §R4)
+│       └── list-superseded.ts           # registerTool('list_superseded', ...) — FR-034; uses parseAdrRef on each supersededBy target the same way
+└── test/
+    ├── side-effect-denial-preload.mjs    # NEW — Node preload traps enumerated network, filesystem mutation, subprocess, worker, and native-addon APIs; Bun companion traps Bun mutation/spawn/shell paths (research §R10; SC-005/SC-013)
+    └── fixtures/                        # offline corpora: one record per Status; duplicate local ids; a log-qualified ref/supersededBy target; oversized source; dangling supersededBy; inert package/entity matchers
+
+scripts/check-deps.ts                    # T036: add '@adrkit/mcp' direct-declaration allow-list
+scripts/release-pack.ts                  # T038: add RELEASE_PACKAGES/bin/installed-smoke wiring; release-publish.ts unchanged
+scripts/smoke-node.mjs                   # T039: add Node 22/24 handle import + real stdio smoke under side-effect denial
+docs/RELEASING.md                        # T040: add @adrkit/mcp distribution/order/coordinated-version guidance; no publication
+```
+
+**Structure Decision**: the corpus projection, ordering comparator, cursor codec, and
+search normalizer are each their **own** small module inside `packages/mcp/src/`,
+mirroring `@adrkit/evaluator`'s existing convention of one concern per module
+(`targets/`, `assertions/`, `identity/`, `routing/`, `report/`) rather than one large
+file — each is independently unit-testable against fixtures with no tool registered at
+all. The four tool modules under `src/tools/` each own exactly one `registerTool` call
+and its handler; internal `src/server.ts` is the only place that imports all four and
+registers them, public `src/index.ts` exposes only the sealed lifecycle factory/types, and
+`src/bin.ts` is the only place that ever reads `process.argv`/`process.env` or invokes
+that lifecycle for a real `StdioServerTransport`.
+The dependency direction is `@adrkit/mcp` → `@adrkit/core`; no reverse edge exists
+(FR-038). `@adrkit/mcp` sits inside the Principle III isolation boundary exactly as
+`@adrkit/cli`/`@adrkit/ci`/`@adrkit/evaluator` already do: a first-party surface package
+with its own vetted public dependency, never an adapter and never core (research §R2).
+
+## Constitution Check (post-design re-check)
+
+*GATE: re-evaluated **after** the Phase 1 design (data-model, three contracts, research
+decisions R0–R11). Still no violations; Complexity Tracking remains empty.*
+
+| Principle | Post-design assessment |
+|---|---|
+| **I. Git is the source of truth** | PASS — the designed output contract (contracts/tools.md) has **no** write path anywhere: no tool's output schema includes a field that could carry a proposed mutation, no `--write` flag exists on the bin, and every one of the four tools' resolution semantics (§§4–7) only ever *reads* `CorpusProjection`. The side-effect-denial harness traps enumerated Node/Bun filesystem mutation, subprocess, worker, native-addon, and shell paths while an independent full disposable-sandbox/parent-sentinel/`HOME`/`TMPDIR` snapshot checks the exercised paths (US5 AC1; research §R10). |
+| **II. Clean clone builds green** | PASS — Constitution v1.0.2 permits public-registry access only during the frozen Bun install. The new dependency is vetted, public, MIT, zero-advisory as of 2026-07-20, and exact-pinned; after install, every gate and runtime path is network-disabled. This package imports only SDK stdio/in-memory subpaths, while side-effect-denial execution plus import discipline provide bounded evidence that network/write/spawn paths do not execute (research §R10). Pre/post root, directory, and candidate validation discards every projection with an observed containment/type/identity change (data-model.md §3.3), without claiming an atomic hostile-filesystem snapshot. |
+| **III. Core depends on no adapter** | PASS — the designed core change (contracts/core-projection.md) is the smallest one that satisfies the task: one new file, one new export line, and one existing `@adrkit/evaluator` file migrated to call the new export in place of its own private copy, preserving that rule's exact observable behavior and result shape — no behavior change anywhere and no new dependency added to `@adrkit/core` or `@adrkit/evaluator`. `@adrkit/mcp`'s own dependency set (`@adrkit/core`, `@modelcontextprotocol/sdk`, `zod`) contains no adapter and nothing under `packages/adapters/**`; the extended `check-deps.ts` allow-list mechanically asserts that direct-declaration boundary. Static declaration checks and the dynamic side-effect-denial harness remain distinct, bounded evidence. |
+| **IV. Deterministic before probabilistic** | PASS — the designed search contract (contracts/tools.md §5) is a fixed, three-step, ICU-free, engine-builtin normalization pipeline (research §R5) with no ranking; the designed context contract (§6) reuses `@adrkit/core`'s existing pure `resolveAffects` unchanged, called per record specifically to avoid inventing any new resolution semantics (research §R4); every result set's order is the one fixed comparator (§2); no model, embedding, or heuristic weight exists anywhere in the design. |
+| **V. The schema is the contract** | PASS — no schema change (`schema/adr.schema.json` untouched); `get_decision`'s `FullDecision.frontmatter` reuses `AdrFrontmatter` verbatim, nested inside a discriminated-union variant — a pattern explicitly re-verified empirically to work with the SDK's own output-schema validation despite the schema's `.refine()` cross-field checks (research §R1.1), not assumed. The reconciliation between SDK-enforced schema validation and FR-015's three structured-error cases is a specific, cited, empirically-verified mechanism (research §R1.2; contracts/tools.md §3), not a hand-wave. |
+
+**Result**: PASS (pre- and post-design). The design introduces no new schema field, no
+new severity, no new escalation reason, and no persistence or model path. SC-016
+was satisfied by explicit maintainer scope ratification on 2026-07-20; the
+release-version-timing question research §R10 surfaces is a scheduling decision
+for actual release time, not a design gap.
+
+## Complexity Tracking
+
+*No constitution violations — this table is intentionally empty.* The two
+precommitments carried forward from research are both closed: (1) the Phase 4
+real-user gate is satisfied (recorded in `spec.md`'s header callout and restated
+at the top of this plan); (2) **SC-016** was satisfied by explicit maintainer
+ratification of the exact four-tool scope on 2026-07-20. They remain governance
+evidence rather than Complexity Tracking justifications.

--- a/specs/006-mcp-server/quickstart.md
+++ b/specs/006-mcp-server/quickstart.md
@@ -1,0 +1,381 @@
+# Quickstart: MCP Server (Read-Only Retrieval) — Phase 5
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Contracts**:
+[contracts/tools.md](./contracts/tools.md),
+[contracts/pagination-and-cursors.md](./contracts/pagination-and-cursors.md),
+[contracts/core-projection.md](./contracts/core-projection.md) | **Date**: 2026-07-20
+
+> **⏳ NOT RUNNABLE YET.** No `packages/mcp/` directory, package manifest, or
+> source file exists yet. The Phase 4 real-user gate and **SC-016** are both
+> satisfied (`spec.md`'s header callouts), and the 43-task graph is generated.
+> Current critical/high artifact remediation and a clean analysis pass precede
+> implementation. Every command below describes the
+> validation flow once implementation lands. Nothing in this document is
+> evidence that anything below has actually been run.
+
+---
+
+## What `@adrkit/mcp` is
+
+A local, stdio-transport, read-only Model Context Protocol server exposing **exactly
+four tools** — `search_decisions`, `get_decision`, `get_decision_context`,
+`list_superseded` — over the same corpus `@adrkit/core` already parses, validates, and
+resolves `affects` matchers against for the CLI and CI surface. It reads git-tracked
+decision records already on disk; it never fetches, indexes, caches, mutates, or writes
+anything (ADR-0001, ADR-0004). Every call reloads the corpus fresh (FR-010).
+
+---
+
+## The offline flow, once implementation lands
+
+The frozen install may contact only the unauthenticated public package registry.
+Everything after that step runs with networking disabled, no credentials or services,
+and no model configured.
+
+```bash
+# 0) Pinned stable Bun, matching every other package in this workspace.
+bun --version            # expect 1.3.14
+bun install --frozen-lockfile
+# Disable networking here for every remaining command and server process.
+bun run build
+
+# 1) Public programmatic launch — still stdio-only, with no caller-supplied transport.
+#    Illustrative shape, not implementation code:
+#
+#      import { createAdrkitMcpServer } from '@adrkit/mcp';
+#
+#      const handle = createAdrkitMcpServer({ cwd: process.cwd(), dir: 'docs/adr' });
+#      await handle.start(); // validates roots, creates the private StdioServerTransport
+#      // await handle.close() during controlled shutdown
+#
+#    The SDK server, registration methods, and transport are intentionally private.
+#    Repository tests use a package-internal builder with InMemoryTransport; that
+#    builder is absent from package exports.
+
+# 2) Real stdio subprocess (proves no non-protocol stdout — research §R8, FR-007),
+#    against this repository's own real docs/adr/ corpus:
+adrkit-mcp --cwd "$PWD" --dir docs/adr
+# (blocks on stdin; a harness or the SDK's own StdioClientTransport speaks JSON-RPC to it)
+```
+
+### Example call and response — `search_decisions`
+
+```jsonc
+// tools/call { name: "search_decisions", arguments: { query: "bun", limit: 20 } }
+{
+  "content": [{ "type": "text", "text": "Returned 2 decision results; 0 findings on this page." }],
+  "structuredContent": {
+    "corpusHealth": { "fingerprint": "…64 hex chars…", "recordCount": 11, "excludedCount": 0 },
+    "result": {
+      "outcome": "results",
+      "items": [
+        { "id": "0006", "title": "License Apache-2 and single monorepo",
+          "status": "accepted", "sourcePath": "docs/adr/0006-license-apache-2-and-single-monorepo.md",
+          "matchedFields": ["body"] },
+        { "id": "0010",
+          "title": "Use Bun as the package manager and test runner while publishing Node-targeted artifacts",
+          "status": "accepted", "sourcePath": "docs/adr/0010-bun-toolchain.md",
+          "matchedFields": ["body", "title"] }
+      ],
+      "cursor": null,
+      "findings": { "items": [], "cursor": null }
+    }
+  }
+}
+```
+
+Note: **exactly one** of the two `content`/`structuredContent` channels is
+human-readable prose (FR-013); every field a caller would branch on programmatically
+lives only in `structuredContent`, and `result.outcome` is present on every response
+regardless of which of FR-015's three cases applies (contracts/tools.md §3). There is no
+`log`/`ref` field anywhere in this response — this phase's identity is the bare `id`
+alone (FR-021).
+
+### An `ambiguous-local-id` `get_decision` lookup
+
+```jsonc
+// tools/call { name: "get_decision", arguments: { ref: "0012" } }
+// — an already-invalid fixture corpus where two DIFFERENT files both declare id 0012
+// (already flagged elsewhere by a `unique-id` error finding).
+{
+  "content": [{ "type": "text", "text": "Returned 2 candidates for ambiguous local ref \"0012\"; 1 finding on this page." }],
+  "structuredContent": {
+    "corpusHealth": { "fingerprint": "…", "recordCount": 13, "excludedCount": 0 },
+    "result": {
+      "outcome": "ambiguous-local-id",
+      "requestedRef": "0012",
+      "candidates": [
+        { "id": "0012", "title": "…", "status": "accepted", "sourcePath": "docs/adr/0012-original.md" },
+        { "id": "0012", "title": "…", "status": "proposed", "sourcePath": "docs/adr/0012-duplicate.md" }
+      ],
+      "cursor": null,
+      "findings": {
+        "items": [
+          { "rule": "unique-id", "severity": "error", "id": "0012", "field": "id",
+            "message": "ADR id \"0012\" is used by multiple records: docs/adr/0012-duplicate.md, docs/adr/0012-original.md" }
+        ],
+        "cursor": null
+      }
+    }
+  }
+}
+```
+
+Candidates are distinguished only by `sourcePath` — there is no log qualifier to
+distinguish them by, and this phase supplies no way to disambiguate further; the
+caller's actionable next step is fixing the corpus, not retrying with a different input
+(US1 AC4).
+
+### A `federated-log-unavailable` `get_decision` lookup
+
+```jsonc
+// tools/call { name: "get_decision", arguments: { ref: "payments:0012" } }
+{
+  "content": [{ "type": "text", "text": "Named-log federation is unavailable for \"payments:0012\"; 0 findings on this page." }],
+  "structuredContent": {
+    "corpusHealth": { "fingerprint": "…", "recordCount": 13, "excludedCount": 0 },
+    "result": {
+      "outcome": "federated-log-unavailable",
+      "requestedRef": "payments:0012",
+      "log": "payments",
+      "id": "0012",
+      "findings": { "items": [], "cursor": null }
+    }
+  }
+}
+```
+
+The qualifier is recognized only far enough to produce this outcome — it is never
+stripped to retry as a bare `0012` lookup, and a local record with id `0012` (if one
+exists) is never substituted for it (FR-021, FR-022, US1 AC5).
+
+### A `list_superseded` entry with an ambiguous target — `candidateCount`, not a nested candidate list
+
+```jsonc
+// tools/call { name: "list_superseded", arguments: {} }
+{
+  "content": [{ "type": "text", "text": "Returned 1 superseded decision entry; 2 findings on this page." }],
+  "structuredContent": {
+    "corpusHealth": { "fingerprint": "…", "recordCount": 13, "excludedCount": 0 },
+    "result": {
+      "outcome": "entries",
+      "items": [
+        { "id": "0003", "title": "Use YAML for config", "status": "superseded",
+          "sourcePath": "docs/adr/0003-use-yaml-for-config.md",
+          "supersededBy": { "resolved": false, "targetRef": "0012", "reason": "ambiguous", "candidateCount": 2 } }
+      ],
+      "cursor": null,
+      "findings": {
+        "items": [
+          { "rule": "unique-id", "severity": "error", "id": "0012", "field": "id",
+            "message": "ADR id \"0012\" is used by multiple records: docs/adr/0012-duplicate.md, docs/adr/0012-original.md" },
+          { "rule": "superseded-target-ambiguous", "severity": "warn", "id": "0003", "field": "supersededBy",
+            "message": "supersededBy target \"0012\" resolves to 2 local records; see get_decision(\"0012\") for the full candidate list" }
+        ],
+        "cursor": null
+      }
+    }
+  }
+}
+```
+
+Note two things this response demonstrates together: (1) `findings.items` mixes a
+**corpus** finding (`unique-id`, from `corpusFindings` — the same finding the earlier
+`get_decision` example surfaced) with a **derived** finding
+(`superseded-target-ambiguous`, minted by this tool call itself), merged and re-sorted
+into one list — neither channel is the other; and (2) the ambiguous entry itself carries
+only `candidateCount: 2`, never an embedded list of the two candidates — a caller who
+needs their id/title/`sourcePath` calls `get_decision({ ref: "0012" })`, which returns
+exactly the `ambiguous-local-id` shape shown earlier in this document, already paginated
+and already bounded.
+
+### An inert (degraded, still useful) `get_decision_context` match — a finding-channel excerpt, not a full response
+
+The following is one item from a `findings.items` array inside an otherwise-ordinary
+`'matches'` response — not a standalone example in its own right (a full response always
+has the complete envelope shown throughout this document):
+
+```jsonc
+{ "rule": "affects-unresolvable", "severity": "info",
+  "message": "Package matcher \"react@>=19\" requires a changed-dependency snapshot and is inert." }
+```
+
+This is a **derived** finding — `resolveAffects` produced it for this specific call's
+`files[]`, so it rides this call's `findings` channel alongside `corpusFindings`, never
+inside `corpusHealth.fingerprint` (data-model.md §3.5) — never a fabricated match and
+never a fatal error for the rest of the call (FR-032; ADR-0009).
+
+### Invalid-cursor responses — same envelope, and no `findings` field at all
+
+Every `invalid-cursor` response uses the identical envelope every other response uses —
+`content` **and** `structuredContent`, and `corpusHealth` present, because computing it
+only requires a successfully-loaded corpus, which a cursor mismatch does not prevent.
+Neither `invalid-cursor` nor `corpus-unavailable` carries a `findings` field at all: both
+are non-substantive branches — one about a cursor, one about the corpus failing to load
+at all — never a claim about which records or findings this call found, so there is
+nothing to report on that channel (contracts/pagination-and-cursors.md §2).
+
+```jsonc
+// tools/call { name: "search_decisions", arguments: { query: "bun", cursor: "<a cursor minted before a record was added>" } }
+// corpusHealth.fingerprint below is freshly computed for THIS call and differs from the
+// fingerprint embedded inside the supplied cursor — that mismatch is what "corpus-changed" reports.
+{
+  "content": [{ "type": "text", "text": "Corpus changed after this cursor was issued." }],
+  "structuredContent": {
+    "corpusHealth": { "fingerprint": "…", "recordCount": 12, "excludedCount": 0 },
+    "result": { "outcome": "invalid-cursor", "reason": "corpus-changed",
+                 "message": "Corpus changed after this cursor was issued." }
+  }
+}
+```
+
+```jsonc
+// tools/call { name: "get_decision", arguments: { ref: "0012", cursor: "<a candidates-page cursor minted the last time \"0012\" was ambiguous>" } }
+// — the same corpus, but "0012" now resolves to exactly one record (the duplicate was
+// fixed since the cursor was minted), so this call's outcome is `found`, which has no
+// `candidates` channel for the supplied cursor to apply to.
+{
+  "content": [{ "type": "text", "text": "Cursor does not apply to this outcome." }],
+  "structuredContent": {
+    "corpusHealth": { "fingerprint": "…", "recordCount": 12, "excludedCount": 0 },
+    "result": { "outcome": "invalid-cursor", "reason": "cursor-not-applicable",
+                 "message": "Cursor does not apply to this outcome." }
+  }
+}
+```
+
+---
+
+## What "green" means
+
+- **Exactly four tools**, every response's `tools/list` entry declaring `readOnlyHint:
+  true, destructiveHint: false, idempotentHint: true, openWorldHint: false` and a
+  root-`object` `outputSchema` (contracts/tools.md §2) — no fifth tool, no resource, no
+  prompt registered (verified via `client.listTools()` in the in-process fixture).
+- **The graveyard is searched and fetchable by default** — a fixture query matching
+  only a `rejected` record's body, and a direct `get_decision` on a `superseded` record,
+  both succeed with no status filter supplied (SC-002, SC-001).
+- **The three-way local-id outcome holds, and a log-qualified ref is a distinct fourth
+  outcome** — zero/one/many fixtures for `get_decision` each produce exactly
+  `not-found`/`found`/`ambiguous-local-id`, never a silent first match, distinguished
+  only by `sourcePath`; a separate fixture proves a log-qualified ref always produces
+  `federated-log-unavailable`, never a local substitute and never the qualifier silently
+  stripped (SC-003).
+- **`get_decision_context` never merges or drops a status bucket** — a fixture with one
+  record per `Status` value places each in exactly one of `governing`/
+  `activeProposals`/`history` (SC-004).
+- **No adversarial input escapes its input schema** — path traversal, absolute paths,
+  backslash-containing paths, unknown extra fields, oversized `query`/`files[]`/`tags[]`,
+  and a whitespace-only `query` all produce `isError: true` before any corpus access,
+  with zero reads outside the configured `--cwd`, zero outbound network calls, and zero
+  absolute paths in any successful response (SC-005).
+- **Observed root, ADR-directory, and candidate-file swaps are rejected** — startup
+  rejects an escaping directory symlink; deterministic swaps injected at every
+  pre/post validation checkpoint return `corpus-unavailable` and no changed-path data.
+  These portable checks do not claim an atomic guarantee against a hostile swap that
+  occurs and reverts entirely between checkpoints (SC-005; research §R7;
+  data-model.md §8).
+- **`stdout` carries only protocol frames** — the real stdio-subprocess capture test
+  (research §R8) reports zero non-protocol bytes across a full exercise of all four
+  tools (SC-006).
+- **Every response has both channels** — `content` (the exact deterministic template
+  from `contracts/tools.md` §2.1, at most 512 UTF-16 code units) and
+  `structuredContent` (schema-valid) on every one of the four tools' successful calls,
+  **and** on every `invalid-cursor`/`corpus-unavailable` response too — neither of those
+  two branches carries a `findings` field, because neither is a substantive answer about
+  corpus content (SC-007).
+- **Pagination is lossless, deterministic, and every supplied cursor is checked** —
+  walking any cursor (results or findings, any tool) to completion against a multi-page
+  fixture returns every item exactly once with no gap or duplicate, in canonical order,
+  byte-identically on repeat runs against an unchanged corpus (SC-008, SC-014); a cursor
+  is never silently accepted or silently ignored — a mutated payload, an unsupported
+  version, a wrong-tool/wrong-field scope, a stale corpus or query-shape, a primary
+  cursor presented against a call whose outcome has no primary channel
+  (`cursor-not-applicable`), and an in-range-looking `offset` that no longer indexes
+  inside the freshly recomputed channel (`offset-out-of-range`) each independently
+  produce their own named `invalid-cursor` reason, never a silent fallback to page 1.
+- **One bad record never blocks the rest, and a corpus invariant never removes a valid
+  record** — a fixture with exactly one schema-invalid file still answers correctly for
+  every other record via `search_decisions`/`get_decision_context`, with the invalid one
+  surfaced only as a finding (SC-009); a separate fixture proves a record flagged by a
+  corpus invariant (`unique-id`, a dangling reference) remains fully present and
+  retrievable everywhere — the invariant adds a finding, never an exclusion.
+- **Missing backing sources are inert, never fabricated or fatal** — a `package`
+  matcher with no lockfile snapshot resolves inert with an informational finding
+  (SC-010).
+- **`list_superseded` resolves direct, local edges only, and never picks a target
+  silently — and never inlines an unbounded candidate list either** — a dangling target
+  surfaces via the corpus's own existing finding; a duplicate-local-id target surfaces a
+  deterministic, fixed-template `superseded-target-ambiguous` finding naming the target
+  id and a `candidateCount` (never every candidate's path/title inline), with the
+  complete candidate list separately obtainable via a follow-up `get_decision` call; and
+  a log-qualified target surfaces an informational federated-unavailable finding — none
+  dropped, none fabricated, none silently chosen (SC-011).
+- **A tool's `findings` channel is corpus findings plus that call's own derived
+  findings, composed fresh every call, never a mutation of a shared projection** — a
+  fixture proves `get_decision_context`'s per-record `resolveAffects` findings and
+  `list_superseded`'s minted findings change with that call's own inputs while
+  `corpusHealth.fingerprint` stays anchored to the corpus alone, and a fixture proves
+  `search_decisions`/`get_decision` never derive any findings of their own.
+- **Search filters compose exactly as specified — any-of within `status`/`scope`,
+  all-of within `tags`, ANDed across categories** — a fixture with two supplied tags
+  proves a record carrying only one of them does not match, while a fixture with two
+  supplied `status` values proves a record matching either one does.
+- **Clean-clone, frozen-install, then offline and correct** — the only network use is
+  `bun install --frozen-lockfile` against the unauthenticated public registry; build,
+  typecheck, test, lint, package, smoke, and all four tool calls then pass with
+  networking disabled, no credential, and no service (SC-012).
+- **The dependency-graph gate holds, and no-network is separately proven, as
+  defense-in-depth executed-path evidence, at runtime** — `@adrkit/mcp`'s declared,
+  direct dependencies are exactly `@adrkit/core`, the pinned SDK, and `zod` (extending
+  `core-has-no-adapter-deps` exactly as it already extends to `@adrkit/evaluator`), and a
+  side-effect-denial preloads plus independent complete-sandbox/parent-sentinel/
+  `HOME`/`TMPDIR` snapshots prove that the exercised real-server paths invoke none of
+  the enumerated network, filesystem-mutation, subprocess, worker, native-addon, or
+  Bun-shell APIs — complementary bounded evidence, not a formal proof against every
+  conceivable channel (SC-005, SC-013).
+- **Declared relation refs are surfaced, never expanded** — a `conflictsWith` fixture on
+  both `get_decision` and `get_decision_context` shows the ref unresolved, and a
+  follow-up `get_decision` call using it returns the full referenced record (SC-015).
+
+Green does **not** mean "implementation may begin." That is SC-016 alone, and it is a
+maintainer decision, not a test result.
+
+---
+
+## What is explicitly NOT here
+
+- **No fifth tool, no write/mutation/PR-creation capability of any kind** (FR-001,
+  FR-002) — when write capability lands, per `plan.md` (root), it opens PRs like every
+  other machine write in this project.
+- **No MCP prompts, resources, subscriptions, or sampling** (FR-003).
+- **No model call, embedding, or ranking** — search is deterministic normalized literal
+  matching only (FR-004, FR-025/FR-026, research §R5).
+- **No HTTP/SSE transport, no authentication** — local stdio subprocess only, launched
+  by the harness that trusts it (FR-005, FR-006).
+- **No persistent cache, index, or database** — every call rereads the corpus (FR-010).
+- **No transitive supersession walk** — `list_superseded` reports direct edges only
+  (FR-034).
+- **No named-log or multi-repository federation** — a log-qualified `ref` or
+  `supersededBy` target is recognized only far enough to answer
+  `federated-log-unavailable` or an unresolved, informational entry, never resolved,
+  stripped, or substituted (FR-021, FR-022, FR-034).
+- **No expansion of declared relation refs** — surfaced, never fetched or inlined by
+  `get_decision`/`get_decision_context` (FR-024, FR-033).
+- **No implementation yet** — `tasks.md` exists after SC-016 ratification, but the
+  current cross-artifact findings must be cleared before production work begins.
+
+---
+
+## Gate evidence
+
+**Phase 4 real-user gate**: recorded in `spec.md`'s header callout — the maintainer's
+`adr evaluate` run against the genuine, then-`proposed` ADR-0007, with a real first-run
+failure, a one-line fix, and a clean, fully-deterministic rerun. This plan treats it as
+satisfied and does not re-run or re-litigate it.
+
+**This phase's own gate — SC-016**: satisfied on 2026-07-20. The maintainer
+explicitly ratified the four-tool boundary and its exclusions. Search ranking,
+transitive-supersession scope, `conflictsWith` visibility, and log-identity
+semantics were already fixed to conservative defaults in the Functional
+Requirements. No maintainer-facing product decision remains open.

--- a/specs/006-mcp-server/research.md
+++ b/specs/006-mcp-server/research.md
@@ -1,0 +1,1269 @@
+# Research: MCP Server (Read-Only Retrieval) — Phase 5
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Date**: 2026-07-20
+
+This document is decision-oriented. Every claim about the MCP protocol or the
+`@modelcontextprotocol/sdk` was checked against a first-party source on 2026-07-20 —
+the npm registry, the SDK's own `v1.x`-branch source at the exact pinned tag, or
+`modelcontextprotocol.io` — and, where the SDK's actual runtime behavior was the
+question rather than its documented API, verified empirically by installing the exact
+pinned version in an isolated scratch directory and running it. Nothing below is
+carried over from general training-time knowledge of older SDK releases without a
+2026-07-20 check, because this SDK has changed shape (see R0) since most such
+knowledge would have been formed.
+
+---
+
+## R0 — SDK package and version: stable `@modelcontextprotocol/sdk@1.29.0`; v2 is a separate, beta, split-package line
+
+**Decision**: depend on the single, unified, stable `@modelcontextprotocol/sdk`
+package at **exact `1.29.0`**, imported only via its `server/mcp.js`, `server/stdio.js`,
+`inMemory.js`, and (test-only) `client/index.js` subpaths. Do **not** depend on the
+split `@modelcontextprotocol/server` / `@modelcontextprotocol/client` packages.
+
+**Evidence**:
+- `npm view @modelcontextprotocol/sdk dist-tags --json` → `{"latest":"1.29.0"}` on
+  2026-07-20; `npm view @modelcontextprotocol/sdk versions --json` lists `1.29.0` as
+  the highest of 78 published versions, with no `2.x` version ever published under
+  this package name.
+- The SDK repository's `main` branch README (fetched from
+  `raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md`)
+  states in its banner: *"This is the `main` branch — v2 of the SDK, **now in
+  beta**"* (`@modelcontextprotocol/server`, `@modelcontextprotocol/client`),
+  targeting the **2026-07-28** MCP spec revision, and: *"We expect a stable release
+  alongside the full release of the 2026-07-28 spec... Until then, **v1.x remains
+  the supported release for production**; it keeps receiving bug fixes and security
+  updates for at least 6 months after v2 ships."* `npm view @modelcontextprotocol/server
+  dist-tags --json` confirms the actual published state: `{"latest":"2.0.0-beta.4","beta":"2.0.0-beta.4"}`
+  — a beta channel, no `latest`-stable v2 release exists.
+- v2 is precisely **beta**, not alpha, and it is architecturally a **split-package
+  rewrite** (`@modelcontextprotocol/server`/`client`, Standard-Schema-based tool/prompt
+  schemas instead of a Zod-specific API) rather than a point release of the unified
+  package. This spec's Assumption A5 is stated as "beta", matching this finding exactly
+  — either framing ("alpha" or "beta") would reach the same design conclusion: v2 is
+  unstable, pre-1.0-of-its-own-numbering, and explicitly not the production-recommended
+  line as of this date — exactly the profile ADR-0007 already treats as disqualifying
+  for a build-time dependency ("several are explicitly pre-1.0... coupling the core to
+  any of them transfers their churn directly into ours").
+- `@modelcontextprotocol/sdk@1.29.0`'s own `package.json`: `license: MIT`,
+  `repository: git+https://github.com/modelcontextprotocol/typescript-sdk.git`,
+  `engines.node: >=18` (compatible with this project's `>=22` floor),
+  `peerDependencies: { zod: "^3.25 || ^4.0", "@cfworker/json-schema": "^4.1.1" }`, with
+  `peerDependenciesMeta` marking `zod` required and `@cfworker/json-schema` **optional**
+  (satisfied by this workspace's existing `zod@^4`; `@cfworker/json-schema` is not
+  installed and is not needed by anything this server imports — R2's subpath-import
+  boundary applies to it exactly as it does to the SDK's other unused, HTTP/OAuth-only
+  dependencies). `npm audit --json` against a scratch install of exactly this version
+  reported `{"info":0,"low":0,"moderate":0,"high":0,"critical":0}` on 2026-07-20.
+
+**Rationale**: ADR-0007/ADR-0010 already commit this project to depending only on
+stable, non-pre-1.0 public surfaces wherever avoidable, and to a Node-targeted
+published artifact. The unified `1.x` package is the one still documented as "the
+supported release for production" by its own maintainers, has a long, otherwise-
+unremarkable release history (0.4.0 → 1.29.0 over many minor/patch releases, one
+`-beta` prerelease at 1.23.0 that promoted cleanly), and its documented `McpServer` /
+`registerTool` / `StdioServerTransport` / `InMemoryTransport` surface (R1) is exactly
+what this spec's Assumption A5 already anticipated. Pinning **exact** (no `^`/`~`)
+matches this project's existing precedent for a single vetted engine dependency
+(`@adrkit/evaluator`'s `jsonpath-rfc9535@1.3.0`, research 005 §R1) and means a
+Renovate/Dependabot bump is a reviewed PR, not a silent transitive change to a
+protocol-facing dependency.
+
+**Alternatives rejected**:
+- *Depend on `@modelcontextprotocol/server`/`client` v2* — rejected: beta, targets a
+  spec revision not yet finalized (2026-07-28, still eight days out from this
+  research date), and is a different package/API shape this spec did not scope.
+  Revisit only after v2 reaches a stable release **and** after this phase has its
+  own real-user gate (mirroring the outcome-ladder posture already applied to SDK
+  choices elsewhere in this project).
+- *Depend on a caret range (`^1.29.0`)* — rejected for the same reason
+  `jsonpath-rfc9535` was pinned exact: a protocol SDK is exactly the kind of
+  dependency this project wants a reviewed diff for, not an automatic minor bump.
+- *Vendor a minimal hand-rolled JSON-RPC/stdio implementation instead of the SDK* —
+  rejected: reimplementing the protocol duplicates work the spec's own Assumption A5
+  already treats as a given, forgoes the SDK's own conformance with
+  `tools/list`/`tools/call`/pagination/annotation shapes (R1), and is exactly the kind
+  of "second implementation" this project's own affects-resolution precedent
+  (ADR-0009) warns against normalizing away from a canonical one.
+
+---
+
+## R1 — SDK server surface: `McpServer` + `registerTool` + `StdioServerTransport` + `InMemoryTransport`, and how schema validation reconciles with structured errors
+
+**Decision**: use a closure-private `McpServer`
+(`@modelcontextprotocol/sdk/server/mcp.js`) with
+`registerTool(name, { title, description, inputSchema, outputSchema, annotations },
+handler)`, `StdioServerTransport` (`@modelcontextprotocol/sdk/server/stdio.js`) for the
+bin, and `InMemoryTransport.createLinkedPair()` (`@modelcontextprotocol/sdk/inMemory.js`)
+plus `Client` (`@modelcontextprotocol/sdk/client/index.js`) for in-process tests through
+a package-internal builder. The public package exports only
+`createAdrkitMcpServer(options)`, which returns a frozen null-prototype
+`{ start, close }` handle; the concrete server, registration APIs, low-level server,
+internal builder, and transport remain unavailable to consumers. This is first-party
+documented (`docs/server.md` on the SDK's `v1.x` branch) and was additionally verified by
+installing `@modelcontextprotocol/sdk@1.29.0` + `zod@4` in an isolated scratch project
+and exercising it directly (five scratch scripts, referenced by finding below; not part
+of this repository).
+
+### R1.1 Tool registration and output-schema shape (verified)
+
+`inputSchema`/`outputSchema` accept either a **raw shape** (a plain object literal of
+`{ field: ZodType }`, which the SDK wraps in `z.object(...)` itself) or a full Zod
+schema instance directly. Per the MCP spec's own `Tool` data type
+(`modelcontextprotocol.io/specification/2025-06-18/server/tools`) and the SDK's
+`ToolSchema` (`src/types.ts`): *"`outputSchema`: ... **Must have `type: 'object'` at the
+root level per MCP spec**."*
+
+**Finding, verified empirically**: passing a bare, top-level
+`z.discriminatedUnion('outcome', [...])` directly as `outputSchema` **is broken** in
+1.29.0 — `tools/list` reports `outputSchema: undefined` (the SDK's internal
+`normalizeObjectSchema`/`toJsonSchemaCompat` conversion has no root-object form for a
+union), and **every** call to that tool — even a call that should succeed — then throws
+`Cannot read properties of undefined (reading '_zod')` from inside the SDK's own output
+validation and is caught by the SDK's own catch-all into a generic `isError: true`
+text-only result. This is not a corner case; it reproduced on the first attempt and
+would have shipped a broken server had it not been checked.
+
+**Working pattern, verified empirically**: nest the discriminated union **one level
+down**, as the value of a single key in the raw shape — e.g.
+`outputSchema: { result: z.discriminatedUnion('outcome', [...]) }`. The emitted
+`tools/list` JSON Schema is then a valid root object (`type: 'object'`,
+`properties.result.oneOf: [...]`, `additionalProperties: false`), and calls succeed with
+`structuredContent: { result: { outcome: '...', ... } }` validating correctly. This was
+re-verified with three union variants, arrays of extended object schemas nested inside
+variants, and a **reused** Zod schema carrying a cross-field `.refine()` nested two
+levels deep (mirroring reuse of `@adrkit/core`'s `AdrFrontmatter`) — all passed through
+registration and a real `tools/list` + `tools/call` round trip with no crash and correct
+validation. **Design consequence** (data-model.md §6, contracts/tools.md §2): every
+tool's `outputSchema` raw shape is `{ corpusHealth: CorpusHealthSchema.optional(),
+result: <ToolName>Outcome }`, where `<ToolName>Outcome` is a `z.discriminatedUnion`
+nested under `result`, never at the schema root.
+
+### R1.2 Reconciling SDK-level schema validation with FR-015's three structured cases (verified, not hand-waved)
+
+Reading `@modelcontextprotocol/sdk@1.29.0`'s `src/server/mcp.ts` at the exact pinned
+tag, the `CallToolRequestSchema` handler `McpServer` installs internally is:
+
+```ts
+this.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+  try {
+    // ...tool lookup...
+    const args = await this.validateToolInput(tool, request.params.arguments, name); // throws McpError(InvalidParams) on Zod failure
+    const result = await this.executeToolHandler(tool, args, extra);                  // my handler runs here
+    await this.validateToolOutput(tool, result, name);                                // throws McpError(InvalidParams) on schema mismatch — SKIPPED when result.isError
+    return result;
+  } catch (error) {
+    if (error instanceof McpError && error.code === ErrorCode.UrlElicitationRequired) throw error; // irrelevant here
+    return this.createToolError(error instanceof Error ? error.message : String(error));            // { content: [text], isError: true } — NO structuredContent
+  }
+});
+```
+
+`validateToolOutput` additionally contains `if (result.isError) { return; }` — output-
+schema conformance is **only enforced when the result is not an error**.
+
+This was verified empirically end to end (not just read): an unknown extra field, a
+value over a declared `z.string().max(256)`, a wrong-typed field, and a custom
+`.refine()` rejecting `..`/absolute/drive-qualified/empty `files[]` entries **all**
+surfaced as `{ isError: true, content: [{ type: 'text', text: 'MCP error -32602:
+Input validation error: ...<exact Zod issue path/message>...' }] }`, produced entirely
+by the SDK **before** the tool handler ran at all — never a raw, unhandled exception,
+and never a bare JSON-RPC protocol-level error reaching the caller as something other
+than a `CallToolResult`. A handler that threw a plain `Error` was caught the same way.
+A handler returning `isError: true` with **no** `structuredContent`, and separately one
+returning `isError: true` with an arbitrary **off-schema** `structuredContent`, both
+passed through completely unvalidated. A handler returning a non-error result whose
+`structuredContent` violated the declared `outputSchema` was itself caught and
+converted to the same `isError: true` text-only shape (a safety net against *this
+server's own* implementation bugs, never something a caller can trigger by supplying
+adversarial input, since output-schema mismatches at the wire boundary while `isError`
+is false can only be produced by miscoded server logic — see contracts/tools.md §3).
+
+**Design consequence — the two-tier error model** (contracts/tools.md §3):
+
+1. **Raw input-shape violations** (unknown/extra field, wrong type, over a bound the
+   Zod input schema declares, or a semantic-but-string-shaped violation expressed as an
+   input-schema `.refine()` — e.g. `files[]` path-traversal/absolute/drive-qualified/
+   empty) are **not handled by this server's own code at all**. They are FR-015 case
+   (a) satisfied entirely by the SDK's own `validateToolInput`, "before any corpus
+   access" (FR-012/FR-030) by construction, because the handler never runs. The result
+   is a genuine `CallToolResult` (satisfying "a structured, actionable tool result... not
+   a raw, unhandled exception") whose `content[0].text` names the tool and echoes the
+   exact violated Zod issue; it carries no `structuredContent`, which is accepted
+   because FR-016's "findings must be part of structured content" duty is scoped to
+   findings encountered *while answering* a well-formed call — a call this malformed
+   never reaches "answering" at all.
+2. **Everything else that is anticipated and name-able** — an ambiguous unqualified id,
+   a well-formed empty search, a decision-context match with zero results, an invalid,
+   mismatched, or stale pagination cursor (contracts/pagination-and-cursors.md), or an
+   unavailable corpus at call time — is modeled as an **ordinary, non-error,
+   fully schema-validated branch** of the same `outcome` discriminated union every
+   substantive answer uses (never `isError`). This is a deliberate choice, not the only
+   one the SDK would allow: it keeps every anticipated condition inside the one
+   SDK-enforced contract (so a coding mistake there is caught the same way a malformed
+   success would be, per the safety net above), gives callers exactly one place
+   (`structuredContent.result.outcome`) to branch on regardless of which of the three
+   FR-015 cases applies, and reserves `isError` for the narrow, genuinely exceptional
+   set: the SDK's own pre-handler rejections, and an unanticipated internal exception
+   (which the SDK's own catch-all still turns into a well-formed, non-crashing result —
+   never a raw exception — even though this server does not construct it directly).
+
+**Alternatives rejected**:
+- *Throw a custom `McpError(ErrorCode.InvalidParams, ...)` from inside a handler for
+  anticipated conditions (ambiguous id, invalid cursor)* — rejected after verifying it
+  is behaviorally identical to throwing a plain `Error`: the same outer catch-all
+  converts it to `{ isError: true, content: [text] }` with no `structuredContent`,
+  which would then fail FR-016 for exactly the conditions (findings-adjacent,
+  anticipated) that most need structured detail. `McpError` is reserved for the one
+  sentinel this server never uses (`UrlElicitationRequired`); ordinary anticipated
+  conditions gain nothing from throwing it over returning a typed union branch, and
+  lose `structuredContent`.
+- *A single generic `{ ok: boolean, error?: string }` output shape* — rejected: FR-015
+  explicitly forbids conflating usage errors, empty results, and findings into "a
+  single generic failure shape"; a flat boolean cannot express which of the three
+  applies without a second, redundant field, and loses the SDK's own schema
+  enforcement on the substantive payload.
+- *Flat object with an `outcome` enum plus a pile of `.optional()` fields, no true Zod
+  union* — considered and rejected in favor of the nested-union pattern above:
+  functionally works (also verified) and is one level shallower, but the emitted JSON
+  Schema cannot express "these fields are required together for this outcome" the way
+  `oneOf` variants can, which matters for the "strict... discriminated outcomes"
+  requirement this design is explicitly asked to satisfy precisely.
+
+### R1.3 Tool annotations (verified against `ToolAnnotationsSchema`, `src/types.ts`)
+
+`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` are each
+`z.boolean().optional()`; the SDK's own doc comments state
+`destructiveHint`/`idempotentHint` are "meaningful only when `readOnlyHint == false`."
+All four tools declare `readOnlyHint: true, destructiveHint: false, idempotentHint:
+true, openWorldHint: false` per the binding design direction. Declaring
+`destructiveHint`/`idempotentHint` explicitly is harmless and improves the annotation's
+legibility as a complete, accurate statement (FR-014) even though the SDK's own
+comment marks them as informative-only once `readOnlyHint` is `true`; `openWorldHint:
+false` is the one annotation doing real work here — it is the accurate declaration
+that this server's domain of interaction is the one configured corpus, never anything
+beyond it (FR-008, FR-014).
+
+### R1.4 `InMemoryTransport` (verified against `src/inMemory.ts` at the pinned tag)
+
+`InMemoryTransport.createLinkedPair(): [InMemoryTransport, InMemoryTransport]` returns
+a `[clientTransport, serverTransport]` pair; connecting an SDK `Client` to one and an
+`McpServer` to the other lets a test call `client.listTools()`/`client.callTool()`
+against the real registered handlers with no subprocess, no stdio framing, and no
+filesystem beyond whatever fixture corpus the test itself points at. This is the
+mechanism data-model.md and quickstart.md use for the fast in-process test/example path,
+and is exactly what the binding design direction and this spec's contracts require.
+
+---
+
+## R2 — Package placement and dependency vetting: `@adrkit/mcp` is a first-party surface package, one new public dependency
+
+**Decision**: `packages/mcp/` (`@adrkit/mcp`), a peer of `@adrkit/cli`, `@adrkit/ci`, and
+`@adrkit/evaluator` — **not** under `packages/adapters/**`. Its only new public
+dependency is `@modelcontextprotocol/sdk` (exact `1.29.0`, R0); it also depends on
+`@adrkit/core` (`workspace:*`) and `zod` (`^4`, matching the rest of the workspace).
+
+**Rationale**: Principle III's literal text names `@adrkit/core`, `@adrkit/cli`, and
+"the schema" as depending on nothing but the filesystem, workspace packages, and
+`zod`/`yaml`. It does not name `@adrkit/evaluator`, `@adrkit/ci`, or (now) `@adrkit/mcp`
+— and the project already has a settled precedent for this exact situation:
+`@adrkit/evaluator`'s own plan.md Constitution Check reasons that a first-party
+**surface** package (not core, not cli, not schema, not an adapter) may depend on one
+additional vetted, deterministic, network-free, credential-free public library beyond
+`zod`/`yaml`, provided it is individually vetted the way `@adrkit/evaluator` vetted
+`jsonpath-rfc9535` (research 005 §R1) and the way this document vets
+`@modelcontextprotocol/sdk` in R0/R1 above (license, advisories, maintenance, exact
+pin). `@adrkit/mcp` follows that same precedent for the same reason `@adrkit/evaluator`
+did: it introduces no new *external integration* (it reads the same git-backed corpus
+`@adrkit/core` already parses; the MCP protocol is a local, stdio, in-process
+serialization concern, not a network integration ADR-0007 was written to fence off),
+so it is not an adapter, and it is small and single-purpose enough not to need its own
+package tier.
+
+**A deliberately narrow import boundary, stated precisely rather than left implicit**:
+`@modelcontextprotocol/sdk@1.29.0`'s own `dependencies` (not just `devDependencies`)
+include `express`, `hono`, `@hono/node-server`, `cors`, `express-rate-limit`, `jose`,
+`eventsource`, `pkce-challenge`, `ajv`, `ajv-formats`, and `cross-spawn` — an HTTP/SSE/
+OAuth-transport dependency tree, because npm/Bun install a package's **full declared
+dependency graph** regardless of which subpath is imported. This project's own
+`clean-clone-builds`/`core-has-no-adapter-deps` gates (`scripts/check-deps.ts`) operate
+at **declared-manifest** granularity — they check what each *workspace* package
+directly declares, not what a third-party dependency's own transitive tree contains —
+exactly as they already do for every other dependency in the project (they do not, for
+example, recursively vet `zod`'s own transitive tree either). No gate-mechanics change
+is needed. What matters, and what this design states explicitly rather than leaving to
+inference: `@adrkit/mcp`'s own source imports **only** `@modelcontextprotocol/sdk/server/
+mcp.js`, `.../server/stdio.js`, and `.../inMemory.js` in its production code path (plus
+`.../client/index.js` in test-only code) — never `.../server/streamableHttp.js`,
+`.../server/express.js`, `.../client/*` in the bin, or any OAuth module. Those unused
+subpaths' code is installed on disk but never `import`ed, so it never executes; FR-005/
+FR-006/FR-011 ("no network listener," "no authentication," "no network access of any
+kind") bind to what `@adrkit/mcp`'s own code does, not to what bytes happen to sit
+unexecuted in `node_modules`. Building/testing/publishing this package still requires
+no credential and no runtime network call, satisfying ADR-0007's actual constraint.
+
+**Alternatives rejected**:
+- *Place `@adrkit/mcp` under `packages/adapters/*`* — rejected: it integrates with
+  nothing external; it is a reader of the same corpus every other first-party surface
+  package already reads. Adapter placement exists for upstreams "permitted to break on
+  upstream churn" via runtime-configured discovery (ADR-0007) — the wrong shape for a
+  server whose only job is to expose `@adrkit/core`'s existing capabilities over stdio.
+- *Vet and adopt only a subset of the SDK by re-exporting hand-picked internals* —
+  rejected: the SDK does not offer a slimmer package boundary than subpath imports
+  already provide (verified: `exports` includes `./client`, `./server`, `./validation`,
+  `./experimental`, and a catch-all `./*`, not a further-split package), and hand-
+  slicing internals would create exactly the kind of second, parallel implementation
+  this project's affects-resolution precedent already warns against.
+
+---
+
+## R3 — `@adrkit/core`'s current loading surface: the real gap, and the minimal additive fix
+
+**Finding** (grep-verified across `packages/core/src`, `packages/cli/src`,
+`packages/ci/src`, `packages/evaluator/src`): two *different* loaders exist in
+`@adrkit/core` today, and only one of them is actually used by any shipped code path.
+
+1. `loadCorpus()` / `Corpus { records, byId }` (`packages/core/src/load/corpus.ts`) is
+   **fail-fast** — `loadAdrFile` calls `AdrFrontmatter.parse(...)`, which **throws** on
+   the first schema-invalid record — and its `byId: Map<string, Adr>` is keyed by the
+   bare `record.frontmatter.id` only, so two records sharing a bare id (the only way
+   this can occur today; see below) silently overwrite each other. **This function and
+   `Corpus`/`byId` are not called by any of `@adrkit/cli`, `@adrkit/ci`, or
+   `@adrkit/evaluator`** — confirmed by grep; they remain exported from
+   `packages/core/src/index.ts` (so an external consumer could still reach them) but
+   are otherwise dead code today.
+2. `lintCorpus()` (`packages/core/src/validate/index.ts`) is what every real consumer
+   (`adr lint`/`graph`/`explain`/`check`/`evaluate`, `@adrkit/ci`, `@adrkit/evaluator`)
+   actually calls. It already does the graceful thing this feature needs: it discovers
+   every candidate file (via `expandRecordInputs`, which discovers via `discoverAdrFiles`
+   when no explicit `paths` are given, or resolves exactly the given `paths` otherwise —
+   both exported from `packages/core/src/load/corpus.ts`), `try`/`catch`es each
+   parse+validate individually, pushes a parse/contract `Finding` for anything invalid,
+   and returns `{ checked, findings, records }` where `records` contains **only** the
+   schema-valid, invariant-checked `Adr[]` — one bad record never blocks the rest, and it
+   never throws for a single invalid record. It has **no** `byId` index at all, and its
+   own `unique-id` corpus invariant (`validate/corpus-invariants.ts`) flags any bare-id
+   collision as an `error`-severity finding **without removing either colliding record
+   from `records[]`** — both remain fully present and loadable. This invariant, and
+   `lintCorpus` generally, is entirely **local and log-unaware**: it groups by
+   `record.frontmatter.id` alone (never by any `log` field) and its dangling-reference
+   check (`ids.has(ref)`) tests a raw ref string against that same bare-id set — so a
+   genuinely log-qualified ref (e.g. `payments:0012`) never matches, even if the numeric
+   id `0012` exists locally. `@adrkit/mcp` relies on exactly this existing, unmodified
+   behavior rather than working around it.
+
+**Decision**: `@adrkit/mcp` builds exclusively on `lintCorpus()` — never on
+`loadCorpus()`/`Corpus`/`byId` — and this feature makes the smallest possible change
+that lets a caller-supplied `ref` string be parsed once, canonically, instead of twice
+(independently) as it is today: `@adrkit/core` gains **one new file** with **two new
+exported functions**, plus **one migrated caller**. Nothing in `load/corpus.ts` or
+`validate/*.ts` is modified; no existing file's *behavior* changes; no dependency
+changes anywhere.
+
+**New file**: `packages/core/src/schema/ref.ts`
+
+```ts
+export interface ParsedAdrRef {
+  readonly id: string;
+  readonly log?: string;
+}
+
+/** Splits a caller-supplied ref string on its first ':' into a (log, id) pair.
+ *  A leading colon or no colon at all is treated as unqualified — returns { id: ref }
+ *  (the untouched original string, since it is never split in that case) — identical
+ *  observable behavior and object shape to the private `parseRef` already duplicated in
+ *  `packages/evaluator/src/rules/no-orphan-refs.ts`, promoted to one canonical,
+ *  exported location so it is no longer implicitly re-derived per consumer. */
+export function parseAdrRef(ref: string): ParsedAdrRef { /* ref.indexOf(':'); idx <= 0 → { id: ref } */ }
+```
+
+Re-exported additively from `packages/core/src/index.ts` via one new
+`export * from './schema/ref.ts';` line, alongside the existing thirteen. There is no
+`formatAdrRef` — see "Why no inverse function" below.
+
+**The migration this promotion actually requires, done now rather than deferred**:
+`packages/evaluator/src/rules/no-orphan-refs.ts`'s private `parseRef` (same `indexOf`,
+same `idx <= 0` guard) is replaced by an import of the new `parseAdrRef` — a safe,
+one-line-import substitution verified by that rule's own existing test suite passing
+unchanged, since the two functions are specified to preserve exact observable behavior
+and object shape for every input, not merely to happen to agree on the cases already
+tested. ("Byte-identical" is deliberately not the claim: the two source files were never
+compared byte-for-byte, and nothing about this promotion requires them to have been — what
+matters, and what is specified, is that calling either with the same input string returns
+deep-equal objects with the same keys present.) Promoting the logic to a shared export but
+leaving the evaluator's own private copy in place would recreate the exact duplication
+this project's "no second parser" posture exists to close — this is genuine,
+previously-duplicated parsing logic with a second real caller today, not a hypothetical
+future one, so deferring the migration to "a separate, optional follow-up" was the wrong
+call and is corrected here: the migration ships in the same change that adds the export.
+
+**Why no inverse function (`formatAdrRef`)**: an earlier draft of this research proposed
+one, reasoned as "kept for round-tripping an unqualified local id through one shared,
+tested function." That reasoning does not survive contact with this feature's actual
+call sites: every place this design echoes a ref back to a caller (`GetDecisionResult`'s
+`requestedRef`, `SupersededEntry`'s `targetRef`) reuses the caller's or the frontmatter's
+own original string verbatim — never reconstructs one from a parsed `{ id, log? }` pair.
+`get_decision`/`list_superseded` (contracts/tools.md §§4, 7) each call `parseAdrRef`
+exactly once, to detect **whether** a ref is log-qualified, and never need to serialize
+one back afterward. Shipping an inverse function with zero production callers in this
+feature would be exactly the kind of speculative, unrequested surface this project's
+"smallest change that satisfies the task" posture (§3 below) argues against elsewhere in
+this same research entry — so it is removed here for the same reason, not added.
+
+**Why this is the whole fix, and why it is smaller than "a new loader"**: `lintCorpus`
+already satisfies "returns valid ADRs plus structured per-record findings" completely —
+that is what it is. The only genuinely missing piece is a **local, multi-valued `id`
+index** (`id` → every record sharing that id — never a canonical log-qualified index,
+because this phase has no `log` dimension to index by at all; see the
+forward-compatibility note below), and building that from `lintCorpus`'s output is a
+six-line loop directly over a field the `Adr` interface already exposes
+(`record.frontmatter.id`) — it needs no string-splitting and therefore no shared parser,
+so it lives entirely inside `@adrkit/mcp`'s own `src/corpus/projection.ts` (data-model.md
+§3), built once per call from that call's fresh `lintCorpus()` result. The one piece
+worth promoting into core is `parseAdrRef`, because it is genuine, previously-duplicated
+**parsing** logic (the project's own evaluator already needed it and wrote a private
+copy) applied to a caller-**supplied ref string** (`get_decision`'s `ref` argument, and
+each `superseded` record's `supersededBy` value inside `list_superseded`) — a different
+operation from indexing already-loaded records, and the one this project's "no
+duplicate parser" posture actually binds to. Its entire job in `@adrkit/mcp` is
+detecting **whether** a ref is log-qualified (so the tool can answer
+`federated-log-unavailable` instead of attempting a local lookup with it) — never
+building or consulting a log-aware index, because none exists.
+
+**The size guard is deliberately not a core addition, and it runs *before* `lintCorpus`,
+never after.** Neither `loadCorpus` nor `lintCorpus` caps source file size today, and
+this design needs one (FR-012, `record-too-large`). That cap is a **product policy
+specific to this one consumer** (64 KiB, contracts/tools.md §8) — `adr lint`/`graph`/
+`check` must not silently start excluding large-but-valid records as a side effect of
+this feature. `@adrkit/mcp` applies the cap itself, entirely as a **pre-read** step:
+it calls the already-exported `discoverAdrFiles(dir, cwd)` directly (the same discovery
+`lintCorpus` would otherwise perform internally), `stat()`s each candidate path, and
+passes only the paths that are within-limit at that check to `lintCorpus({ paths, cwd })`.
+A second `stat()` after `lintCorpus` compares each survivor's `dev`/`ino`/`size`/
+nanosecond `mtime` tuple with the pre-read value and rechecks the cap; a mismatch makes
+the whole call `corpus-unavailable` / `corpus-changed-during-load`, so a changing or
+now-oversized candidate is never returned or fingerprinted as stable. A `stat()` failure
+on one candidate (e.g. a permission error or a race-deleted file) becomes its own
+structured, path-only finding; a failure discovering the ADR directory itself (it does
+not exist, is not a directory, or is not readable) is corpus-wide unavailable, not a
+per-file finding. This ordering prevents files already known to be oversized from
+entering core's unbounded read path and prevents a normal stat-to-read race from leaking
+an oversized or internally inconsistent record into a response. It does not claim that
+a file which grows during core's `readFile()` was never read; it rejects that provisional
+load before output. This adds no new `@adrkit/core` export and touches no existing one;
+`discoverAdrFiles` was already exported before this feature.
+
+**A verified implementation pitfall this design must special-case, not merely note**:
+reading `packages/core/src/load/corpus.ts`'s `expandRecordInputs` directly shows `if
+(!paths || paths.length === 0) { return discoverAdrFiles(dir, cwd); }` — an **empty**
+`paths` array is treated identically to **no** `paths` argument at all, and both fall
+back to a fresh, unfiltered `discoverAdrFiles(dir, cwd)` call. If the pre-read guard
+above excludes every discovered candidate (the corpus's one file is oversized, say),
+naively calling `lintCorpus({ paths: [], cwd })` would silently **re-discover and
+re-include** the exact file the guard just excluded, defeating it for that specific edge
+case. `@adrkit/mcp` therefore special-cases zero within-limit paths by skipping the
+`lintCorpus` call entirely and returning zero records with only the guard's own findings
+(data-model.md §3.3) — this is not an edge case a reviewer should have to infer; it is
+observable by reading `expandRecordInputs` directly, and a design that called
+`lintCorpus({ paths: keptPaths })` unconditionally would have silently reintroduced
+exactly the bug this guard exists to close.
+
+**Forward-compatibility, stated precisely — this phase defers federation completely,
+not partially**: `Adr.log` (`packages/core/src/schema/adr.schema.ts:315`) is a real,
+typed, optional field on the runtime `Adr` interface — but grep-confirmed, **nothing in
+`@adrkit/core` today ever sets it**; every record `loadCorpus`/`lintCorpus` produces has
+`log === undefined`, and this server's own discovery (via `discoverAdrFiles`) is
+non-recursive over the one configured ADR directory, so there is no way for this phase
+to observe more than one named log from what it actually loads even in principle. This
+design does **not** carry a vestigial `(log ?? "", id)` tuple through its index "ready to
+degrade gracefully" the moment core starts populating `.log` — that framing was
+considered and is deliberately rejected (see Alternatives Rejected): it would keep a
+structural placeholder for a capability this phase does not build, test, or specify, and
+the review guidance for this correction is explicit that named-log/multi-repository
+federation is deferred **completely**, governed by the root `plan.md`'s own open
+question, not quietly half-designed here. Concretely: the local index is `id → readonly
+Adr[]`, full stop; two records sharing a bare `id` (an authoring mistake today, or
+whatever a future same-corpus, multi-log design would eventually need to distinguish)
+are exactly the "zero/one/many" `ambiguous-local-id` case FR-022 already requires, with
+no log-shaped hook reserved for later. If `@adrkit/core` ever starts populating `.log`
+for a genuine multi-log corpus, resolving it is new, out-of-scope design work for that
+future feature, not a field this phase's index already accommodates.
+
+**Alternatives rejected**:
+- *Fix `loadCorpus`/`Corpus`/`byId` in place* — rejected: not needed (nothing calls it),
+  and touching it would be a change to `@adrkit/core`'s existing exported surface this
+  task explicitly asks to avoid; leaving it exactly as-is is strictly safer.
+- *Add an inverse `formatAdrRef(log, id)` alongside `parseAdrRef`* — rejected, and
+  corrected from an earlier draft of this research: no call site this feature actually
+  builds ever needs to reconstruct a `log:id` string from parsed parts (§3, "Why no
+  inverse function"). Every ref this design echoes back to a caller is the original,
+  caller- or frontmatter-supplied string, reused verbatim. An unused inverse function
+  would be speculative surface, not a promotion of proven, duplicated logic — the
+  opposite of the standard `parseAdrRef` itself is held to.
+- *A new `loadCorpusForMcp()`-style function in `@adrkit/core` that re-implements
+  discovery + parse + validate + index in one call* — rejected: this would be a second,
+  parallel corpus loader alongside `lintCorpus`, risking exactly the kind of drift
+  ADR-0009's "no second resolver" posture warns against for `affects`; every existing
+  consumer's behavior must stay provably identical, which is easiest to guarantee by
+  changing nothing they call.
+- *Push the byte-size cap into `@adrkit/core` as a `lintCorpus` option* — rejected: it
+  would change `adr lint`/`graph`/`check`'s observable behavior (a new, silently-
+  applicable exclusion path) for a policy that belongs to exactly one consumer.
+- *Apply the size guard after `lintCorpus` returns, by `stat`-ing each returned record's
+  path* — rejected, and corrected from an earlier draft of this research: it would mean
+  `lintCorpus` (and therefore `parseAdrFile`) already read and parsed an oversized
+  file's full bytes before this server decides to exclude it, which is exactly the "never
+  read into an unbounded response" property FR-012 forbids weakening. Pre-reading via
+  `discoverAdrFiles` + `stat()`, then calling `lintCorpus({ paths })` with only the
+  survivors, is the only ordering that keeps the guarantee genuine.
+- *Retain a `(log ?? "", id)`-shaped index with a single, deterministically-chosen
+  "representative" record per key even when more than one record shares a bare id* —
+  rejected: an arbitrary representative is precisely the "silent choice" FR-022
+  forbids; every consumer of the local index gets the full bucket (`readonly Adr[]`)
+  and decides zero/one/many for itself.
+- *Call `lintCorpus({ paths: keptPaths, cwd })` unconditionally, including when
+  `keptPaths` is empty* — rejected after tracing `expandRecordInputs`: an empty array is
+  treated identically to "no `paths`," silently re-triggering a full, unfiltered
+  `discoverAdrFiles` and reintroducing every file the guard just excluded — exactly the
+  bug the special case above exists to close, not a theoretical concern.
+- *Defer migrating `no-orphan-refs.ts` to a separate, later change* — rejected: the
+  duplication this promotion exists to close already has a second, real caller today;
+  shipping the export without its one known consumer migrated leaves the duplication
+  exactly as it was, just with an unused third copy of the same logic sitting beside it.
+
+---
+
+## R4 — Reusing `resolveAffects`: per-record invocation to keep matches unambiguous
+
+**Decision**: `get_decision_context` reuses `@adrkit/core`'s existing, pure
+`resolveAffects({ records, changedFiles, snapshots, log })`
+(`packages/core/src/affects/index.ts`) unchanged — the exact function `adr check`,
+`adr explain`, and `@adrkit/ci` already call — but calls it **once per record**
+(`records: [oneRecord]`) rather than once for the whole corpus, and never supplies a
+`log` value (consistent with FR-035: this phase configures no log identity for the
+server at all).
+
+**Rationale**: `resolveAffects`'s `AffectsMatch` result carries only `recordId: string`
+(`record.frontmatter.id`, bare) and `firedMatchers[]` — not a reference back to the
+`Adr` object itself. When the corpus contains two records sharing a bare id (R3 — the
+only way this happens today), a single batched call across the whole corpus could
+return two `AffectsMatch` entries with the **identical** `recordId`, and nothing in
+`resolveAffects`'s public contract promises a stable, documented way to re-associate
+each match with the specific record that produced it (the array happens to preserve the
+input-record iteration order before its own internal final sort, but that is an
+implementation detail of a function this package does not own, not a contract to depend
+on). Calling `resolveAffects` once per record trivially removes the ambiguity — each
+call's `matches` array has zero or one entries, and if one, it is unambiguously that
+record — at the cost of `O(records)` calls instead of one, which is immaterial at this
+project's actual corpus sizes (tens to low thousands of records) and does not change
+`resolveAffects`'s semantics, inputs, or purity in any way (ADR-0009's per-ADR
+union-not-winner match semantics are per-record by definition already; calling it per
+record does not alter what "matches" means). Findings returned per call (e.g.
+`affects-unresolvable` for a `package` matcher with no snapshot) are this tool's
+**derived** findings (data-model.md §3.5): concatenated across all per-record calls,
+then merged with `CorpusProjection.corpusFindings` into this call's own
+`responseFindings`, re-sorted canonically, and only then paginated (contracts/
+pagination-and-cursors.md) — `CorpusProjection` itself is read, never written to, by this
+step.
+
+**A disclosed, existing-behavior consequence of passing no `log`**: `AffectsMatcher.repo`
+(schema-documented as "Qualifier for federated logs. Omit for same-repo.") makes
+`resolveAffects`'s own, unmodified `matcherAppliesToLog` check (`!matcher.repo ||
+matcher.repo === log`) skip any matcher whose `repo` is set whenever `log` is
+`undefined` — and it skips it **silently**, with `continue` before any match/finding
+logic runs, unlike a `package`/`entity`/other unbacked matcher, which still produces an
+explicit inert/informational finding. Because this phase never configures a `log`
+(FR-035), any `repo`-qualified `affects` matcher on any record therefore never fires and
+never contributes a finding through `get_decision_context`, exactly as `adr check`/
+`adr explain` already behave for the same input today — this is existing, unmodified
+`@adrkit/core` behavior this design relies on rather than a new gap, but it is stated
+here explicitly so a future reader does not mistake "no match, no finding" for a bug:
+resolving `repo`-qualified matchers is the same out-of-scope, federation-adjacent
+capability named in [Assumption A1](../spec.md#assumptions).
+
+**Alternatives rejected**:
+- *One batched call, reconstruct association by array position* — rejected after
+  tracing `resolveAffects`'s implementation: the reconstruction would depend on an
+  internal iteration-order detail of a function this package does not own and whose
+  contract does not promise it: fragile, and the exact kind of thing "do not hand-wave"
+  is warning against.
+- *One batched call, reconstruct association via `find(r => r.frontmatter.id ===
+  match.recordId)`* — rejected: silently wrong under id collision (returns the first
+  match, which is exactly the "silent first match" FR-022 forbids, just relocated into
+  `get_decision_context` instead of `get_decision`).
+- *Fork `resolveAffects` to also return the source `Adr`* — rejected: this is exactly
+  the "no duplicate... affects matcher" the task guards against; the per-record call
+  achieves the same correctness using the function exactly as published.
+
+---
+
+## R5 — Search normalization: trim → NFKC → locale-independent `toLowerCase()`
+
+**Decision**: `normalize(s) = s.trim().normalize('NFKC').toLowerCase()`, applied
+identically to the query and to every searchable field (id, title, each tag, body)
+before a literal substring comparison. No stemming, fuzzy matching, locale collation,
+embeddings, or per-field/per-record weighting (FR-026).
+
+**A whitespace-only query is an input-contract rejection, not a match-everything
+query.** `search_decisions.query`'s input schema requires `query.trim().length >= 1`, in
+addition to the raw `1–256` code-unit bound (contracts/tools.md §5, §8) — checked, and
+rejected as an ordinary input-shape violation (FR-015 case (a), before any corpus
+access), independently of the raw-length check. This closes a real correctness gap an
+earlier draft left open: a raw bound of `min(1)` alone accepts a string of one or more
+space characters, which then normalizes to the empty string; `String.prototype.includes('')`
+is `true` for every string, so an un-guarded whitespace-only query would silently match
+**every** record in the corpus, which is a fundamentally different (and wrong) result
+from "no query supplied" or "query matched nothing." Requiring non-emptiness after
+`trim()` — not merely non-emptiness of the raw input — closes this before the query ever
+reaches the matching step.
+
+**Rationale, first-party per ECMA-262**: `String.prototype.toLowerCase()` (no argument)
+is defined by the ECMAScript specification to apply the Unicode default case-conversion
+algorithm and is explicitly **not** locale-sensitive — that is the specific, narrower
+`String.prototype.toLocaleLowerCase()`, which *is* locale-sensitive (the canonical
+example being Turkish `İ`/`i`/`I`/`ı`) and is exactly what this design must avoid,
+because a locale-sensitive fold would make search results depend on the server
+process's runtime locale — a hidden, environment-dependent input this project's
+determinism posture (Principle IV, extended by this spec's FR-004/FR-026) cannot admit.
+Plain `toLowerCase()`/`String.prototype.normalize('NFKC')` are core ECMA-262/Unicode-
+data-table built-ins implemented directly in the JS engine (V8, in both Node and Bun);
+neither requires Node's `--with-intl=full-icu` flag or any ICU data bundle — that
+requirement is specific to `Intl.*` and the `toLocale*` family, not to `normalize()` or
+plain case folding. This makes the three-step pipeline portable and reproducible across
+Node 22, Node 24, and Bun with no build flag or bundled-data dependency, satisfying
+FR-039/FR-040's clean-clone/Node-targeted requirements as a byproduct of using only
+engine-builtin, non-ICU string operations.
+
+**Order**: trim first (strip incidental caller whitespace before it can affect
+normalization), then `normalize('NFKC')` (fold compatibility variants — e.g. full-width
+forms, some ligatures — into their canonical composed form), then `toLowerCase()`
+(case-fold the already-normalized codepoints) — the exact order the binding design
+direction specifies, and the sensible general order (normalize codepoints, then fold
+case on the result) rather than the reverse.
+
+**Alternatives rejected**:
+- *Accept any raw `query` of length >= 1, relying on normalization alone* — rejected and
+  corrected from an earlier draft: as described above, a whitespace-only raw query
+  normalizes to `''`, which matches every record via `includes('')` — a silent,
+  surprising, effectively-unbounded result for what looks like a narrow, specific query.
+  Validating `query.trim().length >= 1` in the input schema itself closes this before
+  matching ever runs.
+- *`toLocaleLowerCase()` / `Intl.Collator`-based comparison* — rejected: introduces a
+  hidden, runtime-locale-dependent input into a channel FR-014/FR-026 require to be
+  deterministic and closed-world; two identical calls on two different locale-configured
+  hosts could disagree.
+- *NFC instead of NFKC* — rejected: NFC only canonically composes; NFKC additionally
+  folds compatibility variants, which is the more forgiving, more useful choice for a
+  literal-substring search surface and is what the binding design direction specifies.
+- *Stemming or fuzzy matching* — rejected outright by FR-004/FR-026/A2: this phase is
+  deterministic literal matching only; a ranking heuristic is a future, explicitly
+  out-of-scope, probabilistic feature (Out of Scope).
+
+---
+
+## R6 — Pagination cursors and the corpus fingerprint
+
+**Decision**: every cursor is an opaque (by protocol convention, not by any
+confidentiality guarantee — see Rationale), base64url-encoded, versioned, JSON envelope —
+never a raw offset or a raw query echoed back — bound to (a) a **corpus fingerprint**
+covering `records`/`corpusFindings`/`corpusHealth` and (b) a **hash of the exact
+query-shape parameters** (`qh`) it was minted against, so that a corpus change or a
+parameter change between pages is caught explicitly rather than silently gapping or
+duplicating results. See contracts/pagination-and-cursors.md for the full wire format,
+the exact fingerprint algorithm, and the field-scoping rules (which input field a given
+cursor is valid in). Summarized here:
+
+- **The one comparator this feature defines**: a fixed, locale-independent code-unit
+  comparator, `compare(a, b) = a < b ? -1 : a > b ? 1 : 0` over plain JS strings (which
+  compares by UTF-16 code unit, never by `localeCompare`'s locale-sensitive collation).
+  `@adrkit/mcp` uses this **one** function everywhere an order matters: the canonical
+  `(id, sourcePath)` record/result order (contracts/tools.md §2), every `matchedFields`
+  array, and — the reason it is introduced here — recursively sorting object keys when
+  building the canonical JSON below. `@adrkit/core`'s own `sortFindings()`
+  (`validate/findings.ts`) is **not** reused for any of this, because it calls
+  `String.prototype.localeCompare`, which is locale-sensitive and therefore not the
+  deterministic, environment-independent ordering this feature's fingerprint and
+  pagination guarantees depend on; `lintCorpus`'s own `localeCompare`-ordered findings
+  array is accepted as **input** (an already-deduplicated, already-structured set) and
+  then **re-sorted** by `@adrkit/mcp`'s own comparator — using the same field-priority
+  tuple `sortFindings` already uses (`rule`, then `id ?? ""`, then `pattern ?? ""`, then
+  `path ?? ""`, then `field ?? ""`, then `message`) but comparing each field with the
+  code-unit comparator instead of `localeCompare` — before it is fingerprinted, paginated,
+  or returned on any tool's `findings` channel.
+- **Fingerprint scope: corpus findings only, not every tool-derived finding.** SHA-256,
+  hex-encoded, over the **canonical JSON serialization** (object keys sorted recursively
+  with the code-unit comparator above, no whitespace) of exactly:
+
+  ```ts
+  {
+    records: /* every valid, within-limit record, in canonical (id, sourcePath) order */
+      readonly { sourcePath: string; frontmatter: AdrFrontmatter; body: string }[],
+    corpusFindings: /* @adrkit/mcp's own re-sorted findings for THIS PROJECTION ONLY —
+                       lintCorpus's own findings plus the pre-read guard's own findings;
+                       never a tool-derived finding (below) */ readonly Finding[],
+    corpusHealth: { recordCount: number; excludedCount: number },
+  }
+  ```
+
+  This is the **wire-relevant corpus projection**, not raw file bytes and not "every
+  finding any tool could ever produce for this call": it hashes exactly the parsed,
+  structured corpus data every tool's response is built *from* (the same
+  `frontmatter`/`body` `get_decision` echoes verbatim, the same `corpusFindings` every
+  tool folds into its own response, the same counts `corpusHealth` reports) — so it
+  changes on every change to the **corpus projection** itself, and requires no second
+  file read, because every value it hashes is already in hand once
+  `loadCorpusProjection` has run (`lintCorpus`'s own parse step already produced
+  `frontmatter`/`body` for every within-limit record; the pre-read guard and
+  `lintCorpus` together already produced `corpusFindings` and the two counts). It is
+  deliberately insensitive to a raw *frontmatter* formatting edit that parses to an
+  identical `AdrFrontmatter` object (key order, quoting style, incidental whitespace
+  inside the YAML block) — hashing the parsed object, not the YAML bytes, is what makes
+  that true — and, by the same reasoning, insensitive to a change in an oversized
+  candidate's raw bytes as long as the file remains oversized under the same path (its
+  contribution to the projection stays "excluded, `record-too-large`, this `path`"
+  either way — hashing the parsed/derived projection, never raw bytes, is what makes
+  *that* true too) — while remaining fully sensitive to any change in `body` (the raw
+  Markdown text is echoed verbatim with no normalization, so any byte of it changing
+  changes the fingerprint), any change in `sourcePath`, any change in which files are
+  discovered at all, and any change to a corpus finding or either health count.
+
+  **What the fingerprint deliberately excludes, and why that is still safe**: a
+  tool-derived finding — `get_decision_context`'s per-record `resolveAffects` findings,
+  `list_superseded`'s `superseded-target-ambiguous`/`superseded-target-federated-unavailable`
+  findings (data-model.md §3.5) — is never part of the hashed value above. An earlier
+  draft of this research described the fingerprint as covering "the complete findings
+  set for this call" and claimed it "changes on every change observable through any tool
+  result or finding"; both statements are corrected here, because neither was ever true
+  for a tool-derived finding, which depends on that call's own substantive inputs
+  (`files[]`, or nothing beyond the corpus itself), not on the corpus alone. Excluding
+  them from the fingerprint is safe, not merely convenient: each tool-derived finding is
+  a **pure, deterministic** function of `(CorpusProjection, that call's own substantive
+  inputs)`, and the cursor's `qh` (contracts/pagination-and-cursors.md §4) already
+  covers exactly those inputs for the channel being paginated. An unchanged `fingerprint`
+  together with an unchanged `qh` therefore already pins down the derived findings
+  exactly, with no need to fold them into the hashed corpus projection as well — doing so
+  anyway would be redundant at best, and would be actively wrong for
+  `list_superseded`'s findings-channel `qh`, which intentionally hashes nothing but
+  `findingsLimit` (that tool takes no filter input) — if a tool-derived finding were part
+  of the hashed corpus projection, a change to it would need to invalidate every open
+  cursor for every tool, including tools whose own inputs never changed, which is not
+  this design's intent.
+
+  The canonical JSON serialization and SHA-256 pass are the dominant additional
+  per-call CPU/allocation cost introduced by this feature: every call already reads the
+  full within-limit corpus through `lintCorpus`, then serializes and hashes that full
+  parsed projection even when the requested result is one record. This remains the
+  explicitly accepted linear-in-corpus cost for Phase 5's no-cache design.
+
+  An earlier draft of this research also proposed hashing `path + "\0" +
+  sha256(fileBytes)` for every discovered candidate file's raw bytes, reusing bytes
+  `lintCorpus`'s own `parseAdrFile` already read; that claim is likewise corrected here
+  — this design never hashes raw candidate-file bytes. A candidate already oversized at
+  the pre-read check is never handed to `lintCorpus`; a candidate that changes during
+  loading causes the provisional projection to be rejected before hashing (R3).
+- **Cursor payload**: `{ v: 1, scope: '<tool>.<channel>', fp: <fingerprint>, qh: <query-
+  shape hash>, offset: <positive safe integer> }`, JSON-encoded with a fixed field order
+  and base64url-encoded. `offset` is never `0`: the implicit first page of any channel
+  needs no cursor at all, and every minted continuation cursor's `offset` is the prior
+  offset (or `0`, for an implicit first page) plus that page's item count, which is at
+  least `limit`'s own minimum of `1` — so a genuine, server-minted cursor's `offset` is
+  always `>= 1`, and a decoded `0` (or any non-positive or non-safe value) is rejected
+  outright as malformed. An **offset**, not an opaque "resume-after key," is safe here
+  specifically *because* it is always paired with an exact-match fingerprint check and an
+  explicit in-range check: if the fingerprint and query-shape hash both match, the freshly
+  recomputed, deterministically sorted candidate array for that call is byte-identical to
+  the one the offset was issued against, and an explicit `offset < array.length` check
+  (contracts/pagination-and-cursors.md §2, step 8) catches an offset that was never
+  validly issued against that exact array — so slicing at that offset cannot drift, gap,
+  duplicate, or read past the end.
+- **Two independent cursors per call**: every tool's input carries a primary-channel
+  `cursor`/`limit` pair and an independent `findingsCursor`/`findingsLimit` pair
+  (contracts/pagination-and-cursors.md §4) — "how result and findings cursors coexist"
+  is exactly this: both are minted against the same fingerprint but distinct `scope`
+  values and query-shape hashes, and track independent offsets into two
+  independently-sorted, independently-paginated arrays, so a caller can walk one channel
+  to completion without being forced to walk the other. **Every supplied cursor is
+  always decoded and verified — never silently skipped** because a call's substantive
+  outcome turns out to have no channel for it to apply to; see the decode/verify order
+  below and contracts/pagination-and-cursors.md §5 for exactly when a primary cursor
+  applies and when it does not (`get_decision`'s `found`/`not-found`/
+  `federated-log-unavailable` outcomes have no primary channel at all).
+- **Decode/verify order**: base64url-decode → parse as JSON strictly → check `v` is a
+  version this build understands → check `scope` matches the specific input field (and
+  tool) the cursor arrived in (a findings-cursor value presented in the primary `cursor`
+  field, or a cursor scoped to a different tool entirely, is rejected, not silently
+  reinterpreted) → check `fp` equals this call's freshly computed fingerprint → check
+  `qh` equals this call's freshly computed query-shape hash → (primary cursor only)
+  check this call's resolved substantive outcome actually has a paginated primary
+  channel for this scope to apply to → recompute that channel and check the offset is
+  still in range → only then use `offset` as an array index. Any failure at any step is
+  the shared `invalid-cursor` outcome (§R1.2) with a specific `reason`
+  (`decode-failed | version-unsupported | wrong-channel | query-mismatch |
+  corpus-changed | cursor-not-applicable | offset-out-of-range`) — never a silent
+  fallback to page 1 and never a thrown exception.
+
+**Rationale, and what "opaque" actually protects.** MCP itself defines an
+**opaque**-cursor convention for its own list methods (`tools/list`, `resources/list`,
+etc.) — `modelcontextprotocol.io/specification/2025-06-18/server/utilities/pagination`:
+*"the cursor is an opaque string token... Clients MUST treat cursors as opaque tokens:
+don't make assumptions about format, don't parse or modify, don't persist across
+sessions... Invalid cursors SHOULD result in an error."* This project's four tools never
+grow in number, so there is no protocol-level `tools/list` pagination need — the cursors
+this design defines are entirely inside each tool's own `structuredContent`, not the
+protocol's own `params.cursor`/`result.nextCursor`, and MCP does not standardize a
+tool-result-level pagination shape. This design deliberately mirrors the *idiom*
+(opaque, non-parseable, invalid-is-an-explicit-error) for consistency with the rest of
+MCP's own vocabulary — a caller is not *meant* to construct, parse, or persist one, and
+this design never asks a caller to — while implementing it as an ordinary Zod-validated
+string field, base64url-encoded, because nothing in the protocol does this for tool
+results already. **Base64url is a plain, reversible encoding, not a cryptographic one**:
+it grants zero confidentiality and provides no integrity guarantee on its own; anyone who
+reads this document can compute a matching `qh` and hand-construct a plausible cursor
+with no help from this server. This design never claims otherwise, and never relies on
+that being hard. What actually protects correctness is the strict decode/verify sequence
+above, run identically regardless of where the cursor value came from: any mismatch at
+any step is rejected as `invalid-cursor`, never silently accepted. This is a
+**correctness/staleness** binding, not an authentication or security mechanism — there is
+no secret to protect, and a cursor that passes every check can, at most, hand the caller
+an in-range offset into their own already-authorized, read-only view of the same corpus
+they could otherwise page through one item at a time.
+
+**Alternatives rejected**:
+- *Raw numeric offset as a plain input field, no cursor object* — rejected: not
+  bound to a specific corpus/query (nothing stops reusing an offset from a completely
+  different query against a different corpus state) and not "versioned" (no way to
+  evolve the format later without breaking every in-flight cursor silently).
+- *An "after last-key" resumption token instead of an offset* — rejected as unnecessary
+  complexity: it only pays for itself when the underlying collection isn't guaranteed to
+  be byte-identical across calls with a matching fingerprint, which is precisely the
+  case this design's fingerprint check already rules out.
+- *Encrypt or HMAC-sign the cursor* — rejected: there is no confidentiality or forgery
+  concern to defend against — a forged, edited, or hand-constructed cursor can, at worst,
+  cause a benign `invalid-cursor` response (a mismatched `fp`/`qh`, an inapplicable
+  scope, or an out-of-range offset) or a benign in-range offset into the caller's **own**
+  already-authorized view of the same read-only corpus; it can never widen access, skip
+  validation, or reach a different corpus. Signing would add real implementation cost
+  (key management, for a server with no other secret to manage) to close a threat this
+  design does not have.
+- *Reuse `@adrkit/core`'s `sortFindings()` directly for the findings channel's order and
+  for canonical-JSON key sorting* — rejected: `sortFindings` compares with
+  `String.prototype.localeCompare`, whose result can vary by the server process's
+  runtime locale (ICU data, `Intl` defaults) — the same category of hidden,
+  environment-dependent input R5 already rules out for search normalization. A
+  fingerprint or a page boundary that could differ between two otherwise-identical
+  processes purely because of a locale setting would silently break the "byte-identical
+  on repeat calls" guarantee this contract exists to provide; the one-line, engine-builtin
+  code-unit comparator has no such dependency.
+- *Hash raw candidate-file bytes (the earlier draft's approach) instead of the parsed
+  wire projection* — rejected and corrected (see the Fingerprint bullet above): it
+  requires reading every candidate file's bytes, including candidates already known by
+  the pre-read size guard (R3) to exceed the response policy, and it does not actually match
+  "changes whenever the corpus projection changes" as precisely as hashing the parsed
+  projection does (e.g. it would falsely change on a no-op frontmatter re-serialization
+  that alters YAML byte layout without altering the parsed result).
+- *Fold every tool-derived finding into the hashed corpus projection* — rejected and
+  corrected from an earlier draft that implied this by describing the fingerprint as
+  covering "the complete findings set for this call": doing so would make a
+  `get_decision_context` cursor invalidate on a `files[]` change that is already fully
+  captured by that channel's own `qh`, would make `list_superseded`'s cursor
+  (deliberately `findingsLimit`-only in its `qh`) either need a redundant, corpus-scoped
+  hash input it does not otherwise need or silently stop noticing a change it should
+  notice, and conflates a corpus-scope concern (the fingerprint) with a call-scope
+  concern (`qh`) that this design otherwise keeps cleanly separated (contracts/
+  pagination-and-cursors.md §4; data-model.md §3.5).
+- *Silently ignore a primary cursor whenever the call's outcome resolves to a
+  non-paginated singleton* — rejected and corrected from an earlier draft, which reasoned
+  "there is nothing to resume, so a stale value there cannot surface as a spurious
+  failure." That reasoning trades away a real signal for a marginal convenience: a
+  `get_decision` caller who supplies a `cursor` expecting an `ambiguous-local-id` page and
+  instead silently gets a clean `found`/`not-found` answer has no way to tell "your cursor
+  was ignored" from "there was never anything to page through," which can mask a client
+  bug (a caller that assumed a previous, no-longer-ambiguous ref was still ambiguous).
+  Explicitly reporting `invalid-cursor` / `cursor-not-applicable` in that specific case
+  costs one extra branch and is honest about what happened instead.
+
+---
+
+## R7 — Startup configuration and CLI conventions: `adrkit-mcp --cwd <path> --dir <path>`
+
+**Decision**: a dedicated bin, `adrkit-mcp`, distinct from the existing `adr` CLI bin,
+accepting `--cwd <path>` (default `process.cwd()`) and `--dir <path>` (default
+`docs/adr`, resolved relative to `--cwd` unless absolute) — reusing `lintCorpus`'s own
+`{ cwd, dir }` parameter names exactly, and matching the CLI's existing `--dir docs/adr`
+convention verbatim (`packages/cli/src/index.ts`'s `runLint`/`runGraph`/`runCheck`, all
+`{ dir: { type: 'string', default: 'docs/adr' } }`). Optional environment-variable
+fallbacks `ADRKIT_MCP_CWD` / `ADRKIT_MCP_DIR` are accepted (CLI flags win when both are
+given) for harnesses that configure subprocess launches via an environment map more
+naturally than argv. No other startup input exists — no log-identity setting, no
+backing-snapshot path, no port, no config file (FR-035).
+
+**Rationale**: `grep`-confirmed, no existing `@adrkit/*` bin exposes a `--cwd` flag
+today — every CLI command implicitly uses `process.cwd()` and only varies `--dir`. This
+is a deliberate, justified departure from that specific precedent, not an accidental
+one: the CLI is invoked by a human from inside the repository being governed, so
+`process.cwd()` is already correct; an MCP server is launched as a subprocess by a
+third-party agent harness (ADR-0010) whose own working directory is not guaranteed to
+be — and in general-purpose harnesses commonly is not — the governed repository root.
+An explicit, separately-nameable `--cwd` decouples "where the harness happened to start
+the subprocess" from "which corpus this server answers for," which is exactly the
+boundary FR-008/FR-035 need to be unambiguous about. `--dir` is reused verbatim because
+nothing about it needs to change: it is already exactly "the ADR directory, relative to
+the root," under a different name for "root" only.
+
+**Root and directory validation at startup — realpath-based, path-segment-safe
+containment, and why it needs no shell-out**: `--cwd` (after resolving flag → env var →
+`process.cwd()` default) MUST canonicalize, via `fs.realpath`, to a directory that is
+readable and contains a readable `.git` entry directly beneath it — `fs.stat`/`fs.access`
+on `<canonicalCwd>/.git`, accepting either a **directory** (an ordinary clone) or a
+**file** (a linked worktree's `.git` file, which contains a `gitdir:` pointer rather than
+being the object database itself — this server only needs to confirm the entry exists
+and is readable, not parse or follow that pointer). No `git` CLI invocation or other
+shell-out is required or performed; this is a plain filesystem check, consistent with
+FR-011's "no network access" and this project's general preference for filesystem truth
+over shelling out to a tool. `--dir` is then resolved **against** the canonical `cwd` and
+must itself canonicalize, via `fs.realpath`, to a readable directory whose canonical path
+equals or is **path-segment-safely contained within** the canonical `cwd` — computed as
+`path.relative(canonicalCwd, canonicalDir)` and rejecting unless that value is empty or
+its first segment is not `..` (never a plain `startsWith()` string-prefix test, which a
+sibling directory sharing a name prefix — e.g. `/repo` vs. `/repo-secrets` — would
+defeat). An absolute `--dir` that does not fall under `cwd`, a `--dir` whose resolved
+path escapes `cwd` via a `..` traversal segment, and — the gap a purely lexical check
+like the one above misses — a `--dir` that is, or whose canonical resolution passes
+through, a **symlink** that lands outside `cwd` are all rejected identically: all are
+"unusable configuration" (FR-036), not a corpus-content problem. `fs.realpath`
+specifically is what catches the symlink case: it resolves every symlink on the path,
+including in intermediate segments, before the containment check ever runs on the two
+canonical strings, so a `dir` string that reads as perfectly contained lexically (no
+literal `..`) but resolves through a symlink to somewhere outside `cwd` is still caught.
+This closes the startup-time lexical/symlink gap FR-008/FR-009 already close for
+tool-input paths. It does not by itself claim an atomic filesystem snapshot.
+
+**Startup establishes an expected canonical root; every load revalidates all path
+boundaries.** The public handle performs no I/O at construction. Its `start()` validates
+`cwd`/`dir`, retains the immutable configured strings plus the expected canonical root,
+and only then constructs the private server and stdio transport. Before and after every
+core load, the implementation re-realpaths and validates both configured paths, requires
+the fresh root to equal the startup root, and repeats the `.git`, readability, and
+segment-safe containment checks. Each discovered candidate is additionally
+`lstat`-checked as a regular non-symlink, realpath-contained in the fresh ADR directory,
+and bigint-`stat` checked for `dev`/`ino`/`size`/nanosecond-`mtime` equality across the
+load. Any observed difference discards the complete projection.
+
+These are portable Node `>=22` consistency checkpoints, not a lock or uniform atomic
+open-beneath/no-follow guarantee. A hostile swap that occurs and reverts entirely
+between checkpoints while core performs a path-based read cannot be proven absent and
+is explicitly outside this phase's guarantee.
+
+**A separate bin, not a subcommand of `adr`**: `adr` is today a purely one-shot,
+argument-in/exit-code-out program with zero long-running subcommands; `adrkit-mcp` is a
+process that blocks on `stdin` for its entire lifetime. Mixing those two operational
+shapes under one entrypoint (`adr mcp`) would make `adr`'s own usage/exit-code contract
+ambiguous (what does `adr mcp --help` exit with, if the process is meant to run
+forever?) for no benefit — the two are launched by different callers (a human's shell
+vs. an agent harness's subprocess spawner) for different reasons, and this spec's
+Assumption A4/A6 already frame `@adrkit/mcp` as its own package, not a CLI feature.
+
+**Alternatives rejected**:
+- *No `--cwd`, rely on the harness setting the subprocess's working directory
+  correctly* — rejected: shifts a correctness-critical, security-relevant boundary
+  (FR-008: "no tool input may expand, redirect, or escape [the corpus] boundary") onto
+  every harness's launch configuration getting `cwd` exactly right, with no way for this
+  server to state or verify what it is actually rooted at.
+- *A `.adrkitrc`/config-file convention* — rejected: FR-035 fixes configuration to
+  "startup-only" via "environment variables, CLI flags, or equivalent launch
+  configuration," explicitly not a third persistent-file mechanism this phase has no
+  other need for, and adding one would be new, unrequested surface area.
+- *Shell out to `git rev-parse --show-toplevel`/`git rev-parse --is-inside-work-tree` to
+  validate the root* — rejected: it requires a `git` executable on `PATH` (a new,
+  unstated runtime dependency this project has otherwise avoided) and a child-process
+  spawn for a fact a direct filesystem check already answers; it would also subtly change
+  behavior inside a linked worktree depending on which `git` subcommand and version is
+  installed, where a plain `.git`-entry check is both simpler and more predictable.
+- *Skip root validation entirely and only check `--dir` is readable* — rejected: a
+  readable directory that happens not to be a git working tree at all (e.g. a stray
+  directory of Markdown files) would silently pass, defeating the "git holds the record"
+  posture (ADR-0001) this server's whole premise depends on; requiring a `.git` entry is
+  the cheap, direct check that the configured root is genuinely the thing ADR-0001 and
+  ADR-0004 are talking about.
+- *Check containment on the raw, uncanonicalized `--cwd`/`--dir` strings (reject only a
+  literal `..` segment or a leading `/`)* — rejected, and corrected from an earlier draft
+  of this research: a lexical-only check is blind to a `dir` that resolves, once symlinks
+  are followed, to somewhere outside `cwd` — every character of the configured string can
+  look perfectly contained while the real, followed path is not. `fs.realpath` on both
+  sides before the containment check is what actually closes this, not an additional
+  string pattern to blocklist.
+- *Check containment with `canonicalDir.startsWith(canonicalCwd)`* — rejected: a plain
+  string-prefix test is fooled by a sibling directory that merely shares a name prefix
+  (`/repo` vs. `/repo-secrets`); `path.relative` plus a check that the result's first
+  segment is not `..` is the standard, path-segment-safe form of this check.
+- *Validate `cwd`/`.git`/`dir` once, at startup only, and trust them for the life of the
+  process* — rejected: a long-lived MCP server can outlive a filesystem change to any of
+  those paths. Both root and directory are revalidated before and after every load.
+
+---
+
+## R8 — stdio safety and the test strategy that proves it
+
+**Decision**: two independent lines of evidence, mirroring this project's existing
+dual bun-test/Node-smoke pattern rather than inventing a third:
+
+1. **In-process** (`bun test`, fast, no subprocess): `InMemoryTransport.createLinkedPair()`
+   (§R1.4) drives the SDK's own `Client` against a package-internal concrete-server
+   builder that is absent from every public export for the large majority of behavioral
+   tests — every tool's
+   discriminated-outcome branches, cursor/fingerprint edge cases, and annotation/schema
+   shape assertions. This is the primary test surface because it is fast and exercises
+   the real registered handlers with no protocol-framing concerns of its own.
+2. **Real stdio subprocess** (both `bun test`, against `src/bin.ts` via Bun, and the
+   Node-targeted smoke pipeline, against the built `dist/bin.js` under Node 22/24): spawn
+   the bin as a child process against a fixture corpus, write one newline-delimited
+   `initialize` request followed by one `tools/call` request to its `stdin`, capture
+   every byte written to its `stdout`, and assert (a) each line parses as well-formed
+   JSON-RPC and (b) the expected response for each request appears — proving, on the
+   real transport, that `stdout` carries **only** protocol frames (FR-007), directly
+   satisfying `modelcontextprotocol.io`'s own stdio transport rule: *"The server **MUST
+   NOT** write anything to its `stdout` that is not a valid MCP message"*
+   (`specification/2025-06-18/basic/transports`). Any diagnostic output this server ever
+   emits is written to `stderr` only (the spec permits this: *"The server **MAY** write
+   UTF-8 strings to its standard error... for logging purposes"*) — though per
+   Assumption A7, this phase does not require any log output to exist at all, so the
+   simplest compliant implementation emits none, and the no-stdout-pollution test still
+   holds trivially.
+
+**Rationale**: this is precedent, not invention — `scripts/smoke-node.mjs` and
+`.release/smoke/smoke.mjs` already spawn the built `@adrkit/cli`/`@adrkit/ci` artifacts
+as subprocesses under Node and assert on their output; the MCP bin gets the same
+treatment plus the one MCP-specific assertion (line-by-line JSON-RPC well-formedness)
+neither of those existing checks needs, because neither of them is a long-lived,
+bidirectional stdio protocol server. Because the SDK's `StdioServerTransport` reads
+`process.stdin` and writes `process.stdout` via standard Node-compatible stream APIs,
+and Bun implements those APIs compatibly, the same bin runs correctly under both
+runtimes with no separate code path — matching ADR-0010's Bun-for-development/
+Node-for-published-artifact split exactly, with Bun used for the fast dev-loop subprocess
+test and Node used for the artifact-fidelity smoke test.
+
+**Alternatives rejected**:
+- *Only the in-memory test, treat the stdio framing as "the SDK's problem"* —
+  rejected: the SDK cannot protect this server from a bug in *this server's own* code
+  that writes to `console.log`/`process.stdout.write` directly (bypassing the transport
+  entirely) — only a real subprocess-level byte-capture test can catch that class of
+  regression, and FR-007/SC-006 are explicit that this must be verified on the actual
+  stream, not inferred from using the "right" transport class.
+- *A hand-rolled JSON-RPC framing test that reimplements newline-delimited parsing* —
+  unnecessary: `StdioServerTransport` already frames correctly (R1); the test only
+  needs to assert every captured line is valid JSON, not implement a second parser.
+
+---
+
+## R9 — Why prompts, resources, HTTP/auth, and indexing are excluded
+
+Not four independent choices — one posture, stated once and applied uniformly, per
+FR-001–FR-011 and the constitution's Principles I/II/IV:
+
+- **Prompts/resources/subscriptions/sampling (FR-003)**: MCP defines these as
+  genuinely separate, optional capabilities from tools
+  (`modelcontextprotocol.io/specification/2025-06-18/server/tools` explicitly documents
+  tools, resources, and prompts as three distinct primitives with their own capability
+  flags) — nothing about exposing four **read tools** requires declaring any of the
+  other three, and this spec's scope (plan.md Phase 5 exit criteria: "read tools only")
+  is exactly four named tools, not a broader "expose the corpus over MCP" mandate.
+  Sampling specifically would mean asking the connected client's model to generate
+  content mid-call — a probabilistic step this phase's Principle IV posture forbids
+  entering before (or here, at all within) the deterministic retrieval path.
+- **HTTP/SSE/auth (FR-005, FR-006)**: `modelcontextprotocol.io`'s own transport spec
+  requires Streamable HTTP servers to validate the `Origin` header, prefer binding to
+  `127.0.0.1`, and "**SHOULD** implement proper authentication for all connections" —
+  a whole security surface (DNS-rebinding protection, auth) that exists only because an
+  HTTP transport is reachable by something other than the process that spawned it.
+  stdio has none of that surface by construction (the client *is* the process that
+  spawned this server); adding HTTP would mean adopting Express/Hono/CORS/host-header
+  validation/OAuth machinery this project has zero present need for, purely to satisfy
+  a transport this feature does not use — directly the kind of "authenticated, network,
+  or service access" ADR-0007's clean-clone posture treats as disqualifying by default.
+- **Indexing/caching/database (FR-010)**: ADR-0004 already settles this for the whole
+  project — "the CLI and CI action never require the index; `@adrkit/core` performs its
+  work against the filesystem alone" — and explicitly names "the MCP retrieval tools" as
+  a reader of that same filesystem-or-index reality, never a second writer or a required
+  consumer of an index. Building a private cache inside `@adrkit/mcp` would reintroduce
+  exactly the "database quietly becomes authoritative" failure mode ADR-0004 was written
+  to prevent, one layer down and unreviewed by that record's own reasoning.
+
+---
+
+## R10 — Distribution wiring and side-effect gates
+
+Phase 5 implementation changes the following non-behavioral package/verification
+surfaces. Actual publication, tag creation, release-version selection, and
+`scripts/release-publish.ts` changes remain excluded:
+
+| File | Change needed when this phase implements |
+|---|---|
+| `packages/mcp/package.json` (new) | `name: "@adrkit/mcp"`, `bin: { "adrkit-mcp": "./dist/bin.js" }`, `exports["."]` for only the sealed lifecycle factory + types (no internal builder subpath), `dependencies: { "@adrkit/core": "workspace:*", "@modelcontextprotocol/sdk": "1.29.0", "zod": "^4" }` (exact pin on the SDK, `^4` on zod matching the rest of the workspace — R0/R2), `engines.node: ">=22"`, `publishConfig.access: "public"`, `files: ["dist", "README.md", "src"]` — mirroring `@adrkit/evaluator`'s manifest shape field-for-field. |
+| `scripts/check-deps.ts` | One new branch in `allowedDependenciesFor`: `'@adrkit/mcp'` → `{ dependencies: {'@adrkit/core','@modelcontextprotocol/sdk','zod'}, devDependencies: {'@types/bun'} }`, mirroring the existing `@adrkit/evaluator` branch exactly in shape. |
+| `packages/mcp/test/side-effect-denial-preload.mjs` (new) | A Node preload module (loaded via `node --import`/`--require`) that patches through `createRequire` plus `syncBuiltinESMExports()` and throws on the enumerated network APIs; filesystem write/create/truncate/rename/copy/remove/directory/link/permission/ownership/time APIs in callback, sync, promise, stream, and returned-`FileHandle` forms; write-capable `open` flags; child-process/cluster/worker/native-addon paths. A Bun companion traps `Bun.write`, file writer/delete, spawn/spawnSync, and shell access. The same tests start the built server, call all four tools, retain full-sandbox/parent-sentinel/`HOME`/`TMPDIR` snapshots, and report only bounded executed-path evidence. |
+| `scripts/release-pack.ts` | One new `RELEASE_PACKAGES` entry (`name: '@adrkit/mcp'`, `directory: 'packages/mcp'`, `expectedFiles` mirroring evaluator's list plus `dist/bin.js`, `workspaceDependencies: ['@adrkit/core']`), one new assertion mirroring the existing CLI-only `packedManifest.bin?.adr === './dist/index.js'` check (`packedManifest.bin?.['adrkit-mcp'] === './dist/bin.js'`), and a new import+functional check appended to the generated `.release/smoke/smoke.mjs` template inside `prepareSmokeProject`. |
+| `scripts/release-publish.ts` | No change: it already publishes `manifest.artifacts` in the order `release-pack.ts` produced them, so the new entry's position in `RELEASE_PACKAGES` alone determines publish order. |
+| `scripts/smoke-node.mjs` | A new section: import the built `packages/mcp/dist/index.js` factory and assert it returns only the sealed `start`/`close` handle; spawn the built `packages/mcp/dist/bin.js` under Node and side-effect denial against this repository's own real `docs/adr/` corpus, send initialize/list plus one call per tool, and assert well-formed responses with zero non-protocol `stdout` bytes (R8). |
+| `.github/workflows/ci.yml` | **No direct edit** — `clean-clone-builds`'s `bun run --filter='*' build/lint` and `bun test`, and `node-smoke-built-artifacts`'s `node scripts/smoke-node.mjs` / `.release/smoke/smoke.mjs`, already pick up any new workspace package generically once `scripts/smoke-node.mjs` itself is updated (previous row). |
+| `docs/RELEASING.md` | Add a `@adrkit/mcp` \| npm row to the distribution table; extend "Packages publish in dependency order: core, evaluator, CLI" to name `@adrkit/mcp` at the end of that list (it depends only on core, so its position relative to evaluator/cli is not functionally constrained, but appending it preserves the list's existing chronological-addition ordering). |
+| Root `package.json` | **No change required** for workspace discovery — `workspaces: ["packages/*", "packages/adapters/*"]` already globs any new `packages/mcp/` directory. |
+
+**Clean-clone interpretation after Constitution v1.0.2.** With Bun 1.3.14
+preinstalled, `bun install --frozen-lockfile` may contact only the unauthenticated
+public package registry and must use committed `bun.lock` plus the repository
+`bunfig.toml` settings. Networking is then disabled for build, typecheck, tests, lint,
+release-pack generation, installed-tarball smoke, built Node 22/24 smoke, and server
+execution. A warm global package cache is neither required evidence nor a substitute
+for the frozen public install.
+
+**Exact side-effect APIs exercised by the denial harness.** Node coverage includes
+callback, sync, and `node:fs/promises` forms where present:
+
+- filesystem content/mutation: `write`, `writev`, `writeFile`, `appendFile`,
+  `createWriteStream`, `truncate`, `ftruncate`, `rename`, `copyFile`, `cp`,
+  `unlink`, `rm`, `rmdir`, `mkdir`, `mkdtemp`, `link`, `symlink`, `chmod`,
+  `fchmod`, `lchmod`, `chown`, `fchown`, `lchown`, `utimes`, `futimes`, and
+  `lutimes`; plus `open`/`openSync`/`promises.open` when flags permit write,
+  append, create, truncate, or update;
+- returned `FileHandle`: `write`, `writev`, `writeFile`, `appendFile`, `truncate`,
+  `createWriteStream`, `chmod`, `chown`, `utimes`, `sync`, and `datasync`;
+- process/runtime escape: every `child_process` spawn/exec/execFile/fork sync and
+  async form, `cluster.fork`, `new worker_threads.Worker`, and `process.dlopen`;
+- network: `fetch`, net/http/https/dgram connect/request/get/socket/listen paths;
+- Bun: `Bun.write`, `Bun.file(...).writer()`, `Bun.file(...).delete()`,
+  `Bun.spawn`, `Bun.spawnSync`, and static rejection of Bun shell imports/member
+  use when no reliable patch point exists.
+
+Passing proves only that the exercised startup and four-tool paths invoked none of
+these enumerated JavaScript-level APIs. It is defense-in-depth evidence, not proof
+against raw native syscalls or future unenumerated runtime APIs.
+
+**How the preload actually intercepts a builtin — verified empirically, not a
+hand-wave (checked directly for this correction, `node -v` `v22.22.2`).** Simply
+reassigning a property on the object returned by `require('node:http')` is not
+sufficient *in every ordering*: Node lazily constructs each builtin's ES Module facade
+the first time anything actually does `import 'node:http'` (or a named/default import
+from it) in the process, and the docs for `module.syncBuiltinESMExports()` demonstrate,
+and this research independently re-verified with two small scratch scripts, exactly
+when that matters.
+
+- **Scratch script 1** (patch via `require()` *before* anything has ever imported
+  `node:http` as an ES Module, i.e., a `--require` preload running ahead of the rest of
+  the program — the intended deployment shape for this harness): the later `import {
+  request } from 'node:http'` already observed the patched function, **even without**
+  calling `syncBuiltinESMExports()` — because the ESM facade did not exist yet at patch
+  time, so its first construction simply reads the already-patched object.
+- **Scratch script 2** (patch via `require()` *after* the process has already done
+  `await import('node:http')` once — i.e., the ESM facade already exists, exactly the
+  shape Node's own `module.syncBuiltinESMExports()` documentation example walks through):
+  the SAME later `import('node:http')` call returned the **stale, cached facade** —
+  calling the "patched" `request` on it did **not** throw; it attempted a real
+  `ECONNREFUSED` TCP connection instead, a real, observable network-call leak. Calling
+  `syncBuiltinESMExports()` immediately after the patch, and only then, made the same
+  cached facade observe the patched function and throw as intended.
+
+The conclusion this research draws from both results together: whether a bare
+`require()`-side patch alone is already sufficient depends on an internal, undocumented
+ordering (has anything materialized this builtin's ESM facade yet?) that this design has
+no reliable way to guarantee holds for every builtin, every Node minor version, and every
+possible module-graph shape `@modelcontextprotocol/sdk` or its dependencies might exercise
+in the future. Calling `syncBuiltinESMExports()` unconditionally, immediately after every
+patch, removes that dependency entirely — it is a documented no-op when the facade did not
+exist yet, and it is load-bearing, demonstrated-necessary correctness when it did. The
+preload therefore, for every builtin function it intercepts: (1) obtains each target
+builtin's real, mutable CJS exports object via `createRequire(import.meta.url)` (or, if
+the preload itself runs as CJS under `--require`, via a plain `require()`) — this is the
+same live object `http`/`https`/`net`/`dgram` are backed by everywhere in the process,
+CJS or ESM; (2) reassigns the specific functions to intercept (`request`, `get`,
+`connect`, `createConnection`, `createSocket`) directly on that object, and separately
+patches `net.Server.prototype.listen` (a shared prototype **method** on a class object,
+reachable identically regardless of how a caller imported `net`/`http`/`https`, since a
+prototype is one shared object with no separate ESM-namespace snapshot to go stale — this
+one target genuinely needs no `syncBuiltinESMExports()` call, unlike the named function
+exports above); and (3) calls `syncBuiltinESMExports()` (`node:module`) immediately after
+every property patch, unconditionally, so that `import { request } from 'node:http'`
+elsewhere in the same process (including inside `@modelcontextprotocol/sdk`'s own
+compiled output, wherever and whenever it happens to import a builtin from) is guaranteed
+to observe the patched, throwing function, never a stale cached one. `globalThis.fetch`
+needs none of this — it is a plain global, not a builtin module export, so reassigning it
+directly is sufficient.
+
+**What this harness actually proves, stated at the same confidence level the tests
+support — no more.** A pass means: across the specific executed code paths exercised by
+starting the stdio server and calling each of the four tools once, no JavaScript-level
+call to any enumerated network, filesystem-mutation, subprocess, worker, native-addon,
+or Bun-shell entry point occurred. This is genuine, defense-in-depth,
+**executed-path** evidence — meaningfully stronger than the declared-dependency
+allow-list alone, because it observes runtime behavior rather than inferring it from a
+manifest. It is deliberately **not** claimed as proof that no network access could occur
+through any conceivable channel: a native Node addon, a worker thread with its own,
+separately-patched global scope, a raw file-descriptor/syscall path bypassing every
+patched JS-level API entirely, or a future SDK version routing through a builtin this
+list does not yet name, would all fall outside what this specific harness observes. This
+project's `@adrkit/mcp` source imports no native addon and spawns no worker thread
+(R2: only the SDK's `server/mcp.js`/`server/stdio.js`/`inMemory.js` subpaths, plus
+`client/index.js` in test-only code), so those particular escape hatches are closed by
+import discipline rather than by this harness — the harness and the import-discipline
+check are deliberately two different, complementary lines of evidence for that reason,
+neither claimed sufficient alone. Together — the direct-declaration allow-list (what this
+package declares), the import-discipline check (which of the SDK's own subpaths this
+package's code actually imports), and this preload harness (which network-capable
+JS-level entry points actually execute) — they satisfy this phase's no-network contract
+(FR-011) to the standard "no network access of any kind, verified by executed-path
+evidence at every layer this design controls" — not to the stronger, and here
+unclaimed, standard of a formal proof that no imaginable channel exists in the runtime
+underneath it.
+
+**Why `check-deps.ts` alone is not sufficient evidence of "no network access," stated
+precisely (SC-013)**: `checkDependencyRules` (confirmed by reading
+`scripts/check-deps.ts` directly) reads each workspace package's **own** `package.json`
+`dependencies`/`devDependencies`/`peerDependencies`/`optionalDependencies` sections and
+compares each declared entry against a per-package allow-list — a **direct-declaration**
+check, exactly as it already operates for every existing package (it does not, for
+example, walk `zod`'s own transitive tree either — R2). Extending it with an
+`@adrkit/mcp` branch proves this package declares only `@adrkit/core`, the pinned SDK,
+and `zod` — a real, useful, mechanical guarantee — but it does **not**, by construction,
+inspect what code the SDK's own transitive dependencies (`express`, `hono`, `jose`,
+`ajv`, `cross-spawn`, etc. — R2) would do if ever invoked, because that question is about
+runtime import/execution behavior, not declared manifests. This phase therefore treats
+FR-002/FR-011 as proven by complementary checks: the direct-declaration allow-list
+(what this package declares), import-discipline/static rejection (which escape surfaces
+source can reach), the side-effect-denial preloads (which enumerated APIs execute), and
+independent complete disposable-sandbox/parent-sentinel/`HOME`/`TMPDIR` snapshots.
+No one check is sufficient; together they cover declared, reachable, executed, and
+observable filesystem surfaces at the bounded defense-in-depth confidence stated above.
+
+**The one genuine deferred scheduling decision this research surfaces (not a design
+ambiguity or Phase 5 implementation task)**: `docs/RELEASING.md`'s own stated release guarantee is "all public package
+versions are identical." Introducing `@adrkit/mcp` as a fourth public package therefore
+forces a coordinated version bump of `@adrkit/core`, `@adrkit/evaluator`, and
+`@adrkit/cli` to whatever version `@adrkit/mcp` first ships at, at the moment it first
+ships — a real release-scheduling decision (which version, and whether it lands in the
+same release as other in-flight changes to the other three packages), not a technical
+unknown. This is named here as exactly the "release-version timing" item flagged in the
+completion summary, deliberately left for the maintainer to decide at actual release
+time. Phase 5 adds distribution/pack/smoke/docs wiring only; it does not choose a version,
+publish, tag, or change `scripts/release-publish.ts`.
+
+---
+
+## R11 — Fixed limits and their rationale
+
+| Limit | Value | Rationale |
+|---|---|---|
+| Query length (`search_decisions.query`) | 1–256 raw UTF-16 code units; non-empty after `trim()` | Generous for any realistic search phrase; bounds worst-case normalization/scan cost per call to a small constant multiple of the query length, independent of corpus size. The `trim()`-non-empty check (research §R5) is not a size bound but a correctness one: a whitespace-only raw query would otherwise normalize to `''`, which matches every record. |
+| `ref` length (`get_decision.ref`) | 1–128 chars | Comfortably exceeds any realistic `AdrRef` (a numeric id or a ULID, optionally `log:`-prefixed); bounds the cost of the `AdrRef`-grammar `.refine()` check and of `parseAdrRef` per call. |
+| Path length (`get_decision_context.files[i]`) | max 1024 chars | Comfortably exceeds real filesystem path-length limits on every OS this project targets, while bounding the cost of the `.refine()` traversal/absolute/drive-letter/backslash checks (§R1.2) per entry. |
+| `files[]` count | max 256 entries | A realistic upper bound on "files touched by one PR/plan" (the actual calling scenario, US2) with headroom; bounds the number of per-record `resolveAffects` calls (R4) a single request can trigger to `256 × recordCount`, a known, finite cost. |
+| `tags[]` count (`search_decisions.tags`) | 1–32 unique entries when present | An earlier draft left this filter unbounded in count — corrected here: 32 comfortably exceeds any realistic per-query tag combination while bounding the cost of the per-record, all-of tag-membership check (contracts/tools.md §5) to a small constant per record, independent of corpus size. Requiring at least one entry when the field is present (rather than allowing an ambiguous explicit empty array) mirrors the same "if present, non-empty" rule `status`/`scope` already use. |
+| `tags[i]` length | 1–64 chars | Matches this project's own slug convention (`^[a-z0-9][a-z0-9-]*$`, `packages/core/src/schema/adr.schema.ts`) with generous headroom over any realistic tag actually authored in a corpus. |
+| Result page size | default 20, max 100 | Matches this project's own `mcp-builder` reference guidance ("default to 20-50 items... 20-100 typical") and the general MCP ecosystem convention; small enough that a model consuming results does not need to discard most of a page, large enough that a well-formed query rarely needs more than one or two pages. |
+| Findings page size | default 20, max 100 | Same reasoning as result pages, kept numerically identical to avoid a second magic-number pair a caller has to remember; findings are typically far rarer than matches, so this ceiling is rarely reached. |
+| ADR source max | 64 KiB | Comfortably above any real, human-authored decision record (the project's own `docs/adr/*.md` corpus is a small fraction of this); large enough that no legitimate record is ever excluded, small enough to bound `get_decision`'s worst-case response size to a small, fixed multiple of one file. This one cap bounds a record's entire source-derived footprint — frontmatter and body together — so it transitively bounds every summary/finding field derived from that record too (data-model.md §3.5); it is not one of two overlapping budgets with pagination, which bounds item counts, not serialized bytes. |
+| Cursor max | 4 KiB | The actual minted cursor payload (R6) is on the order of 150–250 bytes base64url-encoded; 4 KiB is pure defensive headroom against an oversized/garbage input string, rejected by the input schema before any decode attempt. |
+
+No value above was adjusted from the binding design direction's own starting point for
+the limits it specified — each of those was reviewed against this project's actual scale
+and found already appropriate, which is itself recorded here so a future reviewer does
+not need to re-derive it. The `tags[]` count and per-tag length limits are new in this
+pass, closing a gap an earlier draft left as an unbounded array of unbounded strings.

--- a/specs/006-mcp-server/spec.md
+++ b/specs/006-mcp-server/spec.md
@@ -1,9 +1,9 @@
 # Feature Specification: MCP Server (Read-Only Retrieval)
 
-**Feature Directory**: `006-mcp-server` (not a git branch — this feature is scoped in
-place; no branch is created or switched by this work)
+**Feature Directory**: `006-mcp-server`
+**Implementation Branch**: `feat/phase-5-mcp-server`
 **Created**: 2026-07-20
-**Status**: Scope ratified — pre-implementation analysis remediation
+**Status**: Implemented — PR #19
 **Phase**: 5 (outcome ladder **rung 4**) — read tools only
 (project **Phase 5** ≠ outcome-ladder rung 5. Per `plan.md`, Phase 5 is the MCP server
 and delivers rung 4, "an agent can read the corpus." Rung 5, "a proposal gets routed
@@ -57,9 +57,9 @@ surface, not a hosted service the project operates.
 > exact four-tool, local-only, read-only boundary in this specification: no fifth
 > tool, write path, prompts/resources, HTTP/auth, models, network access,
 > persistent index/database, or named-log federation. Together with the Phase 4
-> evidence above, this clears SC-016. The 43-task graph is generated; implementation
-> remains blocked while current critical/high artifact findings are remediated and until
-> a fresh analysis reports none.
+> evidence above, this cleared SC-016. Fresh analysis passed after artifact
+> remediation with no critical, high, or medium finding; all 43 tasks are
+> complete in PR #19.
 
 ## Overview
 
@@ -91,10 +91,10 @@ or a runtime network call to be useful, that is a later, explicitly-scoped featu
 
 ## User Scenarios & Testing
 
-> **Gate cleared 2026-07-20.** The maintainer ratified the exact scope below, and
-> the Phase 4 real-user evidence is recorded above. Tasks are generated; these stories
-> become eligible for implementation in dependency order only after current artifact
-> remediation and a fresh analysis with no blocking or high-severity findings.
+> **Gate cleared 2026-07-20; implementation complete.** The maintainer ratified
+> the exact scope below, the Phase 4 real-user evidence is recorded above, fresh
+> analysis passed after remediation, and all 43 implementation tasks are
+> complete in PR #19.
 
 ### User Story 1 — An agent looks up one decision it already suspects exists (Priority: P1) 🎯 MVP
 

--- a/specs/006-mcp-server/spec.md
+++ b/specs/006-mcp-server/spec.md
@@ -1,0 +1,1189 @@
+# Feature Specification: MCP Server (Read-Only Retrieval)
+
+**Feature Directory**: `006-mcp-server` (not a git branch — this feature is scoped in
+place; no branch is created or switched by this work)
+**Created**: 2026-07-20
+**Status**: Scope ratified — pre-implementation analysis remediation
+**Phase**: 5 (outcome ladder **rung 4**) — read tools only
+(project **Phase 5** ≠ outcome-ladder rung 5. Per `plan.md`, Phase 5 is the MCP server
+and delivers rung 4, "an agent can read the corpus." Rung 5, "a proposal gets routed
+without a meeting," is project **Phase 4**, the deterministic evaluator, which already
+landed. Internal references to "Phase 5" in this document mean the project phase, not
+the rung.)
+**Normative sources** (the ADRs are normative; where this spec and an ADR disagree, the
+ADR wins):
+[ADR-0001](../../docs/adr/0001-record-architecture-decisions-in-git.md) (git holds the
+record; every consumer, including this server, is a reader),
+[ADR-0002](../../docs/adr/0002-typed-frontmatter-as-madr-superset.md) (the typed schema —
+`status` enum including `rejected`/`superseded`/`deprecated`, the `log`-qualified `id`
+grammar, `supersedes`/`supersededBy`/`relatesTo`/`conflictsWith`),
+[ADR-0004](../../docs/adr/0004-git-is-source-of-truth-database-is-an-index.md) (git is
+truth, the database is a derived, optional, rebuildable index; explicitly names "the MCP
+retrieval tools" as a *reader* of that index or, absent one, the filesystem — never a
+second writer),
+[ADR-0007](../../docs/adr/0007-adapter-isolation-and-public-surface-build.md) (adapter
+isolation and the clean-clone build gate — this server is a first-party, non-adapter
+consumer of `@adrkit/core`),
+[ADR-0009](../../docs/adr/0009-affects-resolution-and-catalog-binding.md) (pure
+`affects` resolution semantics — the affects matcher grammar this server reuses,
+including degrade-to-inert-not-fail for matcher types with no backing snapshot),
+[ADR-0010](../../docs/adr/0010-bun-toolchain.md) (Bun for development; Node-targeted
+published artifacts — ADR-0010 names the MCP server explicitly as launched by
+third-party agent harnesses, typically under Node, not Bun), and
+[`.specify/memory/constitution.md`](../../.specify/memory/constitution.md) Principles
+I–V. [ADR-0003](../../docs/adr/0003-ship-as-spec-kit-extension.md) (ship as a Spec Kit
+extension plus a standalone CLI, not a competing harness) is cited for the project's
+general distribution posture: the MCP server is another **standalone, embeddable**
+surface, not a hosted service the project operates.
+
+> **✅ Phase 4 real-user gate evidence recorded 2026-07-20.** The maintainer ran
+> `adr evaluate` on the genuine, then-`proposed` ADR-0007, using the repository's
+> complete tracked-file inventory and an identity snapshot naming an active human
+> (`@mbeacom`) on the evaluation date. The first run surfaced a **real**
+> `assertions-compile.no-source` error — ADR-0007's two `engine: custom` assertions
+> (`core-has-no-adapter-deps`, `clean-clone-builds`) had no declared `expression` — while
+> still deterministically proving the `one-way-door` escalation trigger and routing it to
+> `@mbeacom` via `deciders`. ADR-0007 was corrected in place to declare the symbolic
+> custom-expression sources; the rerun exited `0` with `outcome: ok`, exactly eleven
+> ordered rules, two honest `warn`-severity findings (`packages/adapters/**` currently
+> resolves to zero real targets; an `affects` overlap with the accepted ADR-0010), the
+> `custom`-engine rules reported **inert** because no trusted custom engine is registered,
+> `one-way-door` proven, and the escalation target resolved to `@mbeacom` via `deciders`.
+> No model call, network access, clock read, or write occurred. This is genuine
+> maintainer-dogfood evidence that Phase 4's evaluator works against real corpus content,
+> not only fixtures — the "real user" this outcome ladder rung requires (`plan.md`).
+>
+> **✅ Phase 5 scope ratified 2026-07-20.** The maintainer explicitly ratified the
+> exact four-tool, local-only, read-only boundary in this specification: no fifth
+> tool, write path, prompts/resources, HTTP/auth, models, network access,
+> persistent index/database, or named-log federation. Together with the Phase 4
+> evidence above, this clears SC-016. The 43-task graph is generated; implementation
+> remains blocked while current critical/high artifact findings are remediated and until
+> a fresh analysis reports none.
+
+## Overview
+
+Phases 0–4 made records valid (schema, `@adrkit/core`), locatable (`affects`
+resolution), importable (MADR migration), visible on the pull requests that touch them
+(`@adrkit/ci`), and — as of Phase 4, landed and now dogfooded on real content per the
+gate evidence above — routable without a meeting (the deterministic Pass 0 evaluator).
+All of that lives in git, read by a CLI a human runs.
+
+Phase 5 opens the corpus to a **different caller**: an autonomous agent, mid-session,
+that needs to check "has this already been decided, tried, or rejected" **before**
+drafting a plan or a proposal ADR — the capability rung 4 names ("an agent can read the
+corpus"). The deliverable is `@adrkit/mcp`: a **local, stdio-transport, read-only** Model
+Context Protocol server exposing **exactly four tools** —
+`search_decisions`, `get_decision`, `get_decision_context(files[])`, and
+`list_superseded` — over the same `@adrkit/core` parsing, validation, graph, and
+`affects`-resolution machinery the CLI already uses. It reads a git-backed corpus already
+on disk; it never fetches, indexes, or caches it elsewhere, and it never proposes,
+mutates, or writes anything (ADR-0001, ADR-0004).
+
+The load-bearing property is the same one that makes the rest of this project credible:
+**git is truth, and this server is a reader.** There is no database, no hosted endpoint,
+no authentication (there is no network listener to authenticate against), no model call,
+and no write path. A clean clone may use only the unauthenticated public registry for its
+frozen dependency install; build, test, package, smoke, and runtime must then complete
+with networking disabled, no credentials, and no running service while returning correct
+answers from a sample corpus (Principle II). If retrieval ever needs a model, an index,
+or a runtime network call to be useful, that is a later, explicitly-scoped feature.
+
+## User Scenarios & Testing
+
+> **Gate cleared 2026-07-20.** The maintainer ratified the exact scope below, and
+> the Phase 4 real-user evidence is recorded above. Tasks are generated; these stories
+> become eligible for implementation in dependency order only after current artifact
+> remediation and a fresh analysis with no blocking or high-severity findings.
+
+### User Story 1 — An agent looks up one decision it already suspects exists (Priority: P1) 🎯 MVP
+
+As an agent (or a human operator testing the server), I want to fetch exactly one
+decision record by its id — including a rejected or superseded one — so I can confirm
+what was actually decided instead of acting on a guess or a stale summary.
+
+**Why this priority**: `get_decision` is the simplest possible reader and the
+foundation every other tool's record shape reuses. It is independently useful the moment
+a caller already has an id (from a search result, a commit message, or a prior
+conversation) and needs the authoritative record, and it is the tool that first proves
+the graveyard (`rejected`/`superseded`/`deprecated`) is retrievable at all, not filtered
+out as noise.
+
+**Independent Test**: Start the server against a fixture corpus containing at least one
+record of each status (`draft`, `proposed`, `accepted`, `rejected`, `superseded`,
+`deprecated`), call `get_decision` with each record's id, and confirm every status comes
+back verbatim as a full document — canonical identity, typed frontmatter, repo-relative
+source path, and complete Markdown body — including the two records related by
+`supersedes`/`supersededBy`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fixture corpus containing an `accepted` record and a `rejected` record,
+   **When** `get_decision` is called with each record's id in turn, **Then** both come
+   back as the full document — local identity `id`, typed frontmatter, repo-relative
+   source path, and the complete Markdown body — never frontmatter alone, with their true
+   status; the rejected record is returned, not hidden or errored.
+2. **Given** a record that is `superseded`, **When** `get_decision` is called with its
+   id, **Then** the response includes its declared `supersededBy` ref so the caller can
+   resolve the replacement with a second `get_decision` call.
+3. **Given** an id that does not exist in the corpus, **When** `get_decision` is called
+   with it, **Then** the tool returns an explicit, unambiguous "not found" result — never
+   a thrown exception, an empty object, or a fabricated placeholder record.
+4. **Given** the same id is used by two different records in this one local corpus (an
+   invalid-corpus condition already flagged elsewhere by the `unique-id` finding —
+   [Assumption A1](#assumptions)), **When** `get_decision` is called with that id,
+   **Then** the response is an explicit **`ambiguous-local-id`** result listing every
+   candidate (id, title, status, and the repo-relative `sourcePath` that distinguishes
+   them, since this phase has no log qualifier to distinguish them by) rather than
+   silently returning one of them or picking one arbitrarily, with cursor pagination if
+   all candidates do not fit in one bounded response. This phase supplies no way to
+   disambiguate further by a second `get_decision` call; the caller's actionable next
+   step is fixing the underlying duplicate-id defect in the corpus, not retrying the tool.
+5. **Given** a log-qualified ref (`payments:0012`) — a well-formed `AdrRef` per
+   ADR-0002's grammar — **When** `get_decision` is called with it, **Then** the response
+   is an explicit, non-error **`federated-log-unavailable`** result naming the requested
+   log and id, because this phase serves exactly one local corpus and no named-log
+   federation ([Assumption A1](#assumptions)); the qualifier is never silently stripped
+   and never substituted with a same-id local record.
+6. **Given** any record returned by `get_decision`, **When** the response's source path is
+   inspected, **Then** it is repo-relative (e.g. `docs/adr/0042-....md`) — the tool never
+   emits an absolute filesystem path, regardless of the server's actual on-disk root.
+7. **Given** a record whose frontmatter declares `supersedes`, `supersededBy`, `relatesTo`,
+   or `conflictsWith` refs, **When** `get_decision` returns it, **Then** those refs remain
+   present in the returned typed frontmatter but no referenced document or resolved
+   summary is inlined; the caller follows a ref with a second `get_decision` call.
+8. **Given** an ADR source larger than the fixed maximum source size, **When** the corpus
+   is loaded for `get_decision`, **Then** the source is excluded with a structured
+   `record-too-large` finding — never read into an unbounded response and never silently
+   truncated. The exact maximum is fixed in the plan and contract fixtures.
+
+---
+
+### User Story 2 — An agent checks what governs the files it is about to change (Priority: P1)
+
+As an agent about to propose a change to a specific set of files, I want to ask which
+decisions currently govern those files, which proposals are already in flight over the
+same area, and which decisions were tried there and rejected or superseded, so I don't
+re-litigate settled questions, collide with in-flight work, or repeat a documented
+mistake.
+
+**Why this priority**: this is the rung's central claim — "an agent can read the corpus"
+**before acting**, not after being told no. `get_decision_context(files[])` is the tool
+that turns retrieval into a genuine pre-flight check rather than a keyword search the
+agent has to interpret itself, and it is the tool most directly built on ADR-0009's
+resolution semantics, so it also proves that reuse rather than a second resolver.
+
+**Independent Test**: Feed `get_decision_context` a fixture file list that matches one
+`accepted` record's `affects` pattern, one `proposed` record's pattern, and one `rejected`
+record's pattern (same path prefix, different specific matchers); confirm the accepted
+record appears only in `governing`, the proposed record appears only in
+`activeProposals`, and the rejected record appears only in `history` — never merged into
+one undifferentiated list — and that the fired matcher is reported for each.
+
+**Acceptance Scenarios**:
+
+1. **Given** a file that matches an `accepted` record's `path` matcher, **When**
+   `get_decision_context` is called with that file, **Then** the record appears in the
+   response's **`governing`** collection together with the matcher that fired.
+2. **Given** a file that matches a `draft` or `proposed` record's `affects` matcher,
+   **When** `get_decision_context` is called with that file, **Then** the record appears
+   in the **`activeProposals`** collection — never merged into `governing` and never
+   dropped because it isn't `accepted` yet.
+3. **Given** a file that matches a `rejected`, `superseded`, or `deprecated` record's
+   `affects` matcher but no `accepted` record's matcher, **When** `get_decision_context`
+   is called with that file, **Then** the record appears in the **`history`** collection,
+   never in `governing` or `activeProposals`, and is not silently dropped for having a
+   graveyard status.
+4. **Given** a file that matches records across more than one status bucket (e.g. an
+   `accepted` record and a `superseded` record's matchers), **When**
+   `get_decision_context` is called, **Then** the response includes the `accepted` record
+   under `governing` **and** the `superseded` record under `history` — both, not a single
+   winner — and, more generally, all six statuses (`draft`, `proposed`, `accepted`,
+   `rejected`, `superseded`, `deprecated`) are visible through one of the three
+   collections whenever a record of that status matches the supplied files; none is
+   structurally unreachable.
+5. **Given** a `package` matcher with no lockfile snapshot supplied to the server, or an
+   `entity`/`resource`/`api`/`data` matcher with no backing catalog/artifact, **When**
+   `get_decision_context` resolves affected records, **Then** that matcher resolves to
+   **inert** with an explicit, informational finding — never a fabricated match and never
+   a fatal error for the rest of the request (ADR-0009).
+6. **Given** an input entry that is not a well-formed repo-relative logical path (an
+   absolute path, a path containing a `..` traversal segment, a Windows drive-qualified
+   path, a path containing a backslash anywhere, or an empty string), **When**
+   `get_decision_context` is called with `files` containing that entry, **Then** the call
+   is rejected as an actionable input-contract error **before** any matcher evaluation or
+   filesystem access — the string is never used to open, read, or stat a file; it is
+   compared only against declared `affects` patterns already loaded from the corpus.
+7. **Given** no file in the supplied list matches any record's `affects` pattern, **When**
+   `get_decision_context` is called, **Then** the response reports all three collections
+   (`governing`, `activeProposals`, `history`) empty — not an error — so a caller can
+   distinguish "nothing governs this yet" from a failure.
+8. **Given** a matched record whose frontmatter declares `supersedes`, `supersededBy`,
+   `relatesTo`, or `conflictsWith` refs, **When** `get_decision_context` returns that
+   record's summary, **Then** the summary includes those declared relation refs (including
+   `conflictsWith`) so the caller can follow any of them with a separate `get_decision`
+   call; `get_decision_context` itself does not expand or fetch the referenced records.
+9. **Given** more matching records than fit in one response, **When** the caller follows
+   the returned cursor, **Then** one canonical pagination walk returns every matched record
+   exactly once across the three status collections, with each page partitioning its
+   records into `governing`, `activeProposals`, and `history`.
+
+---
+
+### User Story 3 — An agent searches the corpus, including the graveyard, before proposing something new (Priority: P1)
+
+As an agent drafting a plan, I want to search prior decisions by topic before writing a
+new proposal, and I want that search to include decisions that were rejected or
+superseded, so I don't propose something the organization already tried and explicitly
+walked away from.
+
+**Why this priority**: this is the entry point for the "has this already been decided"
+question when the agent does not yet know a specific id or a specific changed file — the
+scenario ADR-0009's context explicitly calls out ("the MCP retrieval tools" depending on
+the same resolution semantics) and the one README already promises ("let agents retrieve
+prior decisions, including the rejected ones, before proposing something already
+tried").
+
+**Independent Test**: Search a fixture corpus for a term that appears only in the
+Markdown body of one `accepted` record (not in its id, title, or tags) and only in the
+title of one `rejected` record; confirm both are returned with the correct matched-field
+indicator, that omitting a `status` filter returns both, that a `status: rejected` filter
+returns only the rejected one, and that re-running the identical query twice returns
+results in the identical order.
+
+**Acceptance Scenarios**:
+
+1. **Given** a query term present in an `accepted` record and a `rejected` record's
+   searchable text, **When** `search_decisions` is called with no status filter,
+   **Then** both records are returned — the graveyard is not excluded by default.
+2. **Given** a query term that appears only in a record's Markdown body (not in its
+   id, title, or tags), **When** `search_decisions` is called, **Then** that record is
+   still returned, with its matched-field indicator identifying `body` as the field that
+   matched — the searchable surface is id, title, tags, **and** body, not
+   title/tags/id alone.
+3. **Given** the same query and an explicit `status` filter, **When**
+   `search_decisions` is called, **Then** only records matching the filter are
+   returned, and the filter can select `rejected`/`superseded`/`deprecated` explicitly,
+   not only `accepted`.
+4. **Given** a query containing mixed case or leading/trailing whitespace, **When**
+   `search_decisions` is called, **Then** the query is trimmed and case-folded before
+   matching, using the same normalization applied to each searchable field, so a match
+   depends only on normalized literal substring containment — never on the caller
+   guessing exact case or trimming their own input.
+5. **Given** a corpus larger than one page, **When** `search_decisions` is called
+   repeatedly with the returned pagination cursor, **Then** every matching record is
+   returned exactly once across all pages, in the canonical `(id, sourcePath)` order,
+   with no record skipped or duplicated.
+6. **Given** the identical query, filters, and page parameters, **When**
+   `search_decisions` is run twice with no corpus change between runs, **Then** both
+   runs return the identical ordered result set — ordering is canonical identity order,
+   never a relevance score, so there is no ranking heuristic to be non-deterministic
+   about.
+7. **Given** a query that matches nothing, **When** `search_decisions` is called,
+   **Then** the response is an explicit empty result set with the same shape as a
+   non-empty response — never an error.
+8. **Given** a corpus containing a record that fails schema validation, **When**
+   `search_decisions` is called, **Then** the invalid record is excluded from matches,
+   the corpus-load finding for it is surfaced on the response's findings channel, and
+   every other, valid record is still searchable — a single bad record never blocks the
+   whole corpus.
+9. **Given** a matching record, **When** `search_decisions` returns it, **Then** the
+   result is a bounded summary (id, title, status, source path, matched-field
+   indicators) — never the full Markdown body; a caller that needs the full document
+   follows up with `get_decision`.
+
+---
+
+### User Story 4 - An agent orients itself in the graveyard directly (Priority: P2)
+
+As an agent (or a human onboarding to a corpus it doesn't know), I want to list every
+decision that has been superseded and what replaced it, so I can understand the
+project's decision history and current state without having to search by guesswork.
+
+**Why this priority**: `list_superseded` is explicitly named in the Phase 5 exit
+criteria (`plan.md`) as a distinct capability from search — a direct, complete listing
+rather than a query — useful for building an agent's mental map of "what used to be true
+but no longer is" without needing to already know a search term. It ships after the three
+P1 tools because it is additive orientation, not a blocking dependency for either lookup
+story.
+
+**Independent Test**: Populate a fixture corpus with three `superseded` records, each
+`supersededBy` a different `accepted` record, plus one unrelated `accepted` record with
+no supersession involvement; call `list_superseded` and confirm exactly the three
+superseded records are returned, each paired with its resolved `supersededBy` target's
+id, title, and current status, and that the unrelated `accepted` record does not appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a corpus with several `superseded` records, **When** `list_superseded` is
+   called, **Then** every `superseded` record is returned, each with its `supersededBy`
+   target's id, title, and status resolved — not merely the raw target id string.
+2. **Given** a corpus with no `superseded` records, **When** `list_superseded` is
+   called, **Then** the response is an explicit empty result — never an error.
+3. **Given** a `superseded` record whose `supersededBy` target id does not resolve to any
+   local record (a dangling reference that should have failed corpus validation
+   upstream), **When** `list_superseded` is called, **Then** that record's target is
+   reported unresolved (`resolved: false`) rather than fabricated or silently omitted
+   from the listing, and the corpus's own dangling-reference finding for it is present on
+   the findings channel.
+4. **Given** a `superseded` record whose `supersededBy` target id is used by more than one
+   local record, **When** `list_superseded` is called, **Then** that record's target is
+   reported unresolved with a deterministic `superseded-target-ambiguous` finding naming
+   the target id and the number of candidates — a candidate is never silently picked, and
+   the finding never enumerates every candidate's path/title inline; the complete
+   candidate list is separately obtainable via a follow-up `get_decision` call on the
+   same target id.
+5. **Given** a `superseded` record whose `supersededBy` is a log-qualified ref, **When**
+   `list_superseded` is called, **Then** that record's target is reported unresolved as
+   federated-unavailable with an informational finding, consistent with this phase's
+   single-local-corpus scope ([Assumption A1](#assumptions)) — the qualifier is never
+   silently stripped and a same-id local record is never substituted.
+6. **Given** a corpus larger than one page, **When** `list_superseded` is called with
+   pagination, **Then** the same no-loss, no-duplication, stable-order guarantee as
+   `search_decisions` applies.
+
+---
+
+### User Story 5 — A harness operator trusts the boundary holds (Priority: P2)
+
+As the operator embedding this server inside an agent harness, I want an enforceable
+read-only contract with bounded defense-in-depth evidence that the four tools do not
+write, read caller-selected files outside the configured corpus, reach the network, or
+invoke a model, so adding retrieval does not introduce a silent write path.
+
+**Why this priority**: this is not a feature the agent asks for; it is the property that
+makes it safe to grant an agent this tool at all. Every other story is worthless if this
+one is false, but it is P2 because it is a cross-cutting invariant proven by the same
+fixtures the P1 stories already exercise, not a separate user-facing capability.
+
+**Independent Test**: With the server running against a fixture corpus and networking
+disabled, exercise every outcome branch of every tool with adversarial inputs. Trap the
+enumerated filesystem-mutation/write-capable-open/FileHandle, process, worker,
+native-addon, network/listen, and Bun side-effect APIs; independently compare complete
+sandbox, parent-sentinel, `HOME`, and `TMPDIR` snapshots; and confirm each call returns a
+well-formed result or input-contract error with no out-of-root read and no non-protocol
+stdout. This proves only the enumerated JavaScript-level APIs were not invoked on the
+exercised paths, not that raw native syscalls or future unenumerated APIs are impossible.
+
+**Acceptance Scenarios**:
+
+1. **Given** the server configured with a specific corpus root, **When** any tool is
+   called with an input that could plausibly reference a path outside that root, **Then**
+   no file outside the configured root is read, and the response is an explicit rejection
+   rather than a partial or best-effort read.
+2. **Given** the server running with no network access in its environment, **When** any
+   tool is called, **Then** the call still completes deterministically because no tool
+   ever attempts an outbound connection.
+3. **Given** the server process, **When** it is running and idle or actively answering a
+   call, **Then** nothing but MCP protocol frames is ever written to its stdout stream —
+   any diagnostic or log output goes to stderr or a configured log destination, never
+   stdout, because stdout is protocol traffic.
+4. **Given** a tool call with an extra, undeclared field or a field of the wrong type,
+   **When** the server validates the call, **Then** the call is rejected with an
+   actionable schema error before any corpus access — strict input validation, not
+   best-effort coercion.
+5. **Given** repeated identical calls to any of the four tools with no corpus change
+   between them, **When** the calls are made, **Then** each is safe to repeat any number
+   of times with no side effect and no accumulating state (read-only, non-destructive,
+   idempotent).
+
+### Edge Cases
+
+- **Unqualified id resolution is a three-way outcome, not a boolean.** `get_decision`
+  (and any other tool accepting an id) compares an unqualified id against every loaded
+  record's own local id: zero matches is "not found," exactly one match returns that
+  record, and more than one match returns an explicit, complete candidate list (id,
+  title, status, and the distinguishing repo-relative `sourcePath`) as an
+  **`ambiguous-local-id`** result — never a silent first-match, and never an error that
+  hides the candidates from the caller (US1 AC3, AC4).
+- **A log-qualified ref**: `payments:0012` is well-formed per ADR-0002's `AdrRef`
+  grammar but is never resolved against this phase's single local corpus — Phase 5 has no
+  named-log federation ([Assumption A1](#assumptions)), so `get_decision` returns an
+  explicit **`federated-log-unavailable`** result naming the requested log and id. The
+  qualifier is never silently stripped and a same-id local record is never substituted
+  for it (US1 AC5).
+- **Corpus-wide load failure**: if the corpus fails to load at all (e.g. the configured
+  root is not readable, or is not a git-tracked directory), every tool returns an
+  explicit, actionable startup/availability error rather than a partial or fabricated
+  empty result — this is distinct from a single invalid record, which degrades gracefully
+  (see next).
+- **One invalid record among many valid ones**: a record whose frontmatter fails schema
+  validation (or whose source is unreadable or oversized, see below) is excluded from
+  results and reported as a finding; it never blocks retrieval of the rest of the corpus
+  (US3 AC8). A schema-**valid** record that nonetheless trips a corpus invariant (a
+  duplicate `id`, a dangling `supersedes`/`relatesTo`/`conflictsWith` reference) is
+  **not** excluded by that invariant — it remains fully present and retrievable; only a
+  finding about it is added, never a removal from the corpus this server answers from.
+- **Missing `affects` backing source**: this phase accepts no backing-snapshot startup
+  inputs, so a `package`, `entity`, `resource`, `api`, or `data` matcher resolves to
+  **inert** with an informational finding — never a fabricated match, never a fatal error,
+  and never silently treated as "no match" without saying why (ADR-0009; US2 AC5).
+- **`files[]` path-traversal or non-logical-path input**: any entry that is not a
+  well-formed repo-relative logical path (absolute, containing `..`, drive-qualified,
+  containing a backslash anywhere, or empty) is rejected as an input-contract error
+  before any matcher evaluation; the offending string is never used to open, read, or
+  `stat` a filesystem path (US2 AC6).
+- **`files[]` with zero matches**: an empty result for all three of `governing`,
+  `activeProposals`, and `history` is a valid, non-error outcome (US2 AC7).
+- **`files[]` matching records across more than one status bucket**: every matching
+  record is returned in its own collection (`governing`, `activeProposals`, or `history`)
+  — none of the three is allowed to suppress or absorb another for the same file (US2
+  AC4).
+- **`draft`/`proposed` records matching `files[]`**: surfaced in `activeProposals`, never
+  silently dropped for not yet being `accepted` and never merged into `governing` (US2
+  AC2).
+- **`get_decision_context` never expands relation refs into full records**: a matched
+  record's `supersedes`/`supersededBy`/`relatesTo`/`conflictsWith` refs are listed on its
+  summary so the caller can follow them, but `get_decision_context` itself never fetches
+  or inlines the referenced records' bodies — that always requires a separate
+  `get_decision` call (US2 AC8).
+- **Search with no filters and a term matching every status**: default behavior includes
+  the graveyard; a caller must opt in to narrowing, never opt in to seeing rejected
+  decisions at all (US3 AC1).
+- **Search term present only in a record's Markdown body**: still matches, with the
+  matched-field indicator identifying `body` — the searchable surface is id, title,
+  tags, and body, not a subset of them (US3 AC2).
+- **Search matching nothing**: an explicit empty result, not an error (US3 AC7).
+- **Large result set**: `search_decisions` and `list_superseded` paginate; a caller that
+  walks every page exactly once retrieves the complete result set with no gaps and no
+  duplicates, in the canonical `(id, sourcePath)` order across pages run against an
+  unchanged corpus (US3 AC5, US4 AC4).
+- **Large decision-context result**: `get_decision_context` paginates one canonical
+  ordered walk over all matches, then partitions each page into its three status
+  collections; pagination does not maintain a separate cursor per collection (US2 AC9).
+- **Large findings set**: findings are independently bounded and cursor-paginated so every
+  finding remains retrievable without making any one response unbounded.
+- **Oversized ADR source**: a source above the fixed maximum is excluded with a
+  `record-too-large` corpus finding and is never silently truncated or returned in full.
+- **ADR source changed during a tool call**: if a candidate's file identity, size, or
+  modification time differs between the pre-load guard and the post-load verification,
+  the provisional projection is discarded and the call returns
+  `corpus-changed-during-load`; the caller retries against a fresh corpus state rather
+  than receiving a result assembled from an inconsistent read.
+- **`superseded` record with a dangling `supersededBy` target**: an unqualified target id
+  with zero local matches is reported unresolved via the corpus's own pre-existing
+  `dangling-supersededBy` finding on `list_superseded`'s findings channel, never
+  fabricated, never silently dropped from the listing (US4 AC3).
+- **`superseded` record whose `supersededBy` target id is used by more than one local
+  record**: unresolved with a deterministic `superseded-target-ambiguous` finding naming
+  the target id and the candidate count — never every candidate's path/title inline; a
+  candidate is never silently picked, and the complete candidate list remains available
+  via a follow-up `get_decision` call on that same target id (US4 AC3, US4 AC4).
+- **`superseded` record whose `supersededBy` target is a log-qualified ref**: unresolved
+  as federated-unavailable, with an informational finding, consistent with this phase
+  serving exactly one local corpus ([Assumption A1](#assumptions); US4 AC3).
+- **No `superseded` records at all**: `list_superseded` returns an explicit empty result
+  (US4 AC2).
+- **Unknown/extra field on any tool call**: rejected by strict schema validation before
+  any corpus access (US5 AC4).
+- **Adversarial or malformed input generally**: every tool distinguishes a usage/
+  input-contract problem (bad shape, unknown field, invalid path syntax) from a corpus
+  finding (a record that failed validation) from "not found"/"empty" (a well-formed query
+  that matched nothing) — three distinct, never-conflated response shapes.
+- **Concurrent tool calls**: because every tool is a pure read against the same
+  in-process view of the corpus with no shared mutable state, concurrent calls never
+  interfere with each other's in-memory results and never require shared locking.
+  External filesystem mutation during one call is not treated as an atomic snapshot.
+  The stable-load checks reject any containment, type, identity, size, or timestamp
+  change observed at their validation checkpoints. A hostile swap that occurs and
+  reverts entirely between portable Node validation checkpoints is outside this
+  phase's guarantee.
+- **Server started with missing or invalid startup configuration** (no configured corpus
+  root, a root that is not a readable directory, a root with no readable `.git` entry —
+  so not a git working tree, including a linked worktree — or a configured ADR directory
+  that is unreadable, absolute-outside-root, escapes the root via `..`, or escapes the
+  root because it is, or resolves through, a symlink — checked after following every
+  symlink on its path, not merely by inspecting the literal configured string): the
+  server fails to start with an actionable error rather than starting and returning
+  empty or fabricated   results for every call. The configured root, readable `.git`, and ADR directory are
+  re-realpathed/re-verified before and after every later corpus load, not only once at
+  startup. Candidate files are also `lstat`-checked as non-symlink regular files,
+  realpath-contained, and identity-checked before and after core reads. Any observed
+  swap invalidates the whole call and no data from the changed path is returned.
+
+## Requirements
+
+### Functional Requirements
+
+**Tool surface & exclusivity**
+
+- **FR-001 — Exactly four tools, no more.** The server MUST expose exactly the four read
+  tools named in `plan.md`'s Phase 5 exit criteria: `search_decisions`, `get_decision`,
+  `get_decision_context(files[])`, and `list_superseded`. It MUST NOT expose any
+  additional tool, including any write, mutation, PR-creation, or administrative tool, in
+  this phase.
+- **FR-002 — No write, mutation, or proposal capability of any kind.** No tool call may
+  create, edit, delete, or propose a change to any decision record, any other repository
+  file, any git ref, or any external system. Every tool is read-only, non-destructive, and
+  idempotent (Principle I; ADR-0001, ADR-0004).
+- **FR-003 — No MCP prompts, resources, subscriptions, or sampling.** The server MUST NOT
+  register MCP prompts or resources, MUST NOT support subscriptions/notifications for
+  corpus changes, and MUST NOT use MCP sampling (asking the connected client's model to
+  generate content) in this phase. The four tools are the entire public surface. The
+  public package MUST NOT expose the SDK's concrete `McpServer`, low-level server,
+  registration methods, caller-supplied transport connection, or any public subpath
+  that permits a consumer to extend the registered capability set. At runtime the root
+  factory MUST return a frozen object whose prototype is `null`, whose complete own-key
+  set is exactly the two string keys `start` and `close`, whose symbol-key set is empty,
+  and whose two methods each take no argument and return `Promise<void>`. Public TypeScript
+  declarations MAY additionally expose only the corresponding options/handle/factory
+  types. The package export map MUST expose no internal test builder or server subpath.
+- **FR-004 — No model, embedding, or probabilistic step of any kind.** No tool
+  implementation may call a language model, compute or compare embeddings, or perform any
+  non-deterministic or weighted ranking. Retrieval in this phase is deterministic and
+  lexical — literal normalized substring matching only (FR-026) — never semantic
+  (Principle IV, extended to this phase by the same "deterministic before probabilistic"
+  posture).
+
+**Transport, security posture, and boundary**
+
+- **FR-005 — Local stdio transport only.** The server MUST communicate over a local
+  stdio-based Model Context Protocol transport, launched as a subprocess by an
+  MCP-compatible client/harness. It MUST NOT open a network listener, and MUST NOT
+  support an HTTP, SSE, or other remote transport in this phase. The public library
+  handle accepts no transport; its zero-argument `start()` creates and connects the
+  stdio transport internally.
+- **FR-006 — No authentication.** The server MUST NOT implement or require any
+  authentication or credential exchange, because it has no network listener to
+  authenticate against; trust is delegated entirely to whatever process launches it as a
+  local subprocess.
+- **FR-007 — No stdout logging.** The server MUST NOT write log, diagnostic, or debug
+  output to stdout at any point during startup, operation, or shutdown, because stdout
+  carries MCP protocol frames exclusively. Any log output MUST go to stderr or an
+  explicitly configured log destination, never stdout.
+- **FR-008 — Reads are confined to a stable configured corpus boundary.** Every tool call
+  MUST read only from the corpus root and ADR directory supplied at server startup. No
+  tool input may expand, redirect, or escape that boundary — not via a path parameter,
+  not via a log qualifier, not via any other field. Fresh portable containment and
+  identity checks run before and after the path-based core load; any observed change
+  invalidates the complete call and no result derived from the changed path is returned.
+  These checks are best-effort consistency and containment checks, not a filesystem lock
+  or atomic snapshot: adversarial mutation that occurs and reverts entirely between
+  validation checkpoints is outside this phase's guarantee.
+- **FR-009 — No arbitrary file-content reads.** No tool may use a caller-supplied string
+  (in particular, no entry of `get_decision_context`'s `files[]`) to open, read, or `stat`
+  an arbitrary filesystem path. `files[]` entries are compared, as strings, only against
+  `affects` patterns already loaded from the corpus; they are never used to perform a
+  filesystem read themselves (see FR-030).
+- **FR-010 — No hidden index, cache, or database.** The server MUST NOT maintain a
+  persistent database, a hidden on-disk cache, or any index that could drift from the
+  git-tracked corpus and be treated as authoritative. Each tool call reads the current
+  state of the configured corpus for that call — no call may be answered from a stale,
+  previously-computed snapshot (ADR-0004: git is truth; any index is derived and
+  optional, never required).
+- **FR-011 — No network access of any kind.** No tool implementation may perform an
+  outbound network call (no telemetry, no license check, no remote catalog lookup) as
+  part of answering a tool call.
+
+**Schema, output contract, and annotations**
+
+- **FR-012 — Strict, bounded input and output schemas per tool.** Every tool MUST declare
+  a strict input schema (rejecting unknown/extra fields and out-of-range values) and a
+  strict, bounded output schema. This includes fixed maxima for query length, status/
+  scope/tag filter counts and tag length, `files[]` count and path length, page size,
+  cursor length, summary arrays, findings arrays, and ADR source bytes. Exact values
+  MUST be fixed in the plan and contract fixtures, not selected at runtime. A source above
+  the ADR-size maximum MUST be excluded with a structured `record-too-large` finding and
+  MUST NOT be silently truncated. Malformed input — including a query that is empty after
+  trimming leading/trailing whitespace — is rejected before any corpus access.
+- **FR-013 — Structured content plus deterministic bounded text content on every
+  response.** Every
+  successful tool response MUST include machine-readable structured content conforming to
+  the tool's declared output schema, and MUST also include a human-readable text summary
+  suitable for display without parsing the structured payload. Every tool-authored
+  summary and domain-error message MUST use the exact templates in
+  `contracts/tools.md` §2.1 and MUST be no more than 512 UTF-16 code units. Paths and
+  other unbounded corpus content MUST NOT be interpolated into these messages.
+- **FR-014 — Fixed, accurate tool annotations.** Every tool MUST be annotated read-only,
+  non-destructive, idempotent, and closed-world (the tool does not claim to search
+  anything beyond the configured corpus) — annotations MUST be accurate declarations of
+  the exclusivity and boundary properties in FR-001–FR-011, not aspirational metadata.
+- **FR-015 — Actionable, distinguished tool-result errors.** Every error response MUST be
+  a structured, actionable tool result — not a raw, unhandled exception — and MUST
+  distinguish at least three cases: (a) a usage/input-contract problem (malformed shape,
+  unknown field, invalid path syntax), (b) a well-formed query or lookup that found
+  nothing ("not found" / empty result, not an error), and (c) a corpus finding
+  encountered while otherwise answering the call (see FR-016). These three cases MUST
+  never be conflated into a single generic failure shape.
+- **FR-016 — Corpus findings are surfaced, never silently dropped, and are part of
+  structured content.** Any finding produced while loading or resolving the corpus in
+  service of a tool call (a schema-invalid record, a dangling reference, an inert matcher
+  with no backing source, an unresolved supersession target) MUST be included on the
+  response's findings channel, which MUST be part of the machine-readable structured
+  content required by FR-013 — never text-only. A finding about one record MUST NOT
+  suppress or corrupt results for the rest of the corpus, and a caller MUST be able to
+  detect an incomplete corpus (one or more excluded records) from structured content
+  alone, without parsing the text summary.
+- **FR-017 — Every output path is repo-relative; no tool ever emits an absolute
+  filesystem path.** Every source-path field in any tool's output (including
+  `get_decision`'s source path and any path echoed back from `get_decision_context`'s
+  `files[]`) MUST be a repo-relative, POSIX-separator path, matching the same logical-path
+  contract FR-030 enforces on input. The server's actual on-disk root MUST NOT be
+  observable in any response.
+
+**Determinism and ordering**
+
+- **FR-018 — Deterministic ordering everywhere a result set can contain more than one
+  item, and never by relevance ranking.** Search matches, superseded listings, and each
+  of `get_decision_context`'s three collections (FR-031) MUST be returned in the
+  canonical `(id, sourcePath)` ascending order (FR-027), compared with a fixed,
+  locale-independent code-unit comparator, such that repeated, identical calls against an
+  unchanged corpus return results in the identical order every time. No result set in
+  this phase is ordered by a relevance score or other weighted heuristic.
+- **FR-019 — Pagination for every response channel that can grow.** `search_decisions`,
+  `get_decision_context`, `list_superseded`, and `get_decision`'s ambiguous candidate set
+  MUST support cursor-based pagination.
+  `get_decision_context` MUST paginate one canonical ordered union of all matches and then
+  partition each page into `governing`, `activeProposals`, and `history`; it MUST NOT use
+  independent per-collection walks. Findings MUST be independently bounded and
+  cursor-paginated. Walking each result or findings cursor exactly once MUST return every
+  item exactly once, with no omission or duplicate, in the stable order required by
+  FR-018.
+
+**Corpus and graveyard semantics**
+
+- **FR-020 — The graveyard is included by default.** `search_decisions` and
+  `get_decision` MUST include `rejected` and `superseded` (and, where present,
+  `deprecated`) records by default. A caller MAY narrow results with an explicit status
+  filter, but MUST NOT be required to opt in to seeing the graveyard at all.
+- **FR-021 — Local identity is `id`; named-log federation is deferred completely in this
+  phase.** This phase serves exactly one local corpus and no other. `@adrkit/core`'s
+  loader never populates a record's optional `log` field today, and `@adrkit/mcp`'s own
+  discovery is non-recursive over the one configured ADR directory, so this server has no
+  way to observe more than one named log from what it actually loads. A record's local
+  identity is therefore its bare `id` alone, and the server maintains one multi-valued
+  index (`id` → every local record sharing that id) rather than any per-log or
+  canonical-log-qualified index. True named-log/multi-repository federation — resolving a
+  `log:id`-qualified ref against a different log's corpus — is explicitly **out of
+  scope** for this phase (see [Out of Scope](#out-of-scope)) and remains governed by the
+  root `plan.md`'s own open question on federated-id representation; this server MUST
+  NOT fabricate, guess at, or partially implement it.
+- **FR-022 — Unqualified-id resolution is a three-way, deterministic comparison, never a
+  silent choice; a log-qualified ref is a distinct, fourth, non-error outcome.** When
+  `get_decision` (or any other id-accepting input) is given an **unqualified** id, the
+  server MUST compare that id against every loaded local record's own `id` and return
+  exactly one of three outcomes: **zero matches** → an explicit "not found" result
+  (FR-015, case (b)); **exactly one match** → that record, unambiguously; **more than one
+  match** → an explicit, complete `ambiguous-local-id` candidate list (at minimum: id,
+  title, status, and the repo-relative `sourcePath` that distinguishes the candidates,
+  since this phase has no log qualifier to distinguish them by) covering every match,
+  never a partial list and never a silently chosen one — this many-match case reflects an
+  already-invalid local corpus (the same duplication `@adrkit/core`'s own `unique-id`
+  finding already flags) and this phase provides no way for the caller to disambiguate
+  further by log or to have the server pick one arbitrarily. When the input is instead a
+  well-formed **log-qualified** ref (matching ADR-0002's `AdrRef` grammar), the server
+  MUST NOT attempt any local lookup with it, MUST NOT strip the qualifier and retry as
+  unqualified, and MUST NOT substitute a same-id local record; it MUST instead return an
+  explicit, non-error `federated-log-unavailable` result naming the requested log and id
+  (FR-021).
+
+**`get_decision` specifics**
+
+- **FR-023 — `get_decision` returns the complete document, never frontmatter alone.** A
+  successful `get_decision` response MUST include: the record's local `id`; its full
+  typed frontmatter; its repo-relative source path (FR-017); and its complete Markdown
+  body. A response containing frontmatter with no body, or a truncated/summarized body,
+  is non-conforming — the whole point of this tool is that an agent can act on the
+  authoritative record without a second fetch. This guarantee applies to records within
+  the fixed source-size maximum in FR-012; an oversized source is excluded and surfaced
+  as a finding rather than truncated.
+- **FR-024 — Declared relation refs remain explicit and unexpanded.** For a record whose
+  frontmatter declares `supersedes`, `supersededBy`, `relatesTo`, or `conflictsWith` refs,
+  `get_decision` MUST return those refs as part of the complete typed frontmatter required
+  by FR-023. It MUST NOT resolve, summarize, fetch, or inline any referenced record. The
+  caller follows a ref with a separate `get_decision` call, keeping one tool response
+  bounded to one authoritative document.
+
+**`search_decisions` specifics**
+
+- **FR-025 — The searchable surface is local id, title, tags, and the Markdown body — no
+  more, no fewer.** `search_decisions` MUST match a query against a record's local id,
+  title, tags, and full Markdown body. It MUST NOT search any other field, and MUST NOT
+  omit the body from the searchable surface in favor of frontmatter metadata alone.
+  There is no log filter or canonical-log-qualified-ref search in this phase (FR-021).
+- **FR-026 — Matching is a deterministic, locale-independent normalized literal-match
+  contract, not a weighted heuristic.** The query and every searchable field (FR-025) MUST
+  be trimmed and case-folded using the same documented, locale-independent normalization
+  before comparison. A record matches if and only if the normalized query is a substring
+  of at least one normalized searchable field. A query that is empty after trimming
+  leading/trailing whitespace MUST be rejected as an input-contract error before any
+  corpus access, never silently normalized into an empty-string query that would
+  otherwise match every record. Where a caller supplies a `status`, `scope`, or `tags`
+  filter, each is a **unique** list (`status`: at most six entries; `scope`: at most
+  three entries; `tags`: at most 32 entries, each at most 64 characters); `status` and
+  `scope` use **any-of** semantics (a record matches the filter if its own single value
+  is any one of the listed values), `tags` uses **all-of** semantics (a record matches
+  only if it carries every listed tag, not merely one), and the three filter categories
+  are **ANDed** together — a record must satisfy every supplied category's own condition
+  to remain a candidate at all, and omitting a category means no constraint from that
+  category, never "match nothing." The server MUST NOT apply stemming, fuzzy
+  matching, locale-sensitive collation, embeddings, or any per-field or per-record weight
+  when deciding whether a record matches. The exact normalization primitives (e.g. which
+  Unicode case-folding routine) MAY be pinned at the plan/research stage, provided the
+  choice is portable and fixture-pinned — there is no unresolved ranking decision left to
+  make at that stage.
+- **FR-027 — Canonical result order, never relevance order.** `search_decisions` results
+  MUST be ordered by canonical identity — `(id, sourcePath)` ascending, compared with a
+  fixed, locale-independent code-unit comparator (never `localeCompare` or any other
+  locale-sensitive collation, so ordering cannot vary by the server process's runtime
+  locale) — the same order required generally by FR-018. There is no relevance score,
+  tie-break weight, or field-priority ranking in this phase.
+- **FR-028 — Search results are bounded summaries with matched-field indicators; the full
+  body is retrieved only through `get_decision`.** Each `search_decisions` result MUST be
+  a bounded summary (at minimum: id, title, status, repo-relative source path, and an
+  indicator of which searchable field(s) matched) and MUST NOT include the record's full
+  Markdown body. A caller that needs the full document follows up with `get_decision`.
+
+**`get_decision_context(files[])` specifics**
+
+- **FR-029 — Reuse core `affects`-resolution semantics unchanged.** `get_decision_context`
+  MUST determine matches using `@adrkit/core`'s existing, pure `affects`-resolution
+  implementation (ADR-0009) — the same matcher grammar, per-ADR union-not-winner
+  semantics, and negation-after-include ordering the CLI and CI surface already use. This
+  tool MUST NOT implement a second, parallel resolver.
+- **FR-030 — `files[]` entries are validated repo-relative logical paths only.** Every
+  entry MUST be validated as a well-formed, repo-relative, POSIX-separator logical path
+  before being compared against any `affects` pattern: no leading `/`, no `..` traversal
+  segment, no drive-qualified path, no backslash character anywhere in the string, and no
+  empty string. The backslash rejection is not limited to drive-qualified paths — the
+  contract is POSIX separators only, so any entry containing a `\` character, in any
+  position, is out of contract. An entry failing this validation MUST be rejected as an
+  input-contract error (FR-015, case (a)) for the whole call, before any matcher
+  evaluation — never partially processed.
+- **FR-031 — Three structurally separate collections; no status is structurally
+  unreachable.** The response MUST distinguish, as three separate collections: (a)
+  `governing` — records with status `accepted` whose `affects` matches the supplied
+  files; (b) `activeProposals` — records with status `draft` or `proposed` whose
+  `affects` matches the same files; and (c) `history` — records with status `rejected`,
+  `superseded`, or `deprecated` whose `affects` matches the same files. Every one of the
+  six statuses in `Status` (ADR-0002) MUST be visible through exactly one of these three
+  collections whenever a matching record of that status exists. A single record MUST NOT
+  appear in more than one collection, and the three collections MUST NOT be merged into
+  one undifferentiated list.
+- **FR-032 — Missing backing source remains inert, never fabricated.** Consistent with
+  ADR-0009, this phase accepts no adapter or backing-snapshot startup inputs beyond the
+  corpus root and ADR directory in FR-035. A matcher that requires a lockfile, catalog,
+  IaC plan, OpenAPI document, or other absent backing source therefore MUST resolve to an
+  explicit inert result with an informational finding — never a fabricated match and
+  never a fatal error for the rest of the call.
+- **FR-033 — Each returned summary lists its record's declared relation refs; the tool
+  never expands them.** Every record summary in any of the three collections MUST include
+  that record's declared `supersedes`/`supersededBy`/`relatesTo`/`conflictsWith` refs
+  (when present), so the caller can choose to follow one with a separate `get_decision`
+  call. `get_decision_context` MUST NOT itself fetch, inline, or expand a referenced
+  record's frontmatter or body — it reports refs, it does not walk the graph.
+
+**`list_superseded` specifics**
+
+- **FR-034 — Complete superseded listing (across the full paginated walk) of direct,
+  local edges only.** `list_superseded` MUST return every valid record with status
+  `superseded` in the configured corpus (schema invariant: a `superseded` record always
+  declares `supersededBy`; ADR-0002), across as many pages as the walk requires — no
+  single page is "the complete listing" on its own; walking the primary cursor to
+  completion is. This phase reports only the direct edge; it MUST NOT compute or expose a
+  transitive supersession chain (A superseded by B superseded by C) — that lineage walk
+  is explicitly out of scope for this phase (see [Out of Scope](#out-of-scope)). Target
+  resolution is local-only and MUST distinguish three unresolved cases, never picking a
+  candidate silently and never fabricating a target: (a) an **unqualified** target id
+  used by exactly one local record resolves to that record's id, resolved title, and
+  resolved current status; (b) an unqualified target id used by **more than one** local
+  record is unresolved with a deterministic `superseded-target-ambiguous` finding naming
+  the target id and the number of candidates (`candidateCount`) — never the full
+  candidate list inline; that complete, already-bounded candidate list remains
+  separately obtainable via a follow-up, paginated `get_decision` call on the same target
+  id, which resolves to `ambiguous-local-id` (FR-022); (c) a **log-qualified** target ref
+  is unresolved as federated-unavailable, with an informational finding, consistent with
+  this phase's single-local-corpus scope (FR-021) — the qualifier is never stripped and a
+  same-id local record is never substituted. A target with zero local matches at all (a
+  dangling reference that should have failed corpus validation upstream) remains
+  unresolved, surfaced via the corpus's own existing dangling-reference finding rather
+  than fabricated or silently omitted.
+
+**Configuration**
+
+- **FR-035 — Configuration is corpus root and ADR directory only, explicit and
+  startup-only.** A server instance serves exactly one configured corpus root (one git
+  working tree, including a linked worktree) and one ADR directory within it, supplied
+  only at process startup (environment variables, CLI flags, or equivalent launch
+  configuration); user-friendly, documented defaults MAY be provided for either (e.g. a
+  conventional ADR directory name) as long as they remain overridable at startup. No tool
+  input parameter may set, override, or expand either value for a single call. There is
+  no log-identity, backing-snapshot, or named-log startup setting of any kind — this phase
+  has no per-server or per-record log configuration at all (FR-021).
+- **FR-036 — Startup fails loudly on an unusable configuration, including a non-git
+  root or a directory that escapes the root by any means, including a symlink.** The
+  server MUST fail to start with an actionable error, printed to stderr (FR-007), rather
+  than starting and returning empty or fabricated results for every subsequent call, when
+  any of the following holds: the configured corpus root does not exist, is not a
+  readable directory, or does not contain a readable `.git` entry (a directory for an
+  ordinary clone, or a file for a linked worktree) identifying it as a git working tree;
+  or the configured ADR directory, resolved against that root, is not a readable
+  directory, or does not resolve — after following every symlink on its path, not merely
+  by inspecting the literal configured string — to a location equal to or contained
+  within the root. An absolute path outside the root, a `..` traversal segment, and a
+  symlink (of the directory itself, or of an intermediate path segment) that resolves
+  outside the root are all "escapes the root," checked identically and rejected
+  identically — a directory whose literal, unresolved string contains no `..` MUST NOT be
+  treated as safe merely on that basis if it resolves outside the root once symlinks are
+  followed. The corpus root and ADR-directory checks MUST both be re-run before and after
+  every corpus load while the server is running, not only once at startup. Every
+  discovered candidate MUST be rejected if `lstat` identifies a symlink or non-regular
+  file; its fresh realpath MUST remain segment-safely contained in the fresh ADR-directory
+  realpath, and its bigint `dev`, `ino`, `size`, and nanosecond `mtime` identity MUST
+  match at the post-load check. Any observed containment, type, or identity change
+  returns `corpus-changed-during-load` and discards the complete provisional projection.
+  This is distinct from a single schema-invalid record within an otherwise-loadable
+  corpus, which degrades gracefully per FR-016 rather than failing startup.
+
+**Toolchain and dependency boundary**
+
+- **FR-037 — `@adrkit/mcp` depends only on `@adrkit/core` and vetted deterministic
+  libraries.** The package MUST NOT depend on any package under `packages/adapters/**`
+  and MUST NOT depend on any source requiring authenticated, network, or service access at
+  build, test, or run time (Principle III, ADR-0007's `core-has-no-adapter-deps`
+  boundary, applied identically to this new package).
+- **FR-038 — `@adrkit/core` never depends on `@adrkit/mcp`.** Dependency direction is
+  one-way: this server consumes core parsing, validation, graph, and `affects` machinery;
+  core MUST NOT import from, reference, or otherwise depend on the MCP package.
+- **FR-039 — Clean-clone build.** A fresh clone with Bun 1.3.14, no credentials, and no
+  running services MUST be able to run `bun install --frozen-lockfile` using only the
+  unauthenticated public package registry, the committed `bun.lock`, and the repository's
+  `bunfig.toml`. After that single install step, build, typecheck, test, lint, packaging,
+  smoke tests, and all four tool calls against a sample corpus MUST succeed with network
+  access disabled (Constitution Principle II; ADR-0007's `clean-clone-builds` gate,
+  extended to this package).
+- **FR-040 — Node-targeted published artifact; Bun for development only.** The published
+  package MUST run under Node `>=22` (matching the project's existing engines
+  constraint) without requiring Bun to be installed by the consumer, consistent with
+  ADR-0010's explicit statement that the MCP server is launched by third-party agent
+  harnesses under Node.
+
+### Key Entities
+
+- **Decision record**: the full typed ADR — local identity `id`, `status` (including
+  `rejected`/`superseded`/`deprecated`), title, `affects` matchers,
+  `supersedes`/`supersededBy`/`relatesTo`/`conflictsWith`, and the rest of the schema
+  (ADR-0002) — plus its repo-relative source path and complete Markdown body. This server
+  never constructs a new shape for it; it surfaces the same record the CLI and CI surface
+  already parse, in full, via `get_decision` (FR-023).
+- **Decision-record summary**: a bounded, partial projection of a decision record (at
+  minimum: id, title, status, repo-relative source path) used everywhere a full document
+  would be unbounded or unnecessary — search results (FR-028), candidate sets (FR-022),
+  and the entries of `get_decision_context`'s three collections (FR-031). Never includes
+  the full Markdown body; a caller that needs the body follows up with `get_decision`.
+- **Log-qualified ref (recognized, never resolved, this phase)**: ADR-0002's `AdrRef`
+  grammar permits an optional `log:` prefix disambiguating records across named logs.
+  This phase serves exactly one local corpus, and `@adrkit/core`'s own loader never
+  populates a record's `log` field, so a log-qualified ref is never looked up against
+  local records, never silently stripped to its bare id, and never satisfied by a same-id
+  local substitute — `get_decision` recognizes one and returns
+  `federated-log-unavailable`; `list_superseded` recognizes one on a `supersededBy` target
+  and reports that entry unresolved with an informational finding (FR-021, FR-022,
+  FR-034). True named-log federation remains out of scope (see
+  [Out of Scope](#out-of-scope)).
+- **Search query**: a caller-supplied term plus optional structured filters (status,
+  tags, scope) and pagination parameters. Matching is a deterministic, normalized literal
+  substring match over id, title, tags, and Markdown body (FR-025, FR-026) — never
+  semantic, fuzzy, or model-scored (FR-004). There is no log filter in this phase.
+- **Search result set**: a paginated list of matched decision-record summaries, in
+  canonical `(id, sourcePath)` order (FR-027), each with a matched-field indication
+  (FR-028), plus any corpus findings encountered while searching.
+- **Decision-context result**: the paginated output of `get_decision_context(files[])` —
+  one canonical ordered result walk partitioned on each page into three structurally
+  separate collections, `governing` (`accepted`), `activeProposals`
+  (`draft`/`proposed`), and `history` (`rejected`/`superseded`/`deprecated`) — each entry
+  of which pairs a decision-record summary with the specific fired `affects` matcher(s)
+  and that record's declared relation refs, plus any corpus/resolution findings
+  (including inert-matcher findings) (FR-031, FR-033).
+- **Candidate set (`ambiguous-local-id`)**: the paginated list of record summaries,
+  distinguished by repo-relative `sourcePath`, returned when an unqualified id resolves to
+  more than one local record — an already-invalid-corpus condition (the same duplication
+  `@adrkit/core`'s own `unique-id` finding flags), never a silent first-match and never
+  something this phase resolves further by log (FR-022). `get_decision` is the only place
+  this full candidate set itself appears; `list_superseded` reports an ambiguous
+  `supersededBy` target as a count only (see Supersession edge, next), pointing the
+  caller back to this same channel via a follow-up `get_decision` call rather than
+  re-embedding the set a second time.
+- **Supersession edge**: a directed `supersedes`/`supersededBy` relationship between two
+  records, reused from the existing graph model (`supersedes`, `relatesTo`,
+  `conflictsWith` edge kinds already built by `@adrkit/core`'s graph builder).
+  `list_superseded` reports the direct `supersededBy` edge for every `superseded` record,
+  resolved only against unqualified local targets — not a transitive chain, and not a
+  federated lookup (FR-034). When a target is ambiguous, the entry reports only the
+  target id and a candidate count, never the candidates themselves — the full candidate
+  set is the Candidate set entity above, obtained with a separate `get_decision` call.
+- **Tool-result error**: a structured, actionable error distinguishing usage/
+  input-contract problems from empty-but-valid results from corpus findings (FR-015).
+  Never a raw, unhandled exception surfaced to the caller.
+- **Server configuration**: the startup-only, tool-input-immutable settings — corpus
+  root and ADR directory only — that bound every subsequent tool call for the life of the
+  process (FR-035), where the corpus root must be a readable git working tree (FR-036).
+  There is no log-identity, named-log, or backing-snapshot configuration of any kind in
+  this phase.
+
+## Success Criteria
+
+- **SC-001**: A caller can retrieve any within-limit decision record in a fixture corpus by id,
+  including `rejected`, `superseded`, and `deprecated` records, using only `get_decision`
+  — no record status is ever unreachable through the public tool surface — and every such
+  response includes the record's local id, full typed frontmatter, repo-relative source
+  path, and complete Markdown body; **never** frontmatter with the body omitted or
+  truncated. An over-limit source is instead excluded, before it is ever parsed, with a
+  structured `record-too-large` finding.
+- **SC-002**: A caller can discover, via `search_decisions` with no status filter, at
+  least one `rejected` or `superseded` record relevant to a query term, demonstrating the
+  graveyard is searched by default rather than opt-in; a further fixture case proves a
+  query matching only body text (not id, title, or tags) still returns that record with a
+  `body` matched-field indicator.
+- **SC-003**: Given a fixture corpus where enough local records share one duplicate id to
+  span more than one page (an already-invalid corpus, flagged by `unique-id`), walking
+  `get_decision`'s `ambiguous-local-id` candidate cursor returns **100%** of the true
+  candidates exactly once, distinguished by `sourcePath`, and **never** a silently chosen
+  record; a further fixture case proves a log-qualified ref for any id (colliding or not)
+  returns `federated-log-unavailable` naming the requested log and id, never a local
+  substitute and never the qualifier silently stripped.
+- **SC-004**: Given a fixture corpus with at least one record in each of the six
+  `Status` values, `get_decision_context` places the `accepted` record(s) only in
+  `governing`, the `draft`/`proposed` record(s) only in `activeProposals`, and the
+  `rejected`/`superseded`/`deprecated` record(s) only in `history`, in **100%** of such
+  fixture cases — no merged list, no cross-listing, and no status structurally excluded
+  from all three collections.
+- **SC-005**: The public factory returns a frozen null-prototype handle with exactly own
+  `start`/`close`, no symbols or transport parameter, and no exported SDK server,
+  registration API, or test builder. No tool call, across every outcome branch and the
+  full adversarial-input fixture set (path traversal
+  attempts, absolute paths, backslash-containing paths, unknown extra fields, oversized
+  inputs), causes a read outside the configured corpus root, a write to any file, an
+  outbound network call, or an unhandled exception surfaced to the caller — every one of
+  them instead yields a well-formed input-contract error or well-formed empty result; a
+  further fixture case proves that no successful response, from any of the four tools,
+  ever contains an absolute filesystem path in any field, and a further fixture case
+  proves the server refuses to start when the configured ADR directory is a symlink
+  resolving outside the configured corpus root. Deterministically injected root,
+  directory, and candidate-file swaps at every explicit pre/post validation checkpoint
+  are rejected, and no response contains data derived from the observed changed path.
+  Side-effect denial covers the exact JavaScript-level API inventory in
+  `contracts/tools.md` §10.1 and is paired with complete sandbox, parent-sentinel, `HOME`,
+  and `TMPDIR` snapshots.
+  Tests MUST NOT claim universal atomic no-read behavior for an unscheduled hostile swap
+  that occurs and reverts entirely between portable validation checkpoints, raw native
+  syscalls, or future unenumerated APIs.
+- **SC-006**: Across a full test run exercising every tool at least once, the server's
+  stdout stream contains only well-formed MCP protocol frames — zero non-protocol bytes
+  observed on stdout, verified by capturing the raw stream.
+- **SC-007**: Every one of the four tools' successful responses includes both structured
+  content that validates against its declared output schema and text that equals the
+  applicable deterministic template in `contracts/tools.md` §2.1 and is at most 512
+  UTF-16 code units. Every invalid-cursor and corpus-unavailable reason likewise maps to
+  the exact fixed message in that contract.
+- **SC-008**: Walking any paginated result set (search, decision context, or superseded
+  listing) to completion against a fixture corpus larger than one page returns every
+  matching record exactly once, with no gap and no duplicate; the decision-context walk
+  partitions every page into the three status collections without losing canonical
+  ordering. Walking an independently paginated findings channel likewise returns every
+  finding exactly once. Repeating either walk against an unchanged corpus returns items in
+  the identical canonical order both times.
+- **SC-009**: A fixture corpus containing exactly one schema-invalid record still yields
+  correct, complete results for every other, valid record via `search_decisions` and
+  `get_decision_context`, with the invalid record surfaced as a finding — visible in
+  structured content, not just text — rather than crashing the call or silently vanishing
+  without explanation.
+- **SC-010**: Because Phase 5 accepts no adapter/backing-snapshot startup inputs, every
+  matcher type that requires such a source (for example, a package matcher requiring a
+  lockfile snapshot) is proven, in a fixture case, to resolve inert with an informational
+  finding — never a fabricated `get_decision_context` match and never a fatal error for
+  the rest of the call.
+- **SC-011**: `list_superseded` against a fixture corpus returns every `superseded`
+  record with its direct, unqualified-local `supersededBy` target's id, title, and status
+  resolved (never a transitive lineage walk); a fixture case with a target id used by more
+  than one local record is proven to surface a deterministic `superseded-target-ambiguous`
+  finding naming the target id and the candidate count — never the full candidate list
+  inline — rather than picking one, with a further fixture case proving a follow-up
+  `get_decision` call on that same target id independently returns the complete candidate
+  list via its own paginated `ambiguous-local-id` outcome; a fixture case with a
+  log-qualified target is proven to surface an informational federated-unavailable
+  finding rather than a local substitute; and a fixture case with a wholly dangling
+  target is proven to surface via the corpus's own existing finding rather than being
+  fabricated or dropped from the listing.
+- **SC-012**: A clean clone with Bun 1.3.14, no credentials, and no running service can
+  install only from the unauthenticated public registry using the committed lockfile and
+  repository settings; after installation, an OS-enforced network-disabled environment
+  can build, typecheck, test, lint, package, start the server against a sample corpus, and
+  receive correct answers from all four tools.
+- **SC-013**: The published `@adrkit/mcp` package's declared, direct dependencies are
+  exactly `@adrkit/core`, the pinned `@modelcontextprotocol/sdk`, and `zod` — no package
+  under `packages/adapters/**` and no other declared dependency — asserted by the same
+  class of direct-declaration allow-list check the project already uses for
+  `core-has-no-adapter-deps` (ADR-0007), extended to this package. This check verifies
+  declared manifests only; it does **not** by itself prove that no network, service, or
+  authenticated access occurs at build, test, or run time, because the SDK's own
+  transitive dependency tree includes an HTTP/OAuth surface installed on disk regardless
+  of which subpath is imported. That runtime property is separately proven, as
+  defense-in-depth **executed-path** evidence rather than a formal proof against every
+  conceivable channel (a native addon, a worker thread with its own scope, or a raw
+  syscall bypassing the JavaScript-level APIs observed here are outside what this
+  evidence covers, and are separately closed by this package importing no native addon
+  and spawning no worker thread), by (a) side-effect-denial preloads that fail the process
+  if any enumerated Node/Bun filesystem mutation, write-capable open/returned FileHandle,
+  subprocess, cluster, worker, `process.dlopen`, network/listen, Bun
+  write/delete/writer/spawn, or Bun-shell escape path is invoked while startup and every
+  outcome branch of all four tools are exercised; (b) an import-discipline check that this
+  package's own source imports only the SDK's stdio/in-memory subpaths, never its
+  HTTP/OAuth subpaths; and (c) independent complete disposable-sandbox,
+  parent-sentinel, `HOME`, and `TMPDIR` snapshots. The exact trapped API inventory is
+  normative in `contracts/tools.md` §10. Passing proves only that these enumerated
+  JavaScript-level APIs were not invoked on exercised paths; it is not proof against raw
+  native syscalls or future unenumerated runtime APIs.
+- **SC-014**: Two consecutive `search_decisions` calls with identical query, filters, and
+  pagination parameters, against an unchanged corpus, return byte-for-byte identical
+  ordered result sets — proving determinism independent of caller-perceived randomness or
+  clock/state drift, and proving the ordering is the fixed canonical identity order, not a
+  computed relevance score.
+- **SC-015**: Given a fixture corpus where an `accepted` record's frontmatter declares
+  `conflictsWith` another record, both `get_decision` and `get_decision_context` surface
+  that declared ref without inlining or resolving the referenced record, and a follow-up
+  `get_decision` call using the ref returns the full referenced record — proving the
+  two-step "surface the ref, let the caller follow it" contract end to end.
+- **SC-016 (gate, satisfied 2026-07-20)**: **Phase 5 implementation does not begin
+  until this specification is reviewed and its scope ratified by the maintainer**,
+  in addition to the Phase 4 real-user gate evidence already recorded above. The
+  maintainer explicitly ratified the exact boundary in the header callout; both
+  preconditions are satisfied.
+
+## Assumptions
+
+Documented, ADR-consistent defaults chosen so this spec stays testable without
+prescribing implementation; none is presented as a one-way door, and no
+maintainer-facing product decision remains open after the 2026-07-20 scope
+ratification:
+
+- **A1 — Single local corpus per server instance; named-log federation is deferred
+  completely, not partially built.** This phase serves one configured corpus root (one
+  git working tree) and one ADR directory within it (FR-035). ADR-0002's `AdrRef` grammar
+  permits an optional `log:` prefix, but `@adrkit/core`'s own loader never populates a
+  record's `log` field today, and this server's discovery is non-recursive over the one
+  configured directory — so this phase has no way to load, index, or search by log at
+  all. A record's identity is therefore its bare `id`, held in one multi-valued local
+  index (`id` → every local record sharing that id, never a single arbitrary
+  representative) rather than any canonical-log-qualified index (FR-021). A log-qualified
+  ref is recognized by its grammar only far enough to answer `federated-log-unavailable`
+  (`get_decision`) or an unresolved, informational finding
+  (`list_superseded`) — never resolved, never stripped, never substituted. True
+  multi-repository federation — one server instance aggregating several separate
+  corpora/repos, or genuinely resolving a `log:id` ref — is **not** built in this phase
+  and remains out of scope (see [Out of Scope](#out-of-scope)); `plan.md`'s own separate
+  open question ("whether federated multi-repo aggregation uses ULIDs or log-prefixed
+  ordinals in practice") is about that future, out-of-scope capability and is not a gap in
+  this spec.
+- **A2 — Search is deterministic normalized literal matching, not semantic, and there is
+  no open ranking question.** Consistent with FR-004, FR-025, and FR-026, `search_decisions`
+  matches by normalized (trimmed, case-folded) substring comparison over id, title,
+  tags, and body text, ordered by canonical `(id, sourcePath)` identity — compared with a
+  fixed, locale-independent code-unit comparator, never a relevance score, weight, or
+  tie-break heuristic. This is a fixed decision, not an open item. Only the specific
+  Unicode normalization/case-folding primitive used to implement FR-026 is left to the
+  plan/research stage, and only on the condition that it is portable and pinned by test
+  fixtures — there is no remaining ranking or weighting decision at that stage.
+- **A3 — `list_superseded` reports direct supersession edges, not full transitive
+  chains, by deliberate scope choice.** Each `superseded` record is paired with its
+  immediate `supersededBy` target (FR-034). Walking a multi-hop supersession chain (A
+  superseded by B superseded by C) is left to the caller composing repeated
+  `get_decision`/`list_superseded` calls, or to a later phase — a fixed scope decision for
+  this phase, not an open question (see [Out of Scope](#out-of-scope)).
+- **A4 — Package placement is a first-party, non-adapter surface.** `@adrkit/mcp` is a
+  peer of `@adrkit/core`, `@adrkit/cli`, and `@adrkit/evaluator` — not a package under
+  `packages/adapters/**` — because it introduces no new external integration surface of
+  its own; it only reads the corpus `@adrkit/core` already parses (Principle III,
+  ADR-0007). Exact directory layout is a plan-stage decision.
+- **A5 — MCP SDK and transport primitives.** The stable, current
+  `@modelcontextprotocol/sdk` (1.29.0 as of 2026-07-20) supports the primitives this spec
+  assumes exist — an `McpServer`-style registration API, a `StdioServerTransport`, strict
+  per-tool input/output schemas (Zod 3.25+ or 4 compatible), `outputSchema` +
+  `structuredContent`, and tool annotations. The SDK's v2 is a **beta**, split-package
+  line and explicitly out of scope for this phase. Exact dependency pinning and API usage
+  belong to the plan/research stage, not this spec.
+- **A6 — Launch model.** The server is launched as a local subprocess by an
+  MCP-compatible client/harness (commonly via `npx`-style invocation under Node, per
+  ADR-0010), not run as a long-lived, independently-started service. It reads its
+  configuration once at startup (FR-035) and serves calls for the life of that process.
+- **A7 — No log output required, but if present, never on stdout.** This phase does not
+  require the server to produce any log output at all; FR-007 only constrains where
+  output goes **if** any diagnostic/log output exists, because stdout is exclusively
+  protocol traffic for a stdio MCP server.
+- **A8 — Bun for development; Node for the published artifact.** Built, tested, and
+  bundled with Bun in this repository; the published package targets Node `>=22` and is
+  smoke-tested under Node, matching the project's existing toolchain posture (ADR-0010)
+  rather than introducing a Bun runtime dependency for consumers.
+- **A9 — Distribution wiring is a Phase 5 non-behavioral deliverable.** Phase 5 includes
+  adding `@adrkit/mcp` to the existing package, release-pack, installed-smoke,
+  dependency-order, and release-documentation paths. This does not expand the four-tool
+  behavioral surface. Selecting a release version, publishing to npm, creating a tag,
+  and changing `scripts/release-publish.ts` remain out of scope.
+
+## Traceability
+
+| This spec | Constitution principle | Governing ADR(s) | Outcome ladder |
+|---|---|---|---|
+| FR-002, FR-010, FR-011, US5 | I — Git is the source of truth | ADR-0001, ADR-0004 | Rung 4 read-only posture |
+| FR-005, FR-006, FR-039 | II — Clean clone builds green | ADR-0007 | Rung 4 frozen-install/offline-runtime requirement |
+| FR-037, FR-038, FR-040 | III — Core depends on no adapter | ADR-0007, ADR-0010 | Rung 4 packaging boundary |
+| FR-004, FR-018, FR-029 | IV — Deterministic before probabilistic | ADR-0009 | Rung 4 (no model in retrieval) |
+| FR-012–FR-016, FR-021, FR-022 | V — The schema is the contract | ADR-0002 | Rung 4 (typed, contract-bound responses) |
+| FR-017, FR-023, FR-024 | V — The schema is the contract | ADR-0002 | Rung 4 — full-document contract via `get_decision`; no partial/frontmatter-only read, no absolute path |
+| FR-025–FR-028 | IV — Deterministic before probabilistic | ADR-0002, ADR-0009 | Rung 4 — literal normalized match, canonical order, no relevance ranking |
+| FR-029–FR-032 | III, IV | ADR-0009 | Rung 4 core deliverable — "an agent can read the corpus" before proposing |
+| FR-033 | I, V | ADR-0002 | Rung 4 — declared relation refs surfaced as bounded summaries, never expanded |
+| FR-019, FR-034 | I | ADR-0002, ADR-0004 | Rung 4 — the graveyard is decision memory, not noise |
+| Gate callout, SC-016 | Governance (Amendments/Compliance) | ADR-0005 (Phase 4 evidence) | Rung 5 (Phase 4) real-user evidence gating rung 4 (Phase 5) implementation |
+
+## Open Questions for Maintainer Review
+
+None. Search ranking, transitive-supersession scope, `conflictsWith` visibility,
+and log-identity semantics are fixed to conservative defaults (FR-021, FR-022,
+FR-026, FR-027, FR-033, FR-034, FR-035; A1, A2, A3). On 2026-07-20 the
+maintainer also explicitly ratified the exact four **local, read-only** tools and
+the exclusion of a fifth tool, write capability, named-log federation, and any
+relaxation of the stdio-only/no-auth posture. An implementer does not need to
+make a silent product decision on any of these points.
+
+## Out of Scope
+
+- **Any write, mutation, or PR-creation tool.** When write capability lands, per
+  `plan.md`, it opens PRs like every other machine write in this project (ADR-0001,
+  ADR-0004); no such tool exists in this phase (FR-001, FR-002).
+- **Hosted, HTTP, or SSE transport; any remote deployment of the server.** Local stdio
+  subprocess only (FR-005).
+- **Authentication or authorization of any kind.** There is no network listener to
+  protect (FR-006).
+- **Any model call, embedding, semantic ranking, or retrieval-augmented generation.**
+  Retrieval in this phase is deterministic, normalized literal matching only, ordered by
+  canonical identity — never a relevance score (FR-004, FR-026, FR-027, A2).
+- **MCP prompts, resources, subscriptions/notifications, or sampling.** Not part of the
+  four-tool surface (FR-003).
+- **A database, persistent cache, or rebuildable index specific to this server.** Every
+  call reads the corpus directly; if a shared, optional index exists elsewhere in the
+  project per ADR-0004, this server does not require it (FR-010).
+- **Named-log and multi-repository federation of any kind.** A deliberate scope boundary
+  for this phase, not an unresolved question: this server serves exactly one configured
+  corpus root and never loads, indexes, or resolves by log (FR-021, FR-035, A1). A
+  log-qualified ref is recognized only far enough to answer `federated-log-unavailable`
+  (`get_decision`) or an unresolved, informational finding on a `supersededBy` target
+  (`list_superseded`, FR-034) — never resolved, stripped, or substituted. `plan.md`'s
+  separate open question on federated id representation concerns this later,
+  out-of-scope capability.
+- **Transitive supersession-lineage walks.** `list_superseded` reports only the direct
+  `supersededBy` edge; walking a multi-hop chain to a lineage's current record is a
+  deliberate scope boundary for this phase, not an unresolved question (FR-034, A3).
+- **`get_decision_context` expanding or inlining any referenced record.** Declared
+  relation refs (`supersedes`/`supersededBy`/`relatesTo`/`conflictsWith`) are surfaced on
+  each summary for the caller to follow with `get_decision`; this tool never fetches or
+  inlines a referenced record itself (FR-033).
+- **Catalog, IaC, OpenAPI, or other adapter-backed matcher resolution beyond what
+  `@adrkit/core` already resolves.** This server supplies no new adapter; matchers with no
+  backing snapshot remain inert exactly as they already do in the CLI (FR-032).
+- **Actual publication or release-event execution.** Package/release-pack/smoke wiring is
+  in scope as Phase 5 verification; npm publication, tag creation, version selection,
+  and changes to `scripts/release-publish.ts` are not (A9).
+- **Any implementation outside the ratified boundary.** SC-016 cleared on
+  2026-07-20 for exactly the four local read-only tools defined here; expanding
+  that boundary requires a new explicit scope decision.

--- a/specs/006-mcp-server/tasks.md
+++ b/specs/006-mcp-server/tasks.md
@@ -1,0 +1,420 @@
+---
+description: "Dependency-ordered task list for the local read-only MCP server"
+---
+
+# Tasks: MCP Server (Read-Only Retrieval) — Phase 5
+
+**Input**: Design documents from `specs/006-mcp-server/`
+
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`,
+`contracts/core-projection.md`, `contracts/pagination-and-cursors.md`,
+`contracts/tools.md`, `quickstart.md`, and `checklists/requirements.md`
+
+**Normative**: `docs/adr/0001-record-architecture-decisions-in-git.md`,
+`docs/adr/0002-typed-frontmatter-as-madr-superset.md`,
+`docs/adr/0004-git-is-source-of-truth-database-is-an-index.md`,
+`docs/adr/0007-adapter-isolation-and-public-surface-build.md`,
+`docs/adr/0009-affects-resolution-and-catalog-binding.md`,
+`docs/adr/0010-bun-toolchain.md`, `.specify/memory/constitution.md`, and the
+maintainer's 2026-07-20 ratification of SC-016
+
+> **Scope is closed.** Implement exactly four local stdio read-only tools:
+> `search_decisions`, `get_decision`, `get_decision_context(files[])`, and
+> `list_superseded`. Do not add a fifth tool, write/mutation capability, MCP
+> prompts/resources/subscriptions/sampling, HTTP/SSE/auth, model/embedding/network
+> access, persistent cache/index/database, named-log federation, multi-repository
+> aggregation, or transitive supersession traversal.
+
+**Tests**: REQUIRED and test-first. Every story's tests must be written and observed
+failing before its implementation task begins. All fixtures are local, offline,
+model-free, and credential-free.
+
+**Toolchain**: Use stable Bun **1.3.14** for install, lockfile, build, lint, typecheck,
+and tests. Published artifacts target Node **`>=22`** and must pass Node 22 and 24
+smoke tests. Keep `bun.lock` text and the isolated linker in `bunfig.toml`.
+
+## Format: `[ID] [P?] [Story?] Description with exact file path`
+
+- **[P]**: Parallelizable only when the task uses different files and has no dependency
+  on another incomplete task in the same phase.
+- **[US1]…[US5]**: Used only in user-story phases and mapped directly to `spec.md`.
+- Setup, foundational, and polish tasks intentionally omit story labels.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create the first-party package and offline test substrate without adding
+behavior outside the ratified boundary.
+
+- [x] T001 Scaffold `@adrkit/mcp` in `packages/mcp/package.json`, `packages/mcp/tsconfig.json`, and `packages/mcp/tsconfig.build.json` with the current shared public-package version, repository/license/public-publish metadata and `files: ["dist", "README.md", "src"]` matching `@adrkit/evaluator`, only the sealed lifecycle factory/types at the package root plus the `adrkit-mcp` bin (no internal builder/test subpath), Node `>=22`, matching build/prepack/typecheck scripts, dependencies exactly `@adrkit/core: workspace:*`, `@modelcontextprotocol/sdk: 1.29.0`, and `zod: ^4`, dev dependency only `@types/bun`, then update `bun.lock` using stable Bun 1.3.14 without changing `bunfig.toml`
+- [x] T002 [P] Create the documented offline fixture matrix and provenance notes in `packages/mcp/test/fixtures/README.md`, with one-record-per-status sources in `packages/mcp/test/fixtures/status-corpus/`, duplicate-id and supersession cases in `packages/mcp/test/fixtures/edge-corpus/`, schema-invalid and inert-matcher cases in `packages/mcp/test/fixtures/degraded-corpus/`, and no fetched or generated-at-test-time external content
+- [x] T003 After T001 and T002, add reusable SDK client, temporary git-worktree fixture, complete-sandbox/parent-sentinel/`HOME`/`TMPDIR` snapshot, cursor-walk, and response-schema helpers in `packages/mcp/test/helpers.ts` using `InMemoryTransport.createLinkedPair()` and the pinned SDK client; also add compiling side-effect-free skeleton modules for every planned import in `packages/core/src/schema/ref.ts`, the one `packages/core/src/index.ts` export, `packages/mcp/src/corpus/{ordering,projection}.ts`, `packages/mcp/src/search/normalize.ts`, `packages/mcp/src/pagination/cursor.ts`, `packages/mcp/src/tools/{shared,get-decision,get-decision-context,search-decisions,list-superseded}.ts`, internal `packages/mcp/src/server.ts`, public `packages/mcp/src/index.ts`, `packages/mcp/src/main-module.ts`, and `packages/mcp/src/bin.ts`; each unimplemented callable throws exactly `Error("unimplemented")`, the package compiles, and no behavioral test may fail because a module or named export is absent
+
+**Checkpoint**: The package installs under Bun 1.3.14 and tests can exercise registered
+tool handlers entirely in process against disposable local corpora.
+
+---
+
+## Phase 2: Foundational Contracts
+
+**Purpose**: Freeze and implement the shared parser, stable corpus projection, ordering,
+normalization, findings, fingerprint, cursor, and response contracts that every story
+depends on.
+
+**Blocked by**: Phase 1. Test tasks T004–T010 must fail before their corresponding
+implementation tasks T011–T016 begin.
+
+### Foundational tests — write and observe failing first
+
+- [x] T004 [P] After T003, write failing behavioral deep-equality tests for unqualified, leading-colon, and first-colon-qualified reference parsing in `packages/core/test/ref.test.ts` against the compiling `parseAdrRef` stub; record `packages/evaluator/test/no-orphan-refs.test.ts` green before and after T011 as a behavior-preservation regression guard that is not expected to fail first
+- [x] T005 [P] Write failing locale-independent ordering and trim→NFKC→`toLowerCase()` normalization tests in `packages/mcp/test/ordering-normalize.test.ts`, including canonical `(id, sourcePath)`, finding-field, matched-field, Unicode-compatibility, case, and whitespace cases
+- [x] T006 [P] After T003, write failing canonical-root tests in `packages/mcp/test/roots.test.ts` for ordinary `.git` directories, linked-worktree `.git` files, unreadable/non-git roots, absolute/`..`/string-prefix/symlink escapes, fresh root/dir validation before and after each load, candidate `lstat` rejection, candidate realpath containment, and deterministic root/directory swaps injected at every explicit validation checkpoint
+- [x] T007 [P] After T003, write failing stable-load tests in `packages/mcp/test/projection.test.ts` for pre-read 64 KiB exclusion, `record-stat-error`/`record-too-large` error findings, zero-survivor handling without `lintCorpus({ paths: [] })`, schema-invalid exclusion, invariant-flagged record retention, equality plus zero and independently changed bigint `dev`/`ino`/`size`/`mtimeNs`, deterministic size/type/symlink/containment swaps, post-load rejection with no changed-path response data, fresh reloads, concurrent-call isolation, and the documented limitation that a transient swap reverting entirely between checkpoints is not claimed detectable
+- [x] T008 [P] Write failing canonical-fingerprint tests in `packages/mcp/test/fingerprint.test.ts` for repeat equality, recursively sorted parsed projection bytes, YAML-only reserialization stability, body/source-path/finding/count sensitivity, and exclusion of tool-derived findings
+- [x] T009 [P] Write failing cursor tests in `packages/mcp/test/cursor.test.ts` for fixed-field-order base64url V1 round trips, all eight tool/channel scopes, independent result/findings walks, query-shape hashes, primary-error precedence, and each reason `decode-failed`, `version-unsupported`, `wrong-channel`, `corpus-changed`, `query-mismatch`, `cursor-not-applicable`, and `offset-out-of-range`
+- [x] T010 [P] After T003, write failing shared-contract tests in `packages/mcp/test/shared-contracts.test.ts` for strict bounded inputs, root-object output schemas, nested discriminated outcomes, schema-optional `corpusHealth` present on every branch except `corpus-unavailable`, no findings on non-substantive outcomes, paginated findings on every substantive outcome, exact `contracts/tools.md` §2.1 text/reason templates and the 512-UTF-16-unit bound, structured content, and fixed read-only annotations
+
+### Foundational implementation
+
+- [x] T011 [P] After T004, replace the `parseAdrRef` stub in `packages/core/src/schema/ref.ts` with behavior-preserving `ParsedAdrRef`/`parseAdrRef`, retain T003's single export in `packages/core/src/index.ts`, and replace only the private parser/import usage in `packages/evaluator/src/rules/no-orphan-refs.ts` without adding `formatAdrRef`, dependencies, or any other core/evaluator behavior; rerun the pre-recorded evaluator regression green
+- [x] T012 [P] After T005, implement the sole code-unit comparator and canonical record/finding ordering helpers in `packages/mcp/src/corpus/ordering.ts`, never calling `localeCompare`
+- [x] T013 [P] After T005, implement the sole search normalization helper in `packages/mcp/src/search/normalize.ts` as `trim()` → `normalize('NFKC')` → `toLowerCase()` with no locale, fuzzy, stemming, weight, embedding, or ranking path
+- [x] T014 After T006–T008 and T012, replace the projection stub with `resolveCanonicalRoots` and fresh-per-call `loadCorpusProjection` in `packages/mcp/src/corpus/projection.ts`, revalidating root/`.git`/dir before and after the core load; `lstat`-rejecting non-regular/symlink candidates; realpath-checking segment-safe candidate containment; comparing bigint `dev`/`ino`/`size`/`mtimeNs`; using `discoverAdrFiles`, `lintCorpus` only for nonempty survivor lists, a local multi-valued bare-id index, immutable corpus findings, canonical parsed-projection SHA-256 fingerprinting, and no cache/database/log index; document that this detects observed checkpoint changes rather than claiming an atomic hostile-filesystem snapshot
+- [x] T015 After T008–T009 and T012, implement strict cursor encoding, decoding, verification, query-shape hashing, range checking, and page slicing in `packages/mcp/src/pagination/cursor.ts`, preserving the exact verification order and independent channel semantics in `contracts/pagination-and-cursors.md`
+- [x] T016 After T009–T010 and T012–T015, replace the shared stub with strict Zod limits, page/findings schemas, outcome envelopes, the sole exact text/reason renderer from `contracts/tools.md` §2.1 with a 512-UTF-16-unit cap, and fixed annotations in `packages/mcp/src/tools/shared.ts`, including query 256, ref 128, file 1024/256, tags 32×64, page 20/100, cursor 4 KiB, and source 64 KiB limits
+
+**Checkpoint**: Shared core behavior is preserved, every call can build a stable immutable
+projection, and every growing channel can be bounded and resumed deterministically.
+
+---
+
+## Phase 3: User Story 1 — Fetch One Authoritative Decision (Priority: P1) 🎯 MVP
+
+**Goal**: Fetch a complete within-limit decision by ref, including graveyard records,
+while making absent, duplicate-local-id, and log-qualified outcomes explicit.
+
+**Independent Test**: Against the status fixture, retrieve all six statuses and verify full
+typed frontmatter, complete body, repo-relative path, and unexpanded relations; separately
+walk every duplicate-id candidate and verify not-found and federated-unavailable outcomes.
+
+**Blocked by**: Phase 2.
+
+### Tests for User Story 1 — write and observe failing first
+
+- [x] T017 [P] [US1] After T016, write failing full-document and lookup-branch tests in `packages/mcp/test/get-decision.test.ts` for all six statuses, complete body/frontmatter, repo-relative paths, unexpanded four relation fields, not-found, oversized-source not-found plus finding, duplicate candidates, leading-colon behavior, qualified refs that never fall back to a same-id local record, and exact found/not-found/ambiguous/qualified-ref/corpus-unavailable text with singular/plural findings counts
+- [x] T018 [P] [US1] After T016, write failing contract and pagination tests in `packages/mcp/test/get-decision-pagination.test.ts` for candidate/findings independence, canonical multi-page duplicate walks, all exact cursor text/reason failures including `cursor-not-applicable` on singleton outcomes, schema-valid structured content, the 512-UTF-16-unit content cap, no path or unbounded corpus interpolation, and bounded strict inputs
+
+### Implementation for User Story 1
+
+- [x] T019 [US1] After T017–T018, replace the `get_decision` stub with the registration and handler in `packages/mcp/src/tools/get-decision.ts`, using `parseAdrRef`, the fresh local `byId` bucket, verbatim `AdrFrontmatter`/body, corpus-only findings, the sole shared exact text renderer, and no relation expansion or log-aware lookup
+
+**Checkpoint**: US1 is independently useful through its registered handler and is the
+suggested MVP once the internal four-tool server and sealed stdio lifecycle are integrated
+in US5.
+
+---
+
+## Phase 4: User Story 2 — Retrieve Decision Context for Files (Priority: P1)
+
+**Goal**: Report governing, active-proposal, and historical records for logical file paths
+using the existing resolver unchanged and without reading caller-supplied paths.
+
+**Independent Test**: Supply logical paths matching one record in each status bucket and
+verify all six statuses appear in exactly one collection with fired matchers, relations,
+and honest inert findings.
+
+**Blocked by**: Phase 2. It has no behavioral dependency on US1.
+
+### Tests for User Story 2 — write and observe failing first
+
+- [x] T020 [P] [US2] After T016, write failing context-resolution tests in `packages/mcp/test/get-decision-context.test.ts` for per-record `resolveAffects`, all six statuses partitioned exactly once, multi-bucket matches, zero matches, fired matchers, unexpanded `supersedes`/`supersededBy`/`relatesTo`/`conflictsWith`, repo-qualified matcher inactivity, missing backing sources as informational inert findings, and exact all-found/ambiguous/partial/not-found/corpus-unavailable text with singular/plural request and findings counts
+- [x] T021 [P] [US2] After T016, write failing validation, findings, and pagination tests in `packages/mcp/test/get-decision-context-pagination.test.ts` for absolute/drive/`..`/backslash/empty path rejection before handler access, canonical de-duplicated `files[]` query binding, one flat result walk partitioned after slicing, independently paged derived findings, unchanged corpus fingerprint across input-specific findings, no caller-path filesystem reads, every exact cursor text/reason branch, the 512-UTF-16-unit content cap, and no path or unbounded corpus interpolation
+
+### Implementation for User Story 2
+
+- [x] T022 [US2] After T020–T021, replace the `get_decision_context` stub with the registration and handler in `packages/mcp/src/tools/get-decision-context.ts`, calling `resolveAffects({ records: [record], changedFiles: files })` once per record, composing findings without mutating the projection, paginating the canonical union before status partitioning, and using the sole shared exact text renderer
+
+**Checkpoint**: US2 independently answers pre-change governance questions with no second
+affects resolver and no arbitrary file read.
+
+---
+
+## Phase 5: User Story 3 — Search the Corpus and Graveyard (Priority: P1)
+
+**Goal**: Search id, title, tags, and Markdown body by deterministic normalized literal
+substring, including graveyard records by default and returning bounded summaries only.
+
+**Independent Test**: Search for body-only and rejected-title terms, verify matched-field
+indicators and filter algebra, then repeat a complete paginated walk byte-for-byte.
+
+**Blocked by**: Phase 2. It has no behavioral dependency on US1 or US2.
+
+### Tests for User Story 3 — write and observe failing first
+
+- [x] T023 [P] [US3] After T016, write failing search behavior tests in `packages/mcp/test/search-decisions.test.ts` for id/title/tag/body matching, whitespace/mixed-case/NFKC normalization, whitespace-only rejection before corpus access, graveyard-by-default behavior, empty results, bounded summaries without body, every matched-field indicator, status/scope any-of, tags all-of, category AND composition, uniqueness, all fixed boundaries, and exact results/corpus-unavailable text with zero/one/many result and findings counts
+- [x] T024 [P] [US3] After T016, write failing search determinism tests in `packages/mcp/test/search-decisions-pagination.test.ts` for canonical non-relevance order, byte-identical repeated calls, lossless multi-page result/findings walks, result/findings cursor independence, query/filter/limit mismatch rejection, stale-corpus rejection, schema-invalid-record degradation without suppressing valid matches, every exact cursor text/reason branch, the 512-UTF-16-unit content cap, and no path or unbounded corpus interpolation
+
+### Implementation for User Story 3
+
+- [x] T025 [US3] After T023–T024, replace the `search_decisions` stub with the registration and handler in `packages/mcp/src/tools/search-decisions.ts`, applying filters before the shared normalizer, reporting all matching fields in canonical order, returning summaries only, deriving no findings beyond corpus findings, and using the sole shared exact text renderer
+
+**Checkpoint**: US3 independently answers “has this been decided or tried?” without a
+model, ranking heuristic, or hidden index.
+
+---
+
+## Phase 6: User Story 4 — List Direct Supersession History (Priority: P2)
+
+**Goal**: List every superseded record with its direct local replacement state, preserving
+dangling, ambiguous, and federated-unavailable targets without guessing.
+
+**Independent Test**: Walk a corpus with resolved, dangling, duplicate-id, and qualified
+targets; verify every superseded source appears once, target status is current, ambiguity is
+count-only, and a follow-up `get_decision` returns the full candidates.
+
+**Blocked by**: Phase 2. The follow-up integration assertion uses US1 T019.
+
+### Tests for User Story 4 — write and observe failing first
+
+- [x] T026 [P] [US4] After T016, write failing direct-edge tests in `packages/mcp/test/list-superseded.test.ts` for complete/empty listings, current target status, direct edges only, dangling targets retaining the core finding, qualified targets retaining both core and informational derived findings, no silently selected local substitute, and exact result/corpus-unavailable text with zero/one/many entry and findings counts
+- [x] T027 [P] [US4] After T016, write failing ambiguity and pagination tests in `packages/mcp/test/list-superseded-pagination.test.ts` for canonical lossless pages, `candidateCount` without nested candidates, one fixed warn finding per ambiguous entry, independently paged findings, a follow-up paginated `get_decision` candidate walk, every exact cursor text/reason branch, the 512-UTF-16-unit content cap, and no path or unbounded corpus interpolation
+
+### Implementation for User Story 4
+
+- [x] T028 [US4] After T019 and T026–T027, replace the `list_superseded` stub with the registration and handler in `packages/mcp/src/tools/list-superseded.ts`, resolving only direct unqualified local targets through `byId`, minting only the two specified derived finding templates, never walking lineage or embedding candidate arrays, and using the sole shared exact text renderer
+
+**Checkpoint**: US4 independently exposes the graveyard's direct replacement map without
+federation or unbounded nested results.
+
+---
+
+## Phase 7: User Story 5 — Prove the Harness Boundary (Priority: P2)
+
+**Goal**: Expose only the four ratified tools over local stdio and prove strict validation,
+a sealed lifecycle-only public handle, bounded side-effect denial, no arbitrary reads,
+no non-protocol stdout, and no cross-call mutable state.
+
+**Independent Test**: Run all four tools through the package-internal in-memory builder
+and the public stdio lifecycle under adversarial filesystem/input/side-effect traps;
+verify only four tool registrations, a frozen null-prototype public handle, protocol-only
+stdout, unchanged snapshots, and deterministic completion offline.
+
+**Blocked by**: T019, T022, T025, and T028.
+
+### Tests for User Story 5 — write and observe failing first
+
+- [x] T029 [P] [US5] After T019, T022, T025, and T028, write failing public-surface tests in `packages/mcp/test/surface.test.ts` asserting `createAdrkitMcpServer` has no import-time or construction-time I/O and returns a frozen null-prototype object with exactly own `start`/`close`, no own symbols, no caller transport, and no SDK server/registration/internal builder; through the package-internal builder assert `tools/list` exposes exactly the four named tools with root-object output schemas and fixed annotations and no prompt/resource/subscription/sampling capability
+- [x] T030 [P] [US5] After T003, T019, T022, T025, and T028, write failing boundary tests in `packages/mcp/test/boundary.test.ts` that trap reads/stats outside canonical roots, take complete byte/mode/path snapshots of the disposable sandbox, parent sentinels, `HOME`, and `TMPDIR` before and after every tool, reject unknown/wrong/oversized/traversal inputs before corpus access, scan every successful response for absolute paths, prove fresh rereads after corpus edits, and prove concurrent calls do not share mutable findings/results
+- [x] T031 [P] [US5] After T019, T022, T025, and T028, write failing CLI and real-stdio tests in `packages/mcp/test/bin.test.ts` for flag-over-env-over-default precedence, unknown/missing-value exit 2, invalid root/dir exit 1 with stderr-only diagnostics, linked worktree support, Bun-source subprocess initialize/list/call/shutdown, and line-by-line zero non-JSON-RPC stdout bytes
+- [x] T032 [P] [US5] After T003, write the failing runtime/import boundary test and preload in `packages/mcp/test/side-effect-denial.test.ts` and `packages/mcp/test/side-effect-denial-preload.mjs`; via `createRequire` plus `syncBuiltinESMExports`, fail closed on every exact Node/Bun filesystem-mutation, write-capable open/FileHandle, child-process, cluster, worker, `process.dlopen`, network/listen, and Bun spawn/write/delete/writer API enumerated in `contracts/tools.md` §10.1 and `research.md` §R10; statically reject Bun shell escape paths that cannot be patched reliably plus HTTP/OAuth SDK subpaths, models, embeddings, native addons, worker helpers, and subprocess imports; exercise startup and every outcome branch of all four tools; prove preload coverage for static/dynamic imports, aliases/references, write-flag decoding, and returned FileHandles; and state that passing is bounded executed-path evidence, not proof against raw native syscalls or future unenumerated APIs
+
+### Implementation for User Story 5
+
+- [x] T033 [US5] After T029–T032, replace the internal server and public factory stubs: `packages/mcp/src/server.ts` keeps `McpServer`, registration APIs, and the in-memory test builder package-internal while registering exactly T019/T022/T025/T028; `packages/mcp/src/index.ts` exports only the lifecycle types/factory and returns a frozen null-prototype handle with exactly `start(): Promise<void>` and `close(): Promise<void>`, no symbols, no SDK object, and no caller-supplied transport, while holding only immutable startup configuration
+- [x] T034 [US5] After T031 and T033, replace the `isMainModule`/`main(argv, env)`/bin stubs in `packages/mcp/src/main-module.ts` and `packages/mcp/src/bin.ts`, parsing only `--cwd`/`--dir` plus `ADRKIT_MCP_CWD`/`ADRKIT_MCP_DIR`, failing fast through shared canonical-root checks, constructing and connecting `StdioServerTransport` only inside lifecycle start, reserving stdout for protocol frames, closing cleanly on signals, setting nonzero status on unhandled rejection, and satisfying the side-effect-denial tests without fallback transports or logging
+
+**Checkpoint**: The complete public server is safe to grant to a local harness and all five
+stories are independently verifiable through the real registered surface.
+
+---
+
+## Phase 8: Packaging, Documentation, and Cross-Cutting Verification
+
+**Purpose**: Enforce dependency, distribution, runtime, and release-policy guarantees and
+validate the complete feature in clean-clone and installed-tarball forms.
+
+**Blocked by**: All selected user stories.
+
+- [x] T035 [P] Add failing `@adrkit/mcp` allow-list and rejection cases to `scripts/check-deps.test.ts` for exactly `@adrkit/core`, `@modelcontextprotocol/sdk`, and `zod` production dependencies plus `@types/bun` development-only, rejecting adapters, undeclared SDK subpaths/packages, GitHub toolkits, network/auth/model/embedding/database/cache libraries, native addons, and worker helpers
+- [x] T036 After T001 and T035, extend `allowedDependenciesFor` in `scripts/check-deps.ts` for `@adrkit/mcp`, then verify the direct declaration boundary against `packages/mcp/package.json` and `bun.lock` without claiming that this static check replaces T032's executed-path evidence or proves the SDK transitive closure has no network-capable code
+- [x] T037 [P] Add failing fourth-public-package, aligned-version, sealed-public-export, no-internal-test-export, packed-bin, expected-files, workspace-protocol-rewrite, dependency-order, and installed-tarball assertions for `@adrkit/mcp` in `scripts/release-pack.test.ts`, preserving the policy that every public package manifest has one identical stable SemVer
+- [x] T038 After T029–T034, T037, and all story implementations, add `@adrkit/mcp` after the existing public packages in `RELEASE_PACKAGES`, validate `adrkit-mcp -> ./dist/bin.js`, and extend the generated installed-tarball smoke in `scripts/release-pack.ts` to import and structurally verify the sealed public handle then spawn the packed bin and call all four tools over stdio, leaving `scripts/release-publish.ts` unchanged and requiring `packages/core/package.json`, `packages/evaluator/package.json`, `packages/cli/package.json`, and `packages/mcp/package.json` to remain version-aligned for the eventual coordinated release
+- [x] T039 After T034 and T038, extend the built-artifact Node 22/24 smoke in `scripts/smoke-node.mjs` to import `packages/mcp/dist/index.js`, verify the sealed handle, run `packages/mcp/dist/bin.js` against the real `docs/adr/` corpus under the side-effect-denial preload, exercise all four tools, and reject any non-protocol stdout or Bun-only published-runtime dependency
+- [x] T040 [P] Document factory and `adrkit-mcp --cwd/--dir` use, four-tool contracts, limits, graveyard defaults, cursor restart rules, stderr/stdout behavior, and all exclusions in `packages/mcp/README.md` and `README.md`; update the four-public-package distribution row, dependency/chronological publish order, and coordinated-version release step in `docs/RELEASING.md` without choosing a future release number
+- [x] T041 After T036 and T038–T040, run the clean-checkout flow from `docs/RELEASING.md` with stable Bun 1.3.14: permit only `bun install --frozen-lockfile` to contact the unauthenticated public registry using committed `bun.lock` and `bunfig.toml`, then disable networking and run build/typecheck/test/lint/release-pack plus the packed install and `.release/smoke/smoke.mjs` under Node 22 and 24 with no credentials/services; confirm all four public package versions, packed workspace dependency rewrites, sealed factory import, bin executable, and four tool calls without requiring a warm global package cache
+- [x] T042 After T041, with networking still disabled run the complete post-install repository gates from `package.json` and `.github/workflows/ci.yml`: typecheck, build, release pack, lint, all Bun tests, schema emit with byte-clean `schema/adr.schema.json`, unchanged `packages/ci/dist`, dependency checks, ADR lint, and Node 22/24 built plus installed-tarball smoke; actual npm publication, tag creation, version choice, and `scripts/release-publish.ts` changes remain out of scope
+- [x] T043 After T042, audit the final diff against `specs/006-mcp-server/contracts/core-projection.md` and `specs/006-mcp-server/contracts/tools.md`: outside `packages/mcp/`, release/docs wiring, `packages/core/src/schema/ref.ts`, the one `packages/core/src/index.ts` export, and the parser-only `packages/evaluator/src/rules/no-orphan-refs.ts` migration, reject any extra production surface or schema change and rerun the sealed-handle, side-effect-denial, complete-snapshot, and protocol-only evidence
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (T001–T003)**: Starts immediately. T002 may run beside T001; T003 follows both.
+- **Foundation (T004–T016)**: Depends on Setup. Tests T004–T010 run first and may run in
+  parallel. T011–T016 then follow their named tests and dependencies.
+- **US1 (T017–T019)**: Depends on Foundation and is the MVP behavior.
+- **US2 (T020–T022)**: Depends on Foundation; no behavioral dependency on US1.
+- **US3 (T023–T025)**: Depends on Foundation; no behavioral dependency on US1/US2.
+- **US4 (T026–T028)**: Depends on Foundation; T028 additionally depends on US1 T019 for
+  the specified follow-up candidate integration.
+- **US5 (T029–T034)**: Integrates the package-internal four-tool server and sealed public
+  stdio lifecycle after all four tool handlers exist; T033 waits for T029–T032 and T034
+  waits for T031 plus T033.
+- **Packaging/verification (T035–T043)**: Final release wiring and full gates follow the
+  complete selected story set.
+
+### User Story Completion Graph
+
+```mermaid
+flowchart TD
+  S[Setup T001-T003] --> F[Foundation T004-T016]
+  F --> U1[US1 get_decision T017-T019]
+  F --> U2[US2 get_decision_context T020-T022]
+  F --> U3[US3 search_decisions T023-T025]
+  F --> U4T[US4 tests T026-T027]
+  U1 --> U4[US4 list_superseded T028]
+  U4T --> U4
+  U1 --> U5[US5 boundary T029-T034]
+  U2 --> U5
+  U3 --> U5
+  U4 --> U5
+  U5 --> P[Packaging and verification T035-T043]
+```
+
+### Concrete Critical Path
+
+```text
+T001 + T002 -> T003
+  -> T004-T010
+  -> T011-T016
+  -> T017-T019 (MVP behavior)
+  -> T026-T028
+  +  T020-T022
+  +  T023-T025
+  -> T029-T034
+  -> T035-T043
+```
+
+Each behavioral test task must be observed failing through T003's
+`Error("unimplemented")` stub or the intended behavior/contract assertion before its paired
+implementation begins. Missing modules/exports, fixture typos, unresolved dependencies, and
+unrelated compile errors never satisfy the test-first gate. T004's existing evaluator suite
+is a green regression guard recorded before and after T011, not a deliberately red test.
+
+---
+
+## Success-Criteria Traceability
+
+| Success criterion | Primary proving tasks |
+|---|---|
+| SC-001 full decision/all statuses/size guard | T007, T017–T019 |
+| SC-002 graveyard and body search | T023–T025 |
+| SC-003 duplicate-id walk and qualified ref | T017–T019 |
+| SC-004 six-status context partition | T020–T022 |
+| SC-005 filesystem/write/path boundary | T006–T007, T030, T032–T034, T043 |
+| SC-006 protocol-only stdout | T031, T034, T039 |
+| SC-007 structured plus text responses | T010, T017–T028 |
+| SC-008 lossless result/findings pagination | T009, T018, T021, T024, T027 |
+| SC-009 invalid record degrades | T007, T024 |
+| SC-010 absent backing is inert | T020–T022 |
+| SC-011 direct supersession outcomes | T026–T028 |
+| SC-012 frozen public install, then offline gates | T041–T042 |
+| SC-013 dependency/import/runtime side-effect boundary | T032, T035–T036, T039, T043 |
+| SC-014 byte-identical search | T008–T009, T024–T025 |
+| SC-015 relation refs followed explicitly | T017–T019, T020–T022 |
+| SC-016 maintainer ratification | Satisfied 2026-07-20 before this task list |
+
+---
+
+## Parallel Execution Examples
+
+### User Story 1
+
+```text
+After Foundation: T017 || T018
+Then: T019
+```
+
+### User Story 2
+
+```text
+After Foundation: T020 || T021
+Then: T022
+```
+
+### User Story 3
+
+```text
+After Foundation: T023 || T024
+Then: T025
+```
+
+### User Story 4
+
+```text
+After Foundation: T026 || T027
+Then, after T019: T028
+```
+
+### User Story 5
+
+```text
+After T019 + T022 + T025 + T028: T029 || T030 || T031 || T032
+Then: T033 -> T034
+```
+
+Cross-story tool tests and implementations for US1–US3, plus US4 tests, may proceed in
+parallel after Foundation because they use distinct tool and test files. US5 is the
+intentional integration barrier that exposes exactly four tools through one package-internal
+builder and only a sealed stdio lifecycle through the public factory.
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Setup and Foundation.
+2. Write T017–T018 and observe the intended failures.
+3. Implement US1 T019.
+4. Stop and validate US1 independently against all six statuses, duplicate ids, qualified
+   refs, complete bodies, oversized exclusions, findings, and cursor behavior.
+5. The deployable MCP MVP additionally requires US5's final package-internal four-tool
+   server/sealed-stdio lifecycle boundary; do not publish a temporary one-tool package.
+
+### Incremental Delivery
+
+1. **US1**: Authoritative full-document lookup by ref.
+2. **US2**: File-oriented governing/proposal/history context.
+3. **US3**: Deterministic corpus and graveyard search.
+4. **US4**: Direct supersession orientation.
+5. **US5**: Exact internal four-tool server, sealed public stdio lifecycle, bin, and bounded
+   side-effect/offline boundary.
+6. Add dependency/release wiring, documentation, clean-clone, tarball, and Node 22/24 proof.
+
+### Non-Negotiable Boundaries
+
+- Exactly four tools; no fifth tool or other MCP capability.
+- The public root exports only a frozen null-prototype `{ start, close }` lifecycle handle;
+  SDK servers, registration methods, internal builders, and transports are not exported.
+- Read-only local stdio only; no HTTP/SSE/auth, write/proposal, model, embedding, network,
+  persistent cache/index/database, named-log federation, or multi-repository aggregation.
+- Every tool call reloads the corpus; only configured root/dir strings plus the expected
+  startup canonical root are retained, and root/`.git`/dir/candidates are revalidated
+  around every load.
+- `@adrkit/core` changes only by `parseAdrRef` plus one export; evaluator changes only by
+  migrating its private parser.
+- Stable Bun 1.3.14 is the development gate; published tarballs run on Node `>=22`.
+- A frozen install may contact only the unauthenticated public registry; every later gate and
+  runtime path runs with networking disabled and without credentials or services.
+- All public npm package versions remain identical. The actual next release number is a
+  maintainer scheduling choice made at release time; publication, tags, and
+  `scripts/release-publish.ts` changes are not Phase 5 implementation tasks.
+
+---
+
+## Task Totals
+
+- **Total tasks**: 43
+- **Setup**: 3
+- **Foundational**: 13
+- **US1**: 3
+- **US2**: 3
+- **US3**: 3
+- **US4**: 3
+- **US5**: 6
+- **Packaging/documentation/verification**: 9
+- **Explicit `[P]` opportunities**: 26


### PR DESCRIPTION
## Summary

- add `@adrkit/mcp`, a local stdio-only MCP server exposing exactly `search_decisions`, `get_decision`, `get_decision_context`, and `list_superseded`
- implement deterministic fresh corpus loading, stable fingerprints/cursors, independent findings pagination, exact bounded response text, and explicit degraded-corpus outcomes
- seal the public runtime surface to a frozen null-prototype `{ start, close }` lifecycle handle while keeping the SDK server, registrations, transport, and in-memory builder internal
- promote the behavior-preserving `parseAdrRef` helper into `@adrkit/core` and migrate the evaluator's private parser
- add package, dependency-boundary, release-pack, Node smoke, documentation, and complete Phase 5 specification/task artifacts

## Boundary guarantees

- read-only local stdio; no HTTP/auth, model/embedding, writes, federation, or persistent index/cache/database
- protocol-only stdout and fixed MCP read-only annotations
- root, `.git`, ADR directory, and candidate containment/identity checks around every load, with explicit non-atomic filesystem limitations
- exact side-effect-denial inventory plus complete sandbox/sentinel snapshots
- distribution wiring only; publication, tags, release version selection, and `release-publish.ts` remain out of scope

## Verification

- `bunx bun@1.3.14 test` — 552 passed, 0 failed
- exact-Bun typecheck, build, lint, dependency checks, ADR lint, schema emit, and release pack passed
- built-artifact and installed-tarball smoke passed on Node 22.22.2 and Node 24.16.0
- `schema/adr.schema.json` and `packages/ci/dist` remain unchanged
- independent implementation review found no significant issues
- fresh Spec Kit analysis: PASS, 0 critical/high/medium findings, 100% requirement-to-task coverage, 0 constitution violations