### PR TITLE
docs: scope Phase 6 ARB queue

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,3 @@
-{"feature_directory":"specs/006-mcp-server"}
+{
+  "feature_directory": "specs/007-arb-queue"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 Decision memory for human- and agent-authored plans — machine-readable ADRs
 that are enforceable in CI and legible to agents, without leaving git.
-Status: early — phases 0–4 landed and v0.1.0 is public. `@adrkit/core`,
-`@adrkit/evaluator`, and `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
+Status: early — phases 0–5 landed and v0.2.0 is public. `@adrkit/core`,
+`@adrkit/evaluator`, `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
 `check`, `migrate --from madr`, `evaluate`) are published on npm; the
 repository-backed CI Action is available at `mbeacom/adrkit/packages/ci@v0`.
-The read-only `@adrkit/mcp` server landed in PR #19 with exactly four local
-stdio tools and passed real-session dogfood through the official MCP Inspector;
-coordinated v0.2.0 publication remains (see [`plan.md`](./plan.md)).
+The published `@adrkit/mcp` server has exactly four local stdio tools and passed
+real-session dogfood through the official MCP Inspector. Phase 6 ARB queue
+scoping is in progress under `specs/007-arb-queue/` (see [`plan.md`](./plan.md)).
 
 ## Toolchain
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,17 @@
 Architecture decision records that are machine-readable, enforceable in CI, and
 legible to agents — without leaving git.
 
-> Status: early, under active development. **v0.1.0 is published** with the
-> schema, `@adrkit/core`, `@adrkit/cli`, and the deterministic **Pass 0
-> evaluator** (`@adrkit/evaluator`) implemented — `adr lint`, `new`, `graph`,
+> Status: early, under active development. **v0.2.0 is published** with the
+> schema, `@adrkit/core`, `@adrkit/cli`, the deterministic **Pass 0
+> evaluator** (`@adrkit/evaluator`), and the read-only `@adrkit/mcp` server
+> implemented — `adr lint`, `new`, `graph`,
 > `explain`, `check`,
 > `migrate --from madr`, and `adr evaluate` all work, including `affects`
 > resolution, in-place MADR migration, and the offline eleven-rule Pass 0. The
-> read-only `@adrkit/mcp` server landed in PR #19 with its exact four-tool,
-> local-only boundary and passed real-session dogfood through the official MCP
-> Inspector. Coordinated v0.2.0 publication remains. Not yet built: the later
-> probabilistic passes (Passes 1–3). See [`plan.md`](./plan.md).
+> MCP server exposes its exact four-tool, local-only boundary and passed
+> real-session dogfood through the official MCP Inspector. The Phase 6 ARB queue
+> is fully scoped but not implemented. Also not yet built: the later probabilistic
+> passes (Passes 1–3). See [`plan.md`](./plan.md).
 
 ---
 
@@ -149,7 +150,7 @@ steps:
   - uses: mbeacom/adrkit/packages/ci@v0
 ```
 
-The npm packages, immutable `v0.1.0` release, and moving `v0` Action tag are
+All four npm packages, immutable `v0.2.0` release, and moving `v0` Action tag are
 live. Source checkouts can also run the CLI with `bun run adr`.
 
 ## Design commitments

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,21 +9,23 @@ Action:
 | `@adrkit/evaluator` | npm |
 | `@adrkit/cli` (`adr`) | npm |
 | `@adrkit/mcp` (`adrkit-mcp`) | npm |
-| `packages/ci/action.yml` | Git tag (`v0.1.0`, moving `v0`) |
+| `packages/ci/action.yml` | Git tag (latest immutable release `v0.2.0`, moving `v0`) |
 
 `@adrkit/ci` stays private because GitHub executes the committed Action bundle
 directly from the referenced repository ref.
 
-The initial `v0.1.0` release is complete. All three npm packages now use GitHub
-Actions Trusted Publishing, traditional token publishing is disabled, and the
-`npm` environment contains no long-lived publish token.
+The coordinated `v0.2.0` release is complete. `@adrkit/core`,
+`@adrkit/evaluator`, and `@adrkit/cli` use GitHub Actions Trusted Publishing.
+`@adrkit/mcp` was created with the isolated one-time bootstrap path below; its
+Trusted Publisher and token-restriction cleanup must be completed before the
+temporary `NPM_TOKEN` is removed from the protected `npm` environment.
 
 ## Release guarantees
 
 - All public package versions are identical. Introducing `@adrkit/mcp` as a
   fourth public package therefore requires bumping `@adrkit/core`,
   `@adrkit/evaluator`, and `@adrkit/cli` to the same version in the same
-  coordinated release. The first MCP release is scheduled as v0.2.0.
+  coordinated release. The first MCP release shipped as v0.2.0.
 - The tag is exactly `v<package version>`.
 - Packages publish in dependency order: core, evaluator, CLI, MCP (`@adrkit/mcp`
   depends only on core, so it is appended last to preserve the list's
@@ -46,7 +48,7 @@ From a clean checkout:
 
 ```sh
 bun install --frozen-lockfile
-bun run release:pack -- --tag v0.1.0
+bun run release:pack -- --tag v0.2.0
 # With Node 22 selected in your Node version manager:
 node .release/smoke/smoke.mjs "$PWD"
 # Switch the same shell to Node 24, then run:

