### PR TITLE
docs(adr): draft ADR-0015 — validate descriptors against Backstage field formats before canonicalizing identity

### DIFF
--- a/docs/adr/0015-validate-descriptors-against-backstage-field-formats-before-canonicalizing.md
+++ b/docs/adr/0015-validate-descriptors-against-backstage-field-formats-before-canonicalizing.md
@@ -1,0 +1,293 @@
+---
+schemaVersion: 0.1.0
+id: "0015"
+title: Validate descriptors against Backstage field formats before canonicalizing identity
+status: proposed
+date: 2026-07-25
+deciders: ["@mbeacom"]
+tags: [catalog, governance, matching, core]
+scope: domain
+reversibility: two-way-door
+blastRadius: cross-team
+relatesTo: ["0009", "0012", "0013"]
+affects:
+  - type: path
+    pattern: "packages/core/src/affects/catalog.ts"
+  - type: path
+    pattern: "packages/adapters/catalog-*/**"
+  - type: path
+    pattern: "specs/009-catalog-binding-viability/contracts/entity-identity.md"
+provenance:
+  authoredBy: agent-drafted
+review:
+  tier: arb
+  tierReason: >-
+    Adds a precondition to the canonicalization step ADR-0012 pins, and adds a
+    trigger condition to its org-scope, one-way-door atomic fail-closed clause.
+    ADR-0013 set the precedent that narrowing or extending a frozen clause of an
+    org-scope record takes the ARB tier even when the amending record is itself
+    narrower.
+assertions:
+  - id: entity-admissibility-precedes-canonicalization
+    description: >-
+      Every catalog descriptor is checked against Backstage's own field-format
+      validators, at the commit pinned by ADR-0012, before any canonical
+      identity is computed for it. A descriptor that fails that check aborts the
+      entire snapshot operation with a non-zero status, a distinct
+      inadmissible-descriptor trigger class, and no usable partial output. It is
+      never canonicalized, never compared for identity, and never silently
+      dropped or excluded from the input set.
+    engine: custom
+    expression: entity-admissibility-precedes-canonicalization
+    input: catalog
+    severity: error
+externalRefs:
+  - type: issue
+    id: "25"
+    url: "https://github.com/mbeacom/adrkit/issues/25"
+    label: Decide catalog entity-to-path binding before feature 009
+reviewBy: 2027-01-25
+---
+
+# ADR-0015: Validate descriptors against Backstage field formats before canonicalizing identity
+
+> **Status: `proposed`. This record is a draft for maintainer review and is not
+> ratified.** It authorizes nothing on its own. In particular it does not claim
+> that feature009 is unblocked, does not authorize any spike task, re-run, or
+> generator invocation, and does not sanction any production catalog adapter.
+
+## Context
+
+ADR-0012 pinned the catalog entity-to-path binding contract against a frozen
+Backstage commit, `1121a4facd9e321179d0402c3f355e4a649e84d9`, and located the
+identity rules in `specs/009-catalog-binding-viability/contracts/entity-identity.md`.
+That contract's §1 defines canonicalization as exactly two steps:
+
+1. If `metadata.namespace` is omitted, default it to `default`.
+2. `canonicalId := ${K}:${NS}/${N}`, lowercased in full.
+
+**There is no admissibility or validation step anywhere ahead of those two
+steps**, and nothing under `specs/009-catalog-binding-viability/**` references
+Backstage's entity-name validators at any point. Whatever string appears at
+`metadata.name` is accepted as a name and folded into a canonical identity.
+
+At the same pinned commit, Backstage does not treat those fields as free-form.
+`packages/catalog-model/src/validation/makeValidator.ts` binds four **distinct**
+per-field validators, and `FieldFormatEntityPolicy` applies them to every
+entity:
+
+| Field | Validator binding | Predicate | Applied |
+|---|---|---|---|
+| `apiVersion` | `isValidApiVersion` | prefix/suffix split on `/`, DNS-subdomain prefix, ≤63 per part | required |
+| `kind` | `isValidKind` | `/^[a-zA-Z][a-z0-9A-Z]*$/`, ≤63 | required |
+| `metadata.name` | `isValidEntityName` → `KubernetesValidatorFunctions.isValidObjectName` | `/^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$/`, ≤63 | required |
+| `metadata.namespace` | `isValidNamespace` → `KubernetesValidatorFunctions.isValidDnsLabel` | `/^[a-z0-9]+(?:\-+[a-z0-9]+)*$/`, ≤63 | **only when present** |
+
+The `metadata.name` row has been independently verified by the maintainer at the
+pinned commit. The other three rows are read from the same pinned files and
+**should be re-confirmed at ratification** rather than taken on this record's
+word.
+
+The consequence is a category error in the contract, and it is not hypothetical.
+The tracked feature009 record documents fifteen descriptors — five in
+`community-plugins`, ten in `rhdh-plugins` — whose `metadata.name` is the
+literal, un-rendered scaffolder placeholder `${{ values.name | dump }}`. That
+string fails `isValidObjectName` on character class: `$`, `{`, `}`, `|` and the
+spaces are all outside the permitted set, while ordinary descriptor names pass
+the same predicate unchanged. Backstage would reject those descriptors as
+malformed entities outright. The contract instead accepts each one as a
+well-formed name, lowercases it, concatenates it — and, because they are all the
+same string, reports the result as
+`triggerClass: "duplicate-canonical-id"`.
+
+**The fail-closed rejection there is correct and required by §3.** What is wrong
+is the *classification*: a descriptor that is not a valid Backstage entity at all
+is being characterized as an identity collision *between valid entities*. Those
+are different defects with different remedies, and the contract currently cannot
+tell them apart, because it never asks the question Backstage itself asks first.
+
+This record exists to close that gap. It is warranted by the validator bindings
+above and by nothing else.
+
+## Decision
+
+**A descriptor MUST be admissible before it is canonicalized.** Admissibility is
+evaluated against Backstage's own field-format validators at the commit ADR-0012
+pins, and it is evaluated *before* `entity-identity.md` §1 runs.
+
+### The admissibility check
+
+A descriptor is **admissible** when all of the following hold at the pinned
+commit's semantics:
+
+- `apiVersion` is present and satisfies `isValidApiVersion`.
+- `kind` is present and satisfies `isValidKind`.
+- `metadata.name` is present and satisfies `isValidEntityName`.
+- `metadata.namespace`, **if and only if present**, satisfies `isValidNamespace`.
+
+An omitted `metadata.namespace` is admissible; §1's `default` substitution
+applies afterwards, unchanged. The namespace is validated as authored, never
+after defaulting.
+
+### Ordering
+
+Admissibility is a precondition of §1, not a step inside it. §1's two steps and
+its worked casing/namespace examples are untouched, and §3's duplicate-collision
+table is untouched. No canonical identity is computed for an inadmissible
+descriptor, so no inadmissible descriptor can participate in a uniqueness
+comparison.
+
+### Failure semantics — fail-closed is preserved exactly, not relaxed
+
+An inadmissible descriptor **aborts the entire operation** with a non-zero
+status and no usable partial output, under a new, distinct trigger class
+`inadmissible-descriptor`, carrying the offending path, the failing field, and
+the validator that rejected it.
+
+Inadmissible descriptors are **not** filtered, skipped, excluded from the input
+set, or treated as non-entities. This record adds a failure *class*; it removes
+no failure. Every condition that aborts a run today still aborts a run.
+
+### Relationship to the existing collision rule
+
+`duplicate-canonical-id` retains its exact current meaning: two or more
+**admissible** descriptors canonicalizing to the same identity. Because
+admissibility runs first, a corpus containing both inadmissible descriptors and a
+genuine collision between valid entities will now report the inadmissible ones,
+which is the earlier and more specific defect.
+
+**This narrows what `duplicate-canonical-id` reports; it does not make either
+condition non-fatal.** A corpus that fails today fails after this change too. The
+report says something truer about *why*.
+
+## Options considered
+
+### Option A: Validate before canonicalizing; distinct fatal `inadmissible-descriptor` class (chosen)
+
+Matches Backstage's own ordering, preserves fail-closed exactly, and corrects the
+classification. Strictly additive on the failure surface; removes no abort.
+
+### Option B: Validate, then exclude inadmissible descriptors from the entity set
+
+Rejected. This is the version that would let a corpus containing invalid
+descriptors produce a populated snapshot. It converts a fatal condition into a
+silent drop, directly contradicting ADR-0012's `owned-paths-fail-closed-atomic`
+assertion ("never a partial or silently-dropped set"). It is also the option
+whose appeal comes from the *result it produces* rather than from the validator
+evidence — which is precisely the reasoning this record must not adopt. If
+descriptor exclusion is ever wanted, it needs its own record, its own
+justification, and an explicit amendment to that assertion.
+
+### Option C: Validate, warn, and canonicalize anyway
+
+Rejected. Keeps the wrong classification while adding noise. A descriptor
+Backstage would reject is not a lesser entity; it is not an entity.
+
+### Option D: Exclude by path convention (e.g. scaffolder-template directories)
+
+Rejected. Path shape is not the property that makes a descriptor invalid, and
+the tracked record's own evidence shows placeholder descriptors are not confined
+to a single directory convention. A path rule would be both unprincipled and
+incomplete.
+
+### Option E: Do nothing
+
+Rejected. The contract would go on knowingly canonicalizing input that Backstage
+itself rejects, and go on mis-reporting at least one real, recorded condition.
+The gap is independent of whether feature009 ever executes again.
+
+## Trade-offs
+
+**What this buys.** Classification precision at the identity boundary, and
+alignment with the validator semantics ADR-0012 already pinned but never
+applied. Failures name the defect that actually occurred.
+
+**What is given up:**
+
+- **A public failure surface grows.** `inadmissible-descriptor` becomes a
+  contract-visible trigger class that consumers may branch on. Renaming or
+  removing it later is a breaking change to the failure contract. This is the
+  main reason the record is `two-way-door` rather than trivially reversible: the
+  precondition itself is cheap to delete, but the emitted class is not.
+- **A pinned-commit dependency becomes load-bearing.** Admissibility is defined
+  by Backstage's validators at one frozen commit. If upstream relaxes or
+  tightens a predicate, this contract silently diverges from live Backstage
+  until the pin is deliberately moved. That divergence is already implicit in
+  ADR-0012; this record makes it consequential.
+- **Strictly more corpora become unusable, not fewer.** Because admissibility is
+  fatal rather than filtering, descriptors that previously canonicalized without
+  complaint — for example a name exceeding the 63-character limit that happened
+  not to collide with anything — will now abort a run that previously completed.
+  **This record makes the contract stricter. Anyone reading it as a route to
+  making more real-world corpora usable has read it backwards.**
+- **It buys nothing for annotation-derivation confidence.** Taken up below.
+
+### On what real-corpus evidence can and cannot establish
+
+A cross-check contributed during review holds that real corpora are 100%
+`annotation-absent` — no public corpus carries `adrkit.io/owned-paths`, because
+it is adrkit's own proposed annotation — and therefore that real-corpus evidence
+can never validate annotation-derivation itself, only enumeration and
+determinism.
+
+**Agreed on the substance, with one qualification.** The *positive* derivation
+paths — `explicit-paths` and `explicit-empty` — are unreachable from any public
+corpus by construction, and no volume of real-corpus data will ever exercise
+them; only synthetic fixtures can. Nothing in this record changes that, and this
+record should not be read as improving it.
+
+The qualification is that "only enumeration and determinism" understates the
+case slightly. A 100%-absent result is itself load-bearing: it exercises the
+`annotation-absent` branch of the three-state discriminator at scale, and it
+independently substantiates ADR-0012's founding premise that no authoritative
+entity-to-path binding exists in the wild. That is a real finding, not merely an
+absence of one.
+
+**Why this matters for scoping this record honestly.** Admissibility sits
+*upstream* of annotation handling entirely — it decides whether a descriptor is
+an entity at all, before any annotation is read. So its value lands squarely in
+the enumeration, classification, and determinism layer, which is the layer real
+corpora *can* speak to. That is a point in favour of deciding it on validator
+grounds. But it also means adopting this record moves the annotation-derivation
+evidence gap **not at all**. Any future claim that catalog binding is
+empirically validated must still rest on synthetic fixtures for the derivation
+paths, exactly as it did before.
+
+## Consequences
+
+- `entity-identity.md` §1 gains an admissibility precondition; §1's own two
+  steps and §3's collision table are unchanged.
+- The atomic fail-closed clause ADR-0012 pins gains one trigger condition and
+  loses none.
+- Reports distinguish "this is not a valid Backstage entity" from "these valid
+  entities collide."
+- **The recorded feature009 verdict is unaffected by this record.** It remains
+  `blocked` with `blockedShortfall = "envelope-or-scale-evidence-incomplete"`.
+  Ratifying this record does not re-open, re-run, or re-decide that spike, and
+  does not by itself make SC-010 satisfiable.
+- The carry-forward `reference-oracle.json` blocker recorded in
+  `specs/009-catalog-binding-viability/checklists/evidence-index.md` is
+  untouched and remains in full force: any future feature009 execution must
+  still begin from a fresh T014 → T014a cycle before producing generator output.
+- No production catalog adapter is authorized, created, or implied. No
+  `packages/adapters/catalog-*` package exists or is sanctioned by this record.
+
+## Action items
+
+1. **Confirm the validator bindings at the pinned commit before ratification.**
+   The `metadata.name` binding is maintainer-verified; `apiVersion`, `kind`, and
+   `namespace` are not, and this record should not be ratified on its own
+   assertion of them.
+2. **Obtain one independent review from a fresh context** that did not author
+   this record, checking the four predicates against
+   `makeValidator.ts`, `KubernetesValidatorFunctions.ts`,
+   `CommonValidatorFunctions.ts`, and `FieldFormatEntityPolicy.ts` at
+   `1121a4fa…`. Per this repository's standing model policy the reviewer must be
+   `claude-opus-5`, or `gpt-5.6` for a second, different-lineage pass. No older
+   revision is acceptable; model identity is recorded as evidence.
+3. **Only after ratification**, prepare the corresponding `specs/009-**`
+   contract amendment as a separately-scoped change. No `specs/009-**` edit is
+   authorized by this draft.
+4. **Decide separately** whether descriptor *exclusion* (Option B) is ever
+   wanted. It is out of scope here and would require amending ADR-0012's
+   fail-closed assertion.

