### PR TITLE
docs: record feature 009 network-denial mechanism as available (env probe)

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -58,8 +58,13 @@ Governance authorizes each spike's *execution*; a spike's `plan.md` row may only
 `landed`/complete **after** that spike's own final report and independent evidence audit
 exist (its tracked, sanitized evidence index), not merely because execution was authorized.
 Governance removes the community gate only — it does **not** remove any **technical safety
-gate**; in particular feature 009 is **not executable** unless a genuinely blocking (not
-allowlist-only) network-denial mechanism is available in the execution environment.
+gate**; feature 009 requires a genuinely blocking (not allowlist-only) network-denial
+mechanism, and a **qualifying mechanism is available** in the current environment (a
+2026-07-22 probe confirmed `/usr/bin/sandbox-exec` with `(deny network*)` blocks network
+without privileges — `curl` failed with exit 6; Podman 5.4.2 `--network none` is an optional
+stronger container path; Docker is unavailable). Its `T006` fail-closed discipline stands for
+any environment that lacks such a mechanism, and execution must still record the actual
+mechanism and its limitations.
 
 Phase 4's implementation gate is **cleared**. Phase 3 T018 was completed on
 [`mbeacom/adrkit-t018-dogfood`](https://github.com/mbeacom/adrkit-t018-dogfood):

--- a/specs/009-catalog-binding-viability/research.md
+++ b/specs/009-catalog-binding-viability/research.md
@@ -538,7 +538,14 @@ pressure:
   mechanism is available in the execution environment, the run does not
   satisfy FR-018 and MUST NOT proceed until one is available — this is a
   fail-closed constraint on the execution environment itself, not merely
-  an evidence-recording nicety. This corrects
+  an evidence-recording nicety. **Environment-readiness note (2026-07-22 probe,
+  not spike execution):** a qualifying mechanism-2 sandbox is present in the
+  current environment — `/usr/bin/sandbox-exec` with a `(deny network*)` profile
+  blocked network without privileges (`curl` exit 6); Podman 5.4.2 `--network
+  none` is available as an optional stronger mechanism-1-style container path
+  (Docker daemon unavailable). This establishes readiness only; a future
+  execution session MUST still select, apply, and record the actual mechanism and
+  its limitations. This corrects
   `specs/008-...` R8's own three-tier ranking for this spike's purposes;
   `specs/008-...`'s own spike may still use its original three-tier language
   for its own, separately-scoped feature — this plan does not amend that

--- a/specs/009-catalog-binding-viability/spec.md
+++ b/specs/009-catalog-binding-viability/spec.md
@@ -100,12 +100,16 @@ citation of record for the contract's actual terms.
 > parallelize internally once its foundational checkpoint passes.
 >
 > **Technical safety gates are unaffected.** Governance authorization removes the community
-> gate only; it does **not** remove any technical safety gate. In particular this spike is
-> **not executable** unless a genuinely **blocking** (not allowlist-only) network-denial
-> mechanism is available in the execution environment (FR-018; task T006 fails closed and
-> forbids every derivation task if none is available), and its landed/complete claim requires
-> its own final report and independent evidence audit (not merely authorization). Do not
-> describe this spike as executable in an environment lacking such a mechanism.
+> gate only; it does **not** remove any technical safety gate. This spike requires a genuinely
+> **blocking** (not allowlist-only) network-denial mechanism (FR-018; task T006), and a
+> **qualifying mechanism is available** in the current environment: a 2026-07-22 probe confirmed
+> `/usr/bin/sandbox-exec` with `(deny network*)` blocks network without privileges (`curl` exit
+> 6), with Podman 5.4.2 `--network none` as an optional stronger container path (Docker
+> unavailable). T006 remains **fail-closed** for any environment lacking such a mechanism, and
+> execution MUST record the actual mechanism used and its limitations. The spike's
+> landed/complete claim additionally requires its own final report and independent evidence
+> audit (not merely authorization). Do not treat this probe as spike execution — it only
+> establishes environment readiness.
 >
 > **Satisfied governance preconditions.** Maintainer scoping/contract ratification (adrkit
 > issue #25, both 2026-07-21 decisions), catalog-binding convention governance

--- a/specs/009-catalog-binding-viability/tasks.md
+++ b/specs/009-catalog-binding-viability/tasks.md
@@ -304,7 +304,13 @@ outputs, and none of it is story-specific.
   `<EVIDENCE_DIR>/network-denial.json`. **If neither qualifying mechanism is available in the
   execution environment, this task MUST record that fact and every subsequent derivation task
   in this file MUST NOT proceed** — this is a fail-closed constraint on the execution
-  environment itself, not merely an evidence-recording nicety. Depends on: T004 only.
+  environment itself, not merely an evidence-recording nicety. **Environment-readiness note
+  (2026-07-22 probe; not task execution):** a qualifying mechanism is present here —
+  `/usr/bin/sandbox-exec` with a `(deny network*)` profile blocked network without privileges
+  (`curl` returned exit 6), and Podman 5.4.2 `--network none` is available as an optional
+  stronger container path (Docker daemon unavailable). A future execution session MUST still
+  select, apply, and record the actual mechanism and its limitations at execution time; this
+  note establishes readiness, not completion. Depends on: T004 only.
 
 - [ ] T007 [P] Establish `<GENERAL_SCRATCH>` (`research.md` R2 item 1; Assumption A7). Create a
   disposable scratch directory outside any git-tracked clone of `mbeacom/adrkit`, or a


### PR DESCRIPTION
Fourth follow-up (after merged #30/#31/#32), recording a 2026-07-22 environment probe result for feature 009's readiness. Docs only — no runtime changes, no spike execution, no task marked complete.

## Context
An environment probe confirmed feature 009's **technical network-denial prerequisite is available** here, so the docs should no longer imply it might be absent — while keeping the fail-closed discipline and the requirement to record the actual mechanism at execution.

## Changes
- Recorded the probe result in root `plan.md`, the 009 spec banner, `T006`, and `research.md` R10: `/usr/bin/sandbox-exec` with `(deny network*)` **blocked network without privileges** (`curl` exit 6); Podman 5.4.2 `--network none` is an optional stronger container path; Docker daemon unavailable.
- Removed "not executable unless a blocking mechanism is available" phrasing that could read as implying unavailability; replaced with a positive "**qualifying mechanism is available**" readiness statement.
- **Preserved the safety discipline**: `T006` remains `- [ ]` (unexecuted) and fail-closed for any environment lacking a mechanism; execution must still select, apply, and record the actual mechanism and its limitations. Each note explicitly states it establishes **environment readiness, not spike execution**.

## Verification
`adr lint` 14/0/0 · `bun test` 684 pass · no task checked.

Do **not** merge without coordinator approval.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