--- a/plan.md
+++ b/plan.md
@@ -31,6 +31,7 @@ sync.
 | 3 — CI surface | `specs/004-ci-surface/` | landed (PR #12 merged) |
 | 4 — Deterministic evaluator | `specs/005-deterministic-evaluator/` | landed (PR #14 merged) |
 | 5 — MCP server | `specs/006-mcp-server/` | landed (PR #19 merged); real-user gate met |
+| 6 — ARB queue | `specs/007-arb-queue/` | scoping in progress; implementation permitted; external-team rung 6 exit gate outstanding |
 
 Advance **scoping** (spec → plan → tasks) of the next phase is explicitly permitted
 and encouraged, so a design is review-ready when its turn comes; **implementation** of
@@ -99,6 +100,10 @@ launched the built Node artifact over stdio against this repository's real
 `packages/mcp/package.json` and `.github/workflows/ci.yml` returned accepted
 ADR-0010 plus proposed ADR-0007; `list_superseded` honestly returned no entries.
 All calls reported zero excluded records and the same corpus fingerprint.
+The four coordinated public packages then shipped as v0.2.0; `@adrkit/mcp` was
+created through the documented one-time token bootstrap while the existing
+packages continued to publish through OIDC. MCP Trusted Publisher setup and
+temporary-secret removal remain a post-release maintainer action.
 
 ## Binding constraints
 

--- a/specs/007-arb-queue/checklists/requirements.md
+++ b/specs/007-arb-queue/checklists/requirements.md
@@ -66,5 +66,5 @@
 - The "Out of Scope" section enumerates the full explicit exclusion list from the feature
   brief, supplemented by the four GitHub surface non-forms (upload artifact, tracked file,
   PR comment, issue comment) and PATs, co-located with requirements for planning reference.
-- Implementation is gated on SC-004 (separate-repository/team dogfood); scoping may
-  proceed immediately.
+- Task generation and implementation may proceed after this scoping passes. SC-004
+  (separate-repository/team dogfood) gates only the `landed`/release-ready claim.

--- a/specs/007-arb-queue/checklists/requirements.md
+++ b/specs/007-arb-queue/checklists/requirements.md
@@ -1,0 +1,70 @@
+# Specification Quality Checklist: ARB Operations Queue
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-20
+**Revised**: 2026-07-20 (maintainer resolutions 1–7 applied)
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders (and technical leads)
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded (Out of Scope section enumerates thirteen explicit exclusions
+      including GitHub Actions upload artifacts, tracked repository files for queue output,
+      PR comments, issue comments, and PATs as explicit additions from revision)
+- [x] Dependencies and assumptions identified (eleven assumptions; normative ADRs listed)
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User stories cover primary flows (CLI queue read, SLA determinism, corpus findings vs
+      item findings distinction, GitHub Actions managed issue lifecycle, `auto`-tier safety)
+- [x] Feature meets measurable outcomes defined in Success Criteria (SC-001 through SC-008)
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Zero [NEEDS CLARIFICATION] markers. The feature description
+  was sufficiently detailed to make informed decisions on all critical items (SLA state
+  precedence, `auto`-tier semantics, `reviewBy`-vs-`slaDays` precedence, `not-queued`
+  vs `missing-sla` distinction, GitHub Actions default-token-only operation, corpus-vs-item
+  finding split, GitHub issue surface specifics). These decisions are recorded explicitly
+  in the FR-005 precedence table and Assumptions A3, A5, A8, A9.
+- **Seven-state `slaState` model** (`decided`, `escalated`, `overdue`, `due`, `within-sla`,
+  `missing-sla`, `not-queued`). The former `invalid` state has been removed: files with
+  schema-invalid frontmatter or unsatisfied cross-field invariants (including `one-way-door`
+  + `tier: auto`) do not become `QueueItem`s at all and receive no `slaState`. They appear
+  exclusively in the `QueueReport`'s top-level `corpusFindings` collection as
+  `CorpusFinding`s with `sourcePath` and parser/validator details but no fabricated fields.
+  This two-path model — `CorpusFinding` (corpus level) vs `ItemFinding` (item level) — is
+  recorded in FR-001, FR-015, FR-017, and the Key Entities section.
+- **UTC calendar-date deadline arithmetic**: `deadlineDate` = `queuedAt` + `slaDays`
+  calendar days. With `queuedAt 2026-01-01` and `slaDays 7`, `deadlineDate` is
+  `2026-01-08`; Jan 7 is `within-sla`, Jan 8 is `due`, Jan 9 is `overdue`. All
+  boundary examples in US2 scenario 2 and FR-005 reflect this arithmetic. `slaDays 0`
+  means `deadlineDate` = `queuedAt` (due on queue date, overdue the next calendar day).
+- **GitHub Actions surface** is exactly one dedicated GitHub issue (body = deterministic
+  Markdown report + stable hidden ownership marker). Not a tracked file, not a GitHub
+  Actions upload artifact, not a PR comment, not an issue comment. First run creates it;
+  subsequent runs locate it by the hidden marker and update the body in place.
+  Uses `GITHUB_TOKEN` with `issues: write` only; no PAT. Permission failures name
+  `issues: write` explicitly. Title conflict (existing issue without ownership marker)
+  causes a non-zero exit rather than an overwrite (FR-020, A5, A9).
+- **FR-006 urgency group order** updated to seven states (removed `invalid`):
+  `overdue` → `escalated` → `due` → `within-sla` → `missing-sla` → `not-queued` → `decided`.
+- The "Out of Scope" section enumerates the full explicit exclusion list from the feature
+  brief, supplemented by the four GitHub surface non-forms (upload artifact, tracked file,
+  PR comment, issue comment) and PATs, co-located with requirements for planning reference.
+- Implementation is gated on SC-004 (separate-repository/team dogfood); scoping may
+  proceed immediately.

--- a/specs/007-arb-queue/contracts/cli-contract.md
+++ b/specs/007-arb-queue/contracts/cli-contract.md
@@ -1,0 +1,185 @@
+# Contract: CLI Interface — ARB Queue
+
+**Feature**: [spec.md](../spec.md) | **Data model**: [data-model.md](../data-model.md) | **Date**: 2026-07-20
+
+This contract is the normative reference for the `adr queue` subcommand of the
+`@adrkit/cli` package. It governs the interface visible to all callers: flags,
+defaults, stdout/stderr assignment, exit codes, and invalid-input behavior.
+
+---
+
+## Command Syntax
+
+```
+adr queue [options]
+```
+
+Subcommand of the existing `adr` CLI binary. Emits a queue report of the local
+ADR corpus to stdout.
+
+---
+
+## Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--dir <path>` | string | `docs/adr` | Path to the ADR corpus directory. Resolved relative to CWD. |
+| `--as-of <date>` | string | current UTC date | UTC calendar date for SLA state computation. See §As-Of Resolution. |
+| `--format markdown\|json` | enum | `markdown` | Output format. `markdown` is the default; `json` emits QueueReport v1 JSON. |
+
+---
+
+## As-Of Date Resolution
+
+The `--as-of` flag accepts two forms:
+
+1. **Bare date**: `YYYY-MM-DD` — must match the regex `/^\d{4}-\d{2}-\d{2}$/` AND
+   pass a UTC round-trip validation: `new Date(input + 'T00:00:00Z').toISOString().slice(0,10) === input`.
+   The round-trip check catches invalid months/days that parse without NaN (e.g.
+   `2026-13-01` or `2026-02-30`). If either check fails, exit 2.
+
+2. **ISO datetime with explicit offset**: a string containing `T` and an explicit
+   timezone designator (`Z` or a numeric offset `±HH:MM` or `±HHMM`), e.g.
+   `2026-01-08T01:00:00+05:00` or `2026-01-08T00:00:00Z`. Normalized to UTC:
+   `new Date(input).toISOString().slice(0,10)`. Timezone-less ISO datetimes
+   (e.g. `2026-01-08T10:00:00`) are rejected (exit 2) — they are ambiguous about
+   which UTC day they fall on.
+
+   Detection: an input contains `T` but neither `Z` nor a `+`/`-` offset after the
+   time component is a timezone-less datetime — reject it. Concretely: after removing
+   the date and time portion, if no UTC marker is present, reject with exit 2.
+
+**If absent**: `new Date().toISOString().slice(0,10)` at the CLI call site. The
+resolved date is always included in the report output (as `QueueReport.asOf` in JSON;
+as the `# ARB Queue — {date}` heading in Markdown).
+
+**Invalid `--as-of`**: any of the following triggers exit 2:
+- Does not match bare-date regex AND does not contain `T`.
+- Matches bare-date regex but fails UTC round-trip.
+- Contains `T` but has no explicit timezone designator (timezone-less datetime).
+- Parses to NaN via `new Date(input)`.
+
+**Exact stderr messages** (all followed by `\n`):
+- Bare-date format violation or round-trip failure:
+  `"Invalid --as-of value: '{value}'. Expected YYYY-MM-DD or ISO datetime with explicit timezone (e.g. 2026-01-08 or 2026-01-08T00:00:00Z).\n"`
+- Timezone-less datetime:
+  `"Invalid --as-of value: '{value}'. Timezone-less datetimes are ambiguous — use YYYY-MM-DD or add an explicit timezone offset (e.g. Z or +05:00).\n"`
+
+---
+
+## Stdout Assignment
+
+| Scenario | Stdout |
+|----------|--------|
+| Success (`--format markdown`) | Markdown queue report |
+| Success (`--format json`) | QueueReport v1 JSON with final `\n` |
+| Error-severity finding in corpus (`exit 1`) | **Complete report** (same format as success) emitted to stdout before exit |
+| Invalid flag or value (`exit 2`) | *Empty* (nothing written to stdout) |
+
+The complete report is ALWAYS emitted to stdout before any non-zero exit, except for
+exit-2 (usage errors), where no report is produced.
+
+---
+
+## Stderr Assignment
+
+| Scenario | Stderr |
+|----------|--------|
+| Success (`exit 0`) | Empty |
+| Error-severity finding (`exit 1`) | Empty |
+| Invalid `--format` value (`exit 2`) | Usage message: `"Invalid --format value: '{value}'. Expected markdown or json.\n"` |
+| Invalid `--as-of` value (`exit 2`) | Error message: `"Invalid --as-of value: '{value}'. Expected YYYY-MM-DD or ISO datetime with explicit timezone...\n"` (see §As-Of Resolution for exact messages) |
+| Unrecognized flag (`exit 2`) | Usage message: `"Unknown flag: '{flag}'. See 'adr queue --help'.\n"` |
+| Corpus directory not found (`exit 2`) | Error message: `"Corpus directory not found: '{path}'.\n"` |
+
+---
+
+## Exit Code Matrix
+
+| Code | Meaning | Stdout emitted? |
+|------|---------|-----------------|
+| `0` | Complete report; zero `error`-severity findings | Yes (full report) |
+| `1` | Complete report; one or more excluded-file `error` entries in `report.corpusFindings` | Yes (full report) |
+| `2` | Usage error; invalid flag, value, or unreachable corpus directory | No |
+
+---
+
+## Invalid-Input Behavior: Details
+
+### Invalid `--format` value
+
+```bash
+$ adr queue --format csv
+# stdout: (empty)
+# stderr: Invalid --format value: 'csv'. Expected markdown or json.
+# exit: 2
+```
+
+No report is generated. The kernel is not invoked.
+
+### Invalid `--as-of` value
+
+```bash
+$ bun run adr -- queue --as-of "not-a-date"
+# stdout: (empty)
+# stderr: Invalid --as-of value: 'not-a-date'. Expected YYYY-MM-DD or ISO datetime with explicit timezone (e.g. 2026-01-08 or 2026-01-08T00:00:00Z).
+# exit: 2
+
+$ bun run adr -- queue --as-of "2026-01-08T10:00:00"
+# stdout: (empty)
+# stderr: Invalid --as-of value: '2026-01-08T10:00:00'. Timezone-less datetimes are ambiguous — use YYYY-MM-DD or add an explicit timezone offset (e.g. Z or +05:00).
+# exit: 2
+
+$ bun run adr -- queue --as-of "2026-13-01"
+# stdout: (empty)
+# stderr: Invalid --as-of value: '2026-13-01'. Expected YYYY-MM-DD or ISO datetime with explicit timezone (e.g. 2026-01-08 or 2026-01-08T00:00:00Z).
+# exit: 2
+```
+
+No report is generated. The kernel is not invoked.
+
+### Corpus directory not found
+
+```bash
+$ adr queue --dir /nonexistent/path
+# stdout: (empty)
+# stderr: Corpus directory not found: '/nonexistent/path'.
+# exit: 2
+```
+
+---
+
+## Help Flag
+
+```bash
+$ adr queue --help
+```
+
+Emits usage information to stdout. Exit 0.
+
+---
+
+## Implementation Location
+
+| Concern | File |
+|---------|------|
+| CLI argument parsing + flag validation | `packages/cli/src/queue.ts` (new) |
+| Subcommand registration | `packages/cli/src/index.ts` (new `queue` branch in `main()`) |
+| Pure kernel call | `packages/core/src/queue/kernel.ts` (new) |
+| Output formatting (Markdown) | `packages/core/src/queue/format.ts` (new; `formatQueueReportMarkdown()`) |
+| Output formatting (JSON) | `packages/core/src/queue/format.ts` (new; `formatQueueReportJson()`) |
+
+Both the CLI and the Action import `formatQueueReportMarkdown` and
+`formatQueueReportJson` from `@adrkit/core`. The CLI module itself does NOT contain
+formatting logic. This ensures identical bytes for identical inputs across both surfaces.
+
+The CLI module must NOT import anything from `@actions/core`, `@actions/github`,
+`@adrkit/ci`, or `@adrkit/mcp`. CLI-level dependencies: `@adrkit/core` only.
+
+---
+
+## Determinism Guarantee
+
+Two invocations with identical `--dir` content and identical `--as-of` values MUST
+produce byte-for-byte identical stdout. No timestamps, no random identifiers, no
+platform-specific paths may appear in the output. (SC-001)

--- a/specs/007-arb-queue/contracts/cli-contract.md
+++ b/specs/007-arb-queue/contracts/cli-contract.md
@@ -34,9 +34,12 @@ ADR corpus to stdout.
 The `--as-of` flag accepts two forms:
 
 1. **Bare date**: `YYYY-MM-DD` — must match the regex `/^\d{4}-\d{2}-\d{2}$/` AND
-   pass a UTC round-trip validation: `new Date(input + 'T00:00:00Z').toISOString().slice(0,10) === input`.
-   The round-trip check catches invalid months/days that parse without NaN (e.g.
-   `2026-13-01` or `2026-02-30`). If either check fails, exit 2.
+   pass a safe UTC round-trip validation:
+   `const parsed = new Date(input + 'T00:00:00Z')`;
+   `Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0,10) === input`.
+   The finite-time guard prevents `toISOString()` from throwing on invalid dates such as
+   `2026-13-01`; the round-trip comparison rejects normalized impossible dates such as
+   `2026-02-30`. If any check fails, exit 2.
 
 2. **ISO datetime with explicit offset**: a string containing `T` and an explicit
    timezone designator (`Z` or a numeric offset `±HH:MM` or `±HHMM`), e.g.

--- a/specs/007-arb-queue/contracts/github-action.md
+++ b/specs/007-arb-queue/contracts/github-action.md
@@ -1,6 +1,6 @@
 # Contract: GitHub Action — Managed Queue Issue
 
-**Feature**: [spec.md](../spec.md) | **Plan**: [plan.md](./plan.md) | **Date**: 2026-07-20
+**Feature**: [spec.md](../spec.md) | **Plan**: [plan.md](../plan.md) | **Date**: 2026-07-20
 
 This contract defines the GitHub Action surface for the ARB queue: its `action.yml`
 inputs, outputs, permissions, the `GitHubQueueClient` interface, the managed-issue

--- a/specs/007-arb-queue/contracts/github-action.md
+++ b/specs/007-arb-queue/contracts/github-action.md
@@ -1,0 +1,451 @@
+# Contract: GitHub Action — Managed Queue Issue
+
+**Feature**: [spec.md](../spec.md) | **Plan**: [plan.md](./plan.md) | **Date**: 2026-07-20
+
+This contract defines the GitHub Action surface for the ARB queue: its `action.yml`
+inputs, outputs, permissions, the `GitHubQueueClient` interface, the managed-issue
+discovery algorithm, state-machine transitions, error matrix, and no-partial-write
+semantics.
+
+---
+
+## Action Location
+
+```
+packages/ci/queue/action.yml
+```
+
+Users reference it as:
+
+```yaml
+- uses: mbeacom/adrkit/packages/ci/queue@v0
+```
+
+This is a separate YAML from the existing `packages/ci/action.yml` (the PR
+governing-decisions action). Each action has distinct triggers, permissions, and
+purposes.
+
+---
+
+## `action.yml` Content
+
+```yaml
+name: "ADR ARB Queue"
+author: "adrkit"
+description: >
+  Creates or updates a single GitHub issue containing the current ADR ARB
+  operations queue report. Requires issues: write permission.
+
+inputs:
+  dir:
+    description: "Path to the ADR corpus directory (relative to GITHUB_WORKSPACE)"
+    required: false
+    default: "docs/adr"
+  token:
+    description: >
+      GitHub token with issues: write permission. Calling workflows using
+      actions/checkout must also declare contents: read.
+    required: false
+    default: "${{ github.token }}"
+  issue-title:
+    description: "Title of the managed queue issue"
+    required: false
+    default: "ADR ARB Queue"
+
+outputs:
+  issue-number:
+    description: "The GitHub issue number of the managed queue issue"
+
+runs:
+  using: "node24"
+  main: "../dist/queue-action.js"
+
+branding:
+  icon: "inbox"
+  color: "blue"
+```
+
+---
+
+## Required Permissions
+
+The Action's own GitHub API calls require only:
+
+```yaml
+permissions:
+  issues: write
+```
+
+The default `GITHUB_TOKEN` is sufficient. No PAT, no additional scopes.
+
+**Calling workflow note**: A workflow that also runs `actions/checkout` must declare
+**both** permissions in its `permissions:` block. `contents: read` is required for
+checkout (particularly on private repositories). Example:
+
+```yaml
+permissions:
+  contents: read
+  issues: write
+```
+
+The Action itself does not use `contents: read` — only the checkout step needs it.
+However, explicitly setting `issues: write` in the job `permissions:` block will
+strip all other default permissions (including `contents: read`) unless they are
+also listed. Callers MUST include `contents: read` whenever they also run checkout.
+
+---
+
+## Bundle Entry Point
+
+| Source | Bundle output |
+|--------|---------------|
+| `packages/ci/src/queue-action-entrypoint.ts` | `packages/ci/dist/queue-action.js` |
+
+Built as a separate `bun build` target from the existing `dist/index.js`.
+The entrypoint:
+
+1. Reads `dir`, `token`, `issue-title` from `@actions/core`.
+2. Resolves `GITHUB_WORKSPACE` and calls `lintCorpus({ dir, cwd: workspace })`.
+3. Resolves `asOf` from the current UTC date.
+4. Calls `buildQueueReport({corpus, asOf})` — fingerprint computed inside kernel.
+5. Calls `formatQueueReportMarkdown(report)` from `@adrkit/core` to get the report body.
+6. Calls `managedQueueIssue()` with the rendered Markdown and a `GitHubQueueClient`.
+7. Sets `issue-number` output via `core.setOutput`.
+8. Calls `core.setFailed()` if the report has error-severity findings OR if
+   any GitHub API call fails.
+
+`@actions/core` and `@actions/github` imports are confined to this file only.
+
+---
+
+## GitHubQueueClient Interface
+
+The GitHub API surface required by `managedQueueIssue()`. Defined in
+`packages/ci/src/queue-issue.ts`. The side-effect-free Octokit adapter lives in
+`packages/ci/src/queue-github-client.ts`; the entrypoint passes it the Octokit instance.
+Both are faked structurally in tests without importing `@actions/*`.
+
+```typescript
+export interface GitHubQueueClient {
+  /**
+   * Returns ALL issues (open AND closed) in the repository, excluding pull requests.
+   * Implementation must paginate exhaustively (100 per page).
+   * MUST filter out entries where pull_request is a non-null property —
+   * GitHub's Issues API returns pull requests from listForRepo.
+   */
+  listAllIssues(): Promise<Array<{
+    number: number;
+    state: "open" | "closed";
+    title: string;
+    body: string | null;
+  }>>;
+
+  /**
+   * Creates a new issue with the given title and body.
+   * Returns the new issue's number.
+   */
+  createIssue(title: string, body: string): Promise<{ number: number }>;
+
+  /**
+   * Updates an existing issue's body and optionally its state.
+   * - For an open managed issue: call with { body } only.
+   * - For a closed managed issue: call with { body, state: 'open' } — one atomic
+   *   REST call that sets both body and state together (no separate reopen step).
+   * Does NOT change title.
+   */
+  updateIssue(issueNumber: number, update: { body: string; state?: 'open' }): Promise<void>;
+}
+```
+
+**Octokit implementation** (`queue-github-client.ts`; tests use a structural fake):
+
+```typescript
+function createOctokitQueueClient(octokit: QueueOctokit, owner: string, repo: string): GitHubQueueClient {
+  return {
+    async listAllIssues() {
+      const openIssues = await octokit.paginate(octokit.rest.issues.listForRepo, {
+        owner, repo, state: "open", per_page: 100,
+      });
+      const closedIssues = await octokit.paginate(octokit.rest.issues.listForRepo, {
+        owner, repo, state: "closed", per_page: 100,
+      });
+      // Filter out pull requests — GitHub's Issues API includes them in listForRepo results
+      return [...openIssues, ...closedIssues]
+        .filter(i => i.pull_request == null)
+        .map(i => ({
+          number: i.number,
+          state: i.state as "open" | "closed",
+          title: i.title,
+          body: i.body ?? null,
+        }));
+    },
+    async createIssue(title, body) {
+      const { data } = await octokit.rest.issues.create({ owner, repo, title, body });
+      return { number: data.number };
+    },
+    async updateIssue(issueNumber, update) {
+      await octokit.rest.issues.update({
+        owner, repo, issue_number: issueNumber,
+        body: update.body,
+        ...(update.state ? { state: update.state } : {}),
+      });
+    },
+  };
+}
+```
+
+---
+
+## Marker Constant
+
+```
+<!-- adrkit-managed-queue-issue -->
+```
+
+This HTML comment is invisible in rendered Markdown. It is:
+- Globally unique to adrkit-managed queue issues.
+- Corpus-independent: it does not change with the report content.
+- Stable across all reruns.
+- Always the **first line** of the managed issue body.
+
+The issue body template:
+
+```
+<!-- adrkit-managed-queue-issue -->
+{rendered Markdown queue report}
+```
+
+**Discovery rule**: An issue is "managed" if and only if its `body` starts with the
+marker as the first line — specifically:
+- `body === MARKER` (marker-only body), OR
+- `body.startsWith(MARKER + '\n')` (marker followed by newline and remaining content).
+
+Leading whitespace before the marker disqualifies the issue. Marker appearing only
+in the middle or end of the body does NOT confer ownership. Specifically,
+`body.includes(MARKER)` alone is insufficient — first-line check is mandatory.
+
+This rule prevents arbitrary issue bodies that quote or mention the marker string
+from being misidentified as managed issues.
+
+---
+
+## Paginated Issue Discovery Algorithm
+
+```
+1. issues = await client.listAllIssues()
+   // listAllIssues() paginates internally; returns all open + closed issues
+   // EXCLUDING pull requests (filtered by implementation)
+
+2. managed = issues.filter(i => {
+     const body = i.body ?? "";
+     return body === MARKER || body.startsWith(MARKER + '\n');
+   })
+   // MARKER = "<!-- adrkit-managed-queue-issue -->"
+   // First-line check: marker must be exactly the first line, no leading whitespace
+
+3. switch managed.length:
+   case 0: → CREATE branch (see State Machine below)
+   case 1: → UPDATE or REOPEN+UPDATE branch
+   case 2+: → DUPLICATE-MARKER fail (no write)
+```
+
+The discovery is always exhaustive — it does NOT stop at the first hit when
+looking for duplicates.
+
+---
+
+## State Machine
+
+### Branch: 0 managed issues found
+
+```
+// Title conflict check: examine ALL unowned issues (open AND closed) with the configured title
+unowned = issues.filter(i => i.title === issue-title-input AND NOT isManagedByMarker(i))
+
+IF unowned.length > 0:
+  → TITLE-CONFLICT fail (no write)
+     // Name ALL conflicting issues by number ascending
+     conflicts = unowned.sort((a,b) => a.number - b.number).map(i => '#' + i.number)
+     error message: "Found ${conflicts.length} issue(s) titled '${title}' without adrkit marker: ${conflicts.join(', ')}. Resolve conflicts before running the queue Action."
+     exit: 1
+
+ELSE:
+  → CREATE new issue
+     body: MARKER + "\n" + markdownReport
+     title: issue-title input
+     setOutput("issue-number", newIssue.number)
+     exit: 0 (or 1 if report has error findings — see Error Findings below)
+```
+
+**Title conflict scope**: both open AND closed unowned issues are checked. A closed
+unowned issue with the configured title is a conflict just as much as an open one.
+The operator must rename every conflict, select a different configured title, or
+deliberately add the ownership marker to exactly one issue before a managed issue can
+be created. Closing an issue does not resolve the conflict.
+
+### Branch: 1 managed issue found, state = open
+
+```
+→ UPDATE existing issue (one atomic REST call — body only)
+     await client.updateIssue(managed[0].number, { body: MARKER + "\n" + markdownReport })
+     setOutput("issue-number", managed[0].number)
+     exit: 0 (or 1 if report has error findings)
+```
+
+### Branch: 1 managed issue found, state = closed
+
+```
+→ UPDATE issue atomically (one REST call — body AND state: 'open' together)
+     await client.updateIssue(managed[0].number, {
+       body: MARKER + "\n" + markdownReport,
+       state: 'open'
+     })
+     setOutput("issue-number", managed[0].number)
+     exit: 0 (or 1 if report has error findings)
+```
+
+**No separate reopen call**: body and state are submitted in one `issues.update` REST
+request. There is no client-created intermediate state where the issue is reopened but
+the body has not yet been submitted. A 401/403 permission response performs no queue
+mutation; for transport failures where the server outcome is unknown, a subsequent run
+reconciles the authoritative issue state.
+
+### Branch: 2+ managed issues found
+
+```
+→ DUPLICATE-MARKER fail
+   error message: "Found ${managed.length} issues with adrkit managed queue marker: #${numbers.join(', #')}. Remove the marker from all but one and re-run."
+   NO write to any issue
+   exit: 1
+```
+
+---
+
+## Error Findings Behavior
+
+When `QueueReport.corpusFindings` contains one or more `error`-severity entries:
+
+1. **Write the managed issue** first (create, update, or reopen+update as
+   determined by the state machine above). The full error report IS written.
+2. **Then fail** (call `core.setFailed(errorMessage)`).
+
+The issue is always updated with the current report state, even when the report
+contains errors. This ensures the managed issue reflects the current corpus health.
+
+Error message for `core.setFailed`: `"Queue report contains ${n} corpus error(s). See issue #${issueNumber} for details."`
+
+This sequence is implemented by a pure `publishQueueReport` orchestration helper in
+`queue-issue.ts`. It accepts injected `setOutput` and `setFailed` callbacks so tests can
+assert the exact order without importing `@actions/*`. `managedQueueIssue` remains
+responsible only for marker/title/state discovery and the single issue mutation; it does
+not receive a `QueueReport`.
+
+---
+
+## Error Matrix
+
+| Error | Source | Exit | Write? |
+|-------|--------|------|--------|
+| Error-severity corpus findings | Report | 1 | Yes (then fail) |
+| Permission error on createIssue/updateIssue (403/401) | GitHub API | 1 | No (failed before write) |
+| Duplicate marker: 2+ managed issues | Discovery | 1 | No |
+| Title conflict: unmanaged issue (open or closed) with same title | Discovery | 1 | No |
+| Invalid `dir` input or unavailable workspace/corpus | Action corpus-load boundary | 1 | No |
+| `bun build` bundle error | Build time | — | — |
+
+**Permission error message**: `"GitHub API returned ${status}: insufficient permissions. Ensure the workflow grants 'issues: write' to the GITHUB_TOKEN."`
+
+---
+
+## No-Partial-Write Rule
+
+The Action makes **at most one GitHub write call** per run (excluding `setOutput`):
+- **Create**: one `createIssue` call. If it fails, nothing was written.
+- **Update (open)**: one `updateIssue({body})` call. If it fails, the issue retains
+  its previous body.
+- **Update (closed)**: one `updateIssue({body, state:'open'})` request that submits body
+  and state together, with no separate reopen request.
+
+No prior queue mutation occurs before the single write call. Discovery and report
+generation are read-only. If `updateIssue` succeeds but `setOutput` or
+`core.setFailed` fails, the issue has already been updated (write completed);
+these are non-destructive post-write steps. A transport failure can make the server
+outcome unknown; the next marker-first run reconciles the issue without creating a
+duplicate.
+
+---
+
+## Bundle Smoke Tests
+
+Follow the pattern established by `scripts/smoke-node.mjs` in the repository root.
+The smoke test for the queue Action bundle:
+
+1. **Controlled no-network invocation**: Spawn the committed bundle with a temporary
+   `GITHUB_WORKSPACE` whose configured corpus directory does not exist. Set the
+   minimal required `INPUT_*` environment variables expected by `@actions/core`
+   (`INPUT_DIR`, `INPUT_TOKEN`, `INPUT_ISSUE-TITLE`) to fixture values, and
+   provide `GITHUB_REPOSITORY=owner/repo` and `GITHUB_TOKEN=fake_token`. The entrypoint
+   MUST fail at the corpus-load boundary before constructing or calling the GitHub
+   client. Assert the known corpus error and non-zero exit rather than a
+   module-resolution error. No real API call is permitted.
+
+2. **Do NOT import the executable entrypoint in-process or pass `--help`** — its
+   top-level behavior is the Action invocation and it has no help guard.
+
+3. **Node 22 and Node 24 coverage**: Run the smoke test once on each. The
+   `action.yml` declares `using: node24`; the runner provides that. Local CI
+   only needs to confirm the bundle loads under both currently-supported LTS
+   Node releases. Use the `@actions/core`-less import path if a pure static
+   check is simpler.
+
+5. **Existing action bundle**: The queue bundle smoke test is additive to the
+   existing `scripts/smoke-node.mjs` check for `dist/index.js`. Both tests run
+   in CI. Do not modify the existing smoke script to add queue logic; add a
+   new script (e.g. `scripts/smoke-queue-node.mjs`) or extend the existing one
+   in a backwards-compatible way.
+
+---
+
+## New Files Required
+
+| File | Purpose |
+|------|---------|
+| `packages/ci/queue/action.yml` | Action manifest (this contract) |
+| `packages/ci/src/queue-issue.ts` | `managedQueueIssue()` function + `GitHubQueueClient` interface |
+| `packages/ci/src/queue-github-client.ts` | Side-effect-free Octokit adapter; exhaustive pagination and PR filtering |
+| `packages/ci/src/queue-action-entrypoint.ts` | `@actions/core`/`@actions/github` boundary; wires the adapter and executes |
+
+**`packages/ci/package.json` additions**:
+- New `bun build` script target: `bun build src/queue-action-entrypoint.ts --outfile dist/queue-action.js --target node`.
+- `@adrkit/ci` is a **private** package; this is NOT a public npm export. The
+  bundle is committed to the repository and referenced by the action's `main:` path.
+  No new `"exports"` subpath in `package.json` is needed for the Action distribution.
+
+No new runtime dependencies needed in `@adrkit/ci`; `@actions/core` and
+`@actions/github` are already in the package's dependencies.
+
+---
+
+## Test Coverage
+
+Tests live in `packages/ci/test/queue-issue.test.ts`. The `GitHubQueueClient`
+interface is injected, so tests use a hand-rolled fake — no network, no token.
+
+Required test scenarios:
+
+| Scenario | Expected behaviour |
+|----------|--------------------|
+| 0 managed, 0 conflicts | CREATE new issue |
+| 0 managed, 1 open title conflict | TITLE-CONFLICT fail, no write |
+| 0 managed, 1 closed title conflict | TITLE-CONFLICT fail, no write |
+| 0 managed, 2 title conflicts (open + closed) | All conflict numbers in message ascending, no write |
+| 1 managed open | UPDATE body, single write call |
+| 1 managed closed | Single `updateIssue({body, state:'open'})` call, not two calls |
+| 2 managed | DUPLICATE-MARKER fail, no write |
+| Marker in middle of body | NOT detected as managed |
+| Marker with leading whitespace | NOT detected as managed |
+| Marker exactly alone | Detected as managed |
+| PR in issues list | Filtered out before marker/title logic |
+| listAllIssues returns 100+ items | All pages consumed |
+| Error corpus findings | Write completes, then setFailed |
+| GitHub API 403 on updateIssue | No partial write; error propagated |

--- a/specs/007-arb-queue/contracts/github-action.md
+++ b/specs/007-arb-queue/contracts/github-action.md
@@ -128,10 +128,9 @@ Both are faked structurally in tests without importing `@actions/*`.
 ```typescript
 export interface GitHubQueueClient {
   /**
-   * Returns ALL issues (open AND closed) in the repository, excluding pull requests.
-   * Implementation must paginate exhaustively (100 per page).
-   * MUST filter out entries where pull_request is a non-null property —
-   * GitHub's Issues API returns pull requests from listForRepo.
+   * Returns ALL issues (open AND closed) in the repository.
+   * Implementation must exhaust the GraphQL repository.issues connection
+   * with 100 nodes per cursor page. Pull requests are excluded by the GraphQL type.
    */
   listAllIssues(): Promise<Array<{
     number: number;
@@ -163,21 +162,22 @@ export interface GitHubQueueClient {
 function createOctokitQueueClient(octokit: QueueOctokit, owner: string, repo: string): GitHubQueueClient {
   return {
     async listAllIssues() {
-      const openIssues = await octokit.paginate(octokit.rest.issues.listForRepo, {
-        owner, repo, state: "open", per_page: 100,
-      });
-      const closedIssues = await octokit.paginate(octokit.rest.issues.listForRepo, {
-        owner, repo, state: "closed", per_page: 100,
-      });
-      // Filter out pull requests — GitHub's Issues API includes them in listForRepo results
-      return [...openIssues, ...closedIssues]
-        .filter(i => i.pull_request == null)
-        .map(i => ({
+      const issues = [];
+      let cursor: string | null = null;
+      do {
+        const data = await octokit.graphql(QUEUE_ISSUES_QUERY, {
+          owner, repo, cursor,
+        });
+        const page = data.repository.issues;
+        issues.push(...page.nodes.map(i => ({
           number: i.number,
-          state: i.state as "open" | "closed",
+          state: i.state.toLowerCase() as "open" | "closed",
           title: i.title,
           body: i.body ?? null,
-        }));
+        })));
+        cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+      } while (cursor !== null);
+      return issues;
     },
     async createIssue(title, body) {
       const { data } = await octokit.rest.issues.create({ owner, repo, title, body });
@@ -193,6 +193,13 @@ function createOctokitQueueClient(octokit: QueueOctokit, owner: string, repo: st
   };
 }
 ```
+
+`QUEUE_ISSUES_QUERY` requests
+`repository(owner:$owner,name:$repo).issues(first:100,after:$cursor,states:[OPEN,CLOSED])`
+with `nodes { number state title body }` and
+`pageInfo { hasNextPage endCursor }`. The GraphQL `issues` connection excludes pull
+requests by construction. Exhaustive cursor traversal is required because marker
+ownership and duplicate detection must not rely on eventually consistent search results.
 
 ---
 
@@ -215,10 +222,15 @@ The issue body template:
 {rendered Markdown queue report}
 ```
 
-**Discovery rule**: An issue is "managed" if and only if its `body` starts with the
-marker as the first line — specifically:
-- `body === MARKER` (marker-only body), OR
-- `body.startsWith(MARKER + '\n')` (marker followed by newline and remaining content).
+**Discovery rule**: An issue is "managed" if and only if the exact first line of its
+body equals the marker:
+
+```typescript
+const firstLine = (body ?? "").split(/\r\n|\n|\r/, 1)[0];
+const isManaged = firstLine === MARKER;
+```
+
+This accepts marker-only, LF, CRLF, and CR bodies while preserving exact ownership.
 
 Leading whitespace before the marker disqualifies the issue. Marker appearing only
 in the middle or end of the body does NOT confer ownership. Specifically,
@@ -234,11 +246,11 @@ from being misidentified as managed issues.
 ```
 1. issues = await client.listAllIssues()
    // listAllIssues() paginates internally; returns all open + closed issues
-   // EXCLUDING pull requests (filtered by implementation)
+   // Pull requests cannot appear in the GraphQL repository.issues connection
 
 2. managed = issues.filter(i => {
-     const body = i.body ?? "";
-     return body === MARKER || body.startsWith(MARKER + '\n');
+     const firstLine = (i.body ?? "").split(/\r\n|\n|\r/, 1)[0];
+     return firstLine === MARKER;
    })
    // MARKER = "<!-- adrkit-managed-queue-issue -->"
    // First-line check: marker must be exactly the first line, no leading whitespace
@@ -412,7 +424,7 @@ The smoke test for the queue Action bundle:
 |------|---------|
 | `packages/ci/queue/action.yml` | Action manifest (this contract) |
 | `packages/ci/src/queue-issue.ts` | `managedQueueIssue()` function + `GitHubQueueClient` interface |
-| `packages/ci/src/queue-github-client.ts` | Side-effect-free Octokit adapter; exhaustive pagination and PR filtering |
+| `packages/ci/src/queue-github-client.ts` | Side-effect-free GraphQL issue adapter; exhaustive cursor pagination |
 | `packages/ci/src/queue-action-entrypoint.ts` | `@actions/core`/`@actions/github` boundary; wires the adapter and executes |
 
 **`packages/ci/package.json` additions**:

--- a/specs/007-arb-queue/contracts/kernel.md
+++ b/specs/007-arb-queue/contracts/kernel.md
@@ -1,0 +1,253 @@
+# Contract: Pure Queue Kernel
+
+**Feature**: [spec.md](../spec.md) | **Data model**: [data-model.md](../data-model.md) | **Date**: 2026-07-20
+
+This contract defines the signature, input/output types, purity constraints, and
+caller responsibilities for `buildQueueReport()` — the pure queue kernel function
+in `packages/core/src/queue/kernel.ts`. This function is the single computational
+entry point for the ARB queue feature.
+
+---
+
+## Function Signature
+
+```typescript
+/**
+ * Build a deterministic QueueReport from a corpus snapshot and explicit asOf date.
+ *
+ * Pure function: no ambient clock, no network, no filesystem access.
+ * All inputs are caller-supplied. Identical inputs produce identical outputs.
+ */
+export function buildQueueReport(input: QueueKernelInput): QueueReport;
+```
+
+---
+
+## Input Type
+
+```typescript
+/**
+ * All inputs required by the queue kernel. No defaults; every value is explicit.
+ */
+export interface QueueKernelInput {
+  /**
+   * Direct result of lintCorpus() — the full corpus projection.
+   * The kernel filters to proposed-status records, maps excluded-file findings
+   * to CorpusFinding[], and computes the corpusFingerprint — all internally.
+   * No pre-processing by caller is required.
+   */
+  corpus: LintCorpusResult; // { records: Adr[]; findings: Finding[]; checked: number }
+
+  /**
+   * UTC calendar date for SLA state computation.
+   * Format: "YYYY-MM-DD". Must be a valid date string. No time component.
+   * Caller resolves from CLI flag or current UTC date before calling kernel.
+   */
+  asOf: string;
+}
+```
+
+---
+
+## Output Type
+
+`QueueReport` — see [contracts/queue-report.md](./queue-report.md) for the full
+TypeScript interface and serialization contracts.
+
+---
+
+## Caller Responsibilities
+
+Before calling `buildQueueReport()`, the caller MUST:
+
+1. **Load corpus**: Call `lintCorpus({ dir })` from `@adrkit/core` to obtain
+   the `LintCorpusResult`. Do NOT pass raw filesystem paths to the kernel;
+   pass the complete result of `lintCorpus`. No pre-mapping or pre-fingerprinting
+   is required.
+
+2. **Resolve `asOf` date**: Compute the UTC calendar date string `"YYYY-MM-DD"`.
+   - If a `--as-of` flag is provided: validate and normalize it (see
+     [cli-contract.md §As-Of Resolution](./cli-contract.md)).
+   - If absent: `new Date().toISOString().slice(0, 10)` at the CLI boundary.
+   - Pass the resolved string to the kernel. Do NOT pass `new Date()` or any
+     Date object; the kernel accepts only the pre-resolved string.
+
+3. **Validate inputs**: Reject invalid `asOf` strings at the CLI boundary,
+   NOT inside the kernel. The kernel assumes `asOf` is a valid `"YYYY-MM-DD"` string.
+
+---
+
+## Kernel Invariants (Purity Assertions)
+
+The kernel:
+
+- ❌ Does NOT call `Date.now()`, zero-argument `new Date()`, or any ambient clock
+  function. It MAY use `new Date(callerSuppliedTimestamp)` solely to normalize explicit
+  frontmatter timestamp inputs; that operation is deterministic.
+- ❌ Does NOT call any filesystem API (`fs.readFile`, `Bun.file`, etc.).
+- ❌ Does NOT make any network request.
+- ❌ Does NOT import `@actions/core`, `@actions/github`, or any adapter module.
+- ❌ Does NOT import `@adrkit/ci`, `@adrkit/mcp`, or `@adrkit/evaluator`.
+- ✅ Imports only from `@adrkit/core` internal modules (schema types, Finding types,
+  `fingerprintOf`, `canonicalStringify`, `sortByIdThenPath`, `sortFindingsCanonical`).
+- ✅ Uses `Node.js crypto` (SHA-256) internally for fingerprint computation.
+  `crypto.createHash('sha256')` is deterministic and has no observable side effects;
+  it is acceptable in the pure kernel.
+- ✅ Is referentially transparent: same `QueueKernelInput` → same `QueueReport`.
+
+These constraints are enforced by the `check:deps` static import-graph scan
+(`core-has-no-adapter-deps` gate) and by the unit test fixture strategy (no
+test setup required beyond object construction).
+
+---
+
+## Kernel Algorithm
+
+### Step 1: Identify excluded files
+
+An "excluded" file is one whose path (`Adr.path`) does NOT appear in
+`corpus.records`. These are files that `lintCorpus()` found but could not
+parse into valid records (they produced error-severity findings).
+
+```
+excludedPaths = Set of paths in findings with severity:error
+                MINUS paths present in corpus.records
+```
+
+### Step 2: Project CorpusFindings
+
+For each excluded file, map its `Finding` entries to `CorpusFinding` using the
+rule-to-code mapping table in [data-model.md §6](../data-model.md).
+
+Sort `corpusFindings` by: `sourcePath` → `code` → severity rank → `message`.
+
+### Step 3: Filter to proposed records
+
+```
+proposedRecords = corpus.records.filter(r => r.frontmatter.status === "proposed")
+```
+
+### Step 4: Build QueueItems
+
+For each `proposedRecord`:
+
+1. Extract and normalize all timing fields (see data-model.md §3).
+2. Derive `tierLabel` from `tier` using the closed FR-016 mapping.
+3. Compute `deadlineDate` via the algorithm in data-model.md §2.
+4. Compute `slaState` via the precedence rule in data-model.md §1.
+5. Compute `approvalCount`, `unresolvedObjectionCount`, `resolvedObjectionCount`.
+6. Generate `itemFindings` (see §ItemFinding Generation below).
+
+### Step 5: Sort QueueItems
+
+Sort by: urgency group → deadline date → `queuedAt` → `id`. See
+[research.md §R6](../research.md) for the full comparator definition.
+
+### Step 6: Sort ItemFindings per item
+
+Sort each item's `itemFindings` by: `code` → severity rank → `message`.
+
+### Step 7: Compute fingerprint
+
+```typescript
+const corpusFingerprint = fingerprintOf(
+  sortByIdThenPath(corpus.records),          // ordered Adr[] (all schema-valid records)
+  sortFindingsCanonical(corpus.findings),    // ordered Finding[] (all findings, not just excluded)
+  corpus.records.length,                     // recordCount
+  corpus.checked - corpus.records.length     // excludedCount
+);
+```
+
+This matches the `fingerprintOf` signature from `packages/mcp/src/corpus/projection.ts`
+(lines 188–195) exactly. The `Finding[]` input is the **original core findings array**
+from `lintCorpus`, not the queue-mapped `CorpusFinding[]`.
+
+### Step 8: Assemble QueueReport
+
+```typescript
+return {
+  version: "1",
+  asOf: input.asOf,
+  corpusFingerprint,               // computed internally in Step 7
+  totalItems: items.length,
+  totalCorpusFindings: corpusFindings.length,
+  itemsWithFindings: items.filter(i => i.itemFindings.length > 0).length,
+  items,
+  corpusFindings,
+};
+```
+
+---
+
+## ItemFinding Generation
+
+Three findings are generated in Step 4, checked independently for each item:
+
+### `item.tier-absent`
+
+**Condition**: `record.frontmatter.review?.tier` is absent (undefined or null).
+
+```typescript
+{
+  code: "item.tier-absent",
+  severity: "info",
+  message: "review.tier is absent; routing tier cannot be determined — add review.tier: auto|async|arb to this record",
+}
+```
+
+### `item.review-by-before-queued`
+
+**Condition**:
+- `record.frontmatter.reviewBy` is present, AND
+- `record.frontmatter.review?.queuedAt` is present, AND
+- `toUTCCalendarDate(reviewBy) < toUTCCalendarDate(queuedAt)` (strictly before; equal dates do NOT trigger)
+
+```typescript
+{
+  code: "item.review-by-before-queued",
+  severity: "warn",
+  message: `reviewBy (${reviewBy}) is before queuedAt (${queuedAtDate}); SLA deadline may be inconsistent`,
+  // where reviewBy is the raw field value and queuedAtDate is the UTC calendar date of queuedAt
+}
+```
+
+### `item.deciders-empty`
+
+**Condition**:
+- `record.frontmatter.deciders` is absent, empty, or `[]`, AND
+- `record.frontmatter.review?.queuedAt` is present (record is actively in the queue)
+
+```typescript
+{
+  code: "item.deciders-empty",
+  severity: "info",
+  message: "deciders is empty; routing targets cannot be determined — add at least one decider identity to this record",
+}
+```
+
+---
+
+## Module Structure
+
+| File | Exports |
+|------|---------|
+| `packages/core/src/queue/types.ts` | `QueueItem`, `QueueReport`, `SlaState`, `ItemFinding`, `CorpusFinding`, `QueueKernelInput`, `SLA_STATE_URGENCY_ORDER` |
+| `packages/core/src/queue/kernel.ts` | `buildQueueReport()` |
+| `packages/core/src/queue/sort.ts` | `sortQueueItems()`, `sortCorpusFindings()`, `sortItemFindings()` |
+| `packages/core/src/queue/findings.ts` | `mapFindingToCorpusFinding()`, `RULE_TO_CORPUS_CODE` mapping (excluded files only) |
+| `packages/core/src/queue/format.ts` | `formatQueueReportJson()`, `formatQueueReportMarkdown()` — consumed by both CLI and Action |
+| `packages/core/src/fingerprint/index.ts` | `canonicalStringify()`, `fingerprintOf()` — promoted from `@adrkit/mcp` |
+| `packages/core/src/ordering/index.ts` | `compareCodeUnits()`, `compareFindings()`, `sortFindingsCanonical()`, `compareByIdThenPath()`, `sortByIdThenPath()` — promoted from `@adrkit/mcp` |
+
+All modules are exported from `packages/core/src/index.ts` under their natural names.
+
+---
+
+## What the Kernel Does NOT Do
+
+- Does NOT call `lintCorpus()` — that is the CLI/Action boundary's job.
+- Does NOT format output (Markdown or JSON) — that is `queue/format.ts`'s job
+  (in `@adrkit/core`, consumed by CLI and Action).
+- Does NOT interact with GitHub — that is the Action adapter's job.
+- Does NOT validate the `asOf` string for parse errors — caller validates.
+- Does NOT decide whether to exit non-zero — caller decides based on the returned report.

--- a/specs/007-arb-queue/contracts/queue-report.md
+++ b/specs/007-arb-queue/contracts/queue-report.md
@@ -1,0 +1,371 @@
+# Contract: QueueReport v1 — JSON and Markdown Canonical Formats
+
+**Feature**: [spec.md](../spec.md) | **Data model**: [data-model.md](../data-model.md) | **Date**: 2026-07-20
+
+This contract defines the canonical serialization of the `QueueReport` v1 type in
+both JSON and Markdown formats. It is the normative reference for all serialization
+logic in `packages/cli/src/queue.ts` (formatting) and for consumers of the
+`QueueReport` JSON.
+
+---
+
+## Part I — TypeScript Type Definitions
+
+The following types constitute the complete `QueueReport` v1 type surface.
+They are normative; the data-model document provides derivation context.
+
+```typescript
+/** The seven SLA states. See data-model.md §1 for precedence rule. */
+type SlaState =
+  | "decided"
+  | "escalated"
+  | "overdue"
+  | "due"
+  | "within-sla"
+  | "missing-sla"
+  | "not-queued";
+
+/** A finding attached to a specific QueueItem. Always info or warn severity. */
+interface ItemFinding {
+  code: string;
+  severity: "info" | "warn";
+  message: string;
+}
+
+/** A finding for a file that could not be projected into a QueueItem. Always error severity. */
+interface CorpusFinding {
+  sourcePath: string;
+  code: string;
+  severity: "error";
+  message: string;
+}
+
+/** A single ADR record projected into the queue. */
+interface QueueItem {
+  id: string;
+  title: string;
+  sourcePath: string;
+
+  tier: "auto" | "async" | "arb" | null;
+  tierLabel:
+    | "expedited routing; human acceptance required"
+    | "asynchronous human review"
+    | "ARB human review"
+    | null;
+
+  queuedAt: string | null;      // UTC ISO datetime string, e.g. "2026-01-01T00:00:00.000Z"
+  slaDays: number | null;
+  reviewBy: string | null;      // "YYYY-MM-DD" or null (IsoDate only; never a datetime)
+
+  slaState: SlaState;
+  deadlineDate: string | null;  // "YYYY-MM-DD" computed, or null
+
+  routingTargets: string[];
+  quorum: number | null;
+
+  approvalCount: number;
+  unresolvedObjectionCount: number;
+  resolvedObjectionCount: number;
+
+  escalatedAt: string | null;   // UTC ISO datetime string or null
+  decidedAt: string | null;     // UTC ISO datetime string or null
+
+  itemFindings: ItemFinding[];
+}
+
+/** The top-level queue report. version is always the string "1". */
+interface QueueReport {
+  version: "1";
+  asOf: string;                 // "YYYY-MM-DD" UTC calendar date
+  corpusFingerprint: string;    // lowercase hex SHA-256, 64 chars
+  totalItems: number;
+  totalCorpusFindings: number;
+  itemsWithFindings: number;
+  items: QueueItem[];
+  corpusFindings: CorpusFinding[];
+}
+```
+
+---
+
+## Part II — JSON Serialization
+
+### Method
+
+```typescript
+const output: string = JSON.stringify(report, null, 2) + "\n";
+```
+
+- **Indentation**: 2 spaces per level.
+- **Final newline**: exactly one `\n` after the closing `}`.
+- **No trailing whitespace** on any line.
+- **`undefined` fields**: omitted by `JSON.stringify` semantics. However, all
+  fields declared in the TypeScript interfaces above are always present
+  (either with their value or with `null`). No field is intentionally `undefined`.
+- **`null` fields**: included verbatim as `null` in the JSON output.
+- **Number fields**: plain JSON numbers (not quoted). `slaDays`, `quorum`,
+  `approvalCount`, `unresolvedObjectionCount`, `resolvedObjectionCount`,
+  `totalItems`, `totalCorpusFindings`, `itemsWithFindings` are integers.
+- **String fields**: standard JSON string encoding; no manual escaping needed
+  beyond `JSON.stringify`.
+- **`version` field value**: the string `"1"` — NOT the number `1`.
+
+### Key ordering
+
+The report object MUST be constructed with keys in the order declared in the interfaces
+above. Supported JavaScript runtimes serialize these non-integer string keys in insertion
+order, so the construction order is part of the v1 contract. No additional key sorting is
+applied to the JSON output itself (only to the fingerprint canonical projection — see
+data-model.md §8).
+
+### Example (minimal valid)
+
+```json
+{
+  "version": "1",
+  "asOf": "2026-01-08",
+  "corpusFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "totalItems": 1,
+  "totalCorpusFindings": 0,
+  "itemsWithFindings": 0,
+  "items": [
+    {
+      "id": "0007",
+      "title": "Introduce ARB operations queue",
+      "sourcePath": "docs/adr/0007-arb-queue.md",
+      "tier": "arb",
+      "tierLabel": "ARB human review",
+      "queuedAt": "2026-01-01T00:00:00.000Z",
+      "slaDays": 14,
+      "reviewBy": null,
+      "slaState": "within-sla",
+      "deadlineDate": "2026-01-15",
+      "routingTargets": ["alice", "bob"],
+      "quorum": 2,
+      "approvalCount": 0,
+      "unresolvedObjectionCount": 0,
+      "resolvedObjectionCount": 0,
+      "escalatedAt": null,
+      "decidedAt": null,
+      "itemFindings": []
+    }
+  ],
+  "corpusFindings": []
+}
+```
+
+---
+
+## Part III — Corpus Fingerprint
+
+The `corpusFingerprint` is a lowercase hex-encoded SHA-256 string (64 characters).
+Defined fully in [data-model.md §8](../data-model.md); summarized here:
+
+**Projection** (input to SHA-256):
+```
+canonicalStringify({
+  records: sortByIdThenPath(lintResult.records).map(r => ({ sourcePath: r.path, frontmatter: r.frontmatter, body: r.body })),
+  corpusFindings: sortedRawFindings,  // sortFindingsCanonical(lintResult.findings);
+                                       // original core Finding[], NOT queue CorpusFinding[]
+  corpusHealth: { recordCount: lintResult.records.length, excludedCount: lintResult.checked - lintResult.records.length }
+})
+```
+where the second field is the **original core `Finding[]`** from `lintCorpus()` — all
+findings including both excluded-file error findings AND schema-valid record warn/info
+findings. It is NOT the queue-mapped `CorpusFinding[]`. This matches the signature of
+`fingerprintOf` in `packages/mcp/src/corpus/projection.ts` (line 188) exactly.
+
+**`canonicalStringify`**: keys sorted at every nesting level by code-unit order;
+no whitespace; UTF-8 encoded. Identical to the implementation in
+`packages/core/src/fingerprint/index.ts` (promoted from `@adrkit/mcp`).
+
+---
+
+## Part IV — Markdown Canonical Layout
+
+The Markdown format is the default output of `adr queue`. It must be stable
+(deterministic for identical inputs), readable in plain text and rendered Markdown,
+and **complete** — every field of `QueueReport`, `QueueItem`, `ItemFinding`, and
+`CorpusFinding` has a visual representation.
+
+The implementation lives in `packages/core/src/queue/format.ts`
+(`formatQueueReportMarkdown`), consumed by both the CLI and the Action.
+
+### Structure
+
+```markdown
+# ARB Queue — {asOf}
+
+Corpus fingerprint: `{full 64-char hex fingerprint}`
+{totalItems} item(s) | {totalCorpusFindings} corpus finding(s) | {itemsWithFindings} item(s) with findings
+
+## Corpus Findings
+
+{corpus findings table, or omitted if empty}
+
+## Queue Items
+
+{queue items overview table, or empty state text}
+
+{per-item detail sections, only for items with findings or non-null optional fields}
+```
+
+### Title and Metadata Block
+
+```markdown
+# ARB Queue — 2026-01-08
+
+Corpus fingerprint: `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+3 item(s) | 0 corpus finding(s) | 1 item(s) with findings
+```
+
+- `asOf` is the UTC calendar date from `QueueReport.asOf`.
+- Fingerprint is the full 64-character lowercase hex string — never truncated.
+- All three counts are on the second line.
+
+### Corpus Findings Section
+
+If `corpusFindings.length > 0`, include:
+
+```markdown
+## Corpus Findings
+
+| Source Path | Code | Severity | Message |
+|-------------|------|----------|---------|
+| `docs/adr/0005-bad.md` | `corpus.schema-invalid` | error | Missing required field: id |
+```
+
+- One row per `CorpusFinding`, in the sort order from data-model.md §6.
+- `sourcePath` wrapped in backticks.
+- `code` wrapped in backticks.
+- `severity` verbatim (always `error` for CorpusFindings).
+- Cell values escaped per §Escaping Rules below.
+
+If `corpusFindings.length === 0`, the `## Corpus Findings` section is omitted entirely.
+
+### Queue Items Overview Table
+
+Always included, even if empty.
+
+```markdown
+## Queue Items
+
+| # | ID | Title | Tier | SLA State | Deadline | Approvals | Objections |
+|---|----|-------|------|-----------|----------|-----------|------------|
+| 1 | `0007` | Introduce ARB queue | arb (ARB human review) | overdue | 2026-01-01 | 0/2 | 0 |
+| 2 | `0006` | Integrate MCP server | async (asynchronous human review) | within-sla | 2026-02-01 | 1/1 | 0 |
+```
+
+**Column definitions**:
+
+| Column | Value |
+|--------|-------|
+| `#` | 1-based integer rank (row number in the output table) |
+| ID | `id` wrapped in backticks |
+| Title | `title`; pipe-escaped |
+| Tier | `tier` plus `tierLabel` as `{tier} ({tierLabel})`, or `(none)` if `tier` is null |
+| SLA State | `slaState` as plain ASCII (no emoji) |
+| Deadline | `deadlineDate` value or `-` if `null` |
+| Approvals | `approvalCount`/`quorum` or `approvalCount/-` if `quorum` is null |
+| Objections | `unresolvedObjectionCount` unresolved (plus `resolvedObjectionCount` resolved in parens if `resolvedObjectionCount > 0`, e.g. `0` or `2 (1 resolved)`) |
+
+**If `items` is empty**:
+
+```markdown
+## Queue Items
+
+*No proposed records found.*
+```
+
+### Per-Item Detail Sections
+
+After the overview table, one detail section per `QueueItem`. Each section exposes
+all fields not visible in the overview table. Sections are ordered to match the
+overview table row order (urgency-sorted).
+
+```markdown
+### 0007 — Introduce ARB queue
+
+| Field | Value |
+|-------|-------|
+| Source | `docs/adr/0007-arb-queue.md` |
+| Tier | arb |
+| Tier Label | ARB human review |
+| SLA State | overdue |
+| Queued At | 2026-01-01T00:00:00.000Z |
+| SLA Days | 14 |
+| Review By | - |
+| Deadline | 2026-01-15 |
+| Routing Targets | alice, bob |
+| Quorum | 2 |
+| Approvals | 0 |
+| Unresolved Objections | 0 |
+| Resolved Objections | 0 |
+| Escalated At | - |
+| Decided At | - |
+
+#### Findings
+
+- `item.tier-absent` (info): review.tier is absent; routing tier cannot be determined — add review.tier: auto\|async\|arb to this record
+```
+
+**Field rendering**:
+
+| QueueItem field | Rendered as |
+|----------------|-------------|
+| `sourcePath` | backtick-wrapped |
+| `tier` | value or `(none)` if null |
+| `tierLabel` | derived label from FR-016, or `-` if null |
+| `slaState` | plain ASCII value |
+| `queuedAt` | full ISO datetime string, or `-` if null |
+| `slaDays` | integer, or `-` if null |
+| `reviewBy` | value (YYYY-MM-DD), or `-` if null |
+| `deadlineDate` | value, or `-` if null |
+| `routingTargets` | joined with `, `, or `-` if empty |
+| `quorum` | integer, or `-` if null |
+| `approvalCount` | integer |
+| `unresolvedObjectionCount` | integer |
+| `resolvedObjectionCount` | integer |
+| `escalatedAt` | full ISO datetime string, or `-` if null |
+| `decidedAt` | full ISO datetime string, or `-` if null |
+
+The `#### Findings` subsection is included only if `itemFindings.length > 0`.
+Each finding is one bullet: `` `{code}` ({severity}): {message} ``.
+
+If an item has no findings, the detail section still appears (to expose all field
+values) but the `#### Findings` subsection is omitted.
+
+### Final Newline
+
+The Markdown output must end with exactly one `\n` after the last non-empty line.
+
+### Escaping Rules
+
+| Character | Context | Escaped as |
+|-----------|---------|-----------|
+| `\|` | Table cell value | `\|` |
+| `` ` `` | Table cell value | `` \` `` |
+| `\` | Table cell value | `\\` |
+| CR (`\r`) | Table cell value | ` ` (replaced with a single space) |
+| LF (`\n`) | Table cell value | `<br>` |
+| CRLF (`\r\n`) | Table cell value | `<br>` (normalize to single `<br>`) |
+| All other characters | Table cell value | as-is |
+| `\|` | Bullet list text (item findings message) | `\|` |
+| All other characters | Bullet list text | as-is |
+
+Escaping is applied in this order: normalize CRLF to LF, replace remaining CR with one
+space, replace LF with `<br>`, escape backslashes, then escape pipe and backtick
+characters. This order prevents newly introduced escape backslashes from being escaped
+again.
+
+No HTML encoding is applied beyond the `<br>` substitution above. The output is
+standard CommonMark-compatible Markdown.
+
+### Empty State Summary
+
+| Condition | Behavior |
+|-----------|----------|
+| `corpusFindings.length === 0` | `## Corpus Findings` section omitted entirely |
+| `items.length === 0` | Overview table replaced with `*No proposed records found.*`; no detail sections |
+| Item has `itemFindings.length === 0` | Detail section appears (all field values), `#### Findings` omitted |
+| All items have `itemFindings.length === 0` | No `#### Findings` subsections anywhere; detail sections still present |

--- a/specs/007-arb-queue/contracts/queue-report.md
+++ b/specs/007-arb-queue/contracts/queue-report.md
@@ -4,8 +4,8 @@
 
 This contract defines the canonical serialization of the `QueueReport` v1 type in
 both JSON and Markdown formats. It is the normative reference for all serialization
-logic in `packages/cli/src/queue.ts` (formatting) and for consumers of the
-`QueueReport` JSON.
+logic in `packages/core/src/queue/format.ts`, shared byte-for-byte by the CLI and
+Action, and for consumers of the `QueueReport` JSON.
 
 ---
 
@@ -282,6 +282,11 @@ Always included, even if empty.
 After the overview table, one detail section per `QueueItem`. Each section exposes
 all fields not visible in the overview table. Sections are ordered to match the
 overview table row order (urgency-sorted).
+
+The heading title is normalized to one line before interpolation: normalize CRLF to
+LF, replace every remaining CR or LF with one space, and leave all other characters
+unchanged. This prevents a schema-valid multiline title from injecting headings or
+tables into the canonical report structure.
 
 ```markdown
 ### 0007 — Introduce ARB queue

--- a/specs/007-arb-queue/data-model.md
+++ b/specs/007-arb-queue/data-model.md
@@ -389,4 +389,5 @@ An ADR file is one of:
 - **Schema-valid non-proposed** → ignored by the queue (not in `items`, not in
   `corpusFindings`); but any lint findings ARE included in fingerprint input.
 - **Schema-valid proposed** → appears in `items` as a `QueueItem`; any lint
-  findings appear as `itemFindings` in the item; all findings included in fingerprint input.
+  findings from core lint are omitted from report findings but included in fingerprint
+  input. Only the closed three queue-specific conditions generate `itemFindings`.

--- a/specs/007-arb-queue/data-model.md
+++ b/specs/007-arb-queue/data-model.md
@@ -1,0 +1,392 @@
+# Data Model: ARB Operations Queue — Phase 6
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Date**: 2026-07-20
+
+This document defines all entities, fields, types, relationships, and
+algorithms that the queue kernel and its consumers depend on. It is the
+normative reference for `packages/core/src/queue/types.ts`.
+
+---
+
+## 1. SlaState — Enumeration
+
+The `SlaState` enumeration is a closed set of seven values. Each `QueueItem`
+carries exactly one `slaState`.
+
+| Value | Urgency Rank | When Applied |
+|-------|-------------|--------------|
+| `decided` | 6 (lowest urgency) | `review.decidedAt` is present |
+| `escalated` | 1 | `review.escalatedAt` is present AND `decidedAt` is absent |
+| `overdue` | 0 (highest urgency) | `deadlineDate` is computable AND `asOfDate > deadlineDate` AND `decidedAt` absent AND `escalatedAt` absent |
+| `due` | 2 | `deadlineDate` is computable AND `asOfDate === deadlineDate` AND `decidedAt` absent AND `escalatedAt` absent |
+| `within-sla` | 3 | `deadlineDate` is computable AND `asOfDate < deadlineDate` AND `decidedAt` absent AND `escalatedAt` absent |
+| `missing-sla` | 4 | `queuedAt` is present AND `deadlineDate` is NOT computable AND `decidedAt` absent AND `escalatedAt` absent |
+| `not-queued` | 5 | `review.queuedAt` is absent (or `review` block entirely absent) |
+
+**Precedence rule** (FR-005): Checked in strict priority order. The first
+matching condition is applied:
+
+```
+IF decidedAt present → decided
+ELSE IF escalatedAt present → escalated
+ELSE IF deadlineDate computable:
+    IF asOf > deadlineDate → overdue
+    ELSE IF asOf = deadlineDate → due
+    ELSE → within-sla
+ELSE IF queuedAt present → missing-sla
+ELSE → not-queued
+```
+
+All date comparisons are UTC calendar date comparisons (`"YYYY-MM-DD"` string
+comparison, code-unit order). `asOf` is the caller-supplied UTC calendar date.
+
+---
+
+## 2. Deadline Computation Algorithm
+
+The `deadlineDate` for a QueueItem is computed as follows:
+
+```
+function computeDeadlineDate(record: Adr, asOf: string): string | null {
+  // Priority 1: explicit reviewBy field (from top-level frontmatter)
+  if record.frontmatter.reviewBy is present:
+    return record.frontmatter.reviewBy
+    // reviewBy is schema-valid IsoDate (YYYY-MM-DD), never a datetime
+
+  // Priority 2: queuedAt + slaDays
+  if record.frontmatter.review?.queuedAt is present
+  AND record.frontmatter.review?.slaDays is present:
+    queuedDate = toUTCCalendarDate(record.frontmatter.review.queuedAt)
+    return addCalendarDays(queuedDate, record.frontmatter.review.slaDays)
+    // addCalendarDays: add slaDays calendar days to queuedDate in UTC
+
+  // No deadline computable
+  return null
+}
+```
+
+**`reviewBy` takes precedence over `slaDays`**: When both `reviewBy` and
+`review.slaDays` are present, `reviewBy` wins for the deadline date.
+`slaDays` is still included in the `QueueItem.slaDays` output field for
+informational purposes.
+
+**`slaDays: 0`**: deadline equals `queuedAt` UTC calendar date. On that day
+the item is `due`; on the following UTC calendar day it is `overdue`.
+
+**`reviewBy` date extraction**: `reviewBy` is always a bare `YYYY-MM-DD`
+(IsoDate format). The schema validates it as `IsoDate`; it is NOT a datetime
+field and never contains a timezone offset. Use the value directly as the
+UTC calendar date without any conversion.
+
+---
+
+## 3. Timestamp Normalization Rule
+
+All datetime fields stored in ADR frontmatter (`review.queuedAt`,
+`review.escalatedAt`, `review.decidedAt`) may use any valid ISO 8601 datetime
+string (the Zod schema accepts any valid ISO string). For queue purposes, ALL
+datetime values are normalized to UTC instants before comparison.
+
+**Normalization**: `new Date(storedValue).toISOString()` — produces
+`"YYYY-MM-DDTHH:mm:ss.sssZ"`.
+
+**Calendar date extraction**: `normalizedInstant.slice(0, 10)` — produces
+`"YYYY-MM-DD"` in UTC.
+
+**`--as-of` CLI flag**: If the caller passes a bare `YYYY-MM-DD`, it is used
+as the UTC calendar date directly. If the caller passes a full ISO datetime
+string (e.g. `2026-01-08T01:00:00+05:00`), it is normalized to UTC and the
+date portion extracted (`2026-01-07`).
+
+---
+
+## 4. QueueItem — Entity
+
+One `QueueItem` per `proposed`-status ADR record that passes schema validation
+(i.e., appears in `lintCorpus().records`).
+
+```typescript
+interface QueueItem {
+  // Identity
+  id: string;          // from Adr.frontmatter.id; e.g. "0007"
+  title: string;       // from Adr.frontmatter.title
+  sourcePath: string;  // repo-relative path, forward slashes, from Adr.path
+
+  // Tier
+  tier: "auto" | "async" | "arb" | null;
+  // from Adr.frontmatter.review?.tier; null if absent
+
+  tierLabel:
+    | "expedited routing; human acceptance required"
+    | "asynchronous human review"
+    | "ARB human review"
+    | null;
+  // deterministic label derived from tier; null when tier is absent
+
+  // Queue timing
+  queuedAt: string | null;
+  // UTC ISO string (normalized from review.queuedAt) or null
+
+  // SLA
+  slaDays: number | null;
+  // from Adr.frontmatter.review?.slaDays; null if absent
+
+  reviewBy: string | null;
+  // UTC calendar date "YYYY-MM-DD" (normalized from top-level reviewBy) or null
+
+  // Computed SLA state and deadline
+  slaState: SlaState;
+  deadlineDate: string | null;
+  // Computed per algorithm in §2; "YYYY-MM-DD" or null
+
+  // Routing
+  routingTargets: string[];
+  // from Adr.frontmatter.deciders; empty array if absent or empty
+
+  quorum: number | null;
+  // from Adr.frontmatter.review?.quorum; null if absent
+
+  // Decision tracking
+  approvalCount: number;
+  // from Adr.frontmatter.review?.approvals?.length ?? 0
+  // (approvals array length; normalized to 0 if absent)
+
+  unresolvedObjectionCount: number;
+  // count of Adr.frontmatter.review?.objections entries where resolved !== true
+
+  resolvedObjectionCount: number;
+  // count of Adr.frontmatter.review?.objections entries where resolved === true
+
+  escalatedAt: string | null;
+  // UTC ISO string (normalized from review.escalatedAt) or null
+
+  decidedAt: string | null;
+  // UTC ISO string (normalized from review.decidedAt) or null
+
+  // Per-item findings (queue incompleteness/inconsistency codes)
+  itemFindings: ItemFinding[];
+}
+```
+
+**Field notes**:
+- `sourcePath` uses forward slashes on all platforms (normalize with
+  `path.posix` or `.replace(/\\/g, '/')`).
+- `tier` is `null` (not `undefined`) when absent — JSON serialization must
+  include the field as `null`.
+- `tierLabel` is derived only from `tier` using FR-016's closed mapping and is `null`
+  when `tier` is absent. In particular, `auto` always renders as
+  `expedited routing; human acceptance required`.
+- `queuedAt`, `reviewBy`, `escalatedAt`, `decidedAt`, `deadlineDate` all use
+  `null` (not `undefined`) when absent.
+- `approvalCount`, `unresolvedObjectionCount`, `resolvedObjectionCount` default
+  to `0` when the corresponding field is absent from frontmatter.
+- `routingTargets` is an empty array (not null) when `deciders` is absent.
+
+---
+
+## 5. ItemFinding — Entity
+
+One or more `ItemFinding`s may be attached to a `QueueItem` that has
+incompleteness or inconsistency.
+
+```typescript
+interface ItemFinding {
+  code: string;        // from closed list: item.tier-absent, item.review-by-before-queued, item.deciders-empty
+  severity: "info" | "warn";  // never "error" for ItemFindings
+  message: string;     // human-readable; exact templates in research.md §R2
+}
+```
+
+**Closed codes**: see [research.md §R2](./research.md) for generation conditions,
+exact message templates, and severity rationale.
+
+**Sorting**: within a QueueItem, `itemFindings` are sorted by:
+`code` (code-unit) → severity rank (`error=0, warn=1, info=2`) → `message` (code-unit).
+
+---
+
+## 6. CorpusFinding — Entity
+
+One `CorpusFinding` per error-severity finding from `lintCorpus()` for any file
+that could not be parsed into a valid, queue-processable `Adr` record (or any
+file that failed cross-field invariant validation).
+
+```typescript
+interface CorpusFinding {
+  sourcePath: string;  // repo-relative, forward slashes
+  code: string;        // from closed list: corpus.read-error, corpus.parse-error,
+                       //   corpus.schema-invalid, corpus.one-way-door-auto-tier
+  severity: "error";   // always "error"; corpus findings are always blocking
+  message: string;     // human-readable; see research.md §R2
+}
+```
+
+**Mapping from core `Finding.rule` to `CorpusFinding.code`**:
+
+| Core `Finding.rule` | `CorpusFinding.code` |
+|---------------------|----------------------|
+| `file-read` | `corpus.read-error` |
+| `frontmatter-parse` | `corpus.parse-error` |
+| `frontmatter-fence` | `corpus.parse-error` |
+| `one-way-door-disallows-auto` | `corpus.one-way-door-auto-tier` |
+| `required-field` | `corpus.schema-invalid` |
+| `invalid-type` | `corpus.schema-invalid` |
+| `invalid-enum-value` | `corpus.schema-invalid` |
+| `invalid-format` | `corpus.schema-invalid` |
+| `invalid-size` | `corpus.schema-invalid` |
+| `strict-unknown-key` | `corpus.schema-invalid` |
+| `unique-items` | `corpus.schema-invalid` |
+| `contract-refinement` | `corpus.schema-invalid` |
+| `superseded-requires-supersededBy` | `corpus.schema-invalid` |
+| `supersededBy-requires-superseded-status` | `corpus.schema-invalid` |
+| `accepted-requires-decider-unless-imported` | `corpus.schema-invalid` |
+| `agent-accepted-requires-ratifier` | `corpus.schema-invalid` |
+| *(any unknown future rule)* | `corpus.schema-invalid` (fallback) |
+
+**Scope**: only files that are excluded from `lintCorpus().records` (i.e., files
+whose `Adr.path` does NOT appear in `records`) are projected into CorpusFindings.
+Schema-valid `records` that have lint findings (warn/info severity) are NOT added
+to `corpusFindings` — their lint findings are ignored by the queue (the queue
+focuses on queue-specific item findings, not general lint).
+
+**Sorting**: `sourcePath` (code-unit) → `code` (code-unit) → severity rank → `message` (code-unit).
+
+---
+
+## 7. QueueReport — Entity
+
+The top-level output of the queue kernel. One QueueReport per invocation.
+
+```typescript
+interface QueueReport {
+  version: "1";                 // literal string "1"; never a number
+  asOf: string;                 // "YYYY-MM-DD" UTC calendar date (caller-supplied)
+  corpusFingerprint: string;    // lowercase hex SHA-256, 64 chars; see §8
+  totalItems: number;           // items.length
+  totalCorpusFindings: number;  // corpusFindings.length
+  itemsWithFindings: number;    // count of items where itemFindings.length > 0
+  items: QueueItem[];           // ordered per research.md §R6
+  corpusFindings: CorpusFinding[];  // ordered per research.md §R6
+}
+```
+
+**`version`**: `"1"` is the first and current report version. The integer will
+increment (as a string literal) if the shape changes incompatibly in a future
+version. Consumers should check `version === "1"` before parsing.
+
+---
+
+## 8. Corpus Fingerprint Algorithm
+
+The `corpusFingerprint` is a lowercase hex-encoded SHA-256 of a canonical JSON
+projection of the corpus state. It enables detection of corpus changes between
+runs.
+
+**Projection**:
+
+```typescript
+const projection = {
+  records: sortedRecords.map(r => ({
+    sourcePath: r.path,
+    frontmatter: r.frontmatter,  // full AdrFrontmatter object
+    body: r.body                 // markdown body string
+  })),
+  corpusFindings: sortedRawFindings, // canonical ordering of original core Finding[] from lintCorpus()
+                                     // NOTE: this is Finding[], NOT the queue-mapped CorpusFinding[]
+                                    // It includes ALL findings (error, warn, info) for ALL files —
+                                    // both excluded files and schema-valid records with lint findings.
+  corpusHealth: {
+    recordCount: lintResult.records.length,
+    excludedCount: lintResult.checked - lintResult.records.length
+  }
+}
+```
+
+**Finding ordering for fingerprint**: `sortFindingsCanonical(lintResult.findings)` —
+canonical sort by `(rule, id, pattern, path, field, message)` using code-unit order.
+This sorts ALL findings from lintCorpus, including both excluded-file error findings
+AND schema-valid record warn/info findings. The fingerprint therefore reflects any
+corpus-level lint issues even for records that remain in `items`.
+
+**Record ordering for fingerprint**: by `(id, sourcePath)` ascending (code-unit)
+via `sortByIdThenPath`. This ordering is independent of the QueueReport `items`
+sort order; it is used only for fingerprint stability.
+
+**Canonical serialization**: `canonicalStringify(projection)` — a locale-
+independent JSON serializer that:
+1. Sorts all object keys at every level alphabetically by code-unit order.
+2. Serializes arrays in their given order (no sorting of array elements).
+3. Produces a compact (no whitespace) JSON string.
+4. Encodes to UTF-8.
+
+**SHA-256**: `crypto.createHash('sha256').update(canonicalJson, 'utf8').digest('hex')`.
+Lowercase hex output (Node.js `digest('hex')` default).
+
+**Source**: `fingerprintOf()` function in
+`packages/core/src/fingerprint/index.ts` (promoted from `@adrkit/mcp`). Identical
+algorithm and output to the existing MCP implementation.
+
+---
+
+## 9. QueueKernelInput — Entry Point Type
+
+The kernel exposes a single pure function:
+
+```typescript
+function buildQueueReport(input: QueueKernelInput): QueueReport
+```
+
+```typescript
+interface QueueKernelInput {
+  corpus: LintCorpusResult;  // direct result from lintCorpus(); no pre-processing by caller
+  asOf: string;              // "YYYY-MM-DD" UTC calendar date; no ambient clock
+}
+
+// LintCorpusResult (from @adrkit/core lintCorpus return type):
+// { records: Adr[]; findings: Finding[]; checked: number }
+```
+
+**Caller responsibilities**:
+- Invoke `lintCorpus()` with the caller-supplied corpus directory and pass the
+  result as `corpus`. No pre-mapping, no pre-fingerprinting required.
+- Resolve the UTC calendar date for `asOf` (from CLI flag, from Action input, or
+  from `new Date().toISOString().slice(0,10)` at the CLI boundary). Do NOT pass
+  in a clock function — compute the date before calling the kernel.
+
+**Kernel responsibilities** (all internal — no caller pre-computation required):
+- Filter `corpus.records` to only `proposed`-status records.
+- Map `corpus.findings` for **excluded files only** to `CorpusFinding[]`.
+  (Schema-valid records with warn/info lint findings are NOT in CorpusFindings.)
+- Compute `slaState`, `deadlineDate`, all counts, and `itemFindings` for each item.
+- Sort items and corpusFindings deterministically.
+- Compute `corpusFingerprint` internally:
+  `fingerprintOf(sortByIdThenPath(corpus.records), sortFindingsCanonical(corpus.findings), corpus.records.length, corpus.checked - corpus.records.length)`
+  — using the **full** `corpus.findings` (all findings, not just excluded-file ones).
+- Return the complete `QueueReport`.
+
+**Purity**: The kernel has no access to filesystem, network, or ambient clock.
+Node.js `crypto.createHash('sha256')` is deterministic and has no observable
+side effects; it is acceptable in the pure kernel.
+
+---
+
+## 10. Entity Relationship Summary
+
+```
+QueueReport 1 ─── * QueueItem
+QueueReport 1 ─── * CorpusFinding
+QueueItem   1 ─── * ItemFinding
+
+QueueReport.asOf             (caller-supplied, UTC calendar date)
+QueueReport.corpusFingerprint (computed by kernel from lintCorpus Finding[])
+QueueItem ← derived from Adr (proposed status, schema-valid)
+CorpusFinding ← derived from Finding (excluded files only; NOT schema-valid record lint findings)
+```
+
+An ADR file is one of:
+- **Excluded** (unreadable, parse-fail, or schema-invalid) → appears in
+  `corpusFindings`, never in `items`; findings included in fingerprint input.
+- **Schema-valid non-proposed** → ignored by the queue (not in `items`, not in
+  `corpusFindings`); but any lint findings ARE included in fingerprint input.
+- **Schema-valid proposed** → appears in `items` as a `QueueItem`; any lint
+  findings appear as `itemFindings` in the item; all findings included in fingerprint input.

--- a/specs/007-arb-queue/plan.md
+++ b/specs/007-arb-queue/plan.md
@@ -167,7 +167,7 @@ packages/
 └── ci/
     ├── src/
     │   ├── queue-issue.ts       # managedQueueIssue() — pure logic; GitHubQueueClient port
-    │   ├── queue-github-client.ts # side-effect-free Octokit adapter; pagination + PR filtering
+    │   ├── queue-github-client.ts # side-effect-free GraphQL issue adapter; cursor pagination
     │   └── queue-action-entrypoint.ts  # createOctokitQueueClient() + entrypoint; @actions/* confined here
     ├── queue/
     │   └── action.yml           # GitHub Action manifest for the queue surface

--- a/specs/007-arb-queue/plan.md
+++ b/specs/007-arb-queue/plan.md
@@ -1,0 +1,258 @@
+# Implementation Plan: ARB Operations Queue — Phase 6
+
+**Feature directory**: `007-arb-queue` | **Implementation branch**:
+`feat/phase-6-arb-queue` | **Date**: 2026-07-20 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/007-arb-queue/spec.md` (Functional
+Requirements FR-001–FR-023, Success Criteria SC-001–SC-008, Assumptions A1–A11).
+**Normative sources** (ADRs win on conflict):
+[ADR-0001](../../docs/adr/0001-record-architecture-decisions-in-git.md) (git is
+truth; the queue is a derived, stateless, read-only projection — never writes
+decision content),
+[ADR-0002](../../docs/adr/0002-typed-frontmatter-as-madr-superset.md) (typed schema:
+`review.tier`, `review.queuedAt`, `review.slaDays`, `review.escalatedAt`,
+`review.decidedAt`, `review.quorum`, `review.approvals`, `review.objections`,
+`reviewBy`, and the `one-way-door + tier:auto` cross-field invariant),
+[ADR-0004](../../docs/adr/0004-git-is-source-of-truth-database-is-an-index.md) (queue
+is a derived, rebuildable projection; no Postgres, no persistent index),
+[ADR-0005](../../docs/adr/0005-deterministic-first-evaluator-with-declarative-escalation.md)
+(the evaluator routes, never approves; `auto` tier means expedited routing, not
+automated acceptance),
+[ADR-0007](../../docs/adr/0007-adapter-isolation-and-public-surface-build.md) (adapter
+isolation; clean-clone build; queue surface is first-party, not an adapter),
+[ADR-0010](../../docs/adr/0010-bun-toolchain.md) (Bun for development; Node-targeted
+published artifacts), and
+[`.specify/memory/constitution.md`](../../.specify/memory/constitution.md)
+Principles I–V (v1.0.2).
+
+> ⏳ **Phase 6 scoped; implementation not yet started.** Scoping (spec → plan →
+> tasks) is permitted now that Phase 5 / rung 5 is landed (PR #19, v0.2.0).
+> Task generation and implementation may proceed on the basis of this plan.
+> **Rung 6 may not be claimed as landed** until SC-004 clears: a team that is
+> not the maintainer's own completes a separate-repository dogfood with the full
+> exit criteria from FR-019 (Assumption A7). SC-004 is the *exit/release gate*,
+> not a pre-implementation gate.
+
+## Summary
+
+Build the **deterministic ARB operations queue**: a read-only projection of the local
+ADR corpus that makes existing typed `review` frontmatter observable as a
+continuously current, actionable workflow artifact. The deliverable has two surfaces:
+
+1. **CLI** (`adr queue`): a local read command that accepts `--format markdown|json`
+   (default `markdown`) and an optional `--as-of` date, emits the queue report to
+   stdout, and exits non-zero only when the report contains `error`-severity findings.
+
+2. **GitHub Action** (`packages/ci/queue/action.yml`): an operational surface that
+   creates or updates exactly one dedicated GitHub issue using `GITHUB_TOKEN` with
+   `issues: write`, locating the issue via a stable hidden ownership marker embedded
+   in the issue body, updating it in place on every run, and failing after writing
+   when the report contains errors.
+
+The **pure queue kernel** (`@adrkit/core`) is a single pure function
+`buildQueueReport({corpus: LintCorpusResult, asOf: string})` — it accepts a
+caller-loaded corpus snapshot and an explicit `asOf` UTC calendar date, internally
+maps excluded-file findings to `CorpusFinding[]`, computes the canonical corpus
+fingerprint (via promoted `fingerprintOf`/`canonicalStringify`), and returns the
+complete `QueueReport`. No ambient clock, no network, no filesystem traversal inside
+the kernel; Node.js `crypto` (SHA-256) is deterministic and acceptable. The CLI
+wraps the kernel with corpus loading and formatting; the Action wraps it identically.
+
+The canonical corpus fingerprint helpers (`canonicalStringify`, `fingerprintOf`,
+`compareCodeUnits`, and canonical ordering functions) are promoted from `@adrkit/mcp`
+to `@adrkit/core`. The fingerprint input uses the original core `Finding[]` from
+`lintCorpus` (not queue-mapped `CorpusFinding[]`), matching the MCP fingerprint
+exactly for the same corpus projection.
+
+The canonical JSON and Markdown formatters (`formatQueueReportJson`,
+`formatQueueReportMarkdown`) live in `@adrkit/core` (`queue/format.ts`), consumed
+by both the CLI and the Action. No `@adrkit/ci` → `@adrkit/cli` dependency exists.
+
+## Technical Context
+
+**Language/Version**: TypeScript targeting Node ≥22; Bun 1.3.14 for
+development/build/test; `bun.lock` frozen.
+
+**Primary Dependencies**: `zod@^4` (already workspace-level); `@actions/core@^1.11.1`,
+`@actions/github@^6.0.1` (already in `@adrkit/ci`). No new runtime dependencies.
+
+**Storage**: None. The queue is a stateless, read-only projection rebuilt from the
+local ADR corpus on every invocation. No database, no persistent index, no tracked
+report files.
+
+**Testing**: `bun test` (all test files `*.test.ts`). Unit tests for kernel + sorting
++ finding-code mapping; integration tests against fixture corpora; contract tests for
+CLI stdout/exit codes; fake `GitHubQueueClient` interface for Action tests (no token,
+no network); bundle smoke test (Node 22 + 24 installed-tarball); static import-graph
+check (`check:deps`) to assert kernel has no adapter dependencies.
+
+**Target Platform**: Node ≥22, cross-platform (Linux/macOS/Windows). GitHub Actions
+runner: `ubuntu-latest` (node24 runtime in `action.yml`).
+
+**Project Type**: Multi-package workspace feature — pure library addition to
+`@adrkit/core`, CLI subcommand addition to `@adrkit/cli`, Action entry addition to
+private `@adrkit/ci` (new `queue/` subdirectory).
+
+**Constraints**: No ambient clock in kernel (Principle IV, FR-004). No network after
+frozen install (Principle II). No GitHub API access except in the Action adapter and
+its tests via a fake client. `core-has-no-adapter-deps` gate must remain green.
+All queue outputs are byte-for-byte deterministic for identical inputs (SC-001).
+
+**Scale/Scope**: Single-repository operation; 10–100 ADR files is the expected range.
+No multi-repository federation.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design below.*
+
+### Pre-Design Check (initial)
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| **I. Git Is the Source of Truth** | ✅ PASS | Queue is a read-only derived projection. Managed GitHub issue body is the Action's output — not a decision record. No ADR file is ever written. |
+| **II. Clean Clone Builds Green** | ✅ PASS | Kernel and CLI: pure, offline, credential-free. Action: GitHub API via injected fake client in tests; no token or network required in test suite. Production Action uses `GITHUB_TOKEN` at runtime only, not at build/test time. |
+| **III. Core Depends on No Adapter** | ✅ PASS | Queue kernel and canonical formatters live in `@adrkit/core`. Both CLI and Action consume `format.ts` from core — no `@adrkit/ci` → `@adrkit/cli` dependency. `@adrkit/ci` queue Action imports `@adrkit/core` (allowed: `@adrkit/ci` is already an adapter-layer consumer). `@adrkit/core` imports nothing from `@adrkit/ci`, `@adrkit/mcp`, or any adapter. The `core-has-no-adapter-deps` CI gate is unaffected. |
+| **IV. Deterministic Before Probabilistic** | ✅ PASS | Kernel is a pure function (corpus snapshot + asOf → QueueReport). No model calls, no ambient clock, no probabilistic step. `auto` tier = expedited routing, never automated acceptance (ADR-0005). |
+| **V. The Schema Is the Contract** | ✅ PASS | Queue reads the existing `AdrFrontmatter` schema; it does not add new Zod fields. `QueueReport` v1 JSON shape is a new, separately-versioned contract defined in `contracts/queue-report.md`. No change to `schema/adr.schema.json`; `schema:emit` gate unaffected. |
+
+No violations. Complexity Tracking table is empty.
+
+### Post-Design Check (after Phase 1)
+
+Re-evaluated after design artifacts are generated — see end of plan. All checks
+remain PASS. See Complexity Tracking (empty — no violations).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-arb-queue/
+├── plan.md              # This file (speckit.plan output)
+├── research.md          # Phase 0 output — all decisions resolved
+├── data-model.md        # Phase 1 output — entities, types, finding-code mapping
+├── quickstart.md        # Phase 1 output — runnable validation scenarios
+└── contracts/
+    ├── cli-contract.md     # CLI syntax, flags, exit-code matrix, stdout/stderr
+    ├── queue-report.md     # QueueReport v1 JSON shape + Markdown canonical layout
+    ├── kernel.md           # Pure kernel function signature and types
+    └── github-action.md    # action.yml surface, GitHubQueueClient, state machine, error matrix
+```
+
+### Source Code (repository root)
+
+```text
+packages/
+├── core/
+│   ├── src/
+│   │   ├── queue/
+│   │   │   ├── types.ts         # QueueItem, QueueReport, SlaState, *Finding interfaces + SLA_STATE_URGENCY_ORDER
+│   │   │   ├── kernel.ts        # buildQueueReport() — pure, zero-clock, zero-network; computes fingerprint internally
+│   │   │   ├── sort.ts          # deterministic item/finding orderings
+│   │   │   ├── findings.ts      # finding-code mapping from core Finding.rule → CorpusFinding.code (excluded files only)
+│   │   │   └── format.ts        # formatQueueReportJson() + formatQueueReportMarkdown() — canonical serializers
+│   │   ├── fingerprint/
+│   │   │   └── index.ts         # canonicalStringify() + fingerprintOf() — promoted from @adrkit/mcp
+│   │   ├── ordering/
+│   │   │   └── index.ts         # compareCodeUnits() + compareFindings() + sort helpers — promoted from @adrkit/mcp
+│   │   └── index.ts             # +export queue/*, fingerprint/*, ordering/*
+│   └── test/
+│       └── fixtures/queue/      # canonical ADR fixture corpora for kernel + CLI integration tests
+│
+├── cli/
+│   └── src/
+│       ├── queue.ts             # runQueue() — corpus loading, date resolution, calls core formatters, exit code
+│       └── index.ts             # +register 'queue' command
+│
+└── ci/
+    ├── src/
+    │   ├── queue-issue.ts       # managedQueueIssue() — pure logic; GitHubQueueClient port
+    │   ├── queue-github-client.ts # side-effect-free Octokit adapter; pagination + PR filtering
+    │   └── queue-action-entrypoint.ts  # createOctokitQueueClient() + entrypoint; @actions/* confined here
+    ├── queue/
+    │   └── action.yml           # GitHub Action manifest for the queue surface
+    ├── dist/
+    │   └── queue-action.js      # bundled Node24 entrypoint
+    └── package.json             # +new "./queue-action" build target (not a public npm export)
+
+packages/core/test/
+├── queue/
+│   ├── kernel.test.ts           # Unit: slaState precedence, item orderings, finding generation, fingerprint
+│   ├── sort.test.ts             # Unit: deterministic sort stability and all edge cases
+│   ├── findings.test.ts         # Unit: Finding.rule → CorpusFinding.code mapping (excluded files only)
+│   └── format.test.ts           # Unit: JSON/Markdown serialization byte-for-byte determinism
+├── fingerprint/
+│   └── fingerprint.test.ts      # Unit + compat: promoted function produces same bytes as old MCP code
+└── ordering/
+    └── ordering.test.ts         # Unit: compareCodeUnits, compareFindings, sort helpers
+
+packages/cli/test/
+└── queue.test.ts                 # Integration: CLI stdout/exit codes against packages/core/test/fixtures/queue/
+
+packages/ci/test/
+└── queue-issue.test.ts           # Unit: GitHubQueueClient fake; all state-machine transitions
+```
+
+**Structure Decision**: Pure kernel in `@adrkit/core`; CLI wrapper in `@adrkit/cli`;
+Action adapter in `@adrkit/ci/queue/`. No new public package. See research.md §R1
+for full rationale and alternatives considered.
+
+## Phase 0: Research
+
+Research artifacts are in [research.md](./research.md). All NEEDS CLARIFICATION items
+are resolved. Summary of binding decisions:
+
+- **R1 Package placement**: `@adrkit/core` + `@adrkit/cli` + `@adrkit/ci/queue/`
+- **R2 Finding codes**: Closed list of 4 CorpusFinding codes + 3 ItemFinding codes; see research.md §R2
+- **R3 QueueReport shape**: Fully typed; see contracts/queue-report.md
+- **R4 CLI syntax**: `adr queue [--dir] [--as-of] [--format]`; see contracts/cli-contract.md
+- **R5 Action surface**: `packages/ci/queue/action.yml`; marker constant `<!-- adrkit-managed-queue-issue -->`; see contracts/github-action.md
+- **R6 Sorting**: urgency group → deadline → queuedAt → id; see research.md §R6
+- **R7 Test strategy**: unit + integration + fake-client + bundle-smoke + dependency-graph; see research.md §R7
+- **R8 Constitution**: All five principles PASS; see Constitution Check above
+- **R9 Primitive reuse**: `canonicalStringify`/`fingerprintOf`/`compareCodeUnits`/`compareFindings`/`sortFindingsCanonical`/`sortByIdThenPath` promoted to `@adrkit/core`; MCP migrates imports; fingerprint input uses original core `Finding[]` (not queue-mapped `CorpusFinding[]`)
+- **R10 Status drift**: Phase 5 merged, v0.2.0 published; Phase 6 scoped only; rung-6 gate preserved
+
+## Phase 1: Design Artifacts
+
+All Phase 1 artifacts are generated:
+
+- **[data-model.md](./data-model.md)**: Entity definitions for `QueueItem`, `SlaState`,
+  `ItemFinding`, `CorpusFinding`, `QueueReport`; SLA deadline computation algorithm;
+  finding-code → rule mapping table; timestamp normalization rule.
+- **[contracts/queue-report.md](./contracts/queue-report.md)**: `QueueReport` v1 JSON
+  shape with full TypeScript types, nullability annotations, summary count semantics,
+  canonical serialization (key order, undefined omission, UTF-8, final newline), corpus
+  fingerprint definition, and Markdown canonical layout with escaping and empty states.
+- **[contracts/cli-contract.md](./contracts/cli-contract.md)**: `adr queue` syntax,
+  flag defaults, invalid-input behavior, stdout/stderr assignment, and exit-code matrix.
+- **[contracts/kernel.md](./contracts/kernel.md)**: Pure kernel function signature,
+  `QueueKernelInput` type, pureness assertions, and caller responsibilities.
+- **[contracts/github-action.md](./contracts/github-action.md)**: `action.yml`
+  inputs/defaults/outputs, `GitHubQueueClient` interface, marker constant, paginated
+  issue discovery algorithm, state-machine transitions, error matrix, no-partial-write
+  rule, and permissions documentation.
+- **[quickstart.md](./quickstart.md)**: Runnable validation scenarios for CLI and
+  Action with fixture corpus setup, expected outputs, and rung-6 exit criteria.
+
+## Constitution Check (Post-Design)
+
+| Principle | Final Status | Notes |
+|-----------|-------------|-------|
+| **I** | ✅ PASS | Queue read-only; Action writes only the managed issue body and its state; no ADR record or tracked file is ever modified. |
+| **II** | ✅ PASS | Kernel is offline by construction. CLI corpus loading uses existing `lintCorpus`. Action's `@actions/github` call is gated behind `GitHubQueueClient` interface — tests use the fake, no token required. |
+| **III** | ✅ PASS | `canonicalStringify`/`fingerprintOf` promoted to `@adrkit/core` are pure, network-free functions with no adapter dependency. `@adrkit/ci` depends on `@adrkit/core` (allowed; already true). `@adrkit/core` does not import anything from `@adrkit/ci`, `@adrkit/mcp`, or `@adrkit/evaluator`. |
+| **IV** | ✅ PASS | Kernel has no ambient clock. CLI resolves the current UTC date only at its boundary and surfaces it in output; the Action does the same. The kernel may normalize explicit caller-supplied/frontmatter timestamps but never reads current time. `auto` tier: labeled as expedited routing in all outputs; never as acceptance. |
+| **V** | ✅ PASS | No change to `AdrFrontmatter` Zod schema or emitted JSON Schema. `QueueReport` v1 is a new, independently-versioned report contract (version field: `"1"`), not part of the ADR frontmatter schema. |
+
+## Complexity Tracking
+
+> No Constitution Check violations. This table is intentionally empty.
+
+## Phase 2: Task Generation
+
+Tasks are ready to be generated with `/speckit.tasks`. All design artifacts are
+complete. **Rung 6 may not be claimed as landed** until SC-004 clears: a
+separate-team, separate-repository dogfood must pass the full FR-019 exit criteria
+(Assumption A7). That is an *exit/release gate* — it does not block task generation
+or implementation work.

--- a/specs/007-arb-queue/plan.md
+++ b/specs/007-arb-queue/plan.md
@@ -251,8 +251,8 @@ All Phase 1 artifacts are generated:
 
 ## Phase 2: Task Generation
 
-Tasks are ready to be generated with `/speckit.tasks`. All design artifacts are
-complete. **Rung 6 may not be claimed as landed** until SC-004 clears: a
+Task generation is complete: [tasks.md](./tasks.md) defines T001–T049. All design
+artifacts are complete. **Rung 6 may not be claimed as landed** until SC-004 clears: a
 separate-team, separate-repository dogfood must pass the full FR-019 exit criteria
 (Assumption A7). That is an *exit/release gate* — it does not block task generation
 or implementation work.

--- a/specs/007-arb-queue/quickstart.md
+++ b/specs/007-arb-queue/quickstart.md
@@ -22,9 +22,9 @@ bun run typecheck              # no type errors
 
 ## Fixture Corpus Setup
 
-The validation scenarios use a local fixture corpus. The following script
-creates a minimal ADR directory under `/tmp/adrkit-queue-test/` with ADRs
-spanning all seven SLA states plus invalid-file cases.
+The validation scenarios use the committed comprehensive fixture corpus. The following
+script copies it to an isolated directory under `/tmp` with records spanning all seven
+SLA states plus invalid-file cases.
 
 A full fixture corpus definition (with frontmatter content for each state)
 is maintained at `packages/core/test/fixtures/queue/`. The test suite loads
@@ -33,10 +33,9 @@ and point `--dir` at it.
 
 ```bash
 CORPUS=/tmp/adrkit-queue-test
-mkdir -p $CORPUS
-
-# See packages/core/test/fixtures/queue/ for canonical ADR YAML content.
-# Each file is described by the scenario below that uses it.
+rm -rf "$CORPUS"
+mkdir -p "$CORPUS"
+cp packages/core/test/fixtures/queue/comprehensive-corpus/*.md "$CORPUS"/
 ```
 
 ---

--- a/specs/007-arb-queue/quickstart.md
+++ b/specs/007-arb-queue/quickstart.md
@@ -1,0 +1,418 @@
+# Quickstart Validation Guide: ARB Operations Queue — Phase 6
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Date**: 2026-07-20
+
+This guide provides runnable validation scenarios that prove the queue feature
+works end-to-end. It is a validation/run guide, NOT an implementation guide —
+details of the kernel, CLI flags, and Action configuration live in the
+[`contracts/`](./contracts/) directory.
+
+---
+
+## Prerequisites
+
+```bash
+# From repository root
+bun install --frozen-lockfile  # must succeed offline after first install
+bun run build                  # builds all packages including queue
+bun run typecheck              # no type errors
+```
+
+---
+
+## Fixture Corpus Setup
+
+The validation scenarios use a local fixture corpus. The following script
+creates a minimal ADR directory under `/tmp/adrkit-queue-test/` with ADRs
+spanning all seven SLA states plus invalid-file cases.
+
+A full fixture corpus definition (with frontmatter content for each state)
+is maintained at `packages/core/test/fixtures/queue/`. The test suite loads
+from there. For manual quickstart scenarios, create the fixture directory
+and point `--dir` at it.
+
+```bash
+CORPUS=/tmp/adrkit-queue-test
+mkdir -p $CORPUS
+
+# See packages/core/test/fixtures/queue/ for canonical ADR YAML content.
+# Each file is described by the scenario below that uses it.
+```
+
+---
+
+## CLI Validation Scenarios
+
+### QS-CLI-01: Basic JSON output — happy path
+
+**Scenario**: A corpus with one `proposed` record, `queuedAt` in the past,
+`slaDays: 14`, no `decidedAt`. `asOf` is computed to be 7 days after
+`queuedAt`. Expect one `within-sla` item.
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/within-sla-corpus \
+  --as-of 2026-01-08 \
+  --format json
+```
+
+**Expected behavior**:
+- Exit code: `0`
+- Stdout: valid JSON matching `QueueReport` v1 schema (see
+  [contracts/queue-report.md](./contracts/queue-report.md))
+- `version: "1"`, `asOf: "2026-01-08"`
+- `items` array has exactly 1 entry
+- `items[0].slaState: "within-sla"`
+- `items[0].deadlineDate`: `queuedAt_date + 14 days`
+- `totalCorpusFindings: 0`
+- Final newline check:
+
+  ```bash
+  bun run adr -- queue \
+    --dir packages/core/test/fixtures/queue/within-sla-corpus \
+    --as-of 2026-01-08 \
+    --format json > /tmp/run1.json
+  # Verify final newline: last byte is 0x0a
+  tail -c1 /tmp/run1.json | od -An -tx1 | grep -q '0a' && echo "OK: final newline present"
+  ```
+
+### QS-CLI-02: Markdown output — default format
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/within-sla-corpus \
+  --as-of 2026-01-08
+```
+
+**Expected behavior**:
+- Exit code: `0`
+- Stdout: Markdown beginning with `# ARB Queue — 2026-01-08`
+- `## Queue Items` section present with table
+- `## Corpus Findings` section absent (no corpus findings)
+- Final newline
+
+### QS-CLI-03: Overdue item
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/overdue-corpus \
+  --as-of 2026-03-01 \
+  --format json
+```
+
+**Expected behavior**:
+- Exit code: `0` (no error-severity findings)
+- `items[0].slaState: "overdue"`
+- `items[0].deadlineDate` is before `2026-03-01`
+
+### QS-CLI-04: Due item (deadline equals asOf)
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/due-corpus \
+  --as-of 2026-02-15 \
+  --format json
+```
+
+**Expected behavior**:
+- Exit code: `0`
+- `items[0].slaState: "due"`
+- `items[0].deadlineDate: "2026-02-15"`
+
+### QS-CLI-05: Missing SLA (queuedAt present, no deadline computable)
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/missing-sla-corpus \
+  --as-of 2026-01-08 \
+  --format json
+```
+
+**Expected behavior**:
+- Exit code: `0`
+- `items[0].slaState: "missing-sla"`
+- `items[0].deadlineDate: null`
+- `items[0].queuedAt`: non-null (must be present for missing-sla state)
+
+### QS-CLI-06: Decided item
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/decided-corpus \
+  --as-of 2026-01-08 \
+  --format json
+```
+
+**Expected behavior**:
+- Exit code: `0`
+- `items[0].slaState: "decided"`
+- `items[0].decidedAt`: non-null
+
+### QS-CLI-07: Escalated item (escalatedAt, no decidedAt)
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/escalated-corpus \
+  --as-of 2026-01-08 \
+  --format json
+```
+
+**Expected behavior**:
+- Exit code: `0`
+- `items[0].slaState: "escalated"`
+- `items[0].escalatedAt`: non-null
+- `items[0].decidedAt: null`
+
+### QS-CLI-08: Not-queued item (no review block)
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/not-queued-corpus \
+  --as-of 2026-01-08 \
+  --format json
+```
+
+**Expected behavior**:
+- Exit code: `0`
+- `items[0].slaState: "not-queued"`
+- `items[0].queuedAt: null`
+
+### QS-CLI-09: Schema-invalid file → corpus finding + exit 1
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/schema-invalid-corpus \
+  --as-of 2026-01-08 \
+  --format json
+```
+
+**Expected behavior**:
+- Exit code: `1`
+- Stdout: complete JSON report (report IS emitted even on error exit)
+- `corpusFindings` non-empty; at least one entry with `code: "corpus.schema-invalid"` and `severity: "error"`
+- `items` may be empty or contain other valid proposed records
+
+### QS-CLI-10: One-way-door + auto tier cross-invariant → corpus finding + exit 1
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/one-way-door-auto-corpus \
+  --as-of 2026-01-08 \
+  --format json
+```
+
+**Expected behavior**:
+- Exit code: `1`
+- `corpusFindings[0].code: "corpus.one-way-door-auto-tier"`
+- `corpusFindings[0].severity: "error"`
+- Message contains both `one-way-door` and `auto`
+
+### QS-CLI-11: Determinism — two runs produce identical bytes
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/within-sla-corpus \
+  --as-of 2026-01-08 \
+  --format json > /tmp/run1.json
+
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/within-sla-corpus \
+  --as-of 2026-01-08 \
+  --format json > /tmp/run2.json
+
+diff /tmp/run1.json /tmp/run2.json
+echo "diff exit: $?"  # must be 0 (identical)
+```
+
+**Expected behavior**: `diff` exits `0`; no output.
+
+### QS-CLI-12: Timezone normalization
+
+```bash
+# +05:00 datetime that is 2026-01-07 in UTC
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/within-sla-corpus \
+  --as-of "2026-01-08T01:00:00+05:00" \
+  --format json | bun -e "
+    const chunks = [];
+    for await (const c of Bun.stdin.stream()) chunks.push(c);
+    const d = JSON.parse(Buffer.concat(chunks).toString());
+    console.log(d.asOf);
+  "
+```
+
+**Expected output**: `2026-01-07` (UTC normalization: `2026-01-08T01:00:00+05:00`
+= `2026-01-07T20:00:00Z`)
+
+### QS-CLI-13: Invalid `--format` value → exit 2, no report
+
+```bash
+bun run adr -- queue --format csv > /tmp/out.txt 2>/tmp/err.txt; echo "exit: $?"
+```
+
+**Expected behavior**:
+- `exit: 2`
+- `/tmp/out.txt` is empty
+- `/tmp/err.txt` contains usage message mentioning `--format`
+
+### QS-CLI-14: Invalid `--as-of` value → exit 2, no report
+
+```bash
+bun run adr -- queue --as-of "not-a-date" > /tmp/out.txt 2>/tmp/err.txt; echo "exit: $?"
+```
+
+**Expected behavior**:
+- `exit: 2`
+- `/tmp/out.txt` is empty
+- `/tmp/err.txt` contains error message
+
+### QS-CLI-15: Warning-only finding → exit 0
+
+```bash
+bun run adr -- queue \
+  --dir packages/core/test/fixtures/queue/warn-review-by-before-queued-corpus \
+  --as-of 2026-01-08 \
+  --format json
+echo "exit: $?"
+```
+
+**Expected behavior**:
+- `exit: 0` (warn findings do not trigger exit 1)
+- `items[0].itemFindings[0].code: "item.review-by-before-queued"`
+- `items[0].itemFindings[0].severity: "warn"`
+
+---
+
+## Action Validation Scenarios
+
+The Action scenarios require a real GitHub repository with a valid
+`GITHUB_TOKEN` granting `issues: write`. These scenarios are manual
+validation steps — they can be run during implementation to verify
+Action behaviour. QS-ACT-01 through QS-ACT-06 passing in a real
+repository is the prerequisite evidence for the rung-6 dogfood claim
+(SC-004), but SC-004 gates the *rung-6 landed claim*, not the
+implementation itself.
+
+**Setup**:
+```yaml
+# .github/workflows/queue-validate.yml
+name: Validate ARB Queue
+
+on:
+  workflow_dispatch:   # manual trigger for validation
+  push:
+    paths:
+      - 'docs/adr/**'
+
+jobs:
+  queue:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mbeacom/adrkit/packages/ci/queue@v0
+        with:
+          dir: docs/adr
+```
+
+### QS-ACT-01: First run — creates managed issue
+
+**Pre-condition**: No existing GitHub issues in the repository with the
+adrkit marker (`<!-- adrkit-managed-queue-issue -->`).
+
+**Run**: trigger `queue-validate.yml` manually.
+
+**Expected behavior**:
+- Action exits `0` (assuming no error-severity findings)
+- One new GitHub issue created in the repository
+- Issue title: `"ADR ARB Queue"` (or the `issue-title` input if overridden)
+- Issue body: Markdown queue report with marker comment in first line
+- Action log shows: `Created issue #<N>`
+- Step output `issue-number: <N>`
+
+### QS-ACT-02: Second run — updates same issue (idempotent)
+
+**Pre-condition**: QS-ACT-01 has run; issue `#N` is open.
+
+**Run**: trigger `queue-validate.yml` a second time (no ADR changes needed).
+
+**Expected behavior**:
+- Action exits `0`
+- Issue `#N` body is updated (potentially identical content if corpus unchanged)
+- No new issues created
+- `issue-number: <N>` (same issue number as QS-ACT-01)
+
+### QS-ACT-03: Closed managed issue — reopened and updated
+
+**Pre-condition**: Manually close the managed issue `#N` after QS-ACT-01.
+
+**Run**: trigger `queue-validate.yml`.
+
+**Expected behavior**:
+- Action exits `0`
+- Issue `#N` is reopened (state: `open`) and body is updated
+- No new issue created
+- `issue-number: <N>`
+
+### QS-ACT-04: Error findings → issue updated, action fails
+
+**Pre-condition**: Temporarily add a schema-invalid ADR file to `docs/adr/`
+(e.g., missing required `id` field) and commit it.
+
+**Run**: trigger `queue-validate.yml`.
+
+**Expected behavior**:
+- Action exits `1` (non-zero; job fails)
+- Managed issue IS updated with the full error report (not skipped)
+- `corpusFindings` visible in the issue body
+- Issue body includes the schema-invalid finding
+
+**Cleanup**: Remove the invalid ADR file after validation.
+
+### QS-ACT-05: Duplicate marker → action fails, no write
+
+**Pre-condition**: Manually create two additional GitHub issues (open or closed)
+with the marker `<!-- adrkit-managed-queue-issue -->` in their bodies.
+
+**Run**: trigger `queue-validate.yml`.
+
+**Expected behavior**:
+- Action exits `1`
+- Action log names all conflicting issue numbers
+- Neither existing issue body is modified (no write performed)
+
+**Cleanup**: Delete or edit the two extra issues to remove their markers.
+
+### QS-ACT-06: Default token, issues:write only — no PAT required
+
+**Verify**: The workflow uses only `GITHUB_TOKEN` (the default token
+automatically injected by GitHub Actions). No repository secret is needed
+beyond the built-in token.
+
+**Test**: remove the `token` input from `action.yml` usage (rely on default).
+The Action must still succeed (QS-ACT-01 or QS-ACT-02 scenario).
+
+---
+
+## Rung-6 Exit Criteria (SC-004)
+
+Implementation tasks may be generated and executed without SC-004 being cleared.
+SC-004 is the **exit gate for claiming rung 6 as landed / release-ready** — not
+a gate before implementation.
+
+Before calling Phase 6 "landed" and claiming rung 6, a team that is **not the
+maintainer's own** must complete the following dogfood exercise in a **separate
+repository**:
+
+- [ ] Repository contains at least 3 `proposed` ADRs spanning `auto`, `async`, and `arb` tiers
+- [ ] At least one ADR is overdue or at the due boundary as of the run date
+- [ ] At least one ADR has `approvals` and `objections` in its `review` block
+- [ ] `adr queue --format json` produces a valid `QueueReport` v1 JSON
+- [ ] The GitHub Action creates a managed issue on first run
+- [ ] The same managed issue is updated (not replaced) on a second run
+- [ ] Default `GITHUB_TOKEN` with `issues: write` is the only credential used
+- [ ] The external team reports no installation, runtime, or permission blockers
+
+Evidence must be documented and linked before closing SC-004.

--- a/specs/007-arb-queue/research.md
+++ b/specs/007-arb-queue/research.md
@@ -145,13 +145,13 @@ item.tier-absent:
   "review.tier is absent; routing tier cannot be determined — add review.tier: auto|async|arb to this record"
 
 item.review-by-before-queued:
-  "reviewBy ({reviewBy}) is before queuedAt ({queuedAt_utc_date}); SLA deadline may be inconsistent"
+  "reviewBy ({reviewBy}) is before queuedAt ({queuedAtDate}); SLA deadline may be inconsistent"
 
 item.deciders-empty:
   "deciders is empty; routing targets cannot be determined — add at least one decider identity to this record"
 ```
 
-Where `{reviewBy}` is the `reviewBy` field value as-is, and `{queuedAt_utc_date}`
+Where `{reviewBy}` is the `reviewBy` field value as-is, and `{queuedAtDate}`
 is the UTC calendar date derived from `review.queuedAt`.
 
 **Severity rationale**: `item.tier-absent` and `item.deciders-empty` are `info`
@@ -264,21 +264,20 @@ specification. Summary of binding decisions:
 - **Required permissions**: `issues: write` on the Action's own GitHub API calls.
   The *calling workflow* must declare `contents: read` (for `actions/checkout`)
   **plus** `issues: write`. Both must appear in the `permissions:` block — no PAT.
-- **Paginated issue discovery**: call `octokit.rest.issues.listForRepo` with
-  `state: 'open'`, `per_page: 100`, paginate until all pages exhausted; repeat
-  for `state: 'closed'`. Before applying marker or title logic, **filter out all
-  entries where `pull_request` is a non-null property** — GitHub's Issues API
-  returns pull requests from `listForRepo` and they must be excluded to avoid
-  false marker or title matches.
+- **Paginated issue discovery**: use the GitHub GraphQL repository `issues`
+  connection with `states: [OPEN, CLOSED]`, `first: 100`, and cursor pagination until
+  `hasNextPage` is false. This connection returns issues only, so pull requests never
+  enter marker/title logic. Do not use the Search API: its index is eventually
+  consistent and cannot safely prove that exactly zero, one, or multiple marker-owned
+  issues exist for a mutation decision.
 - **State machine**: 0 managed → title-conflict check → create; 1 open → update;
   1 closed → single atomic update (body + state: 'open' together); 2+ → fail
   (names all conflicting numbers, no write).
 - **Marker detection**: an issue is "managed" if and only if the marker
   `<!-- adrkit-managed-queue-issue -->` is **exactly the first line** of the issue
-  body — i.e., `body.startsWith(MARKER + '\n')` (multi-line body) OR
-  `body === MARKER` (marker-only body). Leading whitespace or any other content
-  before the marker disqualifies the issue. Do NOT use `body.includes(MARKER)` for
-  ownership detection.
+  body, determined by splitting on LF, CRLF, or CR and comparing the first line to
+  `MARKER`. Leading whitespace or any other content before the marker disqualifies the
+  issue. Do NOT use `body.includes(MARKER)` for ownership detection.
 - **Title conflict scope**: when no managed issue is found, the title conflict check
   examines both **open AND closed** unowned issues. If one or more unowned issues
   (not managed, not the managed issue being managed) have the configured title, the
@@ -415,8 +414,8 @@ implementation can claim completion:
 - **Fake `GitHubQueueClient`**: in-memory stub; no token, no network.
 - State machine: all 5 branches (0 managed + no title conflict, 0 managed + title
   conflict, 1 open, 1 closed, 2+ managed).
-- `listAllIssues()` stub returns both real issues AND entries with `pull_request`
-  property set; asserts PR entries are filtered before marker/title logic.
+- GraphQL adapter exhausts multiple cursors and returns open and closed issue nodes;
+  pull requests cannot appear in the repository `issues` connection.
 - First run creates issue with marker as **first line** of body.
 - Second run on same corpus updates same issue; issue count unchanged.
 - Closed managed issue: single `updateIssue({body, state:'open'})` call — one write,
@@ -428,8 +427,8 @@ implementation can claim completion:
 - Title conflict: unmanaged open issue with configured title → fail, no write.
 - Title conflict with unmanaged **closed** issue → also fail, no write.
 - Multiple unmanaged title conflicts: all named (ascending issue number), no write.
-- Body detection: marker at line 1 → managed; marker at line 2 → NOT managed;
-  body with leading whitespace then marker → NOT managed.
+- Body detection: marker at line 1 with LF or CRLF → managed; marker at line 2 →
+  NOT managed; body with leading whitespace then marker → NOT managed.
 - Marker in quoted text mid-body → NOT managed (first-line check only).
 
 ### Bundle + static boundary tests

--- a/specs/007-arb-queue/research.md
+++ b/specs/007-arb-queue/research.md
@@ -1,0 +1,596 @@
+# Research: ARB Operations Queue — Phase 6
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Date**: 2026-07-20
+
+This document resolves all planning decisions that must be settled before
+implementation. Every decision is verified against the existing repository
+source (`packages/core`, `packages/cli`, `packages/ci`, `packages/mcp`),
+the accepted ADRs, and the constitution. No item below carries a
+NEEDS CLARIFICATION marker; all are resolved and binding.
+
+---
+
+## R1 — Package Placement
+
+**Decision**: Pure kernel → `@adrkit/core` (`packages/core/src/queue/`); CLI
+subcommand `adr queue` → `@adrkit/cli` (`packages/cli/src/queue.ts`); GitHub
+Action entry → `packages/ci/queue/action.yml` with Node24 entrypoint
+`packages/ci/src/queue-action-entrypoint.ts`. **No new public package.**
+
+**Rationale**:
+
+The existing architecture splits cleanly: neutral pure computations live in
+`@adrkit/core`; CLI wrappers in `@adrkit/cli`; GitHub-API-coupled adapters in
+the private `@adrkit/ci`. The queue kernel is a pure function of
+`(corpus_snapshot, asOf)` → `QueueReport` — no clock, no network, no FS — which
+fits `@adrkit/core` exactly. The only adapters are: (a) the CLI boundary that
+reads the filesystem and clock before calling the kernel, and (b) the Action
+boundary that calls the GitHub Issues API. Both belong in their existing
+packages.
+
+Principle III explicitly names `@adrkit/core`, `@adrkit/cli`, and the schema as
+packages that MUST depend on no adapter. The queue kernel's placement in
+`@adrkit/core` satisfies this: `@adrkit/ci` depends on `@adrkit/core` (already
+true, not a new dependency), and `@adrkit/core` learns of no adapter.
+
+**Alternatives considered**:
+
+- *New `@adrkit/queue-kernel` package* — rejected. No justification: the kernel
+  is a pure addition to the existing `@adrkit/core` surface. The evaluator
+  (`@adrkit/evaluator`) was extracted to its own package because its rule engine
+  and Pass0 input/output shapes were large and independently re-usable. The queue
+  kernel is smaller and has no independent downstream consumers beyond the CLI and
+  Action. A new public package would add publishing overhead and a new versioning
+  surface for minimal isolation benefit.
+
+- *`@adrkit/mcp` placement* — rejected. The MCP package is purpose-built for the
+  local MCP stdio server. Mixing queue logic into it would couple two unrelated
+  features and force MCP consumers to depend on queue types. Out of scope per
+  spec Assumption A10.
+
+- *Two GitHub Actions in one `action.yml`* — rejected. The existing
+  `packages/ci/action.yml` is the PR governing-decisions action. The queue action
+  has a different trigger model (push/cron/PR), different required permissions
+  (`issues: write` vs `pull-requests: write`), and a different logical purpose.
+  A second `action.yml` at `packages/ci/queue/action.yml` is the correct
+  separation. Users reference it as
+  `mbeacom/adrkit/packages/ci/queue@v0`.
+
+**Installability impact**: `@adrkit/core` and `@adrkit/cli` gain new exports
+(additive, non-breaking for existing consumers). `@adrkit/ci` gains a new
+subdirectory and build target. No existing public export changes. Principle I
+(public export changes) is satisfied.
+
+**Format module placement**: Canonical JSON and Markdown formatters
+(`formatQueueReportJson`, `formatQueueReportMarkdown`) live in
+`packages/core/src/queue/format.ts` and are exported from `@adrkit/core`. Both
+the CLI (`packages/cli/src/queue.ts`) and the Action entrypoint
+(`packages/ci/src/queue-action-entrypoint.ts`) import format functions from
+`@adrkit/core`. This eliminates any `@adrkit/ci` → `@adrkit/cli` dependency and
+ensures both surfaces produce byte-identical output for the same report.
+
+---
+
+## R2 — Finding Codes: Closed List
+
+**Decision**: The following finding codes, generation conditions, severities,
+and messages are frozen. Implementation MUST NOT invent additional codes or
+reclassify severity (FR-022).
+
+### CorpusFinding Codes
+
+These codes apply to files that **cannot enter the `QueueItem` collection**: they
+have blocking errors that make it impossible to safely project a record from the
+file. Files with these findings appear only in `corpusFindings`; they are never
+`QueueItem`s. All four are severity **error**.
+
+| Code | Severity | Core `Finding.rule` it maps from | Generation Condition |
+|------|----------|----------------------------------|----------------------|
+| `corpus.read-error` | error | `file-read` | I/O failure reading or stat-ing the file |
+| `corpus.parse-error` | error | `frontmatter-parse`, `frontmatter-fence` | YAML is malformed or frontmatter delimiters are absent/malformed |
+| `corpus.schema-invalid` | error | Any Zod-validation rule EXCEPT `one-way-door-disallows-auto` (e.g., `required-field`, `invalid-type`, `invalid-enum-value`, `invalid-format`, `invalid-size`, `strict-unknown-key`, `unique-items`, `contract-refinement`, `superseded-requires-supersededBy`, `supersededBy-requires-superseded-status`, `accepted-requires-decider-unless-imported`, `agent-accepted-requires-ratifier`) | File parses but fails Zod `AdrFrontmatter.safeParse()` — field-level or other cross-field refinement failure |
+| `corpus.one-way-door-auto-tier` | error | `one-way-door-disallows-auto` | Schema cross-field invariant: `reversibility: one-way-door` + `review.tier: auto` in the same record (ADR-0002, FR-017) |
+
+**Identification algorithm**: After `lintCorpus()` returns, the set of files
+that have `error`-severity findings but whose `displayPath` does NOT appear in
+any `record.path` in `records` are the "excluded" files (i.e., `validateParsedAdr`
+returned `record: undefined` for them). For each such file, collect all its
+`Finding` entries (any severity), and map each `Finding.rule` to the appropriate
+`CorpusFinding.code` per the table above. Group all findings for the same
+`sourcePath` into a single `CorpusFinding` per finding (not per file) so each
+individual finding is visible. Sort by `sourcePath` → `code` → `severity rank` →
+`message` (code-unit order; severity rank: `error=0, warn=1, info=2`).
+
+**Important scope constraint**: Only findings for **excluded** files are mapped to
+`CorpusFinding[]`. Schema-valid records that remain in `lintCorpus().records` may
+also have findings in `lintCorpus().findings` (e.g., corpus-level duplicate IDs,
+dangling references, or `warn`/`info` issues from cross-record checks) — these
+findings appear in the fingerprint input (as part of the full canonical `Finding[]`
+from lintCorpus) but are intentionally ignored by `CorpusFinding` mapping. The
+`CorpusFinding` type represents only files that could not be projected into
+`QueueItem`s, not every warning or info finding in the corpus. The finding code
+list above is therefore the complete and exhaustive list for `CorpusFinding.code`
+values; it does not cover all possible `Finding.rule` values.
+
+**Exact messages**:
+
+```text
+corpus.read-error:   "Cannot read file: {Finding.message}"
+corpus.parse-error:  "{Finding.message}"   (pass through from FrontmatterError)
+corpus.schema-invalid:  "{Finding.message}"  (pass through from Zod issue message)
+corpus.one-way-door-auto-tier:
+  "one-way-door decisions may not take the auto-approve fast path (reversibility: one-way-door, review.tier: auto)"
+```
+
+Note: For `corpus.one-way-door-auto-tier`, the message is the canonical human-
+readable description, NOT the raw Zod issue message (which is `"one-way-door
+decisions may not take the auto-approve fast path"`). The canonical message is
+slightly expanded to name both conflicting fields.
+
+### ItemFinding Codes
+
+These codes apply to schema-valid `proposed` records that ARE `QueueItem`s but
+have queue-specific incompleteness or data inconsistencies.
+
+| Code | Severity | Generation Condition |
+|------|----------|----------------------|
+| `item.tier-absent` | info | `review.tier` is absent (not set in frontmatter); routing tier cannot be determined |
+| `item.review-by-before-queued` | warn | `reviewBy` is present AND `review.queuedAt` is present AND the UTC calendar date of `reviewBy` is strictly before the UTC calendar date of `review.queuedAt` |
+| `item.deciders-empty` | info | `deciders` array is empty AND `review.queuedAt` is present (record is in the queue with no routing targets) |
+
+**Exact messages**:
+
+```text
+item.tier-absent:
+  "review.tier is absent; routing tier cannot be determined — add review.tier: auto|async|arb to this record"
+
+item.review-by-before-queued:
+  "reviewBy ({reviewBy}) is before queuedAt ({queuedAt_utc_date}); SLA deadline may be inconsistent"
+
+item.deciders-empty:
+  "deciders is empty; routing targets cannot be determined — add at least one decider identity to this record"
+```
+
+Where `{reviewBy}` is the `reviewBy` field value as-is, and `{queuedAt_utc_date}`
+is the UTC calendar date derived from `review.queuedAt`.
+
+**Severity rationale**: `item.tier-absent` and `item.deciders-empty` are `info`
+because the record is still a valid proposed record and the queue report is still
+useful without them. `item.review-by-before-queued` is `warn` because it is a
+data inconsistency (logically incoherent chronological ordering) that an operator
+should actively fix, not merely observe. No item finding is severity `error` —
+error findings come only from `corpusFindings`.
+
+**Non-findings for edge cases**:
+
+- `not-queued` state: no item finding is generated for the absence of `review`
+  or `queuedAt` alone (spec edge case: "No item finding is generated for absence
+  of review alone").
+- `missing-sla` state: no item finding is generated; `slaState: missing-sla` is
+  itself the signal; the operator can read the `queuedAt` present / deadline absent
+  from the report.
+- `decidedAt` + `approvalCount < quorum`: the report surfaces both `quorum` and
+  `approvalCount` so the reviewer can see the discrepancy, but no item finding is
+  generated — this is a valid state (a decision can be committed while quorum is
+  below threshold; the queue exposes the numbers and does not editorialize).
+
+---
+
+## R3 — QueueReport v1 JSON Shape
+
+See [contracts/queue-report.md](./contracts/queue-report.md) for the complete
+specification. Summary of binding decisions:
+
+- **`version`**: string literal `"1"` — not a number, not semver.
+- **`asOf`**: `"YYYY-MM-DD"` UTC calendar date (the resolved value used for all SLA comparisons).
+- **`corpusFingerprint`**: lower-case hexadecimal SHA-256, 64 characters, computed
+  **inside the kernel** using the canonical projection: sorted `Adr[]` records
+  (by `(id, sourcePath)`, each serialized as `{ sourcePath, frontmatter, body }`),
+  canonically sorted original core `Finding[]` from `lintCorpus()` (NOT the
+  queue-mapped `CorpusFinding[]` — the raw core findings including all error, warn,
+  and info findings for all files), and corpus health counts
+  `{ recordCount: lintResult.records.length, excludedCount: lintResult.checked - lintResult.records.length }`.
+  Object keys sorted by code-unit order; `undefined` fields omitted; UTF-8 input.
+  This definition is identical to `@adrkit/mcp`'s existing fingerprint function
+  (`fingerprintOf` in `packages/mcp/src/corpus/projection.ts` — the second argument
+  is `readonly Finding[]`, not queue-mapped findings), and the promoted
+  `fingerprintOf()` function in `@adrkit/core` will produce the same bytes for the
+  same projection inputs.
+  
+  **Fingerprint scope caveat**: The MCP loader (`loadCorpusProjection`) includes
+  additional pre-read guards (symlink checks, size limits, post-load re-validation)
+  that the plain `lintCorpus()` call used by the CLI/Action does not replicate. Two
+  calls for the same on-disk ADR corpus will therefore produce identical fingerprints
+  only if the projection inputs (records, findings, counts) are identical — and they
+  will be identical when the same `lintCorpus()` result is used. Do not claim that
+  the MCP server and queue CLI fingerprints for the same physical directory will be
+  identical in all edge cases, because the MCP loader may exclude files that
+  `lintCorpus` accepts (e.g., symlinks or files over the MCP size limit).
+- **`totalItems`**: `items.length`.
+- **`totalCorpusFindings`**: `corpusFindings.length`.
+- **`itemsWithFindings`**: count of items where `itemFindings.length > 0`.
+- **Datetime serialization**: `queuedAt`, `escalatedAt`, `decidedAt` are the
+  UTC-normalized ISO string (`new Date(storedValue).toISOString()`, e.g.
+  `"2026-01-01T00:00:00.000Z"`). The original offset is lost; UTC is canonical.
+- **Tier labels**: `tierLabel` is a closed deterministic projection of `tier`:
+  `auto` → `expedited routing; human acceptance required`; `async` →
+  `asynchronous human review`; `arb` → `ARB human review`; absent → `null`.
+- **`deadlineDate`**: `"YYYY-MM-DD"` string or `null` — the computed UTC calendar
+  deadline date, exposed for informational use (not needed for SLA computation, but
+  useful for debugging and display).
+- **Final newline**: JSON output ends with exactly one `\n` after the closing `}`.
+- **Indentation**: `JSON.stringify(report, null, 2)` — two-space indent; no trailing
+  whitespace on any line.
+
+---
+
+## R4 — CLI Syntax and Exit Code Matrix
+
+See [contracts/cli-contract.md](./contracts/cli-contract.md) for the complete
+specification. Summary of binding decisions:
+
+- **Command**: `adr queue` (new subcommand of the existing `adr` CLI).
+- **Flags**:
+  - `--dir <path>` (optional, default `docs/adr`) — ADR corpus directory.
+  - `--as-of <date>` (optional) — ISO date `YYYY-MM-DD` or ISO datetime with
+    timezone offset. If absent, CLI uses `new Date().toISOString().slice(0,10)` at
+    the call site (current UTC date) and includes the resolved date in output.
+  - `--format markdown|json` (optional, default `markdown`) — output format.
+- **Exit codes**:
+  - `0` — report emitted with zero `error`-severity findings.
+  - `1` — report emitted with one or more `error`-severity findings (complete
+    report is emitted to stdout BEFORE exiting non-zero).
+  - `2` — usage error (invalid flag, invalid `--as-of` value, invalid `--format`
+    value, unrecognized argument). No report emitted. Error message to stderr.
+- **stdout**: exactly the selected format (Markdown or JSON), nothing else.
+- **stderr**: nothing on success or exit-1; usage message on exit-2.
+
+---
+
+## R5 — Action Surface
+
+See [contracts/github-action.md](./contracts/github-action.md) for the complete
+specification. Summary of binding decisions:
+
+- **Location**: `packages/ci/queue/action.yml` — a separate YAML from the existing
+  `packages/ci/action.yml`. Users reference it as
+  `mbeacom/adrkit/packages/ci/queue@v0`.
+- **Runs**: `using: node24`. Entrypoint: `../dist/queue-action.js`.
+- **Bundle**: `packages/ci/src/queue-action-entrypoint.ts` → `packages/ci/dist/queue-action.js`
+  (separate `bun build` target from the existing `dist/index.js`).
+- **Marker constant**: `<!-- adrkit-managed-queue-issue -->` — an HTML comment
+  invisible in rendered Markdown, globally unique to adrkit-managed queue issues,
+  corpus-independent, stable across all reruns.
+- **Required permissions**: `issues: write` on the Action's own GitHub API calls.
+  The *calling workflow* must declare `contents: read` (for `actions/checkout`)
+  **plus** `issues: write`. Both must appear in the `permissions:` block — no PAT.
+- **Paginated issue discovery**: call `octokit.rest.issues.listForRepo` with
+  `state: 'open'`, `per_page: 100`, paginate until all pages exhausted; repeat
+  for `state: 'closed'`. Before applying marker or title logic, **filter out all
+  entries where `pull_request` is a non-null property** — GitHub's Issues API
+  returns pull requests from `listForRepo` and they must be excluded to avoid
+  false marker or title matches.
+- **State machine**: 0 managed → title-conflict check → create; 1 open → update;
+  1 closed → single atomic update (body + state: 'open' together); 2+ → fail
+  (names all conflicting numbers, no write).
+- **Marker detection**: an issue is "managed" if and only if the marker
+  `<!-- adrkit-managed-queue-issue -->` is **exactly the first line** of the issue
+  body — i.e., `body.startsWith(MARKER + '\n')` (multi-line body) OR
+  `body === MARKER` (marker-only body). Leading whitespace or any other content
+  before the marker disqualifies the issue. Do NOT use `body.includes(MARKER)` for
+  ownership detection.
+- **Title conflict scope**: when no managed issue is found, the title conflict check
+  examines both **open AND closed** unowned issues. If one or more unowned issues
+  (not managed, not the managed issue being managed) have the configured title, the
+  Action fails without writing. Multiple conflicts are listed by issue number
+  ascending; the Action names all of them.
+- **Atomic write rule**: the Action makes at most **one GitHub write call** per run.
+  For a closed managed issue: a single `issues.update` REST call sets `body` AND
+  `state: 'open'` together. For an open managed issue: a single `issues.update`
+  call sets `body` only. For a new issue: a single `issues.create` call. There is no
+  two-call reopen + update sequence; this guarantees no prior queue mutation before
+  the write completes. If `issues.update` fails, the issue body and state are
+  unchanged (to the extent GitHub's atomic REST update guarantees atomicity).
+- **Error findings behavior**: write managed issue body (complete report), then exit
+  non-zero. Warning/info-only → write, exit zero.
+
+---
+
+## R6 — Deterministic Sorting
+
+**Decision**: The following sort order is frozen (FR-006).
+
+### QueueItem sort order (primary → secondary → tertiary → quaternary):
+
+1. **Urgency group** (ascending rank, highest urgency first):
+   ```
+   overdue=0, escalated=1, due=2, within-sla=3, missing-sla=4, not-queued=5, decided=6
+   ```
+2. **Deadline date** (ascending `"YYYY-MM-DD"` string comparison, code-unit order)
+   — only applies when `deadlineDate` is non-null; items without a deadline sort
+   after items within the same urgency group that have a deadline.
+3. **`queuedAt` UTC instant** (ascending ISO string comparison, code-unit order)
+   — secondary tiebreak for items within the same urgency group that have `queuedAt`
+   but no `deadlineDate` (i.e., `missing-sla` group with `queuedAt` present).
+4. **`id`** (ascending lexicographic / code-unit order) — mandatory final tiebreak.
+
+**Within-group deadline tie**: within the same urgency group, items WITH a deadline
+date sort before items WITHOUT one (within the group), then by deadline ascending,
+then by `queuedAt` ascending, then by `id` ascending.
+
+**`not-queued` group**: `queuedAt` is absent by definition, so step 3 uses empty
+string for the comparison → effectively sorts by `id` alone within the group.
+
+### `corpusFindings` sort order:
+`sourcePath` (code-unit) → `code` (code-unit) → severity rank (`error=0, warn=1, info=2`) → `message` (code-unit).
+
+### `itemFindings` sort order (per QueueItem):
+`code` (code-unit) → severity rank → `message` (code-unit).
+
+**Comparator**: All string comparisons use code-unit order (the same
+`compareCodeUnits` already defined in `@adrkit/mcp/src/corpus/ordering.ts` and
+promoted to `@adrkit/core` as part of the fingerprint utilities). Never
+`String.prototype.localeCompare`.
+
+---
+
+## R7 — Test Strategy
+
+**Decision**: Test-first (RED/GREEN). Tasks must be ordered: write failing tests
+first, then implement until green. The following coverage is required before
+implementation can claim completion:
+
+### Unit tests (`packages/core/test/queue/`)
+
+- **`kernel.test.ts`**:
+  - All 7 SLA states, correct precedence (each state independently and in precedence
+    pairs: `decided` overrides `escalated`, `escalated` overrides `overdue`, etc.).
+  - `reviewBy` takes precedence over `slaDays` when both present.
+  - `reviewBy` without `review` block: computes deadline correctly.
+  - Timezone edge case: `--as-of 2026-01-08T01:00:00+05:00` → `asOfDate 2026-01-07`.
+  - `slaDays: 0`: deadline equals `queuedAt` date; `due` on that day, `overdue` next.
+  - Empty corpus: empty `items`, empty `corpusFindings`.
+  - No `proposed` records: empty `items`; `corpusFindings` may still be non-empty.
+  - All three item findings generated under their exact conditions.
+  - `item.review-by-before-queued` exact boundary (equal date → no finding; day
+    before → finding).
+  - `decidedAt` present + `approvalCount < quorum` → no item finding.
+  - CorpusFinding code mapping: only for excluded-file findings; schema-valid records
+    with warn/info findings are NOT in `corpusFindings` but their `Finding[]` IS
+    included in the fingerprint input.
+  - Fingerprint computed internally by kernel; identical calls with identical input
+    produce identical fingerprints (no external caller pre-computation required).
+
+- **`sort.test.ts`**:
+  - Stable sort: two runs over same input → byte-for-byte identical output.
+  - All seven urgency groups in correct order.
+  - Within-group deadline ascending; deadline-absent items after deadline-present.
+  - `id` tiebreak: records with identical deadline sort by `id` ascending.
+  - `not-queued` group: sorts by `id` only.
+  - `corpusFindings` sort: `sourcePath` → `code` → severity rank → `message`.
+  - `itemFindings` sort: `code` → severity rank → `message`.
+
+- **`findings.test.ts`**:
+  - Excluded-file `Finding.rule` values (`frontmatter-parse`, `frontmatter-fence`,
+    `file-read`, `one-way-door-disallows-auto`, and each Zod-validation rule that
+    applies to excluded records) map to exactly one `CorpusFinding.code`.
+  - Schema-valid records' warn/info findings do NOT generate `CorpusFinding` entries.
+  - Exact message format for `corpus.one-way-door-auto-tier`.
+  - `item.*` messages include the interpolated values verbatim.
+
+- **`format.test.ts`**:
+  - `formatQueueReportJson` → valid JSON; all fields present; final newline; no
+    trailing whitespace.
+  - `formatQueueReportMarkdown` → all QueueItem fields represented; full 64-char
+    fingerprint; no emoji; correct escaping for pipe/backtick/CR/LF in cell values.
+  - Two calls with identical input → byte-for-byte identical output (determinism).
+
+### Fingerprint compatibility test (`packages/core/test/fingerprint/fingerprint.test.ts`)
+
+- Promoted `fingerprintOf` produces bit-identical output to the reference
+  implementation in `@adrkit/mcp` for the same input projection.
+- Determinism: same input → same bytes across multiple calls.
+- Key-order independence: object with keys in different orders → same bytes.
+
+### CLI integration tests (`packages/cli/test/queue.test.ts`)
+
+- `bun run --cwd packages/cli adr -- queue --format json` on a fixture corpus →
+  valid JSON; all QueueItem fields present.
+- `bun run --cwd packages/cli adr -- queue` (no flags) → Markdown output; contains
+  expected headings; full 64-char fingerprint present.
+- `--format markdown` → identical to default.
+- `--format invalid` → exit 2, no stdout, error message to stderr.
+- `--as-of 2026-01-07` → `asOf: "2026-01-07"` in JSON output.
+- `--as-of 2026-01-08T01:00:00+05:00` → `asOf: "2026-01-07"`.
+- `--as-of 2026-01-08T10:00:00` (no timezone) → exit 2 (timezone-less datetime rejected).
+- `--as-of 2026-13-01` (invalid month) → exit 2 (fails UTC round-trip).
+- `--as-of invalid` → exit 2.
+- Corpus with 1 error finding → complete report emitted, exit 1.
+- Corpus with 0 error findings → exit 0.
+- Two runs with identical corpus and `--as-of` → byte-for-byte identical stdout (SC-001).
+- Fixtures live in `packages/core/test/fixtures/queue/`.
+
+### Action unit tests (`packages/ci/test/queue-issue.test.ts`)
+
+- **Fake `GitHubQueueClient`**: in-memory stub; no token, no network.
+- State machine: all 5 branches (0 managed + no title conflict, 0 managed + title
+  conflict, 1 open, 1 closed, 2+ managed).
+- `listAllIssues()` stub returns both real issues AND entries with `pull_request`
+  property set; asserts PR entries are filtered before marker/title logic.
+- First run creates issue with marker as **first line** of body.
+- Second run on same corpus updates same issue; issue count unchanged.
+- Closed managed issue: single `updateIssue({body, state:'open'})` call — one write,
+  no separate reopen call; no replacement created.
+- Two open marked issues: exits non-zero; names both issue numbers; neither modified.
+- Permission error (403/401): exits non-zero; message names `issues: write`.
+- Error findings in report: issue updated first, then exits non-zero.
+- Warning-only findings: issue updated, exits zero.
+- Title conflict: unmanaged open issue with configured title → fail, no write.
+- Title conflict with unmanaged **closed** issue → also fail, no write.
+- Multiple unmanaged title conflicts: all named (ascending issue number), no write.
+- Body detection: marker at line 1 → managed; marker at line 2 → NOT managed;
+  body with leading whitespace then marker → NOT managed.
+- Marker in quoted text mid-body → NOT managed (first-line check only).
+
+### Bundle + static boundary tests
+
+- **Bundle smoke test**: build `packages/ci/dist/queue-action.js` with
+  `bun build --target=node`. Follow the pattern of `scripts/smoke-node.mjs`: spawn
+  the executable bundle with a controlled GitHub Actions environment and a temporary
+  workspace whose configured corpus is absent. Assert the known corpus-load failure
+  occurs before GitHub client construction, with no network request and no
+  module-resolution failure. Do NOT import the executable entrypoint in-process or use
+  `--help`. Run under Node 22 AND Node 24 in CI. The Action's `action.yml` declares
+  `node24`; the smoke test validates the bundle separately.
+- **`check:deps` static scan**: `@adrkit/core` import graph must not include any
+  path reaching `@adrkit/ci`, `@adrkit/mcp`, `@adrkit/evaluator`, or
+  `@actions/*`. This is the `core-has-no-adapter-deps` gate (Principle III).
+
+### Clean-clone build gate (`clean-clone-builds`)
+
+Run `bun install --frozen-lockfile` followed by
+`bun run build && bun test && bun run typecheck` in a fresh clone; assert
+all pass with no network access beyond the initial install step.
+
+### Rung-6 dogfood gate (SC-004)
+
+Not a CI test — a real-user gate. Evidence must include:
+- A separate repository and team (not the maintainer's own).
+- At least three `proposed` records spanning `auto`, `async`, `arb` tiers.
+- At least one SLA-boundary or overdue case.
+- Approvals and objections present.
+- The same managed GitHub issue body updated in place on a second run.
+- Default-token-only `issues: write` operation confirmed.
+
+---
+
+## R8 — Constitution Checks Before and After Design
+
+See Constitution Check section in [plan.md](./plan.md). All five principles pass
+both before and after design. No violations.
+
+Specifically addressing each sub-question from the planning brief:
+
+- **I (installability/public export changes)**: `@adrkit/core` and `@adrkit/cli`
+  add new exports (queue kernel, `adr queue` subcommand, fingerprint helpers).
+  All additions. No existing export removed. `@adrkit/ci` adds a new subdirectory
+  and a new action — no change to existing `action.yml` or `dist/index.js`.
+- **II (offline clean-clone operation)**: Kernel is offline by construction.
+  CLI corpus loading uses `lintCorpus` (existing, offline). Action test suite uses
+  fake client (no network). Only runtime Action calls need network (GitHub API).
+- **III (dependency direction / Action adapter placement)**: The Action adapter
+  lives in `@adrkit/ci` (existing adapter package). Canonical formatters live in
+  `@adrkit/core` (`queue/format.ts`) — consumed by both CLI and Action, eliminating
+  any `@adrkit/ci` → `@adrkit/cli` coupling. `@adrkit/core` does not learn
+  of `@adrkit/ci`. Dependency direction: `@adrkit/ci` → `@adrkit/core` (allowed
+  and existing). The `core-has-no-adapter-deps` gate remains green.
+- **IV (determinism / no approval semantics)**: Kernel is pure. `auto` tier is
+  labeled as expedited routing in all output text; no output field states or implies
+  acceptance. `QueueReport.items[].tier: "auto"` is a value read from frontmatter,
+  not an approval decision.
+- **V (versioned schema / report contract)**: `AdrFrontmatter` schema and emitted
+  JSON Schema are unchanged. `QueueReport` version field `"1"` is the new contract
+  version. No `schema:emit` gate impact.
+- **VI (breaking changes / migrations)**: No breaking changes to any published
+  package. `@adrkit/core` adds exports (additive). `@adrkit/mcp` migrates two
+  private helper imports from its own file to `@adrkit/core` — internal change,
+  not a public API break (MCP already re-exports nothing from these helpers).
+- **VII (ADR / docs updates)**: A new ADR is NOT required for the queue surface
+  itself; the queue is a first-party consumer of ADR-0004's Option A (derived
+  projection, no persistent index) and ADR-0005 (routing, never approving). The
+  relevant ADRs already govern this feature. However, after Phase 6 is fully
+  implemented and the rung-6 gate clears, the root `plan.md` Phase 6 row must be
+  updated to `landed` and the CLAUDE.md updated to reflect the new `adr queue`
+  command.
+
+---
+
+## R9 — Primitive Reuse: Fingerprint Helpers
+
+**Decision**: Promote `canonicalStringify`, `fingerprintOf`, `compareCodeUnits`,
+`compareFindings`, `sortFindingsCanonical`, `compareByIdThenPath`, and
+`sortByIdThenPath` from `packages/mcp/src/corpus/` to new modules in
+`packages/core/src/`:
+
+- `canonicalStringify` + `fingerprintOf` → `packages/core/src/fingerprint/index.ts`
+- `compareCodeUnits`, `compareFindings`, `sortFindingsCanonical`,
+  `compareByIdThenPath`, `sortByIdThenPath` → `packages/core/src/ordering/index.ts`
+
+Export all from `@adrkit/core`'s `index.ts`. Update `@adrkit/mcp` to import from
+`@adrkit/core` instead of defining locally. The `fingerprintOf` function in core
+uses `compareCodeUnits` from the same package.
+
+**Rationale**: The queue CLI and kernel need to produce the same fingerprint as the
+MCP server for the same corpus projection (FR-009). Duplicating the implementation
+risks silent drift. The functions are pure, have no side effects, and carry no
+MCP-specific coupling — they operate on the generic `Adr[]` + `Finding[]` types
+already in `@adrkit/core`. `compareCodeUnits` and the sort helpers are also needed
+by the queue's `sort.ts`, avoiding a cross-package MCP dependency.
+
+**Fingerprint input clarification**: The `fingerprintOf` function signature is:
+```typescript
+fingerprintOf(
+  records: readonly Adr[],
+  corpusFindings: readonly Finding[], // raw core Finding[], NOT queue CorpusFinding[]
+  recordCount: number,
+  excludedCount: number
+): string
+```
+The second argument is the **original core `Finding[]`** from `lintCorpus()`
+(sorted by `sortFindingsCanonical`), not the queue-mapped `CorpusFinding[]`.
+This matches the existing MCP `fingerprintOf` at
+`packages/mcp/src/corpus/projection.ts` lines 188–195, where `corpusFindings` is
+typed as `readonly Finding[]`. The kernel calls:
+```typescript
+fingerprintOf(
+  sortByIdThenPath(lintResult.records),
+  sortFindingsCanonical(lintResult.findings),  // all findings, not just excluded-file ones
+  lintResult.records.length,
+  lintResult.checked - lintResult.records.length
+)
+```
+
+**Compatibility guarantee**: The promoted `fingerprintOf` must produce bit-identical
+output to the function it replaces in `@adrkit/mcp` for any valid input. A
+compatibility test (`fingerprint.test.ts`) runs both implementations on the same
+fixture and asserts byte equality. The test is then kept permanently to protect
+against regression.
+
+**Migration**: `@adrkit/mcp/corpus/projection.ts` removes its local
+`canonicalStringify` and `fingerprintOf` definitions and imports them from
+`@adrkit/core`. `@adrkit/mcp/corpus/ordering.ts` is kept as a re-export shim (or
+removed and import sites updated) — an implementation detail for task generation.
+No change to `@adrkit/mcp`'s public interface or observable behavior.
+
+**Fingerprint scope caveat**: The MCP loader includes pre-read guards that plain
+`lintCorpus()` does not replicate. Identical fingerprints are guaranteed only when
+the same `LintCorpusResult` is used; do not claim the MCP and CLI fingerprints
+for the same physical directory will always match if the MCP loader excludes files
+that `lintCorpus` does not (e.g., symlinks or files over the MCP size limit).
+
+---
+
+## R10 — Correct Root Status Drift
+
+**Decision**: The correct current state is:
+
+| Phase | Feature | Status |
+|-------|---------|--------|
+| 0–5 | `specs/001-006-*` | All landed; PRs #5, #6, #7, #12, #14, #19 merged |
+| 5 specifically | MCP server | `v0.2.0` published on npm; real-user gate met (maintainer dogfood via MCP Inspector) |
+| 6 | `specs/007-arb-queue` | **Spec + plan only; not implemented**; rung-6 gate NOT cleared |
+
+The root `plan.md` confirms that Phase 6 scoping is in progress, implementation is
+permitted because Phase 5 landed with a real user, and the external-team rung 6 exit
+gate remains outstanding.
+
+**Rung-6 gate**: Explicitly preserved throughout this plan. Task generation and
+implementation work may proceed. **Rung 6 may not be claimed as landed** until
+SC-004 is met: an external team (not the maintainer) runs the full dogfood scenario
+(FR-019) in a separate repository. That is an *exit/release gate*, not a
+pre-implementation or pre-task-generation gate.
+
+**v0.2.0 context**: The current published version is v0.2.0, corresponding to Phase 5
+(MCP server). Phase 6 implementation has not started yet but may proceed after scoping
+passes; the next release-ready claim requires both implementation completion and the
+SC-004 external dogfood evidence.

--- a/specs/007-arb-queue/spec.md
+++ b/specs/007-arb-queue/spec.md
@@ -712,17 +712,17 @@ planning or implementation:
 
 - **`ItemFinding`**: An actionable finding attached to a specific `QueueItem` for
   queue-specific incompleteness or inconsistency in an otherwise schema-valid `proposed`
-  record (e.g., absent `tier`, absent SLA deadline, `reviewBy` before `queuedAt`).
-  Contains the source record identity (`id` and `sourcePath`), a machine-readable finding
-  code, a severity (`error`, `warn`, or `info`), and a human-readable description.
-  Structurally distinct from `CorpusFinding`. The finding code namespace and severity
-  mapping are planning decisions.
+  record (absent `tier`, `reviewBy` before `queuedAt`, or empty `deciders` on a queued
+  record). Contains a machine-readable finding code, severity (`warn` or `info`), and a
+  human-readable description; identity comes from the parent `QueueItem`. Missing SLA
+  data is represented by `slaState: missing-sla`, not a separate finding.
+  Structurally distinct from `CorpusFinding`.
 
 - **`CorpusFinding`**: A top-level finding for a file that cannot enter the `QueueItem`
   collection: schema-invalid or unparseable frontmatter, or an unsatisfied schema
   cross-field invariant (e.g., `one-way-door` + `tier: auto`). Contains `sourcePath`
-  parser/validator details, a machine-readable code, and a severity (`error`, `warn`, or
-  `info`), and a human-readable description. Does not include `id`, `title`, `tier`,
+  parser/validator details, a machine-readable code, severity `error`, and a
+  human-readable description. Does not include `id`, `title`, `tier`,
   `slaState`, or any fabricated field. Appears in the `QueueReport`'s ordered top-level
   `corpusFindings` collection, structurally distinct from `ItemFinding`.
 

--- a/specs/007-arb-queue/spec.md
+++ b/specs/007-arb-queue/spec.md
@@ -1,0 +1,842 @@
+# Feature Specification: ARB Operations Queue
+
+**Feature Directory**: `007-arb-queue`
+**Implementation Branch**: `feat/phase-6-arb-queue`
+**Created**: 2026-07-20
+**Status**: Draft
+**Phase**: 6 (outcome ladder **rung 6**) — single-repository ARB queue surface only
+(Project Phase 6 delivers rung 6, "an org runs its ARB on it." Prior phases 0–5 are
+landed and dogfooded (PRs #5, #6, #7, #12, #14, #19). Task generation and
+implementation may proceed after this scoping passes. The claim that rung 6 is landed
+and release-ready is gated on separate-repository/team dogfood — see SC-004 and
+Assumption A7.)
+**Normative sources** (the ADRs are normative; where this spec and an ADR disagree, the
+ADR wins):
+[ADR-0001](../../docs/adr/0001-record-architecture-decisions-in-git.md) (git is the
+source of truth; the queue is a derived, stateless, read-only projection — it never
+writes decision content),
+[ADR-0002](../../docs/adr/0002-typed-frontmatter-as-madr-superset.md) (the typed schema:
+`review.tier` enum `auto`/`async`/`arb`, `review.queuedAt`, `review.slaDays`,
+`review.escalatedAt`, `review.decidedAt`, `review.quorum`, `review.approvals`,
+`review.objections`, `reviewBy`, and the cross-field invariant barring
+`reversibility: one-way-door` + `tier: auto` in the same record),
+[ADR-0004](../../docs/adr/0004-git-is-source-of-truth-database-is-an-index.md) (the
+queue is a derived, rebuildable projection from the corpus — never an authoritative
+store; no Postgres, no persistent index; the CLI and GitHub Actions surface never
+require a database),
+[ADR-0005](../../docs/adr/0005-deterministic-first-evaluator-with-declarative-escalation.md)
+(the evaluator routes, never approves; tier semantics; escalation trigger set and
+reason codes that may be reflected in committed `evaluation.escalate` and
+`evaluation.escalationReasons`; "the evaluator routes; it never approves"),
+[ADR-0007](../../docs/adr/0007-adapter-isolation-and-public-surface-build.md) (adapter
+isolation; clean-clone build constraint; the queue surface is a first-party, non-adapter
+consumer of `@adrkit/core`),
+[ADR-0010](../../docs/adr/0010-bun-toolchain.md) (Bun for development; Node-targeted
+published artifacts), and
+[`.specify/memory/constitution.md`](../../.specify/memory/constitution.md) Principles I–V.
+
+> ⏳ **Rung 6 exit gate not yet cleared.** Scoping, task generation, and implementation
+> are permitted now that Phase 5 / rung 5 is landed and dogfooded (PR #19, v0.2.0).
+> Phase 6 MUST NOT be called landed or claim outcome-ladder rung 6 until a team that is
+> **not** the maintainer's own completes the separate-repository/team dogfood gate
+> (SC-004, Assumption A7). The maintainer's own repository dogfood does not satisfy rung
+> 6's "a team that isn't yours" exit requirement.
+
+## Overview
+
+Phases 0–5 made records valid (`@adrkit/core`, schema), locatable (`affects`
+resolution), importable (MADR migration), visible on the pull requests that govern them
+(`@adrkit/ci`), routable deterministically without a meeting (Pass 0 evaluator), and
+readable by agents (MCP server). Each surface answers "what was decided" or "what should
+be decided." None of them operationalize the *process* of deciding: who is waiting for
+what, how long they have been waiting, whether a quorum has formed, and whether anything
+is overdue.
+
+Phase 6 closes that gap. The deliverable is a **deterministic, single-repository ARB
+operations queue**: a read-only projection of the local ADR corpus that makes the
+existing typed `review` metadata in committed frontmatter observable as a continuously
+current, actionable workflow artifact.
+
+The queue does not replace the review process. It does not approve, route, notify,
+schedule, or manage lifecycle transitions — those remain ADR pull requests. Its function
+is narrower and more durable: given a committed corpus and an explicit as-of instant,
+produce an ordered, byte-for-byte reproducible queue report — strict versioned JSON for
+machines, deterministic Markdown for humans — that surfaces exactly what the committed
+metadata says and nothing more.
+
+Two surfaces:
+
+- **CLI** (`adr queue` or equivalent command): a local read command that emits one selected
+  representation of the same queue report to stdout, using
+  `--format markdown|json` (default `markdown`), and accepts a caller-supplied `--as-of`
+  option.
+
+- **GitHub Actions**: an operational surface that creates or updates exactly one dedicated
+  GitHub issue whose body contains the deterministic Markdown report and a stable hidden
+  ownership marker — on push, PR, or cron events — using only the repository default token
+  (`GITHUB_TOKEN` with `issues: write`) — with honest permission failure reporting.
+
+The load-bearing property inherited from all prior phases: **git is truth, and the queue
+is a reader.** No database, no service, no model, no ambient clock in the queue kernel,
+and no write path into decision records. A clean clone must build, test, and run the
+queue kernel and CLI with no credentials, services, or network after the frozen
+dependency install. The GitHub Actions wrapper may access only the GitHub API using the
+repository default token (Principles I–II, ADR-0007).
+
+The rung 6 exit gate is a separate-repository/team dogfood with at least three active
+`proposed` records spanning all three tiers (`auto`, `async`, `arb`), at least one
+SLA-boundary or overdue case, approvals and objections present, the same managed GitHub
+issue body updated in place on a second run with default-token-only `issues: write`
+operation — by a team that is not the maintainer's own.
+
+## User Scenarios & Testing
+
+> **User Story gating.** The stories below may be implemented after scoping passes, but
+> Phase 6 MUST NOT be called landed or claim rung 6 until the real-user dogfood gate
+> clears (SC-004, Assumption A7). The gate requires a **separate** team and repository;
+> maintainer dogfooding on this repository alone does not clear it.
+
+### User Story 1 — A maintainer reads the full queue for a local corpus (Priority: P1) 🎯 MVP
+
+As a maintainer or team lead with the corpus cloned locally, I want to run a single
+command that reads every `proposed` record, computes each one's tier, SLA state, routing
+targets, approvals, and objections from committed metadata alone, and produces a
+human-readable Markdown table and a machine-readable JSON report — so I can see at a
+glance which proposals need immediate attention, who is responsible for routing each,
+and whether any are overdue or missing SLA data.
+
+**Why this priority**: This is the rung — "an org runs its ARB on it." The queue report
+is the primary deliverable. Every other user story depends on it being useful. It is
+independently valuable the moment it surfaces the first overdue or missing-SLA proposal.
+
+**Independent Test**: Point the CLI at a fixture corpus containing at least one schema-valid
+`proposed` record in each of the seven SLA states (`not-queued`, `missing-sla`, `within-sla`,
+`due`, `overdue`, `escalated`, `decided`), at least one schema-invalid file that appears in
+`corpusFindings` rather than as a `QueueItem`, and at least one record of each tier
+(`auto`, `async`, `arb`); supply an explicit `--as-of` date; assert that the JSON output
+lists exactly the schema-valid `proposed` records as `QueueItem`s (no `accepted`, `draft`,
+`rejected`, `superseded`, or `deprecated` records appear, and no schema-invalid files appear
+as queue items), each with the correct computed SLA state, tier, routing targets derived from
+`deciders`, approval count, unresolved objection count, and resolved objection count — all
+derived from committed frontmatter, none fabricated.
+
+**Acceptance Scenarios**:
+
+1. **Given** a corpus with records of `proposed`, `accepted`, `rejected`, `superseded`,
+   `deprecated`, and `draft` status, **When** the queue command runs, **Then** only
+   `proposed` records appear in the output; no other status is included.
+
+2. **Given** a `proposed` record with `review.tier: arb`, `review.queuedAt` set,
+   `review.slaDays: 10`, two entries in `review.approvals`, one unresolved entry in
+   `review.objections`, and two entries in `deciders`, **When** the queue command runs
+   with `--as-of` set to a date 12 calendar days after `queuedAt` (with no
+   `review.escalatedAt` or `review.decidedAt`), **Then** the record appears with
+   `slaState: overdue`, `tier: arb`, both routing targets listed, `approvalCount: 2`,
+   `unresolvedObjectionCount: 1` — all values read from committed frontmatter, none
+   fabricated.
+
+3. **Given** a `proposed` record with no `review.queuedAt`, **When** the queue command
+   runs, **Then** the record appears with `slaState: not-queued` and its source identity
+   (`id`, `title`, `sourcePath`); the queue does not omit it, does not fabricate a
+   timestamp, and does not assign any SLA state other than `not-queued`.
+
+4. **Given** a `proposed` record with `review.queuedAt` present but neither
+   `review.slaDays` nor `reviewBy` set, **When** the queue command runs, **Then** the
+   record appears with `slaState: missing-sla`; the queue does not invent a default SLA
+   deadline, does not treat the record as `within-sla`, and surfaces `missing-sla`
+   explicitly.
+
+5. **Given** a `proposed` record with `review.decidedAt` present, **When** the queue
+   command runs, **Then** the record appears with `slaState: decided` — signaling that a
+   decision has been committed to the frontmatter but the lifecycle PR has not yet merged
+   to advance the status.
+
+6. **Given** a `proposed` record with `review.escalatedAt` present and a computed SLA
+   deadline in the past, **When** the queue command runs, **Then** the record appears
+   with `slaState: escalated`, not `overdue`; `escalated` takes precedence.
+
+7. **Given** any `QueueItem` in the output, **When** the output is inspected, **Then**
+   it includes at minimum: `id`, `title`, repo-relative `sourcePath`, `tier` (or `null`
+   if absent), `tierLabel` (the deterministic human-review meaning of `tier`, or `null`),
+   `queuedAt` (or `null`), `slaDays` (or `null`), `reviewBy` (or `null`), `slaState`,
+   `routingTargets` (from `deciders`), `quorum` (or `null`),
+   `approvalCount`, `unresolvedObjectionCount`, `resolvedObjectionCount`,
+   `escalatedAt` (or `null`), `decidedAt` (or `null`), and `itemFindings` (ordered
+   list, possibly empty).
+
+8. **Given** the CLI, **When** it runs without `--format`, **Then** it emits only the
+   Markdown representation to stdout; with `--format json`, it emits only strict JSON;
+   with `--format markdown`, it emits only Markdown; any other value exits non-zero with
+   usage guidance and no partial report.
+
+---
+
+### User Story 2 — SLA state is deterministic from committed metadata and an explicit as-of instant (Priority: P1)
+
+As an auditor or automated system, I want the queue's SLA states to be computed purely
+from committed frontmatter fields and an explicit, caller-supplied as-of instant — with
+no ambient clock, no inferred defaults, and no probabilistic guessing — so the same
+corpus and the same as-of instant always produce the same result and the computation is
+fully explainable.
+
+**Why this priority**: Determinism is the core property that makes the queue trustworthy
+and auditable. An ambient clock makes the queue non-reproducible; invented SLA defaults
+fabricate governance state. Both violate Principle IV and ADR-0004. Ships with US1.
+
+**Independent Test**: Run the queue command twice over the same fixture corpus with the
+same explicit `--as-of` value; assert both JSON outputs are byte-for-byte identical and
+both Markdown outputs are byte-for-byte identical. Then run with a different `--as-of`
+that crosses an SLA boundary; assert exactly the records that cross that boundary change
+SLA state, and no other field changes.
+
+**Acceptance Scenarios**:
+
+1. **Given** identical corpus, configuration, and `--as-of` value, **When** the queue
+   command runs twice, **Then** both JSON outputs are byte-for-byte identical and both
+   Markdown outputs are byte-for-byte identical.
+
+2. **Given** a record with `review.queuedAt: 2026-01-01T00:00:00Z` and
+   `review.slaDays: 7`, **When** the queue runs with `--as-of 2026-01-07`, **Then**
+   `slaState` is `within-sla` (`deadlineDate` is `2026-01-08` = `queuedAt` + 7 calendar
+   days; as-of is before the deadline); with `--as-of 2026-01-08`, it is `due`
+   (`deadlineDate` equals as-of date, UTC); with `--as-of 2026-01-09`, it is `overdue`
+   (as-of is after the deadline; no `review.escalatedAt` present). With `slaDays: 0`,
+   `deadlineDate` equals `queuedAt` itself; the record is `due` on `queuedAt` and
+   `overdue` the following calendar day.
+
+3. **Given** `--as-of 2026-01-08T01:00:00+05:00`, **When** the queue resolves its as-of
+   date, **Then** it uses `2026-01-07`, the UTC calendar date of that instant, rather than
+   the wall-clock date written in the offset timestamp.
+
+4. **Given** both `review.slaDays` and `reviewBy` are present on the same record,
+   **When** the queue computes the SLA deadline, **Then** `reviewBy` takes precedence as
+   the explicit deadline; `review.slaDays` is still exposed in the output for
+   informational purposes but does not participate in deadline computation when `reviewBy`
+   is set (Assumption A3).
+
+5. **Given** a record with `review.escalatedAt` present and a computed SLA deadline
+   strictly before the as-of instant, **When** the queue runs, **Then** `slaState` is
+   `escalated`, not `overdue`; `escalated` takes precedence (FR-005 precedence table).
+
+6. **Given** the queue kernel as a pure library function, **When** its dependency graph
+   is inspected, **Then** it reads no ambient clock, makes no network call, and performs
+   no filesystem traversal beyond the caller-supplied corpus snapshot (FR-004, Principle IV).
+
+---
+
+### User Story 3 — Schema-invalid files appear as corpus findings; schema-valid proposed records with incompleteness appear as QueueItems with item findings (Priority: P1)
+
+As a corpus owner, I want a clear, honest distinction between files that cannot enter the
+queue at all (schema-invalid or unparseable frontmatter, cross-field invariant violations)
+and schema-valid `proposed` records that are simply incomplete (absent `review.tier`, absent
+SLA data, inconsistent dates) — so that the former appear in a top-level `corpusFindings`
+collection with enough detail to locate and fix the problem, and the latter appear as
+`QueueItem`s with item findings — and neither category is silently omitted, fabricated, or
+misrepresented.
+
+**Why this priority**: Silent omission or data fabrication is the failure mode that makes
+governance tooling dangerous. A queue that hides invalid files gives false confidence; a
+queue that invents approval state, tier, or SLA for files it could not parse is worse than no
+queue. The two-path model ("corpus finding" vs "item finding") ensures every file in the
+corpus is accounted for without polluting the QueueItem collection with untrustworthy data.
+Ships with US1.
+
+**Independent Test**: Feed the queue command a corpus containing: (1) a file with
+schema-invalid frontmatter (e.g., an unrecognized `status` value that fails schema
+validation), (2) a `proposed` record with `reversibility: one-way-door` and
+`review.tier: auto` (schema cross-field invariant violation), and (3) a schema-valid
+`proposed` record with no `review.tier` field (queue-specific incompleteness). Assert that
+files (1) and (2) appear in the top-level `corpusFindings` collection (NOT as `QueueItem`s)
+with `sourcePath` and parser/validator details, no fabricated `id`, `title`, `tier`,
+`slaState`, or decision state; and that file (3) appears as a `QueueItem` with `tier: null`
+and an item finding that names the absent routing tier — with no fabricated tier value.
+
+**Acceptance Scenarios**:
+
+1. **Given** a file with schema-invalid frontmatter (fails schema validation or cannot be
+   parsed at all), **When** the queue command runs, **Then** that file appears in the
+   top-level `corpusFindings` collection — not as a `QueueItem`; its entry includes
+   `sourcePath` and parser/validator details; no `id`, `title`, `tier`, `slaState`,
+   `queuedAt`, or decision state is fabricated; the queue does not crash and does not skip
+   the file silently.
+
+2. **Given** a `proposed` record with `reversibility: one-way-door` and
+   `review.tier: auto` (schema cross-field invariant violation), **When** the queue command
+   runs, **Then** that record appears in the top-level `corpusFindings` collection — not
+   as a `QueueItem` — with `sourcePath` and an actionable description citing the
+   `one-way-door` + `auto` invariant violation; the queue does not silently reassign the
+   tier to `arb` or any other value, and does not omit the file.
+
+3. **Given** a schema-valid `proposed` record with no `review.tier` field
+   (queue-specific incompleteness, not a schema error), **When** the queue command runs,
+   **Then** that record appears as a `QueueItem` with `tier: null` and an explicit item
+   finding that the routing tier is absent; the queue does not assign a default tier or
+   infer one from other fields.
+
+4. **Given** `QueueItem`s with item findings alongside top-level `corpusFindings`,
+   **When** the output is produced, **Then** item findings are co-located with their
+   `QueueItem` in the `items` list; corpus findings are in the separate top-level
+   `corpusFindings` collection; the two collections are structurally distinct in both
+   JSON and Markdown output; a record that qualifies as a corpus finding MUST NOT also
+   appear as a `QueueItem`.
+
+5. **Given** any corpus finding in `corpusFindings`, **When** it is inspected, **Then**
+   it includes the repo-relative `sourcePath`, specific parser/validator error or invariant
+   violation detail, a severity, and no fabricated `id`, `title`, `tier`, `slaState`,
+   timestamp, or decision state.
+
+6. **Given** a report containing one or more error-severity findings, **When** the CLI
+   runs, **Then** it still emits the complete JSON or Markdown report and exits non-zero
+   afterward; warning- and info-only findings do not make the command fail.
+
+---
+
+### User Story 4 — The GitHub Actions surface creates or updates a dedicated managed GitHub issue with the queue report (Priority: P2)
+
+As a team using GitHub Actions to automate their ARB workflow, I want the queue action
+to create or update exactly one dedicated GitHub issue whose body contains the
+deterministic Markdown report and a stable hidden ownership marker — using only the
+repository default token (`GITHUB_TOKEN` with `issues: write`), with no PAT or
+additional secrets — so the queue report is always current after a push or merge, the
+issue is updated in place rather than creating new issues on each run, and permission
+failures are reported honestly with the specific required permission named.
+
+**Why this priority**: The GitHub Actions surface is the operational face of the queue
+for most teams. It makes the queue continuously visible without manual CLI runs. It
+depends on the queue kernel (US1–US3) being correct, so it ships second.
+
+**Independent Test**: Run the queue action twice against the same fixture corpus in a
+test repository; on the first run, assert exactly one GitHub issue is created with the
+Markdown queue report in its body and a hidden ownership marker; on the second run,
+assert the same issue body is updated in place (no new issue created, no duplicate), the
+content reflects the current corpus state, and no repository file is committed or
+modified; confirm both runs use only `GITHUB_TOKEN` with `issues: write` and no secrets
+or PATs.
+
+**Acceptance Scenarios**:
+
+1. **Given** no managed queue issue exists in the repository, **When** the queue action
+   runs, **Then** it creates exactly one GitHub issue with the Markdown queue report as
+   its body and a stable hidden ownership marker; no repository file is written or
+   committed.
+
+2. **Given** a managed queue issue already exists (identified by the hidden ownership
+   marker), **When** the queue action runs again with the same corpus and as-of instant,
+   **Then** the issue body is updated in place; no new issue is created; the result is
+   identical to the first run; no repository file is written or committed.
+
+3. **Given** the repository `GITHUB_TOKEN` lacks `issues: write` permission, **When** the
+   queue action runs, **Then** it exits non-zero with an explicit, human-readable
+   permission error naming `issues: write` as the required permission; it does not
+   silently succeed, does not partially update the issue, and does not crash with an
+   unhandled exception (FR-013).
+
+4. **Given** the managed queue issue body is inspected, **When** checked across multiple
+   runs on the same corpus, **Then** the hidden ownership marker is present, stable, and
+   unchanged across all runs; the action uses it to locate the correct issue on subsequent
+   runs without scanning all open issues by title alone.
+
+5. **Given** the queue action runs successfully, **When** the repository file tree is
+   inspected, **Then** no ADR record file, no queue report file, and no other repository
+   file has been written or modified; the only GitHub mutations are creation or body
+   update of the managed queue issue and reopening that same issue when required; the
+   action does not create commits or modify tracked files.
+
+6. **Given** a GitHub issue already exists with the configured title but without the
+   hidden ownership marker (i.e., not managed by adrkit), **When** the queue action runs,
+   **Then** the action does not overwrite that issue; it exits non-zero with a human-readable
+   explanation of the title conflict and a corrective action (choose a different
+   configured title or add the ownership marker to the existing issue manually).
+
+7. **Given** exactly one managed queue issue exists and is closed, **When** the queue
+   action runs, **Then** it reopens that same issue and updates its body; no replacement
+   issue is created.
+
+8. **Given** more than one open or closed issue contains the ownership marker, **When**
+   the queue action runs, **Then** it exits non-zero, names every conflicting issue number,
+   and modifies none of those issues.
+
+9. **Given** exactly one managed queue issue exists and a separate unowned issue has the
+   configured title, **When** the queue action runs, **Then** the marker-owned issue remains
+   authoritative and its body is updated without renaming either issue.
+
+---
+
+### User Story 5 — The `auto` tier is visible as expedited routing, never as automated acceptance (Priority: P2)
+
+As a reviewer or compliance owner, I want `auto`-tier proposals in the queue to be
+clearly labeled as "expedited routing — human acceptance required," never as
+"automatically accepted" or "approved," so the queue cannot be misread as having approved
+anything, and a `one-way-door` record with `tier: auto` is surfaced as an explicit error
+rather than silently passed through or tier-corrected.
+
+**Why this priority**: Misrepresenting `auto` as automated acceptance is the most
+dangerous possible queue output. This is a compliance and safety constraint. ADR-0005
+is explicit: "The evaluator routes; it never approves." The one-way-door + `auto`
+cross-field invariant is enforced at the schema level; the queue surface must surface
+violations consistently, not paper over them.
+
+**Independent Test**: Add a schema-valid `proposed` `two-way-door` record with
+`review.tier: auto` and a `proposed` `one-way-door` record with `review.tier: auto` to
+a fixture corpus; assert the `two-way-door` record appears as a `QueueItem` labeled
+`tier: auto` with no acceptance implied in any output field; assert the `one-way-door`
+record appears in top-level `corpusFindings` with an actionable description of the
+`one-way-door` + `auto` invariant violation — not with `tier: arb` substituted silently,
+and not as a `QueueItem`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `proposed` `two-way-door` record with `review.tier: auto`, **When** the
+   queue output is inspected, **Then** `tier` is `auto`, `tierLabel` is
+   `expedited routing; human acceptance required`, and neither the JSON nor the Markdown
+   output states or implies that the record is approved or will be accepted without a
+   human decision.
+
+2. **Given** a `proposed` `one-way-door` record with `review.tier: auto`, **When** the
+   queue command runs, **Then** the record appears in the top-level `corpusFindings`
+   collection — not as a `QueueItem` — with an actionable description of the
+   `one-way-door` + `auto` schema cross-field invariant violation; the queue does not
+   silently reassign the tier to `arb` or any other value, and does not omit the file.
+
+3. **Given** any `auto`-tier record in the queue, **When** the output is inspected,
+   **Then** routing targets are present (from `deciders`); the queue does not treat `auto`
+   as an absence of routing and does not omit routing targets for `auto`-tier items.
+
+---
+
+### Edge Cases
+
+- **`reviewBy` before `queuedAt`**: a `reviewBy` date earlier than `queuedAt` is a data
+  inconsistency. The queue surfaces it as an actionable finding alongside the normally
+  computed SLA state; it does not fabricate a corrected deadline and does not crash.
+
+- **Both `reviewBy` and `review.slaDays` present**: `reviewBy` is the deadline.
+  `review.slaDays` is still exposed in the output. If `reviewBy` is in the past relative
+  to `queuedAt`, the queue surfaces an actionable finding; it does not suppress the
+  inconsistency.
+
+- **`escalatedAt` and computed deadline both past**: `slaState` is `escalated`. The
+  ordering rationale: `escalatedAt` is an explicit, committed signal that a human action
+  has been taken; `overdue` is a derived state. A record transitions from `overdue` to
+  `escalated` by committing `escalatedAt`.
+
+- **`decidedAt` present with `approvalCount` below `quorum`**: the record appears as
+  `decided` (because `decidedAt` is explicitly committed), but the output surfaces both
+  `quorum` and `approvalCount` so a reviewer can see the discrepancy. The queue does not
+  fabricate a quorum-met signal.
+
+- **Schema-invalid frontmatter (cannot parse at all)**: the file appears in the top-level
+  `corpusFindings` collection — not as a `QueueItem`. The corpus finding includes
+  `sourcePath` and the specific parse error or validation failure detail. `id`, `title`,
+  `tier`, `slaState`, and decision state are never fabricated from untrustworthy partial
+  parses. The queue does not crash and does not skip the file silently.
+
+- **`review` block and top-level `reviewBy` both absent on a `proposed` record**:
+  treated as `not-queued`. This is a valid, expected state for records that have been
+  proposed but not yet entered into the review workflow. No item finding is generated
+  for absence of `review` alone. If `reviewBy` is present without a `review` block, its
+  explicit deadline still produces `within-sla`, `due`, or `overdue` under FR-005.
+
+- **Corpus with no `proposed` records**: the queue produces an empty ordered `QueueItem`
+  list with no item findings; the `corpusFindings` list may still be non-empty if
+  schema-invalid files are present. The JSON output is still well-formed and
+  version-stamped; the Markdown output explicitly states the queue is empty. This is not
+  an error condition.
+
+- **`--as-of` not supplied to CLI**: if not supplied, the CLI uses the current UTC date
+  as the as-of value and includes the resolved as-of in every output so the run is
+  reproducible when replayed with the same value. The queue kernel itself never reads
+  any clock (FR-004). The CLI documents this defaulting behavior.
+
+- **`approvals` entries not in `deciders`**: this is a data condition, not a validation
+  error. All entries in `review.approvals` count toward the approval count. The queue
+  does not filter approvals to the decider list; approver-vs-decider validation, if
+  desired, is a future concern (Assumption A4).
+
+- **GitHub issue title conflict — issue not managed by adrkit**: if a GitHub issue exists
+  with the configured title but does not contain the hidden ownership marker, the GitHub
+  Actions surface MUST NOT overwrite or update it. It exits non-zero with an explicit
+  human-readable error identifying the title conflict and the corrective action (choose a
+  different configured title, or manually add the ownership marker to the existing issue).
+
+- **Managed queue issue was closed**: the Action locates managed issues in both open and
+  closed state. If the marker identifies one closed managed issue, the Action reopens that
+  same issue and updates its body; it does not create a replacement issue.
+
+- **Multiple issues carry the ownership marker**: the Action treats ownership as
+  ambiguous, exits non-zero with the conflicting issue numbers, and changes none of them.
+
+- **Queue report contains error findings**: the Action creates or updates the managed
+  issue first so the findings remain visible, then reports a failed Action outcome. A
+  report with only warning or informational findings updates the issue and succeeds.
+
+- **`review.tier` present but not one of `auto`/`async`/`arb`**: this is a schema
+  validation failure; the file appears in the top-level `corpusFindings` collection —
+  not as a `QueueItem` — with the specific unrecognized-tier-value detail. The queue
+  does not fabricate a tier and does not assign an `slaState`.
+
+- **Empty `deciders` on a queued record**: `routingTargets` is an empty list; no routing
+  target is fabricated. An empty decider list may also generate an informational item
+  finding depending on the record's tier and SLA state, but it is not a corpus-level
+  finding on its own.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The queue MUST include as `QueueItem`s every schema-valid record with
+  `status: proposed` in the local corpus. It MUST NOT include records with any other
+  status (`accepted`, `draft`, `rejected`, `superseded`, `deprecated`). Files with
+  schema-invalid or unparseable frontmatter MUST NOT become `QueueItem`s regardless of
+  what status might be inferred from a partial parse; they appear only in the top-level
+  `corpusFindings` collection (FR-015).
+
+- **FR-002**: For each `QueueItem`, the queue MUST expose: `id`, `title`, repo-relative
+  `sourcePath`, `tier` (or `null`), `tierLabel` (or `null`), `queuedAt` (or `null`),
+  `slaDays` (or `null`), `reviewBy` (or `null`), `slaState` (one of seven defined in
+  FR-005), `routingTargets` (from `deciders`), `quorum` (or `null`), `approvalCount` (derived from
+  `review.approvals.length`), `unresolvedObjectionCount` (derived from the count of
+  `review.objections` entries with `resolved: false`), `resolvedObjectionCount` (derived
+  from the count with `resolved: true`), `escalatedAt` (or `null`), `decidedAt`
+  (or `null`), and `itemFindings` (ordered list of `ItemFinding`s, possibly empty).
+
+- **FR-003**: The queue MUST NOT include any field value not derivable from committed
+  frontmatter or the caller-supplied as-of instant. It MUST NOT fabricate tier,
+  timestamp, SLA deadline, approver identity, quorum, or decision state.
+
+- **FR-004**: SLA state MUST be a pure function of committed frontmatter fields and the
+  caller-supplied as-of instant. The queue kernel MUST NOT read any ambient clock, make
+  any network call, or perform any filesystem traversal beyond the caller-supplied corpus
+  snapshot.
+
+- **FR-005**: The queue MUST compute `slaState` as exactly one of the following seven
+  enumerated values, applied in this precedence order (first match wins). This precedence
+  applies only to schema-valid `proposed` records that have become `QueueItem`s; files in
+  `corpusFindings` do not receive an `slaState`.
+
+  | Precedence | `slaState`    | Condition                                                                                                       |
+  |:----------:|:--------------|:----------------------------------------------------------------------------------------------------------------|
+  | 1          | `decided`     | `review.decidedAt` is present (record still `proposed` in git; lifecycle PR pending)                           |
+  | 2          | `escalated`   | `review.escalatedAt` is present (and not `decided`)                                                             |
+  | 3          | `overdue`     | `deadlineDate` exists and is strictly before `asOfDate` (no `escalatedAt`, no `decidedAt`)                     |
+  | 4          | `due`         | `deadlineDate` exists and equals `asOfDate` (UTC calendar day comparison)                                       |
+  | 5          | `within-sla`  | `deadlineDate` exists and is strictly after `asOfDate`                                                          |
+  | 6          | `missing-sla` | `review.queuedAt` is present but no `deadlineDate` is computable                                                |
+  | 7          | `not-queued`  | `review.queuedAt` is absent after the `decided` and `escalated` precedence checks have failed                  |
+
+  **Deadline computation**: all comparisons are UTC calendar-date comparisons
+  (`YYYY-MM-DD`). `deadlineDate` is derived as follows: if `reviewBy` is present, its
+  UTC calendar date is the `deadlineDate`. Otherwise, if both `review.queuedAt` and
+  `review.slaDays` are present, `deadlineDate` is the UTC calendar date of `queuedAt`
+  plus `slaDays` calendar days. Examples: `queuedAt 2026-01-01` + `slaDays 7` →
+  `deadlineDate 2026-01-08`; `queuedAt 2026-01-01` + `slaDays 0` →
+  `deadlineDate 2026-01-01` (due on queue date, overdue the next calendar day). If
+  neither condition applies, `deadlineDate` is absent and `missing-sla` or `not-queued`
+  applies. A timezone-aware datetime supplied to `--as-of` is first converted to its UTC
+  instant and then to that instant's UTC calendar date; for example,
+  `2026-01-08T01:00:00+05:00` resolves to `asOfDate 2026-01-07`.
+
+- **FR-006**: Queue items MUST be ordered deterministically. For identical corpus,
+  configuration, and as-of input, the ordering MUST be byte-for-byte stable. Items are
+  sorted by SLA urgency group (primary), then by deadline ascending (secondary, for items
+  with a computable deadline), then by `review.queuedAt` ascending (tertiary, for items
+  without a computable deadline but with a `queuedAt`), then by record `id` ascending
+  (lexicographic, as mandatory final tiebreak).
+
+  **Urgency group order** (highest urgency first):
+  `overdue` → `escalated` → `due` → `within-sla` → `missing-sla` →
+  `not-queued` → `decided`. Deadline ordering compares UTC calendar dates.
+  `review.queuedAt` ordering compares normalized UTC instants. Top-level
+  `corpusFindings` are sorted by repo-relative `sourcePath`, then finding code, severity,
+  and human-readable description. Source paths, codes, and descriptions use ascending
+  UTF-16 code-unit order; severity uses the explicit rank `error` → `warn` → `info`.
+  `itemFindings` use the same code, severity-rank, and description ordering.
+
+- **FR-007**: The CLI surface MUST accept a corpus directory path and a caller-supplied
+  as-of value (`--as-of`, ISO date `YYYY-MM-DD` or ISO datetime with timezone). If
+  `--as-of` is not supplied, the CLI uses the current UTC date and MUST include the
+  resolved UTC calendar date (`YYYY-MM-DD`) in every output so the run is fully
+  reproducible when replayed. The CLI MUST accept `--format markdown|json`, default to
+  `markdown`, and emit exactly the selected representation to stdout. The queue kernel
+  MUST NOT read any clock.
+
+- **FR-008**: The CLI surface MUST produce a strict versioned JSON output and a
+  deterministic Markdown output for the same run from the same internal queue report.
+  Both outputs MUST be derivable from the same queue report data; neither may add
+  information the other lacks. Planning MUST define the canonical Markdown headings,
+  table columns, finding sections, escaping, blank lines, empty-state text, and final
+  newline so byte-for-byte determinism is testable.
+
+- **FR-009**: The JSON output MUST carry a `version` field identifying the queue report
+  schema version, an `asOf` field containing the resolved UTC calendar date as
+  `YYYY-MM-DD`, and a `corpusFingerprint` field for drift detection, enabling consumers
+  to detect breaking changes and reproduce runs. It MUST also carry summary counts named
+  `totalItems` (`items.length`), `totalCorpusFindings` (`corpusFindings.length`), and
+  `itemsWithFindings` (number of items whose `itemFindings` list is non-empty). The
+  fingerprint MUST be the lower-case hexadecimal SHA-256 of the
+  same canonical corpus projection used by the MCP surface: ordered schema-valid records
+  represented by repo-relative `sourcePath`, parsed frontmatter, and body; ordered corpus
+  findings; and record/exclusion counts. Object keys are sorted canonically, `undefined`
+  fields are omitted, UTF-8 is used, and caller-specific `asOf` and derived queue fields
+  are excluded so all first-party readers report the same corpus identity.
+
+- **FR-010**: The GitHub Actions operational surface MUST create or update exactly one
+  dedicated GitHub issue per run. The issue body MUST contain the deterministic Markdown
+  queue report. The first run creates the issue; subsequent runs locate it by the hidden
+  ownership marker in the body and update the same issue body in place. It MUST NOT
+  create multiple issues for the same repository.
+
+- **FR-011**: The managed GitHub issue body MUST contain a stable, machine-readable
+  hidden ownership marker that the action uses to locate and update it on subsequent runs.
+  The marker MUST be a corpus-independent constant and remain unchanged across every
+  rerun. The marker format is a planning decision; the spec requires only that it be
+  hidden from rendered Markdown (e.g., an HTML comment) and globally unique to
+  adrkit-managed queue issues.
+
+- **FR-012**: The GitHub Actions surface MUST use only the repository default token
+  (`GITHUB_TOKEN`) and MUST explicitly document `issues: write` as the required
+  permission for its GitHub API calls. A calling workflow that checks out the corpus
+  MUST also retain `contents: read` for `actions/checkout`, especially for private
+  repositories. It MUST NOT require any PAT, secret, or credential beyond the default
+  token.
+
+- **FR-013**: If the GitHub Actions surface cannot create or update the managed issue
+  due to insufficient permissions, it MUST exit non-zero and emit a human-readable error
+  explicitly naming `issues: write` as the required permission. It MUST NOT silently
+  succeed, does not partially write, and does not crash with an unhandled exception.
+
+- **FR-014**: The queue surface MUST NOT write or modify any ADR record file or any
+  tracked repository file; it MUST NOT create any commits. The only GitHub mutations
+  produced by the GitHub Actions surface are creation or body update of the managed queue
+  issue and reopening that same issue when required by FR-021. The CLI surface produces
+  only stdout output. ADR lifecycle changes MUST continue to happen through ADR pull
+  requests (ADR-0001, ADR-0004).
+
+- **FR-015**: Files with schema-invalid or unparseable frontmatter, or records with
+  unsatisfied schema cross-field invariants (e.g., `one-way-door` + `tier: auto`), MUST
+  appear in the `QueueReport`'s top-level `corpusFindings` collection — not as
+  `QueueItem`s and not with any `slaState` assigned. Each `CorpusFinding` MUST include
+  `sourcePath` and parser/validator details. `id`, `title`, `tier`, `slaState`, `queuedAt`,
+  and decision state MUST NOT be fabricated from untrustworthy or absent parse data.
+  These files MUST NOT be silently omitted.
+
+- **FR-016**: The `auto` tier MUST be labeled in all outputs as an expedited review tier,
+  not as automated acceptance. The queue surface MUST NOT state or imply that any record
+  has been approved or accepted without a human decision (ADR-0005, Principle IV).
+  `tierLabel` is derived exactly as follows: `auto` →
+  `expedited routing; human acceptance required`; `async` →
+  `asynchronous human review`; `arb` → `ARB human review`; absent tier → `null`.
+
+- **FR-017**: A record with `reversibility: one-way-door` and `review.tier: auto`
+  violates the schema cross-field invariant (ADR-0002) and MUST appear in the top-level
+  `corpusFindings` collection — not as a `QueueItem`. No `slaState` is assigned. The
+  queue surface MUST NOT silently reassign the tier to any other value, and MUST NOT
+  omit the file.
+
+- **FR-018**: The queue kernel and CLI MUST be buildable, testable, and runnable in a
+  clean clone with no credentials, services, or network access after the frozen
+  dependency install. The GitHub Actions wrapper MUST access no network other than the
+  GitHub API and MUST be tested through an injected fake client with no token or network.
+  This boundary is asserted by the existing `clean-clone-builds` gate in CI (Principle
+  II, ADR-0007).
+
+- **FR-019**: Before rung 6 is claimed, the CLI and GitHub Actions surfaces MUST be
+  exercised in a **separate** repository by a team that is not the maintainer's own, with
+  at least three active `proposed` records spanning all three tiers (`auto`, `async`,
+  `arb`), at least one SLA-boundary or overdue case, approvals and objections present,
+  the same managed GitHub issue body updated in place on a second run, and
+  default-token-only `issues: write` operation (SC-004, Assumption A7).
+
+- **FR-020**: If no managed issue marker exists and a GitHub issue already exists in the
+  repository with the configured issue title but does not contain the hidden ownership
+  marker, the GitHub Actions surface MUST NOT overwrite or update that issue. It MUST exit
+  non-zero with a human-readable error explaining the title conflict and a corrective
+  action (select a different configured title, or manually add the hidden ownership marker
+  to the existing issue).
+
+- **FR-021**: The Action MUST search both open and closed issues for its ownership marker.
+  If exactly one managed issue is closed, it MUST reopen and update that same issue. If
+  multiple issues contain the marker, it MUST exit non-zero, identify every conflicting
+  issue number, and modify none of them. The marker search is authoritative: when exactly
+  one managed issue exists, the Action updates that issue body regardless of other issue
+  titles and does not rename it. Only when no marker exists does it apply the configured
+  title conflict check in FR-020 before creating a new issue.
+
+- **FR-022**: Every `ItemFinding` and `CorpusFinding` MUST carry a severity of `error`,
+  `warn`, or `info`. The CLI MUST emit the complete requested report before exiting
+  non-zero when the report contains any error-severity finding. Warning- and info-only
+  reports MUST exit zero. Before implementation tasks may begin, planning MUST freeze a
+  closed list of queue finding codes, generation conditions, severities, and exact
+  messages; implementation MUST NOT invent additional codes or reclassify severity.
+
+- **FR-023**: When a queue report contains error-severity findings, the GitHub Actions
+  surface MUST create or update the managed issue body with the complete report before
+  reporting a failed Action outcome. Warning- and info-only reports MUST update the issue
+  and succeed. Ownership, permission, or title-conflict failures that prevent a safe issue
+  update MUST fail without modifying any issue.
+
+### Out of Scope
+
+The following are explicitly excluded from this feature and MUST NOT be introduced in
+planning or implementation:
+
+- Postgres, Prisma, or any persistent index; any database required for queue operation
+- Any web UI, HTTP endpoint, or background daemon
+- Multi-repository federation, named log federation, or cross-repo queue aggregation
+- Model calls, rubric scoring (Passes 1–3), semantic ranking, embeddings, or any
+  probabilistic computation in the queue surface
+- Notification delivery (email, Slack, Teams, webhook, calendar integration)
+- Any form of ADR acceptance, rejection, or approval automation by the queue surface
+- Direct edit of ADR content, branch creation, or PR creation by the queue surface
+- Any MCP write tool or fifth MCP tool
+- Any hosted authentication, tenant management, or RBAC system
+- GitHub Actions upload artifacts as the queue report surface
+- Tracked repository files or committed files for queue report output (the queue surface
+  does not create commits or modify any repository file)
+- PR comments or issue comments as the queue report surface (the surface is a dedicated
+  managed issue body, not a comment on an existing PR or issue)
+- Personal access tokens (PATs) or secrets beyond the repository default token
+
+### Key Entities
+
+- **`QueueItem`**: A projected, read-only view of one schema-valid `proposed` record,
+  derived from committed frontmatter and the caller-supplied as-of instant. Contains all
+  fields specified in FR-002. Never stored; computed on demand from the corpus snapshot.
+  Includes an ordered list of `itemFindings` (`ItemFinding`s, zero or more). Files with
+  schema-invalid frontmatter or cross-field invariant violations are never `QueueItem`s.
+
+- **`SlaState`**: One of exactly seven enumerated values (`decided`, `escalated`,
+  `overdue`, `due`, `within-sla`, `missing-sla`, `not-queued`), computed by the
+  precedence rules in FR-005. Applies only to `QueueItem`s; corpus findings do not
+  receive an `SlaState`.
+
+- **`ItemFinding`**: An actionable finding attached to a specific `QueueItem` for
+  queue-specific incompleteness or inconsistency in an otherwise schema-valid `proposed`
+  record (e.g., absent `tier`, absent SLA deadline, `reviewBy` before `queuedAt`).
+  Contains the source record identity (`id` and `sourcePath`), a machine-readable finding
+  code, a severity (`error`, `warn`, or `info`), and a human-readable description.
+  Structurally distinct from `CorpusFinding`. The finding code namespace and severity
+  mapping are planning decisions.
+
+- **`CorpusFinding`**: A top-level finding for a file that cannot enter the `QueueItem`
+  collection: schema-invalid or unparseable frontmatter, or an unsatisfied schema
+  cross-field invariant (e.g., `one-way-door` + `tier: auto`). Contains `sourcePath`
+  parser/validator details, a machine-readable code, and a severity (`error`, `warn`, or
+  `info`), and a human-readable description. Does not include `id`, `title`, `tier`,
+  `slaState`, or any fabricated field. Appears in the `QueueReport`'s ordered top-level
+  `corpusFindings` collection, structurally distinct from `ItemFinding`.
+
+- **`QueueReport`**: The complete output of the queue kernel for one run. Contains: the
+  resolved `asOf` UTC calendar date, a `corpusFingerprint` (for drift detection), a `version`
+  field, an ordered list of `QueueItem`s (per FR-006), an ordered top-level
+  `corpusFindings` list (zero or more `CorpusFinding`s), and summary counts (total
+  queue items, total corpus findings, total items with item findings). Never stored;
+  produced fresh on each run.
+
+- **`ManagedQueueIssue`**: The dedicated GitHub issue created or updated by the GitHub
+  Actions surface. Its body contains the deterministic Markdown queue report and a
+  stable hidden ownership marker (e.g., an HTML comment). Created on first run; located
+  by the ownership marker on subsequent runs and updated in place. Requires `GITHUB_TOKEN`
+  with `issues: write`. Does not commit or modify any repository file. If an issue with
+  the configured title exists without the ownership marker, the action fails rather than
+  overwriting it (FR-020).
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Given identical corpus, configuration, and as-of instant, two independent
+  runs of the queue command produce byte-for-byte identical JSON output and byte-for-byte
+  identical Markdown output.
+
+- **SC-002**: A maintainer operating on a corpus with ten or more `proposed` records can
+  identify all `overdue`, `due`, and `escalated` items — and all records with item
+  findings — and all files with corpus findings — without opening any individual ADR
+  file, using only the queue output.
+
+- **SC-003**: The GitHub Actions surface updates the same managed GitHub issue body in
+  place on every rerun, creating no duplicate issues, for a corpus that has not changed
+  between runs.
+
+- **SC-004**: The rung 6 exit gate is met: a team that is **not** the maintainer's own
+  repository runs the queue surface against their repository with at least three `proposed`
+  records spanning all three tiers (`auto`, `async`, `arb`), at least one SLA-boundary or
+  overdue case, approvals and objections present, the same managed GitHub issue body
+  updated in place on a second run with default-token-only `issues: write` operation.
+
+- **SC-005**: Files with schema-invalid frontmatter appear in the `QueueReport`'s
+  `corpusFindings` collection with `sourcePath` and parser/validator details; no `id`,
+  `title`, `tier`, `slaState`, or other fabricated field is emitted for them; the queue
+  does not crash, does not silently omit them, and does not add them to the `QueueItem`
+  collection.
+
+- **SC-006**: Every field exposed in a `QueueItem` is traceable to a committed frontmatter
+  field or the caller-supplied as-of instant. No queue item contains a fabricated tier,
+  timestamp, SLA deadline, approver identity, quorum, or decision state.
+
+- **SC-007**: The `clean-clone-builds` CI gate remains green after the queue surface
+  packages are added; no credential, service, or network is required for post-install
+  build, test, or local queue execution, and the Action's GitHub API client is exercised
+  in tests without a token or network (Principle II, ADR-0007).
+
+- **SC-008**: Error-severity findings are visible in the complete CLI output and managed
+  issue body before their respective runs report failure; warning- and info-only reports
+  complete successfully.
+
+## Assumptions
+
+- **A1**: The queue operates on a single, local, already-cloned ADR corpus.
+  Multi-repository federation, named logs across repositories, and hosted index
+  federation are explicitly out of scope for this feature (ADR-0004 Option A rationale;
+  Phase 6 scope boundary; see Out of Scope above).
+
+- **A2**: `review.queuedAt` in the ADR frontmatter is the canonical queue-entry
+  timestamp. The queue surface reads it but never writes it. Writing `queuedAt` is a
+  lifecycle action performed through a PR; it is not the queue surface's responsibility.
+
+- **A3**: When both `reviewBy` and `review.slaDays` are present on the same record,
+  `reviewBy` takes precedence as the explicit SLA deadline. `review.slaDays` is
+  informational when `reviewBy` is set.
+
+- **A4**: All entries in `review.approvals` count toward the approval count, regardless
+  of whether they appear in `deciders`. Approver-vs-decider validation, if desired, is a
+  future concern outside this scope.
+
+- **A5**: The GitHub Actions managed queue surface is a dedicated GitHub issue — not a
+  tracked repository file, not a GitHub Actions upload artifact, not a PR comment, and
+  not an issue comment. The issue body contains the deterministic Markdown report and a
+  stable hidden ownership marker. The action creates the issue on first run and updates
+  the body in place on subsequent runs using only `GITHUB_TOKEN` with `issues: write`.
+  The issue title is configurable. The action does not commit files or modify any
+  tracked repository content.
+
+- **A6**: The queue surface is a first-party, non-adapter consumer of `@adrkit/core`. It
+  is not an adapter package and does not live under `packages/adapters/`. It depends on
+  `@adrkit/core` for record parsing, schema validation, and graph traversal (Principle III,
+  ADR-0007).
+
+- **A7**: Implementation MUST NOT claim rung 6 until SC-004 is met. The dogfood evidence
+  MUST be from a repository and team that are not the maintainer's own. The maintainer's
+  own-repository dogfood cleared rungs 1–5 but does not satisfy rung 6's explicit "a team
+  that isn't yours" exit requirement (`plan.md` outcome ladder).
+
+- **A8**: The `auto` review tier means "expedited routing to a human reviewer" — not
+  automated acceptance. A human still approves or rejects. No action taken by any queue
+  surface constitutes acceptance of any record. (ADR-0005: "The evaluator routes; it never
+  approves.")
+
+- **A9**: The GitHub Actions surface uses `GITHUB_TOKEN` (the repository default token)
+  and does not attempt to create PATs, rotate credentials, or escalate permissions. The
+  required permission is `issues: write`; permission failures name this permission
+  explicitly (FR-013). If the default token lacks `issues: write`, the failure is
+  surfaced honestly and not silently suppressed.
+
+- **A10**: This feature does not add a fifth MCP tool, a write MCP tool, or any HTTP
+  service. The queue surface is a CLI command and a GitHub Actions workflow step. Any
+  future MCP integration that exposes queue data is a separate, explicitly-scoped feature.
+
+- **A11**: The `review.objections` array entries carry a `resolved` boolean field (per
+  the committed schema). `unresolvedObjectionCount` is the count of entries with
+  `resolved: false` (or defaulted false); `resolvedObjectionCount` is the count with
+  `resolved: true`. The queue surface reads these values and does not infer resolution
+  state from other fields.

--- a/specs/007-arb-queue/tasks.md
+++ b/specs/007-arb-queue/tasks.md
@@ -1,0 +1,771 @@
+---
+description: "Dependency-ordered task list for the ARB Operations Queue"
+---
+
+# Tasks: ARB Operations Queue — Phase 6
+
+**Input**: Design documents from `specs/007-arb-queue/`
+
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`,
+`contracts/kernel.md`, `contracts/cli-contract.md`, `contracts/github-action.md`,
+`contracts/queue-report.md`, `quickstart.md`
+
+**Normative**: `docs/adr/0001`, `docs/adr/0002`, `docs/adr/0004`, `docs/adr/0005`,
+`docs/adr/0007`, `docs/adr/0010`, `.specify/memory/constitution.md` Principles I–V
+
+> **Scope is closed.** Implement exactly: the pure `buildQueueReport` kernel in
+> `@adrkit/core`, the `adr queue` CLI subcommand in `@adrkit/cli`, and the
+> `packages/ci/queue/action.yml` GitHub Action in private `@adrkit/ci`. Do not add a
+> fifth tool, write path into decision records, database, web service, persistent index,
+> notification system, lifecycle transitions, model/embedding calls, multi-repository
+> federation, or PAT-based auth. No new public package.
+
+**Tests**: REQUIRED and test-first (RED before GREEN). Test-creation tasks precede their
+implementation tasks. Each RED task must be run and its expected failure recorded before
+the corresponding GREEN task begins. No stub modules that throw `Error("unimplemented")`.
+
+**Toolchain**: Bun 1.3.14; `bun.lock` frozen. Published artifacts target Node ≥22.
+
+## Format: `[ID] [P?] [Story?] Description with exact file path`
+
+- **[P]**: Parallelizable — task writes files with no path overlap and has no
+  dependency on another incomplete task in the same phase.
+- **[US1]–[US5]**: Used only in user-story phases; maps directly to `spec.md`.
+- Setup, foundational, and quality phases intentionally omit story labels.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create fixture directories and write fixture ADR files for the offline test
+substrate. Do NOT create production source modules or stub implementations here;
+this phase is fixture-only.
+
+- [ ] T001 Create fixture directory tree: `packages/core/test/fixtures/queue/` with
+  subdirs `within-sla-corpus/`, `overdue-corpus/`, `due-corpus/`, `escalated-corpus/`,
+  `decided-corpus/`, `not-queued-corpus/`, `missing-sla-corpus/`,
+  `schema-invalid-corpus/`, `one-way-door-auto-corpus/`, `no-proposed-corpus/`,
+  `warn-review-by-before-queued-corpus/`, `comprehensive-corpus/`
+
+- [ ] T002 [P] Write `packages/core/test/fixtures/queue/within-sla-corpus/0001.md`:
+  frontmatter `id:"0001"`, `title:"Test Within-SLA ADR"`, `status:proposed`,
+  `date:2026-01-01`, `deciders:["@alice","@bob"]`, `review.tier:arb`,
+  `review.queuedAt:"2026-01-01T00:00:00Z"`, `review.slaDays:14`;
+  on `--as-of 2026-01-08` deadline is 2026-01-15, asOf before deadline → `within-sla`
+
+- [ ] T003 [P] Write `packages/core/test/fixtures/queue/overdue-corpus/0001.md`:
+  frontmatter `id:"0001"`, `title:"Test Overdue ADR"`, `status:proposed`,
+  `date:2025-12-01`, `deciders:["@alice"]`, `review.tier:arb`,
+  `review.queuedAt:"2025-12-01T00:00:00Z"`, `review.slaDays:14`, no `escalatedAt`;
+  on `--as-of 2026-03-01` deadline 2025-12-15 < asOf, no escalatedAt → `overdue`
+
+- [ ] T004 [P] Write `packages/core/test/fixtures/queue/due-corpus/0001.md`:
+  frontmatter `id:"0001"`, `title:"Test Due ADR"`, `status:proposed`, `date:2026-02-01`,
+  `deciders:["@alice"]`, `review.tier:async`, `review.queuedAt:"2026-02-01T00:00:00Z"`,
+  `review.slaDays:14`;
+  on `--as-of 2026-02-15` deadline 2026-02-15 == asOf → `due`
+
+- [ ] T005 [P] Write `packages/core/test/fixtures/queue/escalated-corpus/0001.md`:
+  frontmatter `id:"0001"`, `title:"Test Escalated ADR"`, `status:proposed`,
+  `date:2025-11-01`, `deciders:["@alice"]`, `review.tier:arb`,
+  `review.queuedAt:"2025-11-01T00:00:00Z"`, `review.slaDays:14`,
+  `review.escalatedAt:"2025-11-20T00:00:00Z"`;
+  on `--as-of 2026-01-08` deadline in past + escalatedAt present → `escalated` (not `overdue`)
+
+- [ ] T006 [P] Write `packages/core/test/fixtures/queue/decided-corpus/0001.md`:
+  frontmatter `id:"0001"`, `title:"Test Decided ADR"`, `status:proposed`,
+  `date:2026-01-01`, `deciders:["@alice"]`, `review.tier:arb`,
+  `review.queuedAt:"2026-01-01T00:00:00Z"`, `review.slaDays:14`,
+  `review.decidedAt:"2026-01-05T00:00:00Z"`;
+  `status:proposed` + `review.decidedAt` present → `decided` regardless of deadline
+
+- [ ] T007 [P] Write `packages/core/test/fixtures/queue/not-queued-corpus/0001.md`:
+  frontmatter `id:"0001"`, `title:"Test Not-Queued ADR"`, `status:proposed`,
+  `date:2026-01-01`; no `review` block at all;
+  queuedAt absent → `not-queued` on any asOf
+
+- [ ] T008 [P] Write `packages/core/test/fixtures/queue/missing-sla-corpus/0001.md`:
+  frontmatter `id:"0001"`, `title:"Test Missing-SLA ADR"`, `status:proposed`,
+  `date:2026-01-01`, `deciders:["@alice"]`, `review.tier:async`,
+  `review.queuedAt:"2026-01-01T00:00:00Z"`; NO `review.slaDays`, NO top-level `reviewBy`;
+  queuedAt present, deadline uncomputable → `missing-sla`
+
+- [ ] T009 [P] Write `packages/core/test/fixtures/queue/schema-invalid-corpus/0001.md`:
+  valid YAML with frontmatter `id:"0001"`, `title:"Bad Status ADR"`, `date:2026-01-01`,
+  `status:"not-a-valid-status"` (fails Zod enum validation); `lintCorpus` emits
+  `Finding.rule:"invalid-enum-value"` for this file → maps to `corpus.schema-invalid`
+
+- [ ] T010 [P] Write `packages/core/test/fixtures/queue/one-way-door-auto-corpus/0001.md`:
+  frontmatter `id:"0001"`, `title:"One-Way-Door Auto ADR"`, `status:proposed`,
+  `date:2026-01-01`, `reversibility:one-way-door`, `deciders:["@alice"]`,
+  `review.tier:auto`, `review.queuedAt:"2026-01-01T00:00:00Z"`, `review.slaDays:7`;
+  cross-field invariant `reversibility:one-way-door` + `review.tier:auto` →
+  `corpus.one-way-door-auto-tier` (file excluded from items)
+
+- [ ] T011 [P] Write `packages/core/test/fixtures/queue/no-proposed-corpus/0001.md`:
+  frontmatter `id:"0001"`, `title:"Accepted ADR"`, `status:accepted`, `date:2026-01-01`;
+  only non-proposed records → `items:[]`, `totalItems:0`
+
+- [ ] T012 [P] Write `packages/core/test/fixtures/queue/warn-review-by-before-queued-corpus/0001.md`:
+  frontmatter `id:"0001"`, `title:"ReviewBy Before Queued"`, `status:proposed`,
+  `date:2026-01-01`, `reviewBy:"2025-12-31"`, `deciders:["@alice"]`,
+  `review.tier:async`, `review.queuedAt:"2026-01-01T00:00:00Z"`, `review.slaDays:14`;
+  top-level `reviewBy` (2025-12-31) strictly before UTC calendar date of `queuedAt`
+  (2026-01-01) → item finding `item.review-by-before-queued` severity warn;
+  no corpus.schema-invalid; exit 0 (warn only, not error). Also populate
+  `packages/core/test/fixtures/queue/comprehensive-corpus/` with ten schema-valid
+  `proposed` records (`0001.md`–`0010.md`) spanning all seven SLA states and all three
+  tiers, including one valid two-way-door `auto` item, approvals and resolved/unresolved
+  objections, item findings, and deterministic sort ties; add `9999-invalid.md` with
+  schema-invalid frontmatter so the complete report also exercises a CorpusFinding.
+
+**Checkpoint**: 12 fixture corpora exist under `packages/core/test/fixtures/queue/`.
+`bun test` finds no test files yet; `bun run typecheck` still passes.
+
+---
+
+## Phase 2: Fingerprint and Ordering Promotion
+
+**Purpose**: Promote `canonicalStringify`, `fingerprintOf`, and ordering helpers from
+`@adrkit/mcp` to `@adrkit/core` with a permanent byte-compatibility test, then migrate
+MCP imports — no observable change to any existing behavior.
+
+**Blocked by**: Phase 1 complete.
+
+### RED: write failing tests first
+
+- [ ] T013 [P] Write failing byte-compatibility test in
+  `packages/core/test/fingerprint/fingerprint.test.ts`:
+  (a) before migration, compute one fixed 64-character reference vector from the current
+  MCP algorithm using a one-off `bun -e` command that copies the exact private
+  `fingerprintOf` projection over a small inline fixture (`records: [Adr]`,
+  `findings: [Finding]`, `recordCount: 1`, `excludedCount: 0`), then store only the
+  resulting literal and fixture in the permanent test (do not import the private MCP
+  helper or retain a second implementation);
+  (b) import `fingerprintOf`, `canonicalStringify` from `@adrkit/core` (module export does
+  not yet exist); assert promoted `fingerprintOf` returns the exact reference hex for the
+  same inputs; assert determinism: two calls with identical input → identical hex;
+  assert key-order independence: object with same fields in different order → same hex.
+  Run `bun test packages/core/test/fingerprint/fingerprint.test.ts`; record
+  `Cannot find module '@adrkit/core' export 'fingerprintOf'` or equivalent failure.
+
+- [ ] T014 [P] Write failing ordering-helpers test in
+  `packages/core/test/ordering/ordering.test.ts`:
+  import `compareCodeUnits`, `sortFindingsCanonical`, `sortByIdThenPath`,
+  `compareByIdThenPath` from `@adrkit/core`;
+  assert `compareCodeUnits("ä","b") > 0` (ä U+00E4=228, b U+0062=98; ä > b);
+  assert `compareCodeUnits("a","b") < 0`;
+  assert `compareCodeUnits("a","a") === 0`;
+  assert `sortByIdThenPath` is ascending by id then sourcePath (code-unit order, stable);
+  assert `sortFindingsCanonical` on a fixture Finding[] produces the same array each call.
+  Run `bun test packages/core/test/ordering/ordering.test.ts`; record
+  `Cannot find module '@adrkit/core' export 'compareCodeUnits'` or equivalent failure.
+
+### GREEN: implement promotions
+
+- [ ] T015 After T013+T016: Create `packages/core/src/fingerprint/index.ts` by promoting
+  `canonicalStringify` and `fingerprintOf` verbatim from
+  `packages/mcp/src/corpus/projection.ts` (lines ~170–196);
+  exact `fingerprintOf` signature:
+  `fingerprintOf(records: readonly Adr[], corpusFindings: readonly Finding[], recordCount: number, excludedCount: number): string`;
+  exact projection shape built inside the function:
+  `{ records: records.map(r => ({sourcePath:r.path, frontmatter:r.frontmatter, body:r.body})), corpusFindings, corpusHealth:{recordCount,excludedCount} }`;
+  imports: `Adr` and `Finding` from their relative core modules (no self-package barrel
+  import), `compareCodeUnits` from `../ordering/index.ts`, and `createHash` from
+  `node:crypto`.
+  Run `bun test packages/core/test/fingerprint/fingerprint.test.ts`; assert all assertions green.
+
+- [ ] T016 [P] After T014: Create `packages/core/src/ordering/index.ts` by promoting
+  `compareCodeUnits`, `compareFindings`, `sortFindingsCanonical`, `compareByIdThenPath`,
+  `sortByIdThenPath`, and `OrderedSummary` interface verbatim from
+  `packages/mcp/src/corpus/ordering.ts`;
+  import `Finding` from its relative core module (no self-package barrel import).
+  Run `bun test packages/core/test/ordering/ordering.test.ts`; assert all assertions green.
+
+- [ ] T017 Add named re-exports for `canonicalStringify`, `fingerprintOf`,
+  `compareCodeUnits`, `compareFindings`, `sortFindingsCanonical`, `compareByIdThenPath`,
+  `sortByIdThenPath`, `type OrderedSummary` to `packages/core/src/index.ts`.
+  Run `bun run --filter @adrkit/core typecheck`; assert clean.
+
+### MCP migration (no observable change)
+
+- [ ] T018 [P] Update `packages/mcp/src/corpus/projection.ts`: remove the local
+  `canonicalStringify` and `fingerprintOf` function bodies; add
+  `import { canonicalStringify, fingerprintOf } from '@adrkit/core';` at the top;
+  all call sites are unchanged; no other behavioral modification.
+
+- [ ] T019 [P] Convert `packages/mcp/src/corpus/ordering.ts` to a re-export shim:
+  replace the implementation bodies with
+  `export { compareCodeUnits, compareFindings, sortFindingsCanonical, compareByIdThenPath, sortByIdThenPath, type OrderedSummary } from '@adrkit/core';`;
+  all existing MCP import sites (`import ... from '../corpus/ordering'`) need no change.
+
+- [ ] T020 Run `bun run --filter @adrkit/mcp typecheck && bun test packages/mcp`;
+  assert all MCP tests pass without modification; assert no change to MCP public API
+  or observable tool behavior.
+
+**Checkpoint**: `fingerprintOf` and ordering helpers live in `@adrkit/core` with
+permanent byte-compat test. MCP behavior is bit-identical.
+
+---
+
+## Phase 3: Queue Kernel, Sort, Findings, and Formatters (US1, US2, US3, US5)
+
+**Purpose**: Implement the pure queue core — types, corpus/item finding mapping,
+deterministic sort, `buildQueueReport` kernel, and canonical JSON/Markdown formatters.
+Covers US1 (local queue), US2 (SLA determinism), US3 (corpus vs item finding
+distinction), and US5 (auto tier as expedited routing).
+
+**Blocked by**: Phase 2 (`fingerprintOf`, `sortByIdThenPath`, `sortFindingsCanonical`
+available from `@adrkit/core`).
+
+**Independent Test (US1/US2/US3/US5)**:
+`bun run adr -- queue --dir packages/core/test/fixtures/queue/within-sla-corpus --as-of 2026-01-08 --format json`
+exits 0; JSON output has `version:"1"`, `asOf:"2026-01-08"`, exactly 1 item with
+`slaState:"within-sla"`, `totalCorpusFindings:0`; running twice with the same
+`--as-of` produces byte-identical stdout.
+
+### RED: write failing tests first
+
+- [ ] T021 [P] [US3] Write failing tests in `packages/core/test/queue/findings.test.ts`:
+  import `mapFindingToCorpusFinding`, `RULE_TO_CORPUS_CODE` from `@adrkit/core`;
+  (a) `rule:"file-read"` → code `corpus.read-error`, message `"Cannot read file: {Finding.message}"`;
+  (b) `rule:"frontmatter-parse"` → `corpus.parse-error`, message passed through from Finding;
+  (c) `rule:"frontmatter-fence"` → `corpus.parse-error`, message passed through;
+  (d) `rule:"one-way-door-disallows-auto"` → `corpus.one-way-door-auto-tier`, exact canonical
+  message `"one-way-door decisions may not take the auto-approve fast path (reversibility: one-way-door, review.tier: auto)"`;
+  (e) `rule:"invalid-enum-value"` → `corpus.schema-invalid`, message passed through;
+  (f) `rule:"required-field"` → `corpus.schema-invalid`;
+  (g) any unrecognized rule (e.g. `"contract-xyz"`) → `corpus.schema-invalid` (fallback, not undefined);
+  Schema-valid-record finding exclusion and item-finding generation are tested through
+  `buildQueueReport` in T023, because the corpus mapping helper alone does not know
+  which files produced valid records.
+  Run test; record `Cannot find module '@adrkit/core' export 'mapFindingToCorpusFinding'` failure.
+
+- [ ] T022 [P] [US2] Write failing tests in `packages/core/test/queue/sort.test.ts`:
+  import `sortQueueItems`, `sortCorpusFindings`, `sortItemFindings`, `SLA_STATE_URGENCY_ORDER`
+  from `@adrkit/core`;
+  (a) urgency order assertion: sort items with all 7 slaStates; assert final order
+  `overdue(0)` first, then `escalated(1)`, `due(2)`, `within-sla(3)`, `missing-sla(4)`,
+  `not-queued(5)`, `decided(6)` last;
+  (b) within-group: two `overdue` items with different deadlineDates sort by deadline
+  ascending; item with null deadline sorts AFTER item with non-null deadline in same group;
+  (c) id tiebreak: equal urgency + equal deadlineDate + equal queuedAt → ascending `id`;
+  (d) `not-queued` group: queuedAt absent by definition → sorts by `id` only;
+  (e) `sortCorpusFindings` order: sourcePath → code → severity rank (error=0,warn=1,info=2)
+  → message (code-unit);
+  (f) `sortItemFindings` order: code → severity rank → message (code-unit);
+  (g) determinism: two calls on same input → byte-identical output.
+  Run test; record `Cannot find module` failure.
+
+- [ ] T023 [P] [US1] Write failing tests in `packages/core/test/queue/kernel.test.ts`:
+  import `buildQueueReport` from `@adrkit/core`; construct each input as
+  `LintCorpusResult` with fields `records`, `findings`, `checked` (NOT `recordCount`/`excludedCount`);
+  (1) **all 7 SLA states** — one inline corpus per state: `overdue`, `escalated`, `due`,
+  `within-sla`, `missing-sla`, `not-queued`, `decided`; assert correct `slaState` for each;
+  (2) **timezone normalization** — inline record with
+  `review.queuedAt:"2026-03-08T23:59:59-05:00"`, `review.slaDays:1`; kernel normalizes
+  to UTC date 2026-03-09; deadline = 2026-03-10; with `asOf:"2026-03-10"` →
+  `slaState:"due"` (deadline == asOf); with `asOf:"2026-03-11"` → `slaState:"overdue"`;
+  (3) **slaDays:0** — deadline = queuedAt UTC date; `due` on that date; `overdue` next day;
+  (4) **reviewBy precedence** — both `reviewBy` and `review.slaDays` present; `reviewBy`
+  is the deadline (slaDays ignored for deadline computation, still in output);
+  (5) **escalated beats overdue** — `escalatedAt` present + deadline in past →
+  `slaState:"escalated"`, not `"overdue"`;
+  (6) **decided beats escalated** — `decidedAt` + `escalatedAt` both present →
+  `slaState:"decided"`;
+  (7) **empty corpus** — `records:[]`, `findings:[]`, `checked:0` →
+  `items:[]`, `corpusFindings:[]`, `totalItems:0`;
+  (8) **no proposed** — all records `status:accepted` → `items:[]`;
+  `corpusFindings` may be non-empty if excluded files exist;
+  (9) **item.tier-absent** — proposed record with no `review.tier` → one item finding
+  with code `"item.tier-absent"`, severity `"info"`;
+  (10) **item.deciders-empty** — proposed record with `queuedAt` present and
+  `deciders:[]` → `"item.deciders-empty"` severity `"info"`;
+  (11) **item.review-by-before-queued** — `reviewBy` strictly before UTC calendar date
+  of `queuedAt` → `"item.review-by-before-queued"` severity `"warn"`;
+  equal date → NO finding generated; assert exact frozen messages for all three item
+  finding codes from `research.md §R2`;
+  (12) **decidedAt + approvalCount < quorum** → no item finding (valid state, numbers exposed);
+  (13) **schema-valid proposed with warn lint finding** — Finding with severity warn for
+  a record in `corpus.records`: that finding does NOT appear in `report.corpusFindings`
+  (schema-valid records excluded) but IS included in fingerprint input (`corpus.findings`);
+  (14) **version field** — `report.version === "1"` (string, not number);
+  (15) **excluded file one-way-door-disallows-auto** — `Finding.rule:
+  "one-way-door-disallows-auto"` for a file not in `records` →
+  `corpusFindings[0].code:"corpus.one-way-door-auto-tier"` with exact canonical message;
+  (16) **corpusFingerprint** — returned hex is 64 lowercase chars;
+  (17) **determinism** — identical `LintCorpusResult` + identical `asOf` → identical
+  `corpusFingerprint`; (18) **tier semantics** — `auto`, `async`, and `arb` derive the
+  exact `tierLabel` strings from FR-016, absent tier derives `null`, and the auto label
+  explicitly requires human acceptance.
+  Run test; record `Cannot find module` failure.
+
+- [ ] T024 [P] [US1] Write failing tests in `packages/core/test/queue/format.test.ts`:
+  import `formatQueueReportJson`, `formatQueueReportMarkdown` from `@adrkit/core`;
+  construct a `QueueReport` with `version:"1"` and all fields populated;
+  (a) `formatQueueReportJson`: output is valid JSON; final byte is `\n` (0x0a);
+  no trailing whitespace on any line; top-level JSON key insertion order matches
+  `version → asOf → corpusFingerprint → totalItems → totalCorpusFindings →
+  itemsWithFindings → items → corpusFindings` (construction order);
+  QueueItem key insertion order matches `id → title → sourcePath → tier → tierLabel →
+  queuedAt → slaDays → reviewBy → slaState → deadlineDate → routingTargets → quorum → approvalCount
+  → unresolvedObjectionCount → resolvedObjectionCount → escalatedAt → decidedAt →
+  itemFindings`; `version` value is string `"1"` (not number); null fields present as
+  JSON `null` (not omitted);
+  (b) `formatQueueReportMarkdown`: first line is `# ARB Queue — {asOf}`;
+  second non-blank line contains `Corpus fingerprint: \`` + full 64-char hex + `\``;
+  empty items table renders exactly `*No proposed records found.*`;
+  null field values render as `-` in table cells;
+  pipe character `|` in item title is escaped as `\|` in Markdown cell;
+  `sourcePath` and `code` values are backtick-wrapped in corpus findings section;
+  overview Tier renders exactly `{tier} ({tierLabel})` for a non-null tier and
+  `(none)` for a null tier; every per-item detail section contains a `Tier Label` row
+  with the exact `tierLabel` value (or `-` when null);
+  output ends with exactly one `\n`;
+  (c) determinism: two calls with identical input → byte-identical output.
+  Run test; record `Cannot find module` failure.
+
+### GREEN: implement queue core
+
+- [ ] T025 [US1] Create `packages/core/src/queue/types.ts` with all type and constant
+  declarations (no runtime logic beyond `SLA_STATE_URGENCY_ORDER` constant):
+  `SlaState` union type, `SLA_STATE_URGENCY_ORDER: Record<SlaState, number>` = `{overdue:0,escalated:1,due:2,"within-sla":3,"missing-sla":4,"not-queued":5,decided:6}`,
+  `CorpusFinding` interface, `ItemFinding` interface, `QueueItem` interface (fields in
+  exact contract order), `QueueReport` interface (fields in exact contract order),
+  `QueueKernelInput` interface (`corpus: LintCorpusResult`, `asOf: string`), including
+  `tierLabel`'s exact closed string union from FR-016.
+  Import `LintCorpusResult` from its relative core validation module. No self-package
+  barrel import and no logic.
+
+- [ ] T026 [P] [US3] Create `packages/core/src/queue/findings.ts`:
+  `RULE_TO_CORPUS_CODE` constant map: `"file-read"→"corpus.read-error"`,
+  `"frontmatter-parse"→"corpus.parse-error"`, `"frontmatter-fence"→"corpus.parse-error"`,
+  `"one-way-door-disallows-auto"→"corpus.one-way-door-auto-tier"`, all others (including
+  any unknown future rule) → `"corpus.schema-invalid"` via fallback;
+  `mapFindingToCorpusFinding(finding: Finding, sourcePath: string): CorpusFinding`
+  with exact messages from R2:
+  `corpus.read-error` → `"Cannot read file: " + finding.message`;
+  `corpus.parse-error` and `corpus.schema-invalid` → pass-through `finding.message`;
+  `corpus.one-way-door-auto-tier` → canonical fixed message
+  `"one-way-door decisions may not take the auto-approve fast path (reversibility: one-way-door, review.tier: auto)"`.
+  Import `Finding` from its relative core validation module; `CorpusFinding` from
+  `./types`.
+  Run `bun test packages/core/test/queue/findings.test.ts`; assert green.
+
+- [ ] T027 [P] [US2] Create `packages/core/src/queue/sort.ts` with
+  `sortQueueItems(items: QueueItem[]): QueueItem[]`,
+  `sortCorpusFindings(findings: CorpusFinding[]): CorpusFinding[]`,
+  `sortItemFindings(findings: ItemFinding[]): ItemFinding[]`;
+  exact comparator from R6 for items: urgency (`SLA_STATE_URGENCY_ORDER`) ascending →
+  deadlineDate ascending code-unit (null last within group) → queuedAt ascending
+  code-unit → id ascending code-unit; all string comparisons via `compareCodeUnits`
+  (never `localeCompare`).
+  Import `compareCodeUnits` from `../ordering`; types from `./types`.
+  Run `bun test packages/core/test/queue/sort.test.ts`; assert green.
+
+- [ ] T028 [US1] Create `packages/core/src/queue/kernel.ts` implementing
+  `buildQueueReport({corpus: LintCorpusResult, asOf: string}): QueueReport`
+  per the 8-step algorithm in `contracts/kernel.md`:
+  Step 1 — identify excluded file paths (paths in error-severity findings not in
+  `corpus.records`);
+  Step 2 — map each excluded file's Finding to CorpusFinding via `mapFindingToCorpusFinding`;
+  sort via `sortCorpusFindings`;
+  Step 3 — `proposedRecords = corpus.records.filter(r => r.frontmatter.status === "proposed")`;
+  Step 4 — for each proposedRecord: normalize timing fields
+  (`new Date(v).toISOString().slice(0,10)`) to UTC calendar date; compute `deadlineDate`
+  (reviewBy takes precedence over slaDays; slaDays:0 deadline = queuedAt date; absent
+  queuedAt → null deadline); compute `slaState` via precedence
+  (decidedAt→decided, escalatedAt→escalated, then deadline comparisons against asOf:
+  <asOf→overdue, ==asOf→due, >asOf→within-sla; no deadline+queuedAt→missing-sla;
+  no queuedAt→not-queued); extract `approvalCount`, `unresolvedObjectionCount`,
+  `resolvedObjectionCount` from `review.approvals`/`review.objections`; generate item
+  findings (check `tier-absent`, `review-by-before-queued`, `deciders-empty` conditions
+  per R2); derive `tierLabel` using the exact FR-016 mapping and populate `QueueItem` in
+  exact field order from `QueueItem` interface;
+  Step 5 — `sortQueueItems(items)`;
+  Step 6 — `sortItemFindings` per item;
+  Step 7 — `corpusFingerprint = fingerprintOf(sortByIdThenPath(corpus.records),
+  sortFindingsCanonical(corpus.findings), corpus.records.length,
+  corpus.checked - corpus.records.length)` (uses ALL corpus findings, not just excluded);
+  Step 8 — assemble and return `QueueReport` with `version:"1"`, all summary counts.
+  Imports: `./types`, `./findings`, `./sort`, `../fingerprint`, `../ordering`, and
+  relative core schema/validation modules for core types. Do NOT self-import through
+  `@adrkit/core`, and do NOT import `@actions/*`, `@adrkit/ci`,
+  `@adrkit/mcp`, `@adrkit/evaluator`, or any adapter.
+  Run `bun test packages/core/test/queue/kernel.test.ts`; assert green.
+
+- [ ] T029 [US1] Create `packages/core/src/queue/format.ts` with:
+  `formatQueueReportJson(report: QueueReport): string` — returns
+  `JSON.stringify(report, null, 2) + "\n"` (2-space indent; insertion-order keys; final
+  newline; no additional key sorting on output);
+  `formatQueueReportMarkdown(report: QueueReport): string` — produces canonical Markdown
+  per `contracts/queue-report.md` §IV: heading `# ARB Queue — {asOf}`, fingerprint line
+  `Corpus fingerprint: \`{64-char hex}\``, all three summary counts, concise overview
+  table, and one deterministic detail section per item exposing every QueueItem field
+  (null fields → `-`; `tier:null` → `(none)`; `sourcePath` backtick-wrapped; pipe,
+  backtick, backslash, CR, LF, and CRLF escaped in the contract's exact order), empty
+  items text exactly `*No proposed records found.*`, corpus findings section if
+  non-empty (sourcePath and code values backtick-wrapped), final `\n`.
+  Import `QueueReport`, `QueueItem` from `./types`.
+  Run `bun test packages/core/test/queue/format.test.ts`; assert green.
+
+- [ ] T030 Add all queue exports to `packages/core/src/index.ts`: `buildQueueReport`,
+  `formatQueueReportJson`, `formatQueueReportMarkdown`, `sortQueueItems`,
+  `sortCorpusFindings`, `sortItemFindings`, `mapFindingToCorpusFinding`,
+  `RULE_TO_CORPUS_CODE`, `SLA_STATE_URGENCY_ORDER`, and all type exports
+  (`QueueReport`, `QueueItem`, `CorpusFinding`, `ItemFinding`, `SlaState`,
+  `QueueKernelInput`).
+  Run `bun run --filter @adrkit/core typecheck && bun test packages/core`;
+  assert all tests pass; confirm no `@adrkit/ci`, `@adrkit/mcp`, or `@actions/*`
+  import reachable from the core import graph.
+
+**Checkpoint**: `buildQueueReport` is a pure, offline function producing byte-identical
+output for identical inputs. Full test suite passes for core queue.
+
+---
+
+## Phase 4: CLI Subcommand `adr queue` (US1, US2, US3)
+
+**Purpose**: Wire the kernel to the CLI boundary — argument parsing, `--as-of` date
+validation and normalization, corpus loading, format selection, stdout/exit-code
+assignment.
+
+**Blocked by**: Phase 3 complete.
+
+**Independent Test (US1/US2/US3)**:
+`bun run adr -- queue --dir packages/core/test/fixtures/queue/within-sla-corpus --as-of 2026-01-08 --format json`
+exits 0, emits valid QueueReport v1 JSON with `version:"1"`, `asOf:"2026-01-08"`, 1
+item with `slaState:"within-sla"`, `totalCorpusFindings:0`;
+`--format csv` exits 2 with empty stdout;
+`--as-of "2026-01-08T10:00:00"` (timezone-less) exits 2 with empty stdout.
+
+### RED: write failing test first
+
+- [ ] T031 [US1] Write failing integration tests in `packages/cli/test/queue.test.ts`
+  using `Bun.spawn` against the CLI binary; use Phase 1 fixture corpora:
+  (a) within-sla-corpus `--as-of 2026-01-08 --format json` → exit 0, valid JSON,
+  `version:"1"`, `asOf:"2026-01-08"`, `items.length:1`, `items[0].slaState:"within-sla"`;
+  (b) default format (no flag) on same corpus → exit 0, stdout starts `# ARB Queue — 2026-01-08`;
+  (c) `--format markdown` → identical to (b);
+  (d) `--format csv` → exit 2, stdout empty, stderr contains `"Invalid --format value: 'csv'"`;
+  (e) `--as-of "2026-01-08T10:00:00"` (no TZ) → exit 2, stdout empty,
+  stderr matches `"Timezone-less datetimes are ambiguous"`;
+  (f) `--as-of "2026-01-08T01:00:00+05:00"` → exit 0, `asOf:"2026-01-07"`
+  (UTC normalization: +05:00 offset → UTC 2026-01-07T20:00:00Z → date 2026-01-07);
+  (g) `--as-of "2026-13-01"` (invalid month) → exit 2, stderr contains
+  `"Invalid --as-of value"`;
+  (h) schema-invalid-corpus `--format json` → exit 1, stdout is complete JSON report
+  (non-empty `corpusFindings`), stdout emitted BEFORE exit;
+  (i) one-way-door-auto-corpus → exit 1, `corpusFindings[*].code:
+  "corpus.one-way-door-auto-tier"`;
+  (j) warn-review-by-before-queued-corpus → exit 0 (`item.review-by-before-queued`
+  is warn, no error-severity corpus findings);
+  (k) two runs, identical corpus and `--as-of 2026-01-08` → byte-identical stdout (SC-001).
+  (l) comprehensive-corpus emits all ten proposed items plus its CorpusFinding before
+  exit 1; JSON and Markdown make every overdue/due/escalated item and every item/corpus
+  finding identifiable without opening source files (SC-002);
+  Run `bun test packages/cli/test/queue.test.ts`; record `Cannot find module './queue'`
+  or equivalent failure.
+
+### GREEN: implement CLI subcommand
+
+- [ ] T032 [US1] Create `packages/cli/src/queue.ts`:
+  parse `--dir <path>` (default `docs/adr`), `--as-of <value>` (optional),
+  `--format markdown|json` (default `markdown`);
+  validate `--format`: if value not `"markdown"` or `"json"`, write
+  `"Invalid --format value: '{v}'. Expected markdown or json.\n"` to stderr, exit 2;
+  validate `--as-of` per `contracts/cli-contract.md` §As-Of Resolution:
+  bare YYYY-MM-DD → regex check + UTC round-trip `new Date(v+"T00:00:00Z").toISOString().slice(0,10)===v`;
+  offset datetime (contains `T` + `Z` or `±` after time) → `new Date(v).toISOString().slice(0,10)`;
+  timezone-less datetime (contains `T` but no TZ designator) → stderr
+  `"Invalid --as-of value: '{v}'. Timezone-less datetimes are ambiguous — use YYYY-MM-DD or add an explicit timezone offset (e.g. Z or +05:00).\n"`, exit 2;
+  any other failure → stderr `"Invalid --as-of value: '{v}'. Expected YYYY-MM-DD or ISO datetime with explicit timezone (e.g. 2026-01-08 or 2026-01-08T00:00:00Z).\n"`, exit 2;
+  if `--as-of` absent: `asOf = new Date().toISOString().slice(0,10)`;
+  call `lintCorpus({dir})` from `@adrkit/core`; call `buildQueueReport({corpus, asOf})`;
+  call `formatQueueReportMarkdown(report)` or `formatQueueReportJson(report)`;
+  write to `process.stdout` (emit complete report BEFORE deciding exit code);
+  if `report.corpusFindings.some(f => f.severity === "error")` → exit 1; else exit 0.
+  No `@actions/*`, `@adrkit/ci`, `@adrkit/mcp` imports.
+  Run `bun test packages/cli/test/queue.test.ts`; assert green.
+
+- [ ] T033 [US1] Add `queue` subcommand to `packages/cli/src/index.ts`:
+  add `"queue"` branch to existing `main()` dispatcher; import and call `runQueue`
+  (or equivalent export) from `./queue`.
+  Run `bun run --filter @adrkit/cli typecheck && bun test packages/cli`;
+  assert all tests pass.
+
+**Checkpoint**: Local MVP — `bun run adr -- queue` is fully operational. Independently
+testable with fixture corpora. Exits correctly on error-severity findings. Deterministic.
+
+---
+
+## Phase 5: GitHub Action (US4)
+
+**Purpose**: Implement the managed-issue state machine, Octokit adapter, and Action
+entrypoint; write pure and adapter tests with a fake client; build and include the
+committed-bundle artifact in the feature change set.
+
+**Blocked by**: Phase 3 (`buildQueueReport`, `formatQueueReportMarkdown` available).
+
+**Independent Test (US4)**: `bun test packages/ci` passes; all fake-client
+state machine and pagination tests green; `packages/ci/dist/queue-action.js` exists;
+smoke test (`node scripts/smoke-queue-node.mjs`) fails at corpus-load boundary with
+a known error, no network call, no module-resolution error.
+
+### RED: write failing Action tests first
+
+- [ ] T034 [P] [US4] Write failing pure managed-issue tests in
+  `packages/ci/test/queue-issue.test.ts` using a hand-rolled fake `GitHubQueueClient`
+  (no token, no network):
+  all 5 state machine branches per `contracts/github-action.md`:
+  (A) 0 managed + no title conflict → `createIssue` called once;
+  marker `<!-- adrkit-managed-queue-issue -->` is exactly the first line of body;
+  (B) 0 managed + 1 open title conflict → fail, no write, error message names `#N`;
+  (C) 0 managed + 1 closed title conflict → fail (closed unowned conflicts too), no write;
+  (D) 0 managed + 2 conflicts (open+closed) → all numbers named in ascending order, no write;
+  (E) 1 managed open → `updateIssue({body})` called once (body only, no `state` field);
+  (F) 1 managed closed → single `updateIssue({body, state:'open'})` call; NOT two calls;
+  (G) 2+ managed → fail naming both numbers, no write;
+  marker detection:
+  (H) `body === MARKER` → managed;
+  (I) `body.startsWith(MARKER + "\n")` → managed;
+  (J) marker at line 2 (newline before marker) → NOT managed;
+  (K) leading whitespace before marker → NOT managed;
+  (L) `createIssue` throws 403 → no partial write; error propagated to caller;
+  (M) `updateIssue` throws 403 → prior issue state remains authoritative and the error
+  propagates to the caller;
+  (N) a pure `publishQueueReport` helper given an error-bearing QueueReport records
+  events in exact order `update issue → set issue-number output → setFailed`, with the
+  exact error-count/issue-number message; a clean report omits `setFailed`.
+  Pull-request filtering and report-error handling are adapter/entrypoint concerns
+  except for the pure publish-order helper above; `managedQueueIssue` itself receives
+  neither raw PR entries nor a QueueReport.
+  Run `bun test packages/ci/test/queue-issue.test.ts`; record
+  `Cannot find module '../src/queue-issue'` failure.
+
+- [ ] T035 [P] [US4] Write failing Octokit adapter tests in
+  `packages/ci/test/queue-adapter.test.ts` using a fake Octokit (no token, no network):
+  target a side-effect-free `createOctokitQueueClient` export in the new
+  `packages/ci/src/queue-github-client.ts` module (not the executable entrypoint);
+  (a) `listAllIssues()` exhausts all pages for both `state:'open'` and `state:'closed'`
+  (fake returns 100+ items split across multiple pages; assert all are collected);
+  (b) entries with `pull_request` property non-null are filtered out of the returned list;
+  (c) PR-filtered list is what `managedQueueIssue` operates on (no pull requests reach
+  marker/title logic).
+  Run test; record `Cannot find module` failure.
+
+### GREEN: implement Action modules
+
+- [ ] T036 [US4] Create `packages/ci/src/queue-issue.ts`:
+  export `MARKER = "<!-- adrkit-managed-queue-issue -->"` constant;
+  export `GitHubQueueClient` interface with exactly:
+  `listAllIssues(): Promise<Array<{number:number; state:"open"|"closed"; title:string; body:string|null}>>`,
+  `createIssue(title:string, body:string): Promise<{number:number}>`,
+  `updateIssue(issueNumber:number, update:{body:string; state?:'open'}): Promise<void>`;
+  export `managedQueueIssue(markdownReport:string, client:GitHubQueueClient,
+  issueTitle:string): Promise<{issueNumber:number}>`:
+  implement all 5 state machine branches (create/update-open/update-closed/conflict-fail/
+  duplicate-fail) per `contracts/github-action.md`; first-line marker check only
+  (`body===MARKER || body.startsWith(MARKER+"\n")`);
+  do NOT receive a full `QueueReport`; do NOT return `errorFindingsPresent`;
+  also export the pure `publishQueueReport` helper tested in T034, accepting a
+  QueueReport, rendered Markdown, GitHubQueueClient, issue title, and injected
+  `setOutput`/`setFailed` callbacks; it MUST call `managedQueueIssue`, set
+  `issue-number`, then call `setFailed` only when the report contains error-severity
+  CorpusFindings;
+  no `@actions/core` or `@actions/github` imports in this file.
+  Run `bun test packages/ci/test/queue-issue.test.ts`; assert green.
+
+- [ ] T037 [US4] Create `packages/ci/src/queue-action-entrypoint.ts`:
+  confine ALL `@actions/core` and `@actions/github` imports to this file only;
+  read `dir`, `token`, `issue-title` via `core.getInput`;
+  resolve `workspace = process.env.GITHUB_WORKSPACE ?? process.cwd()`;
+  call `lintCorpus({dir, cwd:workspace})` — if this throws, call `core.setFailed` and
+  return BEFORE constructing Octokit (corpus-load failure before GitHub client);
+  resolve `asOf = new Date().toISOString().slice(0,10)` at this boundary;
+  call `buildQueueReport({corpus, asOf})`;
+  call `formatQueueReportMarkdown(report)`;
+  first create `packages/ci/src/queue-github-client.ts` with the side-effect-free
+  structural Octokit adapter tested in T035 (no `@actions/*` import), then construct
+  `createOctokitQueueClient(octokit, owner, repo)` from the entrypoint, where
+  `owner` and `repo` are split from `process.env.GITHUB_REPOSITORY`;
+  call `publishQueueReport` with callbacks backed by `core.setOutput` and
+  `core.setFailed`; the helper owns the write → output → conditional-failure ordering
+  and exact `"Queue report contains ${n} corpus error(s). See issue #${issueNumber} for details."`
+  message;
+  if GitHub API throws with status 401 or 403 call
+  `core.setFailed("GitHub API returned ${status}: insufficient permissions. Ensure the workflow grants 'issues: write' to the GITHUB_TOKEN.")`;
+  surface every other GitHub API failure through `core.setFailed` without converting it
+  into a success-shaped result.
+  Create `packages/ci/queue/action.yml` with EXACT content from contract:
+  `name: "ADR ARB Queue"`;
+  inputs: `dir` (required:false, default:`docs/adr`), `token` (required:false,
+  default:`${{ github.token }}`), `issue-title` (required:false, default:`ADR ARB Queue`);
+  outputs: `issue-number` (description as in contract);
+  author: `adrkit`; branding: `icon: inbox`, `color: blue`;
+  `runs: {using: "node24", main: "../dist/queue-action.js"}`.
+  Run `bun test packages/ci/test/queue-adapter.test.ts`; assert green.
+
+- [ ] T038 [US4] Update `packages/ci/package.json` `build` script to:
+  `"rm -rf dist && bun build ./src/index.ts --target=node --conditions bun --outfile=dist/index.js && bun build ./src/queue-action-entrypoint.ts --target=node --conditions bun --outfile=dist/queue-action.js"`;
+  no new `"exports"` subpath; `@adrkit/ci` remains private/unpublished.
+  Validate deterministic rebuild: run `bun run --filter @adrkit/ci build` twice;
+  compare SHA-256 of `dist/queue-action.js` across both runs; assert hashes identical.
+
+- [ ] T039 [US4] Build and include `packages/ci/dist/queue-action.js` in the feature
+  change set (do not create a commit unless the user explicitly requests it):
+  run `bun run --filter @adrkit/ci build`; verify `dist/queue-action.js` exists and
+  `dist/index.js` is unchanged; verify `packages/ci/queue/action.yml` `main:
+  ../dist/queue-action.js` resolves correctly from `packages/ci/queue/` to
+  `packages/ci/dist/queue-action.js`.
+
+- [ ] T040 [US4] Write `scripts/smoke-queue-node.mjs` bundle smoke test per
+  `contracts/github-action.md` §Bundle Smoke Tests: spawn the committed
+  `packages/ci/dist/queue-action.js` with `node` (do NOT import in-process; do NOT
+  use `--help`); set a temporary `GITHUB_WORKSPACE` pointing to a directory whose
+  `INPUT_DIR` corpus subdirectory does not exist; set `INPUT_DIR`, `INPUT_TOKEN`,
+  `INPUT_ISSUE-TITLE`, `GITHUB_REPOSITORY=owner/repo`, `GITHUB_TOKEN=fake_token`;
+  assert: process exits non-zero; stderr/stdout contains corpus-load error message
+  (not a module-resolution or import error); NO Octokit is constructed, NO network
+  call occurs before the process exits.
+  Run `node scripts/smoke-queue-node.mjs`; assert it passes.
+  Note: Node 22/24 coverage is validated by the existing CI matrix (`ci.yml`);
+  do not require local runtimes beyond what is available.
+
+- [ ] T041 Run `bun run --filter @adrkit/ci typecheck && bun test packages/ci`;
+  assert clean. Run `node scripts/smoke-node.mjs` to confirm existing `dist/index.js`
+  smoke test still passes and the existing action behavior is unaffected.
+
+**Checkpoint**: Action creates/updates managed issues using fake client; bundle
+committed; queue and existing smoke tests pass.
+
+---
+
+## Phase 6: Quality Gates, Dogfood, Documentation, and Release Gate
+
+**Purpose**: Run all quality suites in progression, maintainer dogfood, documentation
+milestones, and the rung-6 external exit gate.
+
+**Blocked by**: Phases 1–5 complete.
+
+### Scope and boundary validation
+
+- [ ] T042 Scope/boundary gate — run `bun run check:deps`; assert `core-has-no-adapter-deps`
+  gate green: no import path in `@adrkit/core` reaches `@adrkit/ci`, `@adrkit/mcp`,
+  `@adrkit/evaluator`, or `@actions/*`; inspect ONLY the files changed in this feature
+  for scope-creep markers: no fifth tool, no persistent DB call, no notification
+  system, no model/embedding call, no PAT usage in any new source file, no write path
+  into decision records, no multi-repository federation, no new public package.
+
+### Full test suite gate
+
+- [ ] T043 Full suite gate — in sequence: `bun run typecheck && bun run build &&
+  bun run lint && bun run check:deps && bun run schema:emit`; assert `schema:emit`
+  diff is empty (no change to `schema/adr.schema.json`); then `bun test`; assert all
+  tests pass with no failures or skips.
+
+- [ ] T044 Dist reproducibility gate — hash both files in `packages/ci/dist`, run
+  `bun run --filter @adrkit/ci build` again, and assert both hashes are unchanged;
+  inspect `git diff -- packages/ci/dist` to confirm only the expected feature bundle
+  changes are present. After the feature change is committed, CI's existing post-build
+  `git diff --exit-code packages/ci/dist` enforces committed parity on every push.
+
+- [ ] T045 Release pack validation — run
+  `bun run release:pack -- --skip-build` using the existing coordinated pack script;
+  inspect the core and CLI public tarballs for presence of new exports
+  (`fingerprintOf`, `buildQueueReport`, `formatQueueReportJson`,
+  `formatQueueReportMarkdown`, `compareCodeUnits`); verify no tarball is produced for
+  private `@adrkit/ci`; verify Action distribution is confirmed via committed bundle
+  path only, not npm tarball.
+
+### Maintainer dogfood
+
+- [ ] T046 Maintainer dogfood — run
+  `bun run adr -- queue --dir docs/adr --as-of <today> --format json | tee /tmp/mr.json`;
+  assert file is valid JSON; assert `JSON.parse(fs.readFileSync("/tmp/mr.json")).version === "1"`;
+  state item and corpus-finding counts conditionally from actual corpus state (do NOT
+  assert "all accepted" unless you verify no proposed records exist); run a second time
+  with the same explicit `--as-of <today>`; `diff /tmp/run1.json /tmp/run2.json` → exit 0
+  (SC-001 determinism); assert Markdown default output heading is
+  `# ARB Queue — <today>`.
+
+### Documentation milestones (in-progress)
+
+- [ ] T047 Update root `plan.md` Phase 6 status to `in progress` (implementation
+  complete, rung-6 external gate not yet cleared); update `CLAUDE.md` to document
+  `adr queue` command usage. Do NOT update root plan.md to `landed`; do NOT reference
+  a nonexistent release tag.
+
+### External dogfood gate (SC-004 — rung-6 exit gate)
+
+- [ ] T048 (SC-004) External dogfood gate — in a **separate team's repository** (not
+  the maintainer's own): configure the queue Action at the implementation commit SHA
+  or an available release tag (record the exact ref used); add at least **3 `proposed`
+  ADRs spanning ALL THREE tiers** (`auto`, `async`, `arb`); include at least one ADR
+  that is overdue or at the SLA-due boundary as of the run date; include at least one
+  ADR with both `review.approvals` entries AND `review.objections` entries in its
+  frontmatter; trigger the Action → assert exactly one managed issue is created on
+  the first run (title `ADR ARB Queue` by default); trigger the Action again → assert
+  the SAME managed issue body is updated in place (no new issue created, no duplicate);
+  confirm default `GITHUB_TOKEN` with `contents:read` + `issues:write` is the only
+  credential used; verify no installation, runtime, or permission blockers encountered;
+  document evidence (issue URL, workflow run URLs, ref used) and link in this task.
+  **This task gates the `landed` claim for rung 6.**
+  Depends on: T043, T044, T045, T046, T047.
+
+### Post-SC-004 documentation (landed)
+
+- [ ] T049 After SC-004 (T048) clears: update root `plan.md` Phase 6 row to `landed`
+  with a link to the T048 evidence; update `CLAUDE.md` to reflect final state; update
+  `README.md` with `adr queue` and Action usage using the exact validated commit SHA.
+  Advertise `mbeacom/adrkit/packages/ci/queue@v0` only after the moving `v0` tag has
+  actually been updated to a release containing the queue bundle. Do NOT update to
+  `landed` before T048 passes.
+
+---
+
+## Dependency Graph
+
+```
+Phase 1: T001 → T002–T012 [P all]
+
+Phase 2: T013 [P]
+         T014 [P] → T016 [P]
+         T013 + T016 → T015 → T017 → T018 [P] + T019 [P] → T020
+
+Phase 3: T020 → T021 [P] + T022 [P] + T023 [P] + T024 [P]
+              → T025 → T026 [P] + T027 [P] → T028 → T029 → T030
+
+Phase 4: T030 → T031 → T032 → T033
+
+Phase 5: T033 (needs core) → T034 [P] + T035 [P] → T036 → T037 → T038 → T039 → T040 → T041
+
+Phase 6: T041 → T042 → T043 → T044 → T045 → T046 → T047 → T048 → T049
+```
+
+**Parallel opportunities by phase**:
+- Phase 1: T002–T012 simultaneously (11 distinct fixture files, no shared paths)
+- Phase 2: T013+T014 simultaneously (different test files); T016 starts after T014,
+  then T015 starts after both T013 and T016 because fingerprinting imports the promoted
+  comparator; T018+T019 simultaneously after T017 (different MCP files)
+- Phase 3: T021–T024 simultaneously (4 different test files); T026+T027 simultaneously
+  after T025 (different source files)
+- Phase 5: T034+T035 simultaneously (different test files)
+- Phases 4 and 6: sequential within each phase
+
+---
+
+## Implementation Strategy
+
+**Local MVP** (independently testable, not yet independently releasable):
+Phases 1–4, T001–T033. Delivers `bun run adr -- queue` with correct kernel, all 7 SLA
+states, corpus/item finding distinction, deterministic JSON and Markdown output. Can
+be dogfooded locally; no Action or external gate required.
+
+**Full Phase 6 delivery**: Phases 1–5, T001–T041, plus quality gates T042–T046. All
+functionality complete and smoke-tested.
+
+**Rung-6 landed / release-ready**: Only after T048 (SC-004 external dogfood gate)
+completes and T049 updates documentation to `landed`. The external gate requires a
+team separate from the maintainer's own. Calling the feature "landed" before T048 is
+a protocol violation (Assumption A7, R10).

--- a/specs/007-arb-queue/tasks.md
+++ b/specs/007-arb-queue/tasks.md
@@ -453,7 +453,8 @@ item with `slaState:"within-sla"`, `totalCorpusFindings:0`;
   (f) `--as-of "2026-01-08T01:00:00+05:00"` → exit 0, `asOf:"2026-01-07"`
   (UTC normalization: +05:00 offset → UTC 2026-01-07T20:00:00Z → date 2026-01-07);
   (g) `--as-of "2026-13-01"` (invalid month) → exit 2, stderr contains
-  `"Invalid --as-of value"`;
+  `"Invalid --as-of value"` and no unhandled exception; `--as-of "2026-02-30"`
+  (normalized impossible date) also exits 2 without throwing;
   (h) schema-invalid-corpus `--format json` → exit 1, stdout is complete JSON report
   (non-empty `corpusFindings`), stdout emitted BEFORE exit;
   (i) one-way-door-auto-corpus → exit 1, `corpusFindings[*].code:
@@ -475,7 +476,10 @@ item with `slaState:"within-sla"`, `totalCorpusFindings:0`;
   validate `--format`: if value not `"markdown"` or `"json"`, write
   `"Invalid --format value: '{v}'. Expected markdown or json.\n"` to stderr, exit 2;
   validate `--as-of` per `contracts/cli-contract.md` §As-Of Resolution:
-  bare YYYY-MM-DD → regex check + UTC round-trip `new Date(v+"T00:00:00Z").toISOString().slice(0,10)===v`;
+  bare YYYY-MM-DD → regex check, then
+  `const parsed = new Date(v+"T00:00:00Z")` and require
+  `Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0,10)===v`
+  so invalid dates never throw;
   offset datetime (contains `T` + `Z` or `±` after time) → `new Date(v).toISOString().slice(0,10)`;
   timezone-less datetime (contains `T` but no TZ designator) → stderr
   `"Invalid --as-of value: '{v}'. Timezone-less datetimes are ambiguous — use YYYY-MM-DD or add an explicit timezone offset (e.g. Z or +05:00).\n"`, exit 2;
@@ -529,6 +533,8 @@ a known error, no network call, no module-resolution error.
   marker detection:
   (H) `body === MARKER` → managed;
   (I) `body.startsWith(MARKER + "\n")` → managed;
+  (I2) `MARKER + "\r\n" + report` → managed (CRLF first-line handling);
+  (I3) `MARKER + "\r" + report` → managed (bare-CR first-line handling);
   (J) marker at line 2 (newline before marker) → NOT managed;
   (K) leading whitespace before marker → NOT managed;
   (L) `createIssue` throws 403 → no partial write; error propagated to caller;
@@ -547,11 +553,12 @@ a known error, no network call, no module-resolution error.
   `packages/ci/test/queue-adapter.test.ts` using a fake Octokit (no token, no network):
   target a side-effect-free `createOctokitQueueClient` export in the new
   `packages/ci/src/queue-github-client.ts` module (not the executable entrypoint);
-  (a) `listAllIssues()` exhausts all pages for both `state:'open'` and `state:'closed'`
-  (fake returns 100+ items split across multiple pages; assert all are collected);
-  (b) entries with `pull_request` property non-null are filtered out of the returned list;
-  (c) PR-filtered list is what `managedQueueIssue` operates on (no pull requests reach
-  marker/title logic).
+  (a) `listAllIssues()` exhausts every cursor page from the GraphQL
+  `repository.issues(states:[OPEN,CLOSED])` connection (fake returns 100+ issue nodes
+  split across multiple pages; assert all are collected in page order);
+  (b) the query requests only issue nodes with `number`, `state`, `title`, and `body`;
+  assert the adapter never calls REST `issues.listForRepo` or the Search API;
+  (c) GraphQL `OPEN`/`CLOSED` states map exactly to client `open`/`closed`.
   Run test; record `Cannot find module` failure.
 
 ### GREEN: implement Action modules
@@ -565,8 +572,8 @@ a known error, no network call, no module-resolution error.
   export `managedQueueIssue(markdownReport:string, client:GitHubQueueClient,
   issueTitle:string): Promise<{issueNumber:number}>`:
   implement all 5 state machine branches (create/update-open/update-closed/conflict-fail/
-  duplicate-fail) per `contracts/github-action.md`; first-line marker check only
-  (`body===MARKER || body.startsWith(MARKER+"\n")`);
+  duplicate-fail) per `contracts/github-action.md`; marker ownership is exact first-line
+  equality using `(body ?? "").split(/\r\n|\n|\r/, 1)[0] === MARKER`;
   do NOT receive a full `QueueReport`; do NOT return `errorFindingsPresent`;
   also export the pure `publishQueueReport` helper tested in T034, accepting a
   QueueReport, rendered Markdown, GitHubQueueClient, issue title, and injected
@@ -586,7 +593,7 @@ a known error, no network call, no module-resolution error.
   call `buildQueueReport({corpus, asOf})`;
   call `formatQueueReportMarkdown(report)`;
   first create `packages/ci/src/queue-github-client.ts` with the side-effect-free
-  structural Octokit adapter tested in T035 (no `@actions/*` import), then construct
+  structural GraphQL Octokit adapter tested in T035 (no `@actions/*` import), then construct
   `createOctokitQueueClient(octokit, owner, repo)` from the entrypoint, where
   `owner` and `repo` are split from `process.env.GITHUB_REPOSITORY`;
   call `publishQueueReport` with callbacks backed by `core.setOutput` and

--- a/specs/007-arb-queue/tasks.md
+++ b/specs/007-arb-queue/tasks.md
@@ -103,7 +103,8 @@ this phase is fixture-only.
   `corpus.one-way-door-auto-tier` (file excluded from items)
 
 - [ ] T011 [P] Write `packages/core/test/fixtures/queue/no-proposed-corpus/0001.md`:
-  frontmatter `id:"0001"`, `title:"Accepted ADR"`, `status:accepted`, `date:2026-01-01`;
+  frontmatter `id:"0001"`, `title:"Accepted ADR"`, `status:accepted`,
+  `date:2026-01-01`, `deciders:["@alice"]`;
   only non-proposed records → `items:[]`, `totalItems:0`
 
 - [ ] T012 [P] Write `packages/core/test/fixtures/queue/warn-review-by-before-queued-corpus/0001.md`:
@@ -317,6 +318,8 @@ exits 0; JSON output has `version:"1"`, `asOf:"2026-01-08"`, exactly 1 item with
   empty items table renders exactly `*No proposed records found.*`;
   null field values render as `-` in table cells;
   pipe character `|` in item title is escaped as `\|` in Markdown cell;
+  a title containing CRLF/LF/CR is normalized to a single-line detail heading and
+  cannot inject a second heading or table;
   `sourcePath` and `code` values are backtick-wrapped in corpus findings section;
   overview Tier renders exactly `{tier} ({tierLabel})` for a non-null tier and
   `(none)` for a null tier; every per-item detail section contains a `Tier Label` row
@@ -465,6 +468,10 @@ item with `slaState:"within-sla"`, `totalCorpusFindings:0`;
   (l) comprehensive-corpus emits all ten proposed items plus its CorpusFinding before
   exit 1; JSON and Markdown make every overdue/due/escalated item and every item/corpus
   finding identifiable without opening source files (SC-002);
+  (m) `--help` → exit 0 with usage on stdout and empty stderr;
+  (n) `--unknown-flag` → exit 2, empty stdout, and the exact frozen unknown-flag stderr;
+  (o) a missing `--dir` → exit 2, empty stdout, and the exact frozen corpus-not-found
+  stderr rather than the top-level CLI's generic exit-1 path;
   Run `bun test packages/cli/test/queue.test.ts`; record `Cannot find module './queue'`
   or equivalent failure.
 
@@ -485,6 +492,10 @@ item with `slaState:"within-sla"`, `totalCorpusFindings:0`;
   `"Invalid --as-of value: '{v}'. Timezone-less datetimes are ambiguous — use YYYY-MM-DD or add an explicit timezone offset (e.g. Z or +05:00).\n"`, exit 2;
   any other failure → stderr `"Invalid --as-of value: '{v}'. Expected YYYY-MM-DD or ISO datetime with explicit timezone (e.g. 2026-01-08 or 2026-01-08T00:00:00Z).\n"`, exit 2;
   if `--as-of` absent: `asOf = new Date().toISOString().slice(0,10)`;
+  handle `--help` before corpus loading by writing queue usage to stdout and returning
+  0; reject unknown flags with the exact contract message and exit 2; verify the corpus
+  directory is readable before `lintCorpus`, translating missing/unreachable directory
+  errors to the exact corpus-not-found stderr and exit 2 with no stdout;
   call `lintCorpus({dir})` from `@adrkit/core`; call `buildQueueReport({corpus, asOf})`;
   call `formatQueueReportMarkdown(report)` or `formatQueueReportJson(report)`;
   write to `process.stdout` (emit complete report BEFORE deciding exit code);
@@ -543,9 +554,9 @@ a known error, no network call, no module-resolution error.
   (N) a pure `publishQueueReport` helper given an error-bearing QueueReport records
   events in exact order `update issue → set issue-number output → setFailed`, with the
   exact error-count/issue-number message; a clean report omits `setFailed`.
-  Pull-request filtering and report-error handling are adapter/entrypoint concerns
-  except for the pure publish-order helper above; `managedQueueIssue` itself receives
-  neither raw PR entries nor a QueueReport.
+  GraphQL issue-only pagination and report-error translation are adapter/entrypoint
+  concerns except for the pure publish-order helper above; `managedQueueIssue` itself
+  receives neither raw API nodes nor a QueueReport.
   Run `bun test packages/ci/test/queue-issue.test.ts`; record
   `Cannot find module '../src/queue-issue'` failure.
 
@@ -558,7 +569,10 @@ a known error, no network call, no module-resolution error.
   split across multiple pages; assert all are collected in page order);
   (b) the query requests only issue nodes with `number`, `state`, `title`, and `body`;
   assert the adapter never calls REST `issues.listForRepo` or the Search API;
-  (c) GraphQL `OPEN`/`CLOSED` states map exactly to client `open`/`closed`.
+  (c) GraphQL `OPEN`/`CLOSED` states map exactly to client `open`/`closed`;
+  (d) an exported pure `handleGitHubApiError(error, setFailed)` maps both status 401
+  and 403 to the exact `issues: write` guidance, invokes `setFailed` once (therefore a
+  non-zero Action outcome), and maps other API failures to an explicit generic failure.
   Run test; record `Cannot find module` failure.
 
 ### GREEN: implement Action modules
@@ -600,10 +614,11 @@ a known error, no network call, no module-resolution error.
   `core.setFailed`; the helper owns the write → output → conditional-failure ordering
   and exact `"Queue report contains ${n} corpus error(s). See issue #${issueNumber} for details."`
   message;
-  if GitHub API throws with status 401 or 403 call
-  `core.setFailed("GitHub API returned ${status}: insufficient permissions. Ensure the workflow grants 'issues: write' to the GITHUB_TOKEN.")`;
-  surface every other GitHub API failure through `core.setFailed` without converting it
-  into a success-shaped result.
+  route every GitHub API failure through the tested `handleGitHubApiError` helper; 401
+  and 403 call
+  `core.setFailed("GitHub API returned ${status}: insufficient permissions. Ensure the workflow grants 'issues: write' to the GITHUB_TOKEN.")`,
+  while every other failure becomes an explicit generic `setFailed` outcome rather than
+  a success-shaped result.
   Create `packages/ci/queue/action.yml` with EXACT content from contract:
   `name: "ADR ARB Queue"`;
   inputs: `dir` (required:false, default:`docs/adr`), `token` (required:false,
@@ -639,9 +654,15 @@ a known error, no network call, no module-resolution error.
   Note: Node 22/24 coverage is validated by the existing CI matrix (`ci.yml`);
   do not require local runtimes beyond what is available.
 
-- [ ] T041 Run `bun run --filter @adrkit/ci typecheck && bun test packages/ci`;
-  assert clean. Run `node scripts/smoke-node.mjs` to confirm existing `dist/index.js`
-  smoke test still passes and the existing action behavior is unaffected.
+- [ ] T041 Wire and validate Node smoke boundaries: update `scripts/smoke-node.mjs` to
+  invoke the built `packages/cli/dist/index.js queue` against a committed fixture with
+  explicit `--as-of` and `--format json`, asserting `version:"1"` and expected items;
+  add `node scripts/smoke-queue-node.mjs` to the existing Node 22/24
+  `node-smoke-built-artifacts` matrix in `.github/workflows/ci.yml`; update the installed
+  tarball smoke generated by `scripts/release-pack.ts` and its existing tests to execute
+  the installed `adr queue` command under the same Node matrix. Run
+  `bun run --filter @adrkit/ci typecheck && bun test packages/ci`; run both smoke scripts
+  on the available local Node runtime and rely on the existing CI matrix for Node 22/24.
 
 **Checkpoint**: Action creates/updates managed issues using fake client; bundle
 committed; queue and existing smoke tests pass.
@@ -681,9 +702,10 @@ milestones, and the rung-6 external exit gate.
   `bun run release:pack -- --skip-build` using the existing coordinated pack script;
   inspect the core and CLI public tarballs for presence of new exports
   (`fingerprintOf`, `buildQueueReport`, `formatQueueReportJson`,
-  `formatQueueReportMarkdown`, `compareCodeUnits`); verify no tarball is produced for
-  private `@adrkit/ci`; verify Action distribution is confirmed via committed bundle
-  path only, not npm tarball.
+  `formatQueueReportMarkdown`, `compareCodeUnits`); run the generated installed-tarball
+  smoke and confirm `adr queue` succeeds; verify no tarball is produced for private
+  `@adrkit/ci`; verify Action distribution is confirmed via committed bundle path only,
+  not npm tarball.
 
 ### Maintainer dogfood
 


### PR DESCRIPTION
## Summary

- define the deterministic single-repository ARB queue contract and seven-state SLA model
- specify QueueReport v1 JSON/Markdown, `adr queue`, and managed-issue GitHub Action surfaces
- freeze finding codes, ordering, fingerprint compatibility, permissions, and failure behavior
- add 49 dependency-ordered test-first implementation tasks
- align repository and release docs with the published v0.2.0 state

## Scope boundaries

No implementation code is included. The design explicitly excludes databases, hosted services, model calls, notifications, lifecycle automation, MCP additions, PATs, and tracked queue reports.

SC-004 remains the post-implementation exit gate: Phase 6 cannot be called landed or release-ready until a separate team/repository exercises all three tiers, SLA behavior, approvals/objections, same-issue update, and default-token-only permissions.

## Analysis

Final `speckit.analyze`: PASS

- 0 critical
- 0 high
- 0 medium
- 0 low
- 23/23 functional requirements covered
- 8/8 success criteria covered
- Constitution Principles I–V pass