--- a/docs/adr/0015-validate-descriptors-against-backstage-field-formats-before-canonicalizing.md
+++ b/docs/adr/0015-validate-descriptors-against-backstage-field-formats-before-canonicalizing.md
@@ -91,19 +91,28 @@ pinned commit. The other three rows are read from the same pinned files and
 word.
 
 The consequence is a category error in the contract, and it is not hypothetical.
-The tracked feature009 record documents fifteen descriptors — five in
-`community-plugins`, ten in `rhdh-plugins` — whose `metadata.name` is an
-unsubstituted, un-rendered scaffolder placeholder rather than a name. Fourteen
-of them (five and nine respectively) carry the identical string
-`${{ values.name | dump }}`; the fifteenth carries `${{ values.name }}`, which
-is equally unsubstituted but canonicalizes differently. Both strings fail
-`isValidObjectName` on character class: `$`, `{`, `}` and the spaces — and, for
-the first, `|` — are all outside the permitted set, while ordinary descriptor
-names pass the same predicate unchanged. Backstage would reject every one of
-these descriptors as a malformed entity outright. The contract instead accepts
-each as a well-formed name, lowercases it, concatenates it — and, for the
-fourteen that share a string, reports the result as
+Fifteen descriptors in the two corpora feature009 pinned — five in
+`community-plugins` at `92e9e4e09c76cc57f3475029b73e5ec84498a459`, ten in
+`rhdh-plugins` at `3b355ddfedb23c6656bd9effc8510f9926b765c1` — carry an
+unsubstituted, un-rendered scaffolder placeholder at `metadata.name` rather than
+a name. Fourteen of them (five and nine respectively) carry the identical string
+`${{ values.name | dump }}`; the fifteenth, `bulk-import`, carries
+`${{ values.name }}`, which is equally unsubstituted but canonicalizes
+differently. Both strings fail `isValidObjectName` on character class: `$`, `{`,
+`}` and the spaces — and, for the first, `|` — are all outside the permitted set,
+while ordinary descriptor names pass the same predicate unchanged. Backstage
+would reject every one of these descriptors as a malformed entity outright. The
+contract instead accepts each as a well-formed name, lowercases it, concatenates
+it — and, for the fourteen that share a string, reports the result as
 `triggerClass: "duplicate-canonical-id"`.
