### PR TITLE
docs(adr): reconcile ADR-0007/0009 with the offline snapshot generator (ADR-0013)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -33,7 +33,8 @@ adrkit/
         ├── 0009  affects resolution + catalog binding    proposed
         ├── 0010  Bun toolchain, Node-targeted output      accepted
         ├── 0011  host schema at its $id (adrkit.dev)      accepted
-        └── 0012  explicit catalog owned-paths binding     accepted
+        ├── 0012  explicit catalog owned-paths binding     accepted
+        └── 0013  reconcile 0007/0009 with offline gen     accepted
 ```
 
 ## Not included — add at repo creation
@@ -71,7 +72,7 @@ independent of the GitHub namespace and unaffected either way.
 
 ## Verification
 
-12 records, ids 0001–0012, no gaps. All at schema 0.1.0. No dangling `relatesTo`.
+13 records, ids 0001–0013, no gaps. All at schema 0.1.0. No dangling `relatesTo`.
 No one-way door on the auto tier. No accepted record without a decider or an
 import provenance. JSON Schema and Zod agree on property casing. No `@adr/`
 references remain — the scope is `@adrkit/*` throughout.

--- a/docs/adr/0007-adapter-isolation-and-public-surface-build.md
+++ b/docs/adr/0007-adapter-isolation-and-public-surface-build.md
@@ -9,7 +9,7 @@ tags: [architecture, packaging, governance, ip-hygiene]
 scope: org
 reversibility: one-way-door
 blastRadius: org
-relatesTo: ["0003", "0006"]
+relatesTo: ["0003", "0006", "0013"]
 affects:
   - type: path
     pattern: "packages/*/package.json"
@@ -77,6 +77,11 @@ Both forces point to the same structure.
   upstream, not with our core.
 - Adapters depend on the core; the core never learns an adapter exists.
   Discovery is by configuration, resolved at runtime.
+
+> **Amended by ADR-0013.** For the catalog surface specifically, composition uses
+> no dynamic runtime adapter/plugin loader: a catalog adapter is a standalone
+> offline snapshot generator emitting a validated interchange file. This narrows,
+> and does not repeal, the general "discovery is by configuration" rule.
 
 **No package in the default build may depend on an artifact requiring
 authenticated or corporate-device access.**

--- a/docs/adr/0009-affects-resolution-and-catalog-binding.md
+++ b/docs/adr/0009-affects-resolution-and-catalog-binding.md
@@ -9,7 +9,7 @@ tags: [schema, core, matching, catalog]
 scope: org
 reversibility: one-way-door
 blastRadius: org
-relatesTo: ["0002", "0004", "0007"]
+relatesTo: ["0002", "0004", "0007", "0013"]
 affects:
   - type: path
     pattern: "packages/core/src/affects/**"
@@ -117,6 +117,12 @@ its native identifiers into that shape and documents anything lossy.
 
 The snapshot is serializable so it can be committed or cached, which is what
 keeps resolution pure and CI reproducible even when the live catalog moves.
+
+> **Amended by ADR-0013; refined by ADR-0012.** The per-adapter mapping is pinned
+> by ADR-0012's explicit `adrkit.io/owned-paths` contract. The in-memory snapshot
+> is an internal type, not a wire format: any persisted snapshot requires a
+> versioned interchange envelope before production, and composition is a standalone
+> offline generator rather than a dynamic runtime loader.
 
 ## Options considered
 

