### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,9 @@ jobs:
       - name: Publish npm packages with provenance
         run: bun run release:publish
         env:
-          # Used only to bootstrap packages that do not yet exist. Once npm
-          # Trusted Publishers are configured, remove this environment secret.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # The publish script maps this only to @adrkit/mcp. Existing packages
+          # remain on OIDC. Remove the secret after MCP Trusted Publishing works.
+          NPM_BOOTSTRAP_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Status: early — phases 0–4 landed and v0.1.0 is public. `@adrkit/core`,
 `@adrkit/evaluator`, and `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
 `check`, `migrate --from madr`, `evaluate`) are published on npm; the
 repository-backed CI Action is available at `mbeacom/adrkit/packages/ci@v0`.
-The read-only `@adrkit/mcp` server is implemented on PR #19 with exactly four
-local stdio tools; real-session dogfood and coordinated publication remain (see
-[`plan.md`](./plan.md)).
+The read-only `@adrkit/mcp` server landed in PR #19 with exactly four local
+stdio tools and passed real-session dogfood through the official MCP Inspector;
+coordinated v0.2.0 publication remains (see [`plan.md`](./plan.md)).
 
 ## Toolchain
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ legible to agents — without leaving git.
 > `explain`, `check`,
 > `migrate --from madr`, and `adr evaluate` all work, including `affects`
 > resolution, in-place MADR migration, and the offline eleven-rule Pass 0. The
-> read-only `@adrkit/mcp` server is implemented on PR #19 with its exact
-> four-tool, local-only boundary; real-session dogfood and coordinated
-> publication remain. Not yet built: the later probabilistic passes (Passes
-> 1–3). See [`plan.md`](./plan.md).
+> read-only `@adrkit/mcp` server landed in PR #19 with its exact four-tool,
+> local-only boundary and passed real-session dogfood through the official MCP
+> Inspector. Coordinated v0.2.0 publication remains. Not yet built: the later
+> probabilistic passes (Passes 1–3). See [`plan.md`](./plan.md).
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "adr": "./dist/index.js",
       },
@@ -38,7 +38,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -53,7 +53,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -64,7 +64,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -23,8 +23,7 @@ Actions Trusted Publishing, traditional token publishing is disabled, and the
 - All public package versions are identical. Introducing `@adrkit/mcp` as a
   fourth public package therefore requires bumping `@adrkit/core`,
   `@adrkit/evaluator`, and `@adrkit/cli` to the same version in the same
-  coordinated release; the actual next release number is a maintainer scheduling
-  choice made at release time.
+  coordinated release. The first MCP release is scheduled as v0.2.0.
 - The tag is exactly `v<package version>`.
 - Packages publish in dependency order: core, evaluator, CLI, MCP (`@adrkit/mcp`
   depends only on core, so it is appended last to preserve the list's
@@ -89,11 +88,12 @@ For the first release only:
 6. Delete the `NPM_TOKEN` environment secret and set each package's publishing
    access to require 2FA and disallow tokens.
 
-All later releases are tokenless.
+All later releases are tokenless except when a new package needs the one-time
+bootstrap described below.
 
 ## Subsequent releases
 
-1. Update the version in all three public package manifests. Update any
+1. Update the version in all four public package manifests. Update any
    inter-package expectations and run `bun install` with stable Bun 1.3.14 when
    the lockfile changes.
 2. Merge the version change only after CI passes.
@@ -104,3 +104,19 @@ All later releases are tokenless.
 
 Never move an immutable `vX.Y.Z` tag. The release workflow may force-update only
 the moving major Action tag (`v0`, later `v1`, and so on).
+
+### One-time `@adrkit/mcp` bootstrap for v0.2.0
+
+npm requires a package to exist before its Trusted Publisher can be configured.
+For v0.2.0 only, add a short-lived granular `NPM_TOKEN` to the protected `npm`
+environment with publish access limited to `@adrkit/mcp`. The workflow exposes
+it to the release script as `NPM_BOOTSTRAP_TOKEN`, and the script maps it to
+`NODE_AUTH_TOKEN` only for the `@adrkit/mcp` subprocess; the three existing
+packages continue to authenticate with OIDC. After the workflow succeeds:
+
+1. Configure `@adrkit/mcp` with the same GitHub Actions Trusted Publisher
+   (`mbeacom/adrkit`, `release.yml`, environment `npm`).
+2. Require 2FA and disallow tokens for `@adrkit/mcp`.
+3. Delete the temporary `NPM_TOKEN` environment secret.
+
+All releases after v0.2.0 are tokenless for all four packages.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Decision memory for human and agent-authored plans — machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/plan.md
+++ b/plan.md
@@ -30,7 +30,7 @@ sync.
 | 2 — Migration | `specs/003-migration/` | landed (PR #7 merged) |
 | 3 — CI surface | `specs/004-ci-surface/` | landed (PR #12 merged) |
 | 4 — Deterministic evaluator | `specs/005-deterministic-evaluator/` | landed (PR #14 merged) |
-| 5 — MCP server | `specs/006-mcp-server/` | implementation complete (PR #19) |
+| 5 — MCP server | `specs/006-mcp-server/` | landed (PR #19 merged); real-user gate met |
 
 Advance **scoping** (spec → plan → tasks) of the next phase is explicitly permitted
 and encouraged, so a design is review-ready when its turn comes; **implementation** of
@@ -92,9 +92,13 @@ T00A). Rung 3 is also **met**: the `@adrkit/ci` Action ran twice on the separate
 12-record `adrkit-t018-dogfood` repository, selected exactly two governing ADRs, and
 updated one comment in place using only the default token (Phase 3 T018). Rung 5 is
 **met** by the landed Pass 0 evaluator and the ADR-0007 maintainer dogfood above.
-Rung 4 is the next delivery target: its MCP implementation is complete on PR
-#19, but a real MCP-compatible session must still exercise it before the rung is
-met.
+Rung 4 is also **met**: after PR #19 merged, the official MCP Inspector CLI
+launched the built Node artifact over stdio against this repository's real
+11-record corpus and exercised all four tools. Search returned ADRs 0010 and
+0011 for `Bun`; `get_decision` returned complete ADR-0007; context for
+`packages/mcp/package.json` and `.github/workflows/ci.yml` returned accepted
+ADR-0010 plus proposed ADR-0007; `list_superseded` honestly returned no entries.
+All calls reported zero excluded records and the same corpus fingerprint.
 
 ## Binding constraints
 
@@ -204,7 +208,7 @@ Exit criteria:
   configured at all. If it isn't, the rubric passes are being asked to carry
   weight they shouldn't.
 
-### Phase 5 — MCP server (rung 4, implemented; dogfood pending)
+### Phase 5 — MCP server (rung 4, landed and dogfooded)
 
 Deliverables: `@adrkit/mcp`, read tools only.
 
@@ -214,8 +218,8 @@ stdio. No writes, fifth tool, prompts, resources, HTTP transport, authentication
 model, network access, persistent cache, database, or named-log federation.
 Detailed design lives in `specs/006-mcp-server/`. The maintainer explicitly
 ratified this exact scope on 2026-07-20. Fresh analysis passed after artifact
-remediation, all 43 tasks are complete, and PR #19 contains the implementation.
-Merge plus a real MCP-compatible dogfood session remain before rung 4 is met.
+remediation, all 43 tasks completed, PR #19 merged, and the official MCP
+Inspector dogfood recorded above met rung 4.
 
 Exit criteria:
 

--- a/scripts/release-publish.test.ts
+++ b/scripts/release-publish.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   existingIntegrity,
+  publishEnvironment,
   shouldPublishArtifact,
 } from './release-publish.ts';
 import type { ReleaseArtifact } from './release-pack.ts';
@@ -52,5 +53,33 @@ describe('release registry safety', () => {
     expect(() => shouldPublishArtifact(artifact, 'sha512-other')).toThrow(
       'already exists with different integrity',
     );
+  });
+
+  test('keeps bootstrap credentials out of existing package publishes', () => {
+    const environment = publishEnvironment('@adrkit/core', {
+      NPM_BOOTSTRAP_TOKEN: 'bootstrap-token',
+      NODE_AUTH_TOKEN: 'inherited-token',
+      PATH: '/bin',
+    });
+
+    expect(environment).toEqual({ PATH: '/bin' });
+  });
+
+  test('maps the bootstrap credential only to the new MCP package', () => {
+    const environment = publishEnvironment('@adrkit/mcp', {
+      NPM_BOOTSTRAP_TOKEN: 'bootstrap-token',
+      PATH: '/bin',
+    });
+
+    expect(environment).toEqual({
+      NODE_AUTH_TOKEN: 'bootstrap-token',
+      PATH: '/bin',
+    });
+  });
+
+  test('uses OIDC for MCP after the bootstrap credential is removed', () => {
+    expect(publishEnvironment('@adrkit/mcp', { PATH: '/bin' })).toEqual({
+      PATH: '/bin',
+    });
   });
 });

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -5,6 +5,7 @@ const REPOSITORY_ROOT = resolve(import.meta.dir, '..');
 const RELEASE_DIR = join(REPOSITORY_ROOT, '.release', 'npm');
 const NPM_CLI_VERSION = '11.5.1';
 const REGISTRY = 'https://registry.npmjs.org';
+const BOOTSTRAP_PACKAGE = '@adrkit/mcp';
 type RegistryFetch = (url: string) => Promise<Response>;
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -41,6 +42,20 @@ export function shouldPublishArtifact(
   return false;
 }
 
+export function publishEnvironment(
+  packageName: string,
+  source: Record<string, string | undefined> = Bun.env,
+): Record<string, string | undefined> {
+  const environment = { ...source };
+  const bootstrapToken = environment.NPM_BOOTSTRAP_TOKEN;
+  delete environment.NPM_BOOTSTRAP_TOKEN;
+  delete environment.NODE_AUTH_TOKEN;
+  if (packageName === BOOTSTRAP_PACKAGE && bootstrapToken) {
+    environment.NODE_AUTH_TOKEN = bootstrapToken;
+  }
+  return environment;
+}
+
 async function npmPublish(artifact: ReleaseArtifact, dryRun: boolean): Promise<void> {
   const bunx = Bun.which('bunx');
   assert(bunx, 'bunx is required to run the OIDC-aware npm publishing client');
@@ -60,7 +75,7 @@ async function npmPublish(artifact: ReleaseArtifact, dryRun: boolean): Promise<v
     cwd: REPOSITORY_ROOT,
     stdout: 'inherit',
     stderr: 'inherit',
-    env: Bun.env,
+    env: publishEnvironment(artifact.name),
   });
   const exitCode = await process.exited;
   assert(exitCode === 0, `Publishing ${artifact.name}@${artifact.version} failed with exit ${exitCode}`);

--- a/specs/006-mcp-server/plan.md
+++ b/specs/006-mcp-server/plan.md
@@ -34,7 +34,8 @@ I–V.
 > four-tool, local-only, read-only boundary and its exclusions. Both governance
 > preconditions are closed. Fresh analysis passed after artifact remediation with no
 > critical, high, or medium finding. All 43 tasks are complete and the implementation is
-> complete in PR #19.
+> complete in merged PR #19. Post-merge real-session evidence is recorded in
+> `quickstart.md`.
 
 ## Summary
 

--- a/specs/006-mcp-server/quickstart.md
+++ b/specs/006-mcp-server/quickstart.md
@@ -338,8 +338,8 @@ nothing to report on that channel (contracts/pagination-and-cursors.md §2).
   both `get_decision` and `get_decision_context` shows the ref unresolved, and a
   follow-up `get_decision` call using it returns the full referenced record (SC-015).
 
-Green does **not** mean "implementation may begin." That is SC-016 alone, and it is a
-maintainer decision, not a test result.
+Historically, green did **not** by itself authorize implementation; SC-016 was
+the maintainer gate. That gate was satisfied before implementation began.
 
 ---
 
@@ -362,8 +362,8 @@ maintainer decision, not a test result.
   stripped, or substituted (FR-021, FR-022, FR-034).
 - **No expansion of declared relation refs** — surfaced, never fetched or inlined by
   `get_decision`/`get_decision_context` (FR-024, FR-033).
-- **No implementation yet** — `tasks.md` exists after SC-016 ratification, but the
-  current cross-artifact findings must be cleared before production work begins.
+- **No deferred capability was smuggled into implementation** — merged PR #19
+  contains only the ratified four-tool read surface.
 
 ---
 
@@ -379,3 +379,24 @@ explicitly ratified the four-tool boundary and its exclusions. Search ranking,
 transitive-supersession scope, `conflictsWith` visibility, and log-identity
 semantics were already fixed to conservative defaults in the Functional
 Requirements. No maintainer-facing product decision remains open.
+
+### Post-merge real-session evidence
+
+On 2026-07-20, after PR #19 merged as `57e4a40`, the maintainer launched the
+built Node-targeted `packages/mcp/dist/bin.js` through the official MCP
+Inspector CLI using local stdio and this repository's real `docs/adr` corpus.
+The Inspector listed exactly the four ratified tools and then exercised each:
+
+- `search_decisions(query: "Bun")` returned ADR-0010 and ADR-0011.
+- `get_decision(ref: "0007")` returned the complete typed frontmatter and
+  Markdown body for ADR-0007.
+- `get_decision_context(files: ["packages/mcp/package.json",
+  ".github/workflows/ci.yml"])` returned accepted ADR-0010 as governing and
+  proposed ADR-0007 as active, plus the expected informational inert-package
+  finding for ADR-0004.
+- `list_superseded()` returned an empty entries result because the real corpus
+  contains no superseded record.
+
+Every call reported 11 records, zero exclusions, no corpus error, and the same
+fingerprint. This is the real MCP-compatible session required by the root
+outcome ladder, so rung 4 is met.

--- a/specs/006-mcp-server/spec.md
+++ b/specs/006-mcp-server/spec.md
@@ -3,7 +3,7 @@
 **Feature Directory**: `006-mcp-server`
 **Implementation Branch**: `feat/phase-5-mcp-server`
 **Created**: 2026-07-20
-**Status**: Implemented — PR #19
+**Status**: Landed and dogfooded — PR #19
 **Phase**: 5 (outcome ladder **rung 4**) — read tools only
 (project **Phase 5** ≠ outcome-ladder rung 5. Per `plan.md`, Phase 5 is the MCP server
 and delivers rung 4, "an agent can read the corpus." Rung 5, "a proposal gets routed


### PR DESCRIPTION
## Summary

- record the completed Phase 5 MCP Inspector dogfood session and mark outcome rung 4 met
- align the root and all four public package manifests at v0.2.0
- document the one-time `@adrkit/mcp` npm bootstrap and post-release Trusted Publisher cleanup
- isolate the temporary bootstrap token to the `@adrkit/mcp` publish subprocess so the three existing packages continue using OIDC

## Validation

- Bun 1.3.14 full test suite, typecheck, build, lint, dependency checks, ADR lint, and generated-artifact checks
- coordinated v0.2.0 release packing and npm publish dry-run
- installed-tarball smoke tests on Node 22, Node 24, and Bun
- bootstrap environment unit coverage proving existing packages never receive `NODE_AUTH_TOKEN`

## Release gate

The short-lived granular `NPM_TOKEN` is present in the protected `npm` environment and should be scoped to create `@adrkit/mcp`. After the v0.2.0 workflow succeeds, configure Trusted Publishing and token restrictions for `@adrkit/mcp`, then delete the temporary secret.