+
+`bulk-import` is the sharper case, and the reason this is a contract gap rather
+than a reporting one. Being canonically distinct, it collides with nothing. It is
+exactly as invalid as the other fourteen, and the contract has no mechanism of
+any kind that would notice. The duplicate rule catches the fourteen only
+incidentally, as a side effect of their sharing a string; behind it there is
+nothing. Duplicate detection is not a validity check, and the corpus contains a
+descriptor demonstrating that the two conditions come apart.
 
 **The fail-closed rejection there is correct and required by §3.** What is wrong
 is the *classification*: a descriptor that is not a valid Backstage entity at all

--- a/docs/adr/0015-validate-descriptors-against-backstage-field-formats-before-canonicalizing.md
+++ b/docs/adr/0015-validate-descriptors-against-backstage-field-formats-before-canonicalizing.md
@@ -90,14 +90,17 @@ word.
 
 The consequence is a category error in the contract, and it is not hypothetical.
 The tracked feature009 record documents fifteen descriptors — five in
-`community-plugins`, ten in `rhdh-plugins` — whose `metadata.name` is the
-literal, un-rendered scaffolder placeholder `${{ values.name | dump }}`. That
-string fails `isValidObjectName` on character class: `$`, `{`, `}`, `|` and the
-spaces are all outside the permitted set, while ordinary descriptor names pass
-the same predicate unchanged. Backstage would reject those descriptors as
-malformed entities outright. The contract instead accepts each one as a
-well-formed name, lowercases it, concatenates it — and, because they are all the
-same string, reports the result as
+`community-plugins`, ten in `rhdh-plugins` — whose `metadata.name` is an
+unsubstituted, un-rendered scaffolder placeholder rather than a name. Fourteen
+of them (five and nine respectively) carry the identical string
+`${{ values.name | dump }}`; the fifteenth carries `${{ values.name }}`, which
+is equally unsubstituted but canonicalizes differently. Both strings fail
+`isValidObjectName` on character class: `$`, `{`, `}` and the spaces — and, for
+the first, `|` — are all outside the permitted set, while ordinary descriptor
+names pass the same predicate unchanged. Backstage would reject every one of
+these descriptors as a malformed entity outright. The contract instead accepts
+each as a well-formed name, lowercases it, concatenates it — and, for the
+fourteen that share a string, reports the result as
 `triggerClass: "duplicate-canonical-id"`.
 
 **The fail-closed rejection there is correct and required by §3.** What is wrong