--- a/docs/adr/0013-reconcile-adapter-isolation-and-catalog-binding-with-the-offline-snapshot-genera.md
+++ b/docs/adr/0013-reconcile-adapter-isolation-and-catalog-binding-with-the-offline-snapshot-genera.md
@@ -1,0 +1,190 @@
+---
+schemaVersion: 0.1.0
+id: "0013"
+title: Reconcile adapter isolation and catalog binding with the offline snapshot generator
+status: accepted
+date: 2026-07-21
+deciders: ["@mbeacom"]
+tags: [governance, architecture, packaging, catalog]
+scope: org
+reversibility: one-way-door
+blastRadius: org
+relatesTo: ["0007", "0009", "0012"]
+affects:
+  - type: path
+    pattern: "packages/adapters/catalog-*/**"
+  - type: path
+    pattern: "packages/core/src/affects/**"
+provenance:
+  authoredBy: agent-drafted
+  ratifiedBy: "@mbeacom"
+review:
+  tier: arb
+  tierReason: >-
+    Narrows two org-scope, one-way-door clauses (ADR-0007's runtime adapter
+    discovery and ADR-0009's freely-cacheable snapshot) and fixes the composition
+    boundary every future catalog adapter builds against.
+externalRefs:
+  - type: issue
+    id: "25"
+    url: "https://github.com/mbeacom/adrkit/issues/25"
+    label: Decide catalog entity-to-path binding before feature 009
+---
+
+# ADR-0013: Reconcile adapter isolation and catalog binding with the offline snapshot generator
+
+## Context
+
+The 2026-07-21 catalog contract-hardening decision (issue #25, ratified by
+`@mbeacom`) settled how catalog composition and persistence must work: "Catalog
+composition is a standalone offline snapshot generator feeding a validated
+interchange file; no dynamic runtime adapter/plugin loader is authorized," and
+"any persisted `CatalogSnapshot` requires a versioned interchange contract before
+production." ADR-0012 records the entity-to-path binding contract built on that
+boundary.
+
+Two earlier records now contain clauses that the hardening decision narrows:
+
+- **ADR-0007** ("Isolate integrations as optional adapters") states, of adapter
+  discovery generally: "Discovery is by configuration, **resolved at runtime**."
+  The hardening decision forbids a dynamic runtime adapter/plugin loader for the
+  catalog surface specifically.
+- **ADR-0009** ("Pin affects resolution … and bind entity refs to pluggable
+  catalogs") delegates the native-to-normalized entity mapping to each adapter
+  and describes the snapshot as "**serializable so it can be committed or
+  cached**," with adapters implementing a port that is implicitly resolved at
+  run time. The hardening decision pins that mapping (ADR-0012), forbids a runtime
+  loader, and gates any persisted snapshot behind a versioned interchange
+  envelope.
+
+Both ADR-0007 and ADR-0009 are still `status: proposed`. The hardening decision
+also directed that "ADR-0007/0009 must be accepted/amended or explicitly blocked
+before implementation." ADR-0012 took the explicitly-documented-blockers path and
+deferred the reconciliation itself to "a separate, explicit … decision." This is
+that decision. Left unreconciled, ADR-0007's "resolved at runtime" and ADR-0009's
+"committed or cached" language stand as latent contradictions of ratified law —
+exactly the silent-governance-drift failure this project exists to prevent.
+
+## Decision
+
+**Amend the two narrowed clauses; keep ADR-0007 and ADR-0009 `proposed` with an
+explicit acceptance path. Do not fabricate an acceptance that never happened.**
+
+### Clause amendments (by reference; body bytes of the amended records gain only
+a reconciliation note)
+
+- **ADR-0007 — runtime discovery.** For the **catalog** surface, adapter
+  composition uses **no dynamic runtime adapter/plugin loader**. A catalog adapter
+  is a **standalone offline snapshot generator** that emits a validated
+  interchange file which the core consumes; the core still never learns an adapter
+  exists. This narrows, and does not repeal, ADR-0007's general "discovery is by
+  configuration" rule — configuration still selects composition, but for catalogs
+  the composition is offline generation, not runtime loading.
+- **ADR-0009 — mapping and snapshot.** The native-to-normalized entity mapping
+  ADR-0009 delegated to adapters is now **pinned by ADR-0012** (the explicit
+  `adrkit.io/owned-paths` contract). ADR-0009's "serializable so it can be
+  committed or cached" is narrowed: the in-memory `CatalogSnapshot` shape is an
+  internal type, **not** a wire format, and **any persisted snapshot requires a
+  versioned interchange envelope before production**. The port ADR-0009 defines is
+  realized by offline generation, not a dynamic runtime loader.
+
+Resolution purity, per-ADR union matching, degradation-to-inert, and the
+`resolution-is-pure` assertion from ADR-0009 are unchanged and remain in force.
+
+### Status disposition — honest audit, no fabricated history
+
+**ADR-0007 and ADR-0009 remain `proposed`.** This is the honest outcome:
+
+- This corpus has **no accepted-status transition on record**. Every accepted
+  record entered git already `accepted` — 0001, 0002, 0004, 0010, 0011, and the
+  just-merged 0012 (and this record, 0013) — and no ADR has ever been ratified
+  `proposed → accepted` via PR. Both 0007 and 0009 already
+  carry `ratifiedBy: "@mbeacom"` and are enforced as de facto project law through
+  the constitution and green CI assertions, but no explicit accepted-status
+  transition was ever ratified for either. Flipping status now would fabricate
+  that specific governance act.
+- Their implementation-facing action items remain open and gated (below), so
+  acceptance would also outrun the evidence.
+
+This ADR **amends** specific clauses of ADR-0007 and ADR-0009; it does **not**
+supersede them. Their core decisions — adapter isolation, the clean-clone build
+constraint, pinned affects semantics — remain authoritative and unchanged.
+
+### Acceptance path for ADR-0007 and ADR-0009
+
+Either record moves to `accepted` only in its own explicit, reviewed decision once
+its blockers clear:
+
+1. Phase 6 `specs/007-arb-queue/tasks.md` T048/T049 clear.
+2. Non-shipping spike evidence from `specs/009-catalog-binding-viability/`,
+   including a versioned interchange envelope and the security/scale measurements
+   named in ADR-0012.
+3. An independent adopter validates real entity/path outcomes.
+4. Clean-clone / offline / adapter-boundary / release evidence passes (for
+   ADR-0007, its `core-has-no-adapter-deps` and `clean-clone-builds` assertions
+   stay green throughout).
+
+## Options considered
+
+### Option A: Amend the narrowed clauses; hold status `proposed` (chosen)
+
+Reconciles the contradictions immediately, keeps the records honest, and defines a
+concrete acceptance path. Costs a small edit to two records and a dedicated
+governance record.
+
+### Option B: Flip ADR-0007 and ADR-0009 to `accepted` now
+
+**Pros:** removes the "proposed but binding" oddity in one step.
+**Cons:** fabricates a ratification event that never occurred (no accepted-status
+transition precedent; implementation gates unmet), and folds an ARB-tier,
+one-way-door ratification into a reconciliation PR. Explicitly forbidden by the
+maintainer directive not to fabricate acceptance history. Rejected.
+
+### Option C: Supersede ADR-0007 and ADR-0009 with new records
+
+**Pros:** a clean single lineage.
+**Cons:** their cores (adapter isolation, clean-clone, pinned affects semantics)
+remain valid; superseding would discard still-authoritative decisions and
+overstate the change. Rejected.
+
+### Option D: Do nothing
+
+Leave "resolved at runtime" and "committed or cached" standing.
+**Cons:** ratified law and the records disagree in writing — the silent-drift
+failure mode. Rejected.
+
+## Trade-offs
+
+Holding two records `proposed` while a newer `accepted` record amends them is
+unusual, but amendment does not require the amended record to be accepted, and
+`proposed` is the honest status while the gates are unmet. The alternative —
+accepting them to tidy the status — is precisely the fabrication the maintainer
+directed against.
+
+Amending by reference (a note in each record plus this decision) keeps the edit to
+the audited records minimal, at the cost of a reader needing to follow the link to
+see the full narrowing. Accepted: a light, discoverable pointer is safer than
+rewriting one-way-door records in a reconciliation PR.
+
+## Consequences
+
+- Easier: reasoning about catalog composition (offline generation, one model);
+  building `packages/adapters/catalog-backstage` against a fixed boundary; auditing
+  why 0007/0009 are still `proposed`.
+- Harder: two records now carry an amendment pointer that a future acceptance
+  decision must fold in; the versioned-envelope requirement is a standing
+  precondition for any persisted snapshot.
+- **How we would know this was wrong:** the spike reports `blocked`, or an adopter
+  shows the offline-generator boundary cannot express a real catalog — either
+  reopens ADR-0012 and this reconciliation before acceptance.
+- Revisit if: a future decision accepts or supersedes ADR-0007 or ADR-0009, at
+  which point this amendment is folded into that record.
+
+## Action items
+
+1. [ ] Fold these amendments into ADR-0007 and ADR-0009 when each is taken to an
+       explicit accept/supersede decision.
+2. [ ] Ensure `specs/009-catalog-binding-viability/` scoping records the
+       offline-generator/no-dynamic-loader boundary and the versioned envelope.
+3. [ ] Keep `core-has-no-adapter-deps` and `clean-clone-builds` green as the
+       standing evidence for ADR-0007's acceptance path.

--- a/packages/cli/test/lint.test.ts
+++ b/packages/cli/test/lint.test.ts
@@ -23,7 +23,7 @@ describe('adr lint CLI', () => {
   test('passes on this repository corpus', async () => {
     const result = await runAdr(['lint']);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('checked 12 records, 0 errors');
+    expect(result.stdout).toContain('checked 13 records, 0 errors');
     expect(result.stderr).toBe('');
   });
 


### PR DESCRIPTION
## Summary

Follow-up to the merged **ADR-0012** (catalog entity-to-path binding). Adds **ADR-0013**, a dedicated governance decision that **reconciles ADR-0007 and ADR-0009 with the 2026-07-21 contract-hardening decision** (issue #25) and **honestly resolves their status without fabricating acceptance history**.

Base: `main`. **Do not merge** without coordinator approval.

## Why

The hardening comment ratified: *"Catalog composition is a standalone offline snapshot generator feeding a validated interchange file; no dynamic runtime adapter/plugin loader is authorized"* and *"any persisted `CatalogSnapshot` requires a versioned interchange contract before production."* That narrows two clauses still live in `proposed` records:
- **ADR-0007:** "Discovery is by configuration, **resolved at runtime**."
- **ADR-0009:** snapshot "**serializable so it can be committed or cached**" + its delegated per-adapter mapping (now pinned by ADR-0012).

The merged ADR-0012 explicitly deferred this reconciliation to "a separate, explicit decision." This is that decision.

## What ADR-0013 decides

- **Amends** (does not supersede) the two clauses: catalog composition = offline snapshot generator, no dynamic runtime loader; persisted snapshot needs a versioned interchange envelope; the in-memory shape is not a wire format; the per-adapter mapping is pinned by ADR-0012. Resolution purity / union matching / `resolution-is-pure` are unchanged.
- **Status audit — honest, no fabrication:** ADR-0007 and ADR-0009 **stay `proposed`**. This corpus has no accepted-status transition on record (0001/0002/0004/0010/0011/0012 all entered git already `accepted`); both carry `ratifiedBy` and are de-facto-enforced, but no explicit `proposed → accepted` ratification ever occurred, and their gates are unmet. Flipping them would fabricate that governance act — which the maintainer directive forbids.
- Defines the concrete **acceptance path** for each (Phase 6 T048/T049; spike evidence + versioned envelope; independent adopter; clean-clone/offline/adapter-boundary/release evidence).
- Options B (flip to accepted — rejected as fabrication), C (supersede — rejected, cores stand), D (do nothing — rejected, leaves contradictions) are recorded.

ADR-0007 and ADR-0009 gain only a short reconciliation note and a `relatesTo: 0013` link.

## Scope

Decision-record only, plus the tightly-coupled dogfood sync (`packages/cli/test/lint.test.ts` count 12->13; `MANIFEST.md` inventory 0001-0013). No adapter/core/CLI logic; no `.specify`/`specs/009` changes.

## Validation

`adr lint` 13/0/0 · `adr check` clean · `bun test` 684 pass · typecheck · `schema:emit` no drift · `check:deps` ok. Independent **GPT-5.6 Sol** read-only review — one should-fix (accepted-record enumeration) resolved, no blockers.

Refs #25