@@ -253,6 +256,47 @@ evidence gap **not at all**. Any future claim that catalog binding is
 empirically validated must still rest on synthetic fixtures for the derivation
 paths, exactly as it did before.
 
+### This rule does not clear the corpora, and does not unblock feature009
+
+This is the most important limitation on this record, and it is stated here
+rather than buried in Consequences because it is the strongest available
+evidence about *why* this rule is being proposed.
+
+Admissibility does not make the two pinned corpora usable. At least one
+`duplicate-canonical-id` collision in `community-plugins`, pinned at
+`92e9e4e09c76cc57f3475029b73e5ec84498a459`, is **irreducible under any
+admissibility rule of the kind proposed here**. The file
+`workspaces/nexus-repository-manager/plugins/nexus-repository-manager/catalog-info.yaml`
+contains two YAML documents. Both are `kind: Component`; both declare
+`metadata.name: backstage-community-nexus-repository-manager`; they differ only
+in `title`, `spec.type` and `spec.owner`, with the second declaring itself as
+its own `subcomponentOf`. That name is 44 characters of lowercase alphanumerics
+and hyphens. It passes `isValidObjectName` cleanly, as does every other field on
+both documents.
+
+Both documents are therefore fully admissible. This is a genuine duplicate of a
+valid entity — precisely the case `entity-identity.md` §3 exists to catch — and
+the fail-closed abort is the correct outcome for it. No field-format rule can
+reach it, and none should. It is also still present on the upstream default
+branch, so re-pinning the corpus to a newer commit does not avoid it.
+
+The consequence for feature009 is direct. `spec.md` SC-010 names all three
+required real-corpus passes explicitly by corpus, so the `community-plugins`
+pass cannot be substituted away. Adopting this record would reduce the *number*
+of collisions in these corpora and would reclassify the placeholder descriptors
+correctly; it would **not** produce a populated `SnapshotEnvelope` for
+`community-plugins`, and it would **not** satisfy SC-010. The spike's `blocked`
+verdict stands, on its own merits, with or without this record.
+
+**Why this is stated so prominently.** A rule of this kind invites the suspicion
+that it was reverse-engineered from a desired verdict. The check for that
+suspicion is whether the rule survives the discovery that it does not deliver
+the convenient outcome. It does. The warrant for this record is the validator
+binding at `1121a4fa…` and nothing else: a descriptor whose `metadata.name`
+Backstage would reject outright is not an entity whose identity we should be
+canonicalizing. That argument is unchanged by the fact that the corpora remain
+unusable afterwards, which is the test it needed to pass.
+
 ## Consequences
 
 - `entity-identity.md` §1 gains an admissibility precondition; §1's own two
@@ -265,6 +309,12 @@ paths, exactly as it did before.
   `blocked` with `blockedShortfall = "envelope-or-scale-evidence-incomplete"`.
   Ratifying this record does not re-open, re-run, or re-decide that spike, and
   does not by itself make SC-010 satisfiable.
+- **A residual, irreducible collision exists independent of admissibility.** As
+  set out in Trade-offs, `community-plugins` at its pinned commit contains a
+  genuine duplicate of a fully valid entity that no field-format rule can reach,
+  and which is still present upstream. Adopting this record would not produce a
+  populated envelope for that corpus. Anyone reading this record as a route to
+  unblocking feature009 is reading it wrong.
 - The carry-forward `reference-oracle.json` blocker recorded in
   `specs/009-catalog-binding-viability/checklists/evidence-index.md` is
   untouched and remains in full force: any future feature009 execution must

--- a/docs/adr/0015-validate-descriptors-against-backstage-field-formats-before-canonicalizing.md
+++ b/docs/adr/0015-validate-descriptors-against-backstage-field-formats-before-canonicalizing.md
@@ -6,9 +6,9 @@ status: proposed
 date: 2026-07-25
 deciders: ["@mbeacom"]
 tags: [catalog, governance, matching, core]
-scope: domain
+scope: org
 reversibility: two-way-door
-blastRadius: cross-team
+blastRadius: org
 relatesTo: ["0009", "0012", "0013"]
 affects:
   - type: path
@@ -25,8 +25,10 @@ review:
     Adds a precondition to the canonicalization step ADR-0012 pins, and adds a
     trigger condition to its org-scope, one-way-door atomic fail-closed clause.
     ADR-0013 set the precedent that narrowing or extending a frozen clause of an
-    org-scope record takes the ARB tier even when the amending record is itself
-    narrower.
+    org-scope record takes the ARB tier. A misjudged admissibility rule silently
+    removes entities from governance reach entirely, so that no ADR assertion
+    ever fires against them — an org-wide consequence irrespective of how narrow
+    the rule's own mechanism is.
 assertions:
   - id: entity-admissibility-precedes-canonicalization
     description: >-
@@ -204,6 +206,28 @@ The gap is independent of whether feature009 ever executes again.
 **What this buys.** Classification precision at the identity boundary, and
 alignment with the validator semantics ADR-0012 already pinned but never
 applied. Failures name the defect that actually occurred.
+
+**On the governance metadata, since the combination is unusual.** This record is
+deliberately `scope: org` and `blastRadius: org` — equal in reach to ADR-0012,
+ADR-0013 and ADR-0014 — while remaining `two-way-door`, where all three of those
+are one-way-door. **The asymmetry is intended, not an oversight.**
+
+The reach is org-wide because of what a *misjudged* admissibility rule does: it
+removes descriptors from the governed entity set entirely, so no ADR assertion
+ever fires against them. Entities do not appear mis-governed; they appear absent.
+That is precisely the failure mode ADR-0012 exists to prevent, and its
+consequence does not shrink just because this rule's mechanism is a single
+field-format check. A record cannot coherently claim ARB review *on the grounds
+that it amends an org-scope clause* while describing its own blast radius as
+narrower than the clause it amends.
+
+The reversibility is genuinely lower-risk, though, and that difference is worth
+preserving rather than rounding to match the siblings. Admissibility can be
+*widened* additively at any time — accepting a descriptor previously rejected
+strictly enlarges the entity set and invalidates no prior output. What is not
+freely reversible is the emitted `inadmissible-descriptor` trigger class, once
+consumers branch on it. So: org-wide in what it can cost if wrong, two-way-door
+in how hard it is to walk back.
 
 **What is given up:**
 

--- a/packages/cli/test/lint.test.ts
+++ b/packages/cli/test/lint.test.ts
@@ -23,7 +23,7 @@ describe('adr lint CLI', () => {
   test('passes on this repository corpus', async () => {
     const result = await runAdr(['lint']);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('checked 14 records, 0 errors');
+    expect(result.stdout).toContain('checked 15 records, 0 errors');
     expect(result.stderr).toBe('');
   });
 


### PR DESCRIPTION
> **Draft for review — `status: proposed`, not ratified.** This PR authorizes nothing on its own. It does **not** claim feature009 is unblocked, does **not** authorize any spike task, re-run, or generator invocation, does **not** make SC-010 satisfiable, and does **not** sanction any production catalog adapter. No `specs/009-**` file is touched.

Adds one file: `docs/adr/0015-validate-descriptors-against-backstage-field-formats-before-canonicalizing.md`.

## The warrant — Backstage's own validators, and nothing else

`specs/009-catalog-binding-viability/contracts/entity-identity.md` §1 defines canonicalization as exactly two steps — default the namespace, then lowercase `${K}:${NS}/${N}` in full. **There is no admissibility or validation step ahead of it**, and nothing under `specs/009-**` references Backstage's entity-name validators at any point.

At the commit ADR-0012 pins (`1121a4fa`), Backstage does not treat those fields as free-form. `makeValidator.ts` binds four **distinct** per-field validators, applied by `FieldFormatEntityPolicy`:

| Field | Validator binding | Predicate | Applied |
|---|---|---|---|
| `apiVersion` | `isValidApiVersion` | prefix/suffix split, DNS-subdomain prefix | required |
| `kind` | `isValidKind` | `/^[a-zA-Z][a-z0-9A-Z]*$/`, ≤63 | required |
| `metadata.name` | `isValidEntityName` → `KubernetesValidatorFunctions.isValidObjectName` | `/^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$/`, ≤63 | required |
| `metadata.namespace` | `isValidNamespace` → `isValidDnsLabel` | `/^[a-z0-9]+(?:\-+[a-z0-9]+)*$/`, ≤63 | **only when present** |

The `metadata.name` row is maintainer-verified. **The other three are explicitly flagged in the record as needing re-confirmation at ratification** rather than taken on the draft's word — action item 1.

**The category error.** The literal placeholder `${{ values.name | dump }}` fails `isValidObjectName` on character class (`$`, `{`, `}`, `|`, spaces), while ordinary names pass unchanged. Backstage would reject those descriptors as malformed outright. The contract instead accepts each as a well-formed name, lowercases it, concatenates it, and reports the result as `duplicate-canonical-id`. **The fail-closed abort is correct; the classification is not** — a descriptor that is not a valid entity is being characterized as a collision *between valid entities*.

## Decision

Admissibility is a **precondition** of §1, not a step inside it. §1's two steps and §3's collision table are untouched. An inadmissible descriptor aborts the whole operation under a new, distinct `inadmissible-descriptor` trigger class.

**Fail-closed is preserved exactly, not relaxed.** Inadmissible descriptors are not filtered, skipped, or excluded. This adds a failure class and removes none — so it makes the contract **strictly stricter**.

## Why this cannot be reverse-engineered from a desired verdict

The chosen option is the **most conservative** one available, and the record explicitly rejects the permissive one:

- **Option B — validate, then *exclude* inadmissible descriptors — is recorded as considered and rejected.** That is the version that would let a corpus containing invalid descriptors produce a populated snapshot. It converts a fatal condition into a silent drop, contradicting ADR-0012's `owned-paths-fail-closed-atomic` assertion ("never a partial or silently-dropped set"), and its appeal comes from the *result it produces* rather than the validator evidence.
- Options C (warn and canonicalize anyway), D (path-convention exclusion), and E (do nothing) are also recorded and rejected.
- The Tradeoffs section states plainly: *"Strictly more corpora become unusable, not fewer … Anyone reading it as a route to making more real-world corpora usable has read it backwards."*


**And the decisive test: it does not deliver the convenient outcome.** The record now states plainly, in a dedicated Tradeoffs subsection and a matching Consequences bullet, that **ADR-0015 does not unblock feature009**.

At least one `duplicate-canonical-id` collision in `community-plugins`, pinned at `92e9e4e0…`, is **irreducible under any admissibility rule of this kind**. `workspaces/nexus-repository-manager/plugins/nexus-repository-manager/catalog-info.yaml` holds two YAML documents; both are `kind: Component`, both declare `metadata.name: backstage-community-nexus-repository-manager`, differing only in `title`, `spec.type` and `spec.owner` — with the second declaring itself as its own `subcomponentOf`. That name is 44 characters of lowercase alphanumerics and hyphens and passes `isValidObjectName` cleanly, as does every other field on both documents.

Both documents are therefore **fully admissible**. This is a genuine duplicate of a *valid* entity — exactly the case `entity-identity.md` §3 exists to catch — and the fail-closed abort is the correct outcome for it. No field-format rule can reach it, and none should. It is also still present on the upstream default branch, so re-pinning does not avoid it.

`spec.md` SC-010 names all three required real-corpus passes explicitly by corpus, so the `community-plugins` pass cannot be substituted away. Adopting this record would reclassify the placeholder descriptors correctly and reduce the *number* of collisions; it would **not** produce a populated `SnapshotEnvelope` for `community-plugins`, and it would **not** satisfy SC-010. **feature009's `blocked` verdict stands on its own merits, with or without this record.**

That is the check on the reverse-engineering suspicion: the rule survives the discovery that it does not produce the desired verdict, because its warrant is the validator binding at `1121a4fa…` and nothing else.
## Tradeoffs — what is given up

- **A public failure surface grows.** `inadmissible-descriptor` becomes contract-visible; renaming it later is breaking. This is why the record is `two-way-door` rather than trivially reversible.
- **A pinned-commit dependency becomes load-bearing.** Admissibility is defined by one frozen Backstage commit; upstream drift silently diverges until the pin is deliberately moved.
- **Strictly more corpora become unusable.** E.g. an over-length name that previously canonicalized without colliding will now abort a run that previously completed.
- **It does not make the pinned feature009 corpora usable** — a residual, irreducible collision survives it, as above.
- **It buys nothing for annotation-derivation confidence** — below.

### On the `annotation-absent` cross-check

The review cross-check — that real corpora are 100% `annotation-absent`, since `adrkit.io/owned-paths` is adrkit's own proposed annotation, so real-corpus evidence can only ever validate enumeration and determinism — is **engaged directly in Tradeoffs, and agreed on the substance**, with one qualification.

Agreed: the positive derivation paths (`explicit-paths`, `explicit-empty`) are unreachable from any public corpus **by construction**; only synthetic fixtures can exercise them, and this record does not change that.

Qualification (mild pushback): *"only enumeration and determinism"* understates it slightly. A 100%-absent result is itself load-bearing — it exercises the `annotation-absent` branch of the three-state discriminator at scale, and independently substantiates ADR-0012's founding premise that no authoritative entity-to-path binding exists in the wild. That is a finding, not merely an absence of one.

Consequence for scoping, stated in the record: admissibility sits **upstream** of annotation handling entirely, so its value lands in the enumeration/classification/determinism layer — the layer real corpora *can* speak to. But adopting it moves the annotation-derivation evidence gap **not at all**, and any future claim that catalog binding is empirically validated must still rest on synthetic fixtures.

## Metadata

`scope: org` · `blastRadius: org` · `reversibility: two-way-door` · `relatesTo: ["0009","0012","0013"]` · `review.tier: arb` with explicit `tierReason` · one structured assertion, `entity-admissibility-precedes-canonicalization` · `status: proposed`, `provenance.authoredBy: agent-drafted`, **no `ratifiedBy`**.

**Scope and blast radius were raised to `org`/`org` by ARB decision during review** (from `domain`/`cross-team`). Three reasons: every sibling in this lineage (0012, 0013, 0014) is org/org; the original values contradicted the record's own `tierReason`, which justifies the ARB tier *precisely because* the record amends an org-scope clause of ADR-0012 — a record cannot claim ARB review on those grounds while declaring a narrower blast radius than the clause it amends; and substantively, a misjudged admissibility rule removes descriptors from the governed set entirely, so no ADR assertion ever fires against them. Entities do not appear mis-governed, they appear **absent** — the exact failure mode ADR-0012 exists to prevent, org-wide in consequence regardless of how narrow the mechanism is. `tierReason` was rewritten to state this directly rather than its previous understatement ("even when the amending record is itself narrower").

**`reversibility: two-way-door` is deliberately retained**, where all three siblings are one-way-door, and a Trade-offs paragraph now flags the asymmetry as intended rather than an oversight. Widening admissibility later is additive and invalidates no prior output; what is not freely reversible is the emitted `inadmissible-descriptor` trigger class once consumers branch on it. Org-wide in what it can cost if wrong, two-way-door in how hard it is to walk back.

`bun run adr lint` → **15 records, 0 errors, 0 warnings.**

## Action items in the record

1. Re-confirm the three non-maintainer-verified validator bindings before ratification.
2. Obtain one independent fresh-context review — per standing model policy, `claude-opus-5`, or `gpt-5.6` for a second different-lineage pass. No older revision; model identity is recorded as evidence.
3. Only after ratification, prepare the `specs/009-**` amendment as a separately-scoped change.
4. Decide separately whether descriptor exclusion (Option B) is ever wanted.

## Relationship to the other open PR

Independent of the corrections PR. Neither depends on the other; they touch disjoint files and can land in either order or separately.


