### PR TITLE
fix: close the four dogfood defects (#39, #40, #41, #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ answer where the next decision is actually being made.
 ## What it does
 
 - **`adr lint`** — validate records, catch supersession cycles, find decisions
-  that silently contradict each other. Also warns when markdown in the corpus
-  directory is not a discoverable record, so "checked 0 records" is never silent
+  that silently contradict each other. Also warns when markdown under the corpus
+  directory is not discoverable — misnamed, or nested in a subdirectory — so
+  "checked 0 records" is never silent
 - **`adr migrate --from madr`** — adopt an existing MADR corpus in place,
   additively, without breaking your current tooling. Reads status and date from
   MADR 3.x frontmatter, MADR 2.x `* Status:` header bullets, and Nygard

--- a/README.md
+++ b/README.md
@@ -66,11 +66,16 @@ answer where the next decision is actually being made.
 ## What it does
 
 - **`adr lint`** — validate records, catch supersession cycles, find decisions
-  that silently contradict each other
+  that silently contradict each other. Also warns when markdown in the corpus
+  directory is not a discoverable record, so "checked 0 records" is never silent
 - **`adr migrate --from madr`** — adopt an existing MADR corpus in place,
-  additively, without breaking your current tooling
+  additively, without breaking your current tooling. Reads status and date from
+  MADR 3.x frontmatter, MADR 2.x `* Status:` header bullets, and Nygard
+  `## Status` sections. Pass `--rename` to also rename each file to
+  `<id>-<slug>.md` so corpus discovery can see it
 - **`adr explain <path>`** — print every decision governing a file, and the
-  matcher that fired
+  matcher that fired. Only `accepted` records are reported as governing; matched
+  proposals and superseded/rejected/deprecated records are listed separately
 - **`adr check <files...>`** — validate the changed records and list the decisions
   governing a changed-file set; deterministic, provider-agnostic, `--json` for tools
 - **`adr evaluate <proposal> --snapshot <bundle.json> --date YYYY-MM-DD`** — run the

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -47739,6 +47739,10 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 var RECORD_FILE_PATTERN = /^[0-9]{4,}-.+\.md$/;
 var TEMPLATE_FILE_NAME = "0000-template.md";
+var NON_RECORD_FILE_NAMES = new Set(["readme.md", "index.md", "contributing.md", "template.md"]);
+function isConventionalNonRecordFileName(fileName) {
+  return fileName === TEMPLATE_FILE_NAME || NON_RECORD_FILE_NAMES.has(fileName.toLowerCase());
+}
 function isRecordFileName(fileName) {
   return fileName !== TEMPLATE_FILE_NAME && RECORD_FILE_PATTERN.test(fileName);
 }
@@ -47754,6 +47758,11 @@ async function discoverAdrFiles(dir = "docs/adr", cwd = process.cwd()) {
   const absoluteDir = toAbsolutePath(dir, cwd);
   const entries = await readdir(absoluteDir, { withFileTypes: true });
   return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+}
+async function discoverSkippedMarkdownFiles(dir = "docs/adr", cwd = process.cwd()) {
+  const absoluteDir = toAbsolutePath(dir, cwd);
+  const entries = await readdir(absoluteDir, { withFileTypes: true }).catch(() => []);
+  return entries.filter((entry) => entry.isFile() && entry.name.endsWith(".md") && !entry.name.startsWith(".") && !isConventionalNonRecordFileName(entry.name) && !isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
 }
 async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) {
   if (!paths || paths.length === 0) {
@@ -47784,6 +47793,14 @@ async function parseAdrFile(path, cwd = process.cwd()) {
     absolutePath,
     path: normalizeDisplayPath(absolutePath, cwd)
   };
+}
+// ../core/src/status/bucket.ts
+function decisionBucketFor(status) {
+  if (status === "accepted")
+    return "governing";
+  if (status === "draft" || status === "proposed")
+    return "activeProposals";
+  return "history";
 }
 // ../core/src/validate/findings.ts
 function compareOptional(a, b) {
@@ -47985,9 +48002,18 @@ function parseErrorFinding(error51, path) {
     path
   };
 }
+function skippedFileFinding(path) {
+  return {
+    rule: "corpus-file-skipped",
+    severity: "warn",
+    message: "Markdown file in the corpus directory is not a discoverable ADR record and was skipped; rename it to <id>-<slug>.md (four or more leading digits) for it to be linted and enforced",
+    path
+  };
+}
 async function lintCorpus(options = {}) {
   const cwd = options.cwd ?? process.cwd();
-  const files = await expandRecordInputs(options.paths, options.dir ?? "docs/adr", cwd);
+  const dir = options.dir ?? "docs/adr";
+  const files = await expandRecordInputs(options.paths, dir, cwd);
   const records = [];
   const findings = [];
   for (const file2 of files) {
@@ -48001,6 +48027,11 @@ async function lintCorpus(options = {}) {
       }
     } catch (error51) {
       findings.push(parseErrorFinding(error51, displayPath));
+    }
+  }
+  if (!options.paths || options.paths.length === 0) {
+    for (const skipped of await discoverSkippedMarkdownFiles(dir, cwd)) {
+      findings.push(skippedFileFinding(normalizeDisplayPath(skipped, cwd)));
     }
   }
   findings.push(...validateImportIncomplete(records));
@@ -48293,6 +48324,27 @@ function isCorpusRecordPath(file2, dir) {
 function uniqueSorted(values) {
   return [...new Set(values)].sort((a, b) => a.localeCompare(b));
 }
+function toGoverningDecisions(records, matches) {
+  const byId = new Map(records.map((record2) => [record2.frontmatter.id, record2]));
+  return matches.map((match) => {
+    const frontmatter = byId.get(match.recordId)?.frontmatter;
+    const status = frontmatter?.status ?? "draft";
+    return {
+      recordId: match.recordId,
+      title: frontmatter?.title ?? "",
+      status,
+      bucket: decisionBucketFor(status),
+      ...frontmatter?.supersededBy ? { supersededBy: frontmatter.supersededBy } : {},
+      firedMatchers: match.firedMatchers
+    };
+  });
+}
+function bucketDecisions(decisions) {
+  const buckets = { governing: [], activeProposals: [], history: [] };
+  for (const decision of decisions)
+    buckets[decision.bucket].push(decision);
+  return buckets;
+}
 function checkChanges(input) {
   const dir = normalizeDir(input.dir);
   const changedFiles = uniqueSorted(input.changedFiles.map(toForwardSlash));
@@ -48304,16 +48356,21 @@ function checkChanges(input) {
     snapshots: input.snapshots,
     log: input.log
   });
-  const titleById = new Map(input.lint.records.map((record2) => [record2.frontmatter.id, record2.frontmatter.title]));
-  const governedBy = resolution.matches.map((match) => ({
-    recordId: match.recordId,
-    title: titleById.get(match.recordId) ?? "",
-    firedMatchers: match.firedMatchers
-  }));
+  const governedBy = toGoverningDecisions(input.lint.records, resolution.matches);
+  const buckets = bucketDecisions(governedBy);
   const changedRecordFindings = input.lint.findings.filter((finding) => finding.path !== undefined && changedRecordSet.has(finding.path));
   const findings = sortFindings([...resolution.findings, ...changedRecordFindings]);
   const ok = !changedRecordFindings.some((finding) => finding.severity === "error");
-  return { changedFiles, governedBy, changedRecords, findings, ok };
+  return {
+    changedFiles,
+    governedBy,
+    governing: buckets.governing,
+    activeProposals: buckets.activeProposals,
+    history: buckets.history,
+    changedRecords,
+    findings,
+    ok
+  };
 }
 // ../core/src/import/status.ts
 var MADR_RECOGNIZED_STATUSES = [
@@ -48374,6 +48431,11 @@ async function extractChanges(client) {
 var CI_COMMENT_MARKER = "<!-- adrkit:ci -->";
 var HEADING = "### Decisions governing this change";
 var EMPTY_STATE = "No governing decisions for the changed files.";
+var NO_ACCEPTED_STATE = "No **accepted** decisions govern the changed files. Records below matched but do not bind this change.";
+var PROPOSALS_HEADING = "#### Active proposals touching this change";
+var PROPOSALS_NOTE = "These are not yet ratified and do not bind this change:";
+var HISTORY_HEADING = "#### Historical records that once covered this change";
+var HISTORY_NOTE = "These no longer bind this change, and are listed for context only:";
 var MAX_GOVERNING = 50;
 function changedRecordFindings(outcome) {
   const changed = new Set(outcome.changedRecords);
@@ -48384,22 +48446,39 @@ function renderFindingLine(finding) {
   const field = finding.field ? ` (\`${finding.field}\`)` : "";
   return `- ${where} — \`${finding.rule}\`${field}: ${finding.message}`;
 }
+function renderDecisionLines(decision, withStatus) {
+  const status = withStatus ? ` _(${decision.status})_` : "";
+  const successor = decision.supersededBy ? ` — superseded by **${decision.supersededBy}**` : "";
+  const lines = [`- **${decision.recordId}** — ${decision.title}${status}${successor}`];
+  for (const matcher of decision.firedMatchers) {
+    lines.push(`  - via \`${matcher.type}\`: \`${matcher.pattern}\``);
+  }
+  return lines;
+}
+function renderDecisionList(decisions, withStatus) {
+  const shown = decisions.slice(0, MAX_GOVERNING);
+  const lines = shown.flatMap((decision) => renderDecisionLines(decision, withStatus));
+  const remaining = decisions.length - shown.length;
+  if (remaining > 0)
+    lines.push(`- …and ${remaining} more record${remaining === 1 ? "" : "s"}`);
+  return lines;
+}
 function renderComment(outcome) {
   const lines = [CI_COMMENT_MARKER, "", HEADING, ""];
   if (outcome.governedBy.length === 0) {
     lines.push(EMPTY_STATE);
+  } else if (outcome.governing.length === 0) {
+    lines.push(NO_ACCEPTED_STATE);
   } else {
-    const shown = outcome.governedBy.slice(0, MAX_GOVERNING);
-    for (const decision of shown) {
-      lines.push(`- **${decision.recordId}** — ${decision.title}`);
-      for (const matcher of decision.firedMatchers) {
-        lines.push(`  - via \`${matcher.type}\`: \`${matcher.pattern}\``);
-      }
-    }
-    const remaining = outcome.governedBy.length - shown.length;
-    if (remaining > 0) {
-      lines.push(`- …and ${remaining} more governing decision${remaining === 1 ? "" : "s"}`);
-    }
+    lines.push(...renderDecisionList(outcome.governing, false));
+  }
+  if (outcome.activeProposals.length > 0) {
+    lines.push("", PROPOSALS_HEADING, "", PROPOSALS_NOTE);
+    lines.push(...renderDecisionList(outcome.activeProposals, true));
+  }
+  if (outcome.history.length > 0) {
+    lines.push("", HISTORY_HEADING, "", HISTORY_NOTE);
+    lines.push(...renderDecisionList(outcome.history, true));
   }
   const findings2 = changedRecordFindings(outcome);
   const errors4 = findings2.filter((finding) => finding.severity === "error");

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -47759,10 +47759,31 @@ async function discoverAdrFiles(dir = "docs/adr", cwd = process.cwd()) {
   const entries = await readdir(absoluteDir, { withFileTypes: true });
   return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
 }
-async function discoverSkippedMarkdownFiles(dir = "docs/adr", cwd = process.cwd()) {
-  const absoluteDir = toAbsolutePath(dir, cwd);
+var MAX_SKIP_SCAN_DEPTH = 8;
+async function collectSkippedMarkdown(absoluteDir, depth, found) {
   const entries = await readdir(absoluteDir, { withFileTypes: true }).catch(() => []);
-  return entries.filter((entry) => entry.isFile() && entry.name.endsWith(".md") && !entry.name.startsWith(".") && !isConventionalNonRecordFileName(entry.name) && !isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+  for (const entry of entries) {
+    const path = join(absoluteDir, entry.name);
+    if (entry.isDirectory()) {
+      if (!entry.name.startsWith(".") && depth < MAX_SKIP_SCAN_DEPTH) {
+        await collectSkippedMarkdown(path, depth + 1, found);
+      }
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".md") || entry.name.startsWith("."))
+      continue;
+    if (isConventionalNonRecordFileName(entry.name))
+      continue;
+    if (depth > 0)
+      found.push({ path, reason: "nested" });
+    else if (!isRecordFileName(entry.name))
+      found.push({ path, reason: "filename" });
+  }
+}
+async function discoverSkippedMarkdownFiles(dir = "docs/adr", cwd = process.cwd()) {
+  const found = [];
+  await collectSkippedMarkdown(toAbsolutePath(dir, cwd), 0, found);
+  return found.sort((a, b) => normalizeDisplayPath(a.path, cwd).localeCompare(normalizeDisplayPath(b.path, cwd)));
 }
 async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) {
   if (!paths || paths.length === 0) {
@@ -47985,6 +48006,8 @@ function validateImportIncomplete(records) {
   return findings;
 }
 // ../core/src/validate/index.ts
+import { stat as stat2 } from "node:fs/promises";
+import { isAbsolute as isAbsolute2, resolve as resolve2 } from "node:path";
 function parseErrorFinding(error51, path) {
   if (error51 instanceof FrontmatterError) {
     return {
@@ -48002,13 +48025,28 @@ function parseErrorFinding(error51, path) {
     path
   };
 }
-function skippedFileFinding(path) {
+function skippedFileFinding(skipped, cwd) {
+  const message = skipped.reason === "nested" ? "Markdown file is in a subdirectory of the corpus, and discovery reads only the top level of the corpus directory; move it to the corpus root as <id>-<slug>.md for it to be linted and enforced" : "Markdown file in the corpus directory is not a discoverable ADR record and was skipped; rename it to <id>-<slug>.md (four or more leading digits) for it to be linted and enforced";
   return {
     rule: "corpus-file-skipped",
     severity: "warn",
-    message: "Markdown file in the corpus directory is not a discoverable ADR record and was skipped; rename it to <id>-<slug>.md (four or more leading digits) for it to be linted and enforced",
-    path
+    message,
+    path: normalizeDisplayPath(skipped.path, cwd)
   };
+}
+async function isDirectory(path) {
+  return stat2(path).then((info) => info.isDirectory(), () => false);
+}
+async function scannedDirectories(paths, dir, cwd) {
+  if (!paths || paths.length === 0)
+    return [dir];
+  const directories = new Set;
+  for (const path of paths) {
+    const absolutePath = isAbsolute2(path) ? path : resolve2(cwd, path);
+    if (await isDirectory(absolutePath))
+      directories.add(absolutePath);
+  }
+  return [...directories].sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
 }
 async function lintCorpus(options = {}) {
   const cwd = options.cwd ?? process.cwd();
@@ -48029,9 +48067,11 @@ async function lintCorpus(options = {}) {
       findings.push(parseErrorFinding(error51, displayPath));
     }
   }
-  if (!options.paths || options.paths.length === 0) {
-    for (const skipped of await discoverSkippedMarkdownFiles(dir, cwd)) {
-      findings.push(skippedFileFinding(normalizeDisplayPath(skipped, cwd)));
+  const checkedPaths = new Set(files);
+  for (const scanned of await scannedDirectories(options.paths, dir, cwd)) {
+    for (const skipped of await discoverSkippedMarkdownFiles(scanned, cwd)) {
+      if (!checkedPaths.has(skipped.path))
+        findings.push(skippedFileFinding(skipped, cwd));
     }
   }
   findings.push(...validateImportIncomplete(records));

--- a/packages/ci/dist/queue-action.js
+++ b/packages/ci/dist/queue-action.js
@@ -46043,6 +46043,10 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 var RECORD_FILE_PATTERN = /^[0-9]{4,}-.+\.md$/;
 var TEMPLATE_FILE_NAME = "0000-template.md";
+var NON_RECORD_FILE_NAMES = new Set(["readme.md", "index.md", "contributing.md", "template.md"]);
+function isConventionalNonRecordFileName(fileName) {
+  return fileName === TEMPLATE_FILE_NAME || NON_RECORD_FILE_NAMES.has(fileName.toLowerCase());
+}
 function isRecordFileName(fileName) {
   return fileName !== TEMPLATE_FILE_NAME && RECORD_FILE_PATTERN.test(fileName);
 }
@@ -46058,6 +46062,11 @@ async function discoverAdrFiles(dir = "docs/adr", cwd = process.cwd()) {
   const absoluteDir = toAbsolutePath(dir, cwd);
   const entries = await readdir(absoluteDir, { withFileTypes: true });
   return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+}
+async function discoverSkippedMarkdownFiles(dir = "docs/adr", cwd = process.cwd()) {
+  const absoluteDir = toAbsolutePath(dir, cwd);
+  const entries = await readdir(absoluteDir, { withFileTypes: true }).catch(() => []);
+  return entries.filter((entry) => entry.isFile() && entry.name.endsWith(".md") && !entry.name.startsWith(".") && !isConventionalNonRecordFileName(entry.name) && !isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
 }
 async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) {
   if (!paths || paths.length === 0) {
@@ -46289,9 +46298,18 @@ function parseErrorFinding(error51, path) {
     path
   };
 }
+function skippedFileFinding(path) {
+  return {
+    rule: "corpus-file-skipped",
+    severity: "warn",
+    message: "Markdown file in the corpus directory is not a discoverable ADR record and was skipped; rename it to <id>-<slug>.md (four or more leading digits) for it to be linted and enforced",
+    path
+  };
+}
 async function lintCorpus(options = {}) {
   const cwd = options.cwd ?? process.cwd();
-  const files = await expandRecordInputs(options.paths, options.dir ?? "docs/adr", cwd);
+  const dir = options.dir ?? "docs/adr";
+  const files = await expandRecordInputs(options.paths, dir, cwd);
   const records = [];
   const findings = [];
   for (const file2 of files) {
@@ -46305,6 +46323,11 @@ async function lintCorpus(options = {}) {
       }
     } catch (error51) {
       findings.push(parseErrorFinding(error51, displayPath));
+    }
+  }
+  if (!options.paths || options.paths.length === 0) {
+    for (const skipped of await discoverSkippedMarkdownFiles(dir, cwd)) {
+      findings.push(skippedFileFinding(normalizeDisplayPath(skipped, cwd)));
     }
   }
   findings.push(...validateImportIncomplete(records));

--- a/packages/ci/dist/queue-action.js
+++ b/packages/ci/dist/queue-action.js
@@ -46063,10 +46063,31 @@ async function discoverAdrFiles(dir = "docs/adr", cwd = process.cwd()) {
   const entries = await readdir(absoluteDir, { withFileTypes: true });
   return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
 }
-async function discoverSkippedMarkdownFiles(dir = "docs/adr", cwd = process.cwd()) {
-  const absoluteDir = toAbsolutePath(dir, cwd);
+var MAX_SKIP_SCAN_DEPTH = 8;
+async function collectSkippedMarkdown(absoluteDir, depth, found) {
   const entries = await readdir(absoluteDir, { withFileTypes: true }).catch(() => []);
-  return entries.filter((entry) => entry.isFile() && entry.name.endsWith(".md") && !entry.name.startsWith(".") && !isConventionalNonRecordFileName(entry.name) && !isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+  for (const entry of entries) {
+    const path = join(absoluteDir, entry.name);
+    if (entry.isDirectory()) {
+      if (!entry.name.startsWith(".") && depth < MAX_SKIP_SCAN_DEPTH) {
+        await collectSkippedMarkdown(path, depth + 1, found);
+      }
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".md") || entry.name.startsWith("."))
+      continue;
+    if (isConventionalNonRecordFileName(entry.name))
+      continue;
+    if (depth > 0)
+      found.push({ path, reason: "nested" });
+    else if (!isRecordFileName(entry.name))
+      found.push({ path, reason: "filename" });
+  }
+}
+async function discoverSkippedMarkdownFiles(dir = "docs/adr", cwd = process.cwd()) {
+  const found = [];
+  await collectSkippedMarkdown(toAbsolutePath(dir, cwd), 0, found);
+  return found.sort((a, b) => normalizeDisplayPath(a.path, cwd).localeCompare(normalizeDisplayPath(b.path, cwd)));
 }
 async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) {
   if (!paths || paths.length === 0) {
@@ -46281,6 +46302,8 @@ function validateImportIncomplete(records) {
   return findings;
 }
 // ../core/src/validate/index.ts
+import { stat as stat2 } from "node:fs/promises";
+import { isAbsolute as isAbsolute2, resolve as resolve2 } from "node:path";
 function parseErrorFinding(error51, path) {
   if (error51 instanceof FrontmatterError) {
     return {
@@ -46298,13 +46321,28 @@ function parseErrorFinding(error51, path) {
     path
   };
 }
-function skippedFileFinding(path) {
+function skippedFileFinding(skipped, cwd) {
+  const message = skipped.reason === "nested" ? "Markdown file is in a subdirectory of the corpus, and discovery reads only the top level of the corpus directory; move it to the corpus root as <id>-<slug>.md for it to be linted and enforced" : "Markdown file in the corpus directory is not a discoverable ADR record and was skipped; rename it to <id>-<slug>.md (four or more leading digits) for it to be linted and enforced";
   return {
     rule: "corpus-file-skipped",
     severity: "warn",
-    message: "Markdown file in the corpus directory is not a discoverable ADR record and was skipped; rename it to <id>-<slug>.md (four or more leading digits) for it to be linted and enforced",
-    path
+    message,
+    path: normalizeDisplayPath(skipped.path, cwd)
   };
+}
+async function isDirectory(path) {
+  return stat2(path).then((info) => info.isDirectory(), () => false);
+}
+async function scannedDirectories(paths, dir, cwd) {
+  if (!paths || paths.length === 0)
+    return [dir];
+  const directories = new Set;
+  for (const path of paths) {
+    const absolutePath = isAbsolute2(path) ? path : resolve2(cwd, path);
+    if (await isDirectory(absolutePath))
+      directories.add(absolutePath);
+  }
+  return [...directories].sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
 }
 async function lintCorpus(options = {}) {
   const cwd = options.cwd ?? process.cwd();
@@ -46325,9 +46363,11 @@ async function lintCorpus(options = {}) {
       findings.push(parseErrorFinding(error51, displayPath));
     }
   }
-  if (!options.paths || options.paths.length === 0) {
-    for (const skipped of await discoverSkippedMarkdownFiles(dir, cwd)) {
-      findings.push(skippedFileFinding(normalizeDisplayPath(skipped, cwd)));
+  const checkedPaths = new Set(files);
+  for (const scanned of await scannedDirectories(options.paths, dir, cwd)) {
+    for (const skipped of await discoverSkippedMarkdownFiles(scanned, cwd)) {
+      if (!checkedPaths.has(skipped.path))
+        findings.push(skippedFileFinding(skipped, cwd));
     }
   }
   findings.push(...validateImportIncomplete(records));

--- a/packages/ci/src/comment.ts
+++ b/packages/ci/src/comment.ts
@@ -1,4 +1,4 @@
-import type { CheckOutcome, Finding } from '@adrkit/core';
+import type { CheckOutcome, Finding, GoverningDecision } from '@adrkit/core';
 
 /**
  * Stable hidden marker used to locate this Action's own comment for in-place
@@ -9,6 +9,12 @@ export const CI_COMMENT_MARKER = '<!-- adrkit:ci -->';
 
 const HEADING = '### Decisions governing this change';
 const EMPTY_STATE = 'No governing decisions for the changed files.';
+const NO_ACCEPTED_STATE =
+  'No **accepted** decisions govern the changed files. Records below matched but do not bind this change.';
+const PROPOSALS_HEADING = '#### Active proposals touching this change';
+const PROPOSALS_NOTE = 'These are not yet ratified and do not bind this change:';
+const HISTORY_HEADING = '#### Historical records that once covered this change';
+const HISTORY_NOTE = 'These no longer bind this change, and are listed for context only:';
 
 // Display cap for a pathological governing list. The underlying set is never
 // trimmed semantically (R6) — this only shortens what is rendered.
@@ -26,29 +32,58 @@ function renderFindingLine(finding: Finding): string {
 }
 
 /**
+ * One decision as a bullet, annotated with its status and — for superseded records —
+ * the successor that replaced it, so a reviewer is never shown a bare record id and
+ * left to assume it is in force (#39).
+ */
+function renderDecisionLines(decision: GoverningDecision, withStatus: boolean): string[] {
+  const status = withStatus ? ` _(${decision.status})_` : '';
+  const successor = decision.supersededBy ? ` — superseded by **${decision.supersededBy}**` : '';
+  const lines = [`- **${decision.recordId}** — ${decision.title}${status}${successor}`];
+  for (const matcher of decision.firedMatchers) {
+    lines.push(`  - via \`${matcher.type}\`: \`${matcher.pattern}\``);
+  }
+  return lines;
+}
+
+function renderDecisionList(decisions: readonly GoverningDecision[], withStatus: boolean): string[] {
+  const shown = decisions.slice(0, MAX_GOVERNING);
+  const lines = shown.flatMap((decision) => renderDecisionLines(decision, withStatus));
+  const remaining = decisions.length - shown.length;
+  if (remaining > 0) lines.push(`- …and ${remaining} more record${remaining === 1 ? '' : 's'}`);
+  return lines;
+}
+
+/**
  * Render the PR comment for a {@link CheckOutcome}. Selective by construction — the
  * governing list is exactly the resolver's union for the changed files (R6/FR-006),
  * one entry per governing record with the matcher(s) that fired. Includes a concise
  * empty state (FR-007) and, when a changed record has an `error` finding, a
  * validation notice naming the failing record + rule (R7).
+ *
+ * Only `accepted` records appear under the governing heading. Matched proposals and
+ * historical records are reported under their own headings so a reviewer is never told
+ * that a rejected or superseded decision governs their change (#39).
  */
 export function renderComment(outcome: CheckOutcome): string {
   const lines: string[] = [CI_COMMENT_MARKER, '', HEADING, ''];
 
   if (outcome.governedBy.length === 0) {
     lines.push(EMPTY_STATE);
+  } else if (outcome.governing.length === 0) {
+    lines.push(NO_ACCEPTED_STATE);
   } else {
-    const shown = outcome.governedBy.slice(0, MAX_GOVERNING);
-    for (const decision of shown) {
-      lines.push(`- **${decision.recordId}** — ${decision.title}`);
-      for (const matcher of decision.firedMatchers) {
-        lines.push(`  - via \`${matcher.type}\`: \`${matcher.pattern}\``);
-      }
-    }
-    const remaining = outcome.governedBy.length - shown.length;
-    if (remaining > 0) {
-      lines.push(`- …and ${remaining} more governing decision${remaining === 1 ? '' : 's'}`);
-    }
+    lines.push(...renderDecisionList(outcome.governing, false));
+  }
+
+  if (outcome.activeProposals.length > 0) {
+    lines.push('', PROPOSALS_HEADING, '', PROPOSALS_NOTE);
+    lines.push(...renderDecisionList(outcome.activeProposals, true));
+  }
+
+  if (outcome.history.length > 0) {
+    lines.push('', HISTORY_HEADING, '', HISTORY_NOTE);
+    lines.push(...renderDecisionList(outcome.history, true));
   }
 
   const findings = changedRecordFindings(outcome);

--- a/packages/ci/test/action.test.ts
+++ b/packages/ci/test/action.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
 import { lintCorpus } from '@adrkit/core';
-import { cleanupTestDir, recordMarkdown, resetTestDir, writeText } from '../../core/test/helpers.ts';
+import { acceptedRecordMarkdown, cleanupTestDir, resetTestDir, writeText } from '../../core/test/helpers.ts';
 import { runAction, type ActionDeps } from '../src/action.ts';
 import { CI_COMMENT_MARKER } from '../src/comment.ts';
 import type { GitHubClient } from '../src/github.ts';
@@ -32,7 +32,7 @@ describe('runAction (end to end with a fake client)', () => {
     const root = await resetTestDir(DIR_NAME);
     await writeText(
       join(root, 'docs/adr/0001-core.md'),
-      withPathMatcher(recordMarkdown('0001', 'Guard core'), 'packages/core/**'),
+      withPathMatcher(acceptedRecordMarkdown('0001', 'Guard core'), 'packages/core/**'),
     );
     const client = makeFakeClient();
 
@@ -49,7 +49,7 @@ describe('runAction (end to end with a fake client)', () => {
     const root = await resetTestDir(DIR_NAME);
     await writeText(
       join(root, 'docs/adr/0001-core.md'),
-      withPathMatcher(recordMarkdown('0001', 'Guard core'), 'packages/core/**'),
+      withPathMatcher(acceptedRecordMarkdown('0001', 'Guard core'), 'packages/core/**'),
     );
     // A malformed changed record: unterminated frontmatter fence → parse error.
     await writeText(join(root, 'docs/adr/0002-broken.md'), '---\nid: "0002"\ntitle: Broken\n');

--- a/packages/ci/test/comment-render.test.ts
+++ b/packages/ci/test/comment-render.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
 import { checkChanges, lintCorpus } from '@adrkit/core';
-import { cleanupTestDir, recordMarkdown, resetTestDir, writeText } from '../../core/test/helpers.ts';
+import { acceptedRecordMarkdown, cleanupTestDir, recordMarkdown, resetTestDir, supersededRecordMarkdown, writeText } from '../../core/test/helpers.ts';
 import { CI_COMMENT_MARKER, renderComment } from '../src/comment.ts';
 
 const DIR_NAME = 'ci-comment-render';
@@ -18,9 +18,9 @@ async function seed(): Promise<string> {
   const dir = join(root, 'docs/adr');
   await writeText(
     join(dir, '0001-api.md'),
-    withAffects(recordMarkdown('0001', 'Guard the API package'), [...path('packages/api/**'), ...entity('component:default/api')]),
+    withAffects(acceptedRecordMarkdown('0001', 'Guard the API package'), [...path('packages/api/**'), ...entity('component:default/api')]),
   );
-  await writeText(join(dir, '0002-web.md'), withAffects(recordMarkdown('0002', 'Guard the web package'), path('packages/web/**')));
+  await writeText(join(dir, '0002-web.md'), withAffects(acceptedRecordMarkdown('0002', 'Guard the web package'), path('packages/web/**')));
   return root;
 }
 
@@ -76,5 +76,62 @@ describe('renderComment', () => {
     expect(body).toContain('No governing decisions for the changed files.');
     expect(body).not.toContain('**0001**');
     expect(body).not.toContain('**0002**');
+  });
+});
+
+/**
+ * adrkit#39 — a reviewer must never be told that a rejected, superseded, or deprecated
+ * decision governs their change.
+ */
+describe('renderComment status awareness (#39)', () => {
+  async function seedMixed(): Promise<string> {
+    const root = await resetTestDir(DIR_NAME);
+    const dir = join(root, 'docs/adr');
+    await writeText(
+      join(dir, '0001-accepted.md'),
+      withAffects(acceptedRecordMarkdown('0001', 'Accepted record'), path('src/api/**')),
+    );
+    await writeText(join(dir, '0002-draft.md'), withAffects(recordMarkdown('0002', 'Draft record'), path('src/api/**')));
+    await writeText(
+      join(dir, '0003-superseded.md'),
+      withAffects(supersededRecordMarkdown('0003', '0001', 'Superseded record'), path('src/api/**')),
+    );
+    return root;
+  }
+
+  test('only accepted records appear under the governing heading', async () => {
+    const root = await seedMixed();
+    const body = renderComment(await outcomeFor(root, ['src/api/thing.ts']));
+
+    const governingSection = body.slice(
+      body.indexOf('### Decisions governing this change'),
+      body.indexOf('#### Active proposals'),
+    );
+    expect(governingSection).toContain('**0001** — Accepted record');
+    expect(governingSection).not.toContain('0002');
+    expect(governingSection).not.toContain('0003');
+  });
+
+  test('proposals and history are labelled with their status under their own headings', async () => {
+    const root = await seedMixed();
+    const body = renderComment(await outcomeFor(root, ['src/api/thing.ts']));
+
+    expect(body).toContain('#### Active proposals touching this change');
+    expect(body).toContain('**0002** — Draft record _(draft)_');
+    expect(body).toContain('#### Historical records that once covered this change');
+    expect(body).toContain('**0003** — Superseded record _(superseded)_ — superseded by **0001**');
+  });
+
+  test('a change matched only by non-accepted records says no accepted decision governs it', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(
+      join(root, 'docs/adr/0001-draft.md'),
+      withAffects(recordMarkdown('0001', 'Draft record'), path('src/api/**')),
+    );
+
+    const body = renderComment(await outcomeFor(root, ['src/api/thing.ts']));
+
+    expect(body).toContain('No **accepted** decisions govern the changed files.');
+    expect(body).toContain('#### Active proposals touching this change');
   });
 });

--- a/packages/ci/test/selectivity.test.ts
+++ b/packages/ci/test/selectivity.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
 import { checkChanges, lintCorpus } from '@adrkit/core';
-import { cleanupTestDir, recordMarkdown, resetTestDir, writeText } from '../../core/test/helpers.ts';
+import { acceptedRecordMarkdown, cleanupTestDir, resetTestDir, writeText } from '../../core/test/helpers.ts';
 import { renderComment } from '../src/comment.ts';
 
 const DIR_NAME = 'ci-selectivity';
@@ -19,7 +19,7 @@ async function seedLargeCorpus(): Promise<string> {
     const slug = `pkg-${String(index).padStart(2, '0')}`;
     await writeText(
       join(dir, `${id}-${slug}.md`),
-      withPathMatcher(recordMarkdown(id, `Guard ${slug}`), `packages/${slug}/**`),
+      withPathMatcher(acceptedRecordMarkdown(id, `Guard ${slug}`), `packages/${slug}/**`),
     );
   }
   return root;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,8 +13,11 @@ For one-off use:
 bunx @adrkit/cli lint
 ```
 
-The `adr` binary includes `new`, `lint`, `graph`, `explain`, `check`,
+The `adr` binary includes `new`, `lint`, `graph`, `explain`, `check`, `queue`,
 `migrate --from madr`, and the offline deterministic `evaluate` command.
+
+Run `adr --help` for the command list, `adr help <command>` for one command's
+flags, and `adr --version` to print the installed version.
 
 The published ESM CLI runs on Node.js 22 or newer.
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@
 import { parseArgs, type ParseArgsConfig } from 'node:util';
 import {
   buildAdrGraph,
+  bucketDecisions,
   checkChanges,
   countFindings,
   createAdr,
@@ -14,11 +15,20 @@ import {
   renderJsonGraph,
   ScaffoldError,
   sortFindings,
+  toGoverningDecisions,
   type Finding,
+  type GoverningDecision,
 } from '@adrkit/core';
 import { evaluate } from './evaluate.ts';
-import { runQueue } from './queue.ts';
+import { QUEUE_USAGE, runQueue } from './queue.ts';
 import { isMainModule } from './main-module.ts';
+
+/**
+ * The published `@adrkit/cli` version, reported by `adr --version`. Held as a literal
+ * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
+ * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
+ */
+export const CLI_VERSION = '0.2.0';
 
 function writeStdout(text: string): void {
   process.stdout.write(text);
@@ -28,11 +38,9 @@ function writeStderr(text: string): void {
   process.stderr.write(text);
 }
 
-function usage(message?: string): number {
-  if (message) writeStderr(`${message}\n`);
-  writeStderr(`Usage:
+const USAGE = `Usage:
   adr lint [paths...] [--json] [--dir docs/adr]
-  adr migrate --from madr [--dir docs/adr] [--dry-run] [--json]
+  adr migrate --from madr [--dir docs/adr] [--dry-run] [--rename] [--json]
   adr new <title> [--status draft] [--dir docs/adr] [--json]
   adr graph [--dir docs/adr] [--format dot|json]
   adr explain <path> [--dir docs/adr] [--json]
@@ -40,9 +48,136 @@ function usage(message?: string): number {
   adr evaluate <proposal-path> --snapshot <bundle.json> --date YYYY-MM-DD [--json] [--dir docs/adr]
   adr queue [--dir docs/adr] [--as-of YYYY-MM-DD] [--format markdown|json]
 
+  adr help [command]        Show this help, or help for one command
+  adr --version             Print the @adrkit/cli version
+
 Round-trip sync is explicitly unsupported (ADR-0008); migrate is one-way and non-destructive.
-`);
+`;
+
+/**
+ * Per-command help, printed by `adr <command> --help` and `adr help <command>`.
+ * `queue` reuses its own richer usage text so there is a single source for it.
+ */
+const COMMAND_USAGE: Record<string, string> = {
+  lint: `Usage: adr lint [paths...] [options]
+
+Validate the ADR corpus. With no paths, every discoverable record under --dir is checked.
+
+Options:
+  --dir <path>    ADR corpus directory (default: docs/adr)
+  --json          Emit { checked, findings } as JSON
+  --help          Show this help and exit
+
+Exit codes: 0 = no error findings; 1 = one or more error findings; 2 = usage error.
+`,
+  migrate: `Usage: adr migrate --from madr [options]
+
+Migrate a MADR corpus in place, adding adrkit frontmatter and leaving the body untouched.
+One-way and non-destructive; round-trip sync is unsupported (ADR-0008).
+
+Options:
+  --from madr     Source format (required; only madr is supported)
+  --dir <path>    ADR corpus directory (default: docs/adr)
+  --dry-run       Report what would change without writing
+  --rename        Rename each migrated file to <id>-<slug>.md so corpus discovery
+                  can see it. Off by default, because migration is in place.
+  --json          Emit the migration result as JSON
+  --help          Show this help and exit
+
+Exit code: 0. Findings are reported but do not fail the run.
+`,
+  new: `Usage: adr new <title> [options]
+
+Scaffold a new ADR record.
+
+Options:
+  --status <status>   Initial status (default: draft)
+  --dir <path>        ADR corpus directory (default: docs/adr)
+  --json              Emit { id, path } as JSON
+  --help              Show this help and exit
+
+Exit codes: 0 = created; 1 = refused to overwrite an existing file; 2 = usage error.
+`,
+  graph: `Usage: adr graph [options]
+
+Render the decision graph (supersedes, relatesTo, conflictsWith) for the corpus.
+
+Options:
+  --dir <path>            ADR corpus directory (default: docs/adr)
+  --format dot|json       Output format (default: dot)
+  --help                  Show this help and exit
+
+Exit codes: 0 = rendered; 2 = usage error.
+`,
+  explain: `Usage: adr explain <path> [options]
+
+Report which decisions govern one repo-relative path, and why.
+
+Options:
+  --dir <path>    ADR corpus directory (default: docs/adr)
+  --json          Emit { path, governedBy, governing, activeProposals, history, findings }
+  --help          Show this help and exit
+
+Exit codes: 0 = explained; 1 = corpus has error findings; 2 = usage error.
+`,
+  check: `Usage: adr check <files...> [options]
+
+Report the decisions governing a set of changed files, and validate any changed records.
+
+Options:
+  --dir <path>    ADR corpus directory (default: docs/adr)
+  --json          Emit the CheckOutcome as JSON
+  --help          Show this help and exit
+
+Exit codes: 0 = ok; 1 = a changed record has an error finding; 2 = usage error.
+`,
+  evaluate: `Usage: adr evaluate <proposal-path> --snapshot <bundle.json> --date YYYY-MM-DD [options]
+
+Run the deterministic evaluator over one proposal against an offline snapshot bundle.
+
+Options:
+  --snapshot <path>   Snapshot bundle (required)
+  --date <date>       Evaluation date, YYYY-MM-DD (required)
+  --dir <path>        ADR corpus directory
+  --json              Emit the evaluation report as JSON
+  --help              Show this help and exit
+`,
+  queue: QUEUE_USAGE,
+};
+
+const COMMANDS = Object.keys(COMMAND_USAGE);
+
+/** Own-property lookup: `adr help constructor` must be a usage error, not a crash. */
+function commandUsageFor(command: string): string | undefined {
+  return Object.hasOwn(COMMAND_USAGE, command) ? COMMAND_USAGE[command] : undefined;
+}
+
+/** Usage error: message + usage on stderr, exit 2. Explicit help goes to stdout at 0. */
+function usage(message?: string): number {
+  if (message) writeStderr(`${message}\n`);
+  writeStderr(USAGE);
   return 2;
+}
+
+function isHelpFlag(arg: string): boolean {
+  return arg === '--help' || arg === '-h';
+}
+
+/** `adr help [command]` — usage on stdout at 0; unknown command is still a usage error. */
+function runHelp(args: string[]): number {
+  const requested = args.find((arg) => !arg.startsWith('-'));
+  if (requested === undefined) {
+    writeStdout(USAGE);
+    return 0;
+  }
+
+  const commandUsage = commandUsageFor(requested);
+  if (!commandUsage) {
+    return usage(`Unknown command "${requested}". Known commands: ${COMMANDS.join(', ')}`);
+  }
+
+  writeStdout(commandUsage);
+  return 0;
 }
 
 function parseCommandArgs(
@@ -122,7 +257,8 @@ function renderHumanMigrate(result: Awaited<ReturnType<typeof migrateMadr>>): st
   let output = '';
   for (const item of result.results) {
     counts[item.outcome] += 1;
-    output += `${item.outcome}  ${item.path}\n`;
+    const renamed = item.renamedTo ? ` -> ${item.renamedTo}` : '';
+    output += `${item.outcome}  ${item.path}${renamed}\n`;
   }
 
   output += `summary: migrated ${counts.migrated}, updated ${counts.updated}, unchanged ${counts.unchanged}, diverged ${counts.diverged}, skipped ${counts.skipped}\n`;
@@ -152,6 +288,7 @@ async function runMigrate(args: string[]): Promise<number> {
       from: { type: 'string' },
       dir: { type: 'string', default: 'docs/adr' },
       'dry-run': { type: 'boolean', default: false },
+      rename: { type: 'boolean', default: false },
       json: { type: 'boolean', default: false },
     });
   } catch (error) {
@@ -171,6 +308,7 @@ async function runMigrate(args: string[]): Promise<number> {
   const result = await migrateMadr({
     dir: String(parsed.values.dir),
     write: parsed.values['dry-run'] !== true,
+    rename: parsed.values.rename === true,
   });
 
   if (parsed.values.json) {
@@ -258,7 +396,13 @@ async function runExplain(args: string[]): Promise<number> {
   const corpusFindings = sortFindings(corpus.findings);
   if (exitCodeForFindings(corpusFindings) !== 0) {
     if (parsed.values.json) {
-      writeStdout(`${JSON.stringify({ path, governedBy: [], findings: corpusFindings }, null, 2)}\n`);
+      writeStdout(
+        `${JSON.stringify(
+          { path, governedBy: [], governing: [], activeProposals: [], history: [], findings: corpusFindings },
+          null,
+          2,
+        )}\n`,
+      );
     } else {
       const humanFindings = renderHumanLint(corpusFindings);
       if (humanFindings) writeStderr(humanFindings);
@@ -266,29 +410,26 @@ async function runExplain(args: string[]): Promise<number> {
     return 1;
   }
 
-  const recordsById = new Map(corpus.records.map((record) => [record.frontmatter.id, record]));
   const resolution = resolveAffects({ records: corpus.records, changedFiles: [path] });
-  const governedBy = resolution.matches.map((match) => ({
-    recordId: match.recordId,
-    title: recordsById.get(match.recordId)?.frontmatter.title ?? '',
-    firedMatchers: match.firedMatchers,
-  }));
+  const governedBy = toGoverningDecisions(corpus.records, resolution.matches);
+  const buckets = bucketDecisions(governedBy);
   const findings = sortFindings(resolution.findings);
 
   if (parsed.values.json) {
-    writeStdout(`${JSON.stringify({ path, governedBy, findings }, null, 2)}\n`);
+    writeStdout(`${JSON.stringify({ path, governedBy, ...buckets, findings }, null, 2)}\n`);
     return 0;
   }
 
   if (governedBy.length === 0) {
     writeStdout(`No decision governs ${path}.\n`);
   } else {
-    for (const match of governedBy) {
-      writeStdout(`${match.recordId}  ${match.title}\n`);
-      for (const matcher of match.firedMatchers) {
-        writeStdout(`  via ${matcher.type}: ${matcher.pattern}\n`);
-      }
+    if (buckets.governing.length === 0) {
+      writeStdout(`No accepted decision governs ${path}.\n`);
+    } else {
+      writeStdout(renderDecisionGroup(`Decisions governing ${path}:`, buckets.governing));
     }
+    writeStdout(renderDecisionGroup('Active proposals (not yet binding):', buckets.activeProposals));
+    writeStdout(renderDecisionGroup('Historical records (not binding):', buckets.history));
   }
 
   if (findings.length > 0) {
@@ -301,18 +442,37 @@ async function runExplain(args: string[]): Promise<number> {
   return 0;
 }
 
+function renderDecisionGroup(heading: string, decisions: readonly GoverningDecision[], indent = '  '): string {
+  if (decisions.length === 0) return '';
+  let output = `${heading}\n`;
+  for (const decision of decisions) {
+    const successor = decision.supersededBy ? ` (superseded by ${decision.supersededBy})` : '';
+    output += `${indent}${decision.recordId}  [${decision.status}] ${decision.title}${successor}\n`;
+    for (const matcher of decision.firedMatchers) {
+      output += `${indent}  via ${matcher.type}: ${matcher.pattern}\n`;
+    }
+  }
+  return output;
+}
+
 function renderHumanCheck(outcome: ReturnType<typeof checkChanges>): string {
   let output = '';
   if (outcome.governedBy.length === 0) {
     output += 'No decisions govern the changed files.\n';
   } else {
-    output += 'Decisions governing this change:\n';
-    for (const decision of outcome.governedBy) {
-      output += `  ${decision.recordId}  ${decision.title}\n`;
-      for (const matcher of decision.firedMatchers) {
-        output += `    via ${matcher.type}: ${matcher.pattern}\n`;
-      }
+    if (outcome.governing.length === 0) {
+      output += 'No accepted decisions govern the changed files.\n';
+    } else {
+      output += renderDecisionGroup('Decisions governing this change:', outcome.governing);
     }
+    output += renderDecisionGroup(
+      'Active proposals touching this change (not yet binding):',
+      outcome.activeProposals,
+    );
+    output += renderDecisionGroup(
+      'Historical records that once covered this change (not binding):',
+      outcome.history,
+    );
   }
 
   if (outcome.findings.length > 0) {
@@ -323,7 +483,7 @@ function renderHumanCheck(outcome: ReturnType<typeof checkChanges>): string {
   const changedRecordErrors = outcome.findings.filter(
     (finding) => finding.severity === 'error' && finding.path && outcome.changedRecords.includes(finding.path),
   ).length;
-  output += `checked: ${outcome.governedBy.length} governing, ${outcome.changedRecords.length} changed records, ${changedRecordErrors} changed-record errors\n`;
+  output += `checked: ${outcome.governing.length} governing, ${outcome.activeProposals.length} active proposals, ${outcome.history.length} historical, ${outcome.changedRecords.length} changed records, ${changedRecordErrors} changed-record errors\n`;
   return output;
 }
 
@@ -392,6 +552,22 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   const [command, ...args] = argv;
 
   try {
+    if (command === undefined) return usage();
+    if (command === 'help') return runHelp(args);
+    if (isHelpFlag(command)) return runHelp(args);
+    if (command === '--version' || command === '-V') {
+      writeStdout(`${CLI_VERSION}\n`);
+      return 0;
+    }
+
+    // `adr <command> --help` prints that command's usage to stdout at 0. `queue`
+    // parses `--help` itself, so it is excluded here to keep one code path for it.
+    const commandUsage = command === 'queue' ? undefined : commandUsageFor(command);
+    if (commandUsage && args.some(isHelpFlag)) {
+      writeStdout(commandUsage);
+      return 0;
+    }
+
     if (command === 'lint') return await runLint(args);
     if (command === 'migrate') return await runMigrate(args);
     if (command === 'new') return await runNew(args);
@@ -400,7 +576,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
     if (command === 'check') return await runCheck(args);
     if (command === 'evaluate') return await runEvaluate(args);
     if (command === 'queue') return await runQueue(args);
-    return usage(command ? `Unknown command "${command}"` : undefined);
+    return usage(`Unknown command "${command}"`);
   } catch (error) {
     writeStderr(`${error instanceof Error ? error.message : String(error)}\n`);
     return 1;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -84,7 +84,8 @@ Options:
   --json          Emit the migration result as JSON
   --help          Show this help and exit
 
-Exit code: 0. Findings are reported but do not fail the run.
+Exit codes: 0 = migration ran (findings are reported but do not fail the run);
+2 = usage error (missing or unsupported --from, unknown flag, positional argument).
 `,
   new: `Usage: adr new <title> [options]
 
@@ -141,6 +142,12 @@ Options:
   --dir <path>        ADR corpus directory
   --json              Emit the evaluation report as JSON
   --help              Show this help and exit
+
+The evaluator routes; it never approves, persists, or writes. There is no --write.
+
+Exit codes: 0 = evaluated (including warn/info/inert and escalation);
+1 = the proposal was returned on a rubric error; 2 = usage error or a malformed
+snapshot bundle.
 `,
   queue: QUEUE_USAGE,
 };

--- a/packages/cli/src/queue.ts
+++ b/packages/cli/src/queue.ts
@@ -17,6 +17,9 @@ Exit codes: 0 = report, no error findings; 1 = report with corpus error findings
 2 = usage error (invalid flag/value or unreachable corpus directory).
 `;
 
+/** Re-exported so `adr help queue` renders the same text as `adr queue --help`. */
+export const QUEUE_USAGE = USAGE;
+
 type AsOfResolution = { ok: true; date: string } | { ok: false; kind: 'tzless' | 'invalid' };
 
 /** Resolve a `--as-of` value to a UTC calendar date (cli-contract.md §As-Of Resolution). */
@@ -60,7 +63,7 @@ function parseFlags(args: string[]): ParseResult {
     const name = eq !== -1 ? arg.slice(0, eq) : arg;
     const inlineValue = eq !== -1 ? arg.slice(eq + 1) : undefined;
 
-    if (name === '--help') {
+    if (name === '--help' || name === '-h') {
       flags.help = true;
       continue;
     }

--- a/packages/cli/test/check.test.ts
+++ b/packages/cli/test/check.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { join, resolve } from 'node:path';
-import { cleanupTestDir, recordMarkdown, resetTestDir, writeText } from '../../core/test/helpers.ts';
+import {
+  acceptedRecordMarkdown,
+  cleanupTestDir,
+  recordMarkdown,
+  resetTestDir,
+  supersededRecordMarkdown,
+  writeText,
+} from '../../core/test/helpers.ts';
 
 const CLI_PATH = resolve(process.cwd(), 'packages/cli/src/index.ts');
 const DIR_NAME = 'cli-check';
@@ -24,8 +31,8 @@ const pathMatcher = (pattern: string): string => ['affects:', '  - type: path', 
 async function seedCorpus(): Promise<string> {
   const root = await resetTestDir(DIR_NAME);
   const dir = join(root, 'docs/adr');
-  await writeText(join(dir, '0001-core.md'), withAffects(recordMarkdown('0001', 'Use core paths'), pathMatcher('packages/core/**')));
-  await writeText(join(dir, '0002-cli.md'), withAffects(recordMarkdown('0002', 'Use cli paths'), pathMatcher('packages/cli/**')));
+  await writeText(join(dir, '0001-core.md'), withAffects(acceptedRecordMarkdown('0001', 'Use core paths'), pathMatcher('packages/core/**')));
+  await writeText(join(dir, '0002-cli.md'), withAffects(acceptedRecordMarkdown('0002', 'Use cli paths'), pathMatcher('packages/cli/**')));
   return root;
 }
 
@@ -41,9 +48,9 @@ describe('adr check CLI', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('Decisions governing this change:');
-    expect(result.stdout).toContain('0001  Use core paths');
+    expect(result.stdout).toContain('0001  [accepted] Use core paths');
     expect(result.stdout).toContain('via path: packages/core/**');
-    expect(result.stdout).not.toContain('0002  Use cli paths');
+    expect(result.stdout).not.toContain('Use cli paths');
   });
 
   test('exits non-zero when a changed record has an error finding', async () => {
@@ -66,7 +73,31 @@ describe('adr check CLI', () => {
     const result = await runAdr(['check', 'packages/core/src/index.ts', '--dir', 'docs/adr'], root);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('0001  Use core paths');
+    expect(result.stdout).toContain('0001  [accepted] Use core paths');
+  });
+
+  test('a non-accepted record that matches is reported separately, never as governing', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const dir = join(root, 'docs/adr');
+    await writeText(join(dir, '0001-draft.md'), withAffects(recordMarkdown('0001', 'Draft record'), pathMatcher('src/api/**')));
+    await writeText(
+      join(dir, '0002-superseded.md'),
+      withAffects(supersededRecordMarkdown('0002', '0003', 'Superseded record'), pathMatcher('src/api/**')),
+    );
+    await writeText(
+      join(dir, '0003-accepted.md'),
+      withAffects(acceptedRecordMarkdown('0003', 'Accepted record'), pathMatcher('src/api/**')),
+    );
+
+    const result = await runAdr(['check', 'src/api/thing.ts', '--dir', 'docs/adr'], root);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Decisions governing this change:\n  0003  [accepted] Accepted record');
+    expect(result.stdout).toContain('Active proposals touching this change (not yet binding):\n  0001  [draft] Draft record');
+    expect(result.stdout).toContain(
+      'Historical records that once covered this change (not binding):\n  0002  [superseded] Superseded record (superseded by 0003)',
+    );
+    expect(result.stdout).toContain('checked: 1 governing, 1 active proposals, 1 historical,');
   });
 
   test('--json output is stable and deterministically sorted', async () => {
@@ -81,6 +112,10 @@ describe('adr check CLI', () => {
     expect(second.stdout).toBe(first.stdout);
     expect(parsed.changedFiles).toEqual(['packages/cli/src/a.ts', 'packages/core/src/b.ts']);
     expect(parsed.governedBy.map((g: { recordId: string }) => g.recordId)).toEqual(['0001', '0002']);
+    expect(parsed.governing.map((g: { recordId: string }) => g.recordId)).toEqual(['0001', '0002']);
+    expect(parsed.governedBy.map((g: { status: string }) => g.status)).toEqual(['accepted', 'accepted']);
+    expect(parsed.activeProposals).toEqual([]);
+    expect(parsed.history).toEqual([]);
     expect(parsed.ok).toBe(true);
     expect(parsed).toHaveProperty('changedRecords');
     expect(parsed).toHaveProperty('findings');

--- a/packages/cli/test/explain.test.ts
+++ b/packages/cli/test/explain.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { join, resolve } from 'node:path';
-import { cleanupTestDir, recordMarkdown, resetTestDir, writeText } from '../../core/test/helpers.ts';
+import {
+  acceptedRecordMarkdown,
+  cleanupTestDir,
+  recordMarkdown,
+  resetTestDir,
+  supersededRecordMarkdown,
+  writeText,
+} from '../../core/test/helpers.ts';
 
 const CLI_PATH = resolve(process.cwd(), 'packages/cli/src/index.ts');
 const DIR_NAME = 'cli-explain';
@@ -30,14 +37,14 @@ describe('adr explain CLI', () => {
     await writeText(
       join(dir, '0001-core.md'),
       withAffects(
-        recordMarkdown('0001', 'Use core paths'),
+        acceptedRecordMarkdown('0001', 'Use core paths'),
         ['affects:', '  - type: path', '    pattern: "src/**"'].join('\n'),
       ),
     );
     await writeText(
       join(dir, '0002-specific.md'),
       withAffects(
-        recordMarkdown('0002', 'Use specific file'),
+        acceptedRecordMarkdown('0002', 'Use specific file'),
         ['affects:', '  - type: path', '    pattern: "src/file.ts"'].join('\n'),
       ),
     );
@@ -46,10 +53,34 @@ describe('adr explain CLI', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe('');
-    expect(result.stdout).toContain('0001  Use core paths');
+    expect(result.stdout).toContain('0001  [accepted] Use core paths');
     expect(result.stdout).toContain('  via path: src/**');
-    expect(result.stdout).toContain('0002  Use specific file');
+    expect(result.stdout).toContain('0002  [accepted] Use specific file');
     expect(result.stdout).toContain('  via path: src/file.ts');
+  });
+
+  test('separates non-accepted matches from the governing group', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const dir = join(root, 'docs/adr');
+    await writeText(
+      join(dir, '0001-draft.md'),
+      withAffects(recordMarkdown('0001', 'Draft record'), ['affects:', '  - type: path', '    pattern: "src/**"'].join('\n')),
+    );
+    await writeText(
+      join(dir, '0002-superseded.md'),
+      withAffects(
+        supersededRecordMarkdown('0002', '0001', 'Superseded record'),
+        ['affects:', '  - type: path', '    pattern: "src/**"'].join('\n'),
+      ),
+    );
+
+    const result = await runAdr(['explain', 'src/file.ts', '--dir', dir]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('No accepted decision governs src/file.ts.');
+    expect(result.stdout).toContain('Active proposals (not yet binding):\n  0001  [draft] Draft record');
+    expect(result.stdout).toContain('Historical records (not binding):\n  0002  [superseded] Superseded record (superseded by 0001)');
+    expect(result.stdout).not.toContain('Decisions governing');
   });
 
   test('prints a clear line for an ungoverned path and exits zero', async () => {
@@ -99,14 +130,14 @@ describe('adr explain CLI', () => {
     await writeText(
       join(dir, '0002-specific.md'),
       withAffects(
-        recordMarkdown('0002', 'Use specific file'),
+        acceptedRecordMarkdown('0002', 'Use specific file'),
         ['affects:', '  - type: path', '    pattern: "src/file.ts"'].join('\n'),
       ),
     );
     await writeText(
       join(dir, '0001-core.md'),
       withAffects(
-        recordMarkdown('0001', 'Use core paths'),
+        acceptedRecordMarkdown('0001', 'Use core paths'),
         ['affects:', '  - type: path', '    pattern: "src/**"'].join('\n'),
       ),
     );
@@ -115,22 +146,29 @@ describe('adr explain CLI', () => {
     const second = await runAdr(['explain', 'src/file.ts', '--dir', dir, '--json']);
     const parsed = JSON.parse(first.stdout);
 
+    const core = {
+      recordId: '0001',
+      title: 'Use core paths',
+      status: 'accepted',
+      bucket: 'governing',
+      firedMatchers: [{ type: 'path', pattern: 'src/**' }],
+    };
+    const specific = {
+      recordId: '0002',
+      title: 'Use specific file',
+      status: 'accepted',
+      bucket: 'governing',
+      firedMatchers: [{ type: 'path', pattern: 'src/file.ts' }],
+    };
+
     expect(first.exitCode).toBe(0);
     expect(second.stdout).toBe(first.stdout);
     expect(parsed).toEqual({
       path: 'src/file.ts',
-      governedBy: [
-        {
-          recordId: '0001',
-          title: 'Use core paths',
-          firedMatchers: [{ type: 'path', pattern: 'src/**' }],
-        },
-        {
-          recordId: '0002',
-          title: 'Use specific file',
-          firedMatchers: [{ type: 'path', pattern: 'src/file.ts' }],
-        },
-      ],
+      governedBy: [core, specific],
+      governing: [core, specific],
+      activeProposals: [],
+      history: [],
       findings: [],
     });
   });

--- a/packages/cli/test/help-version.test.ts
+++ b/packages/cli/test/help-version.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression tests for adrkit#42 — `adr --help`, `adr --version`, and `adr help` were
+ * all treated as unknown commands and exited 2, and there was no way to ask the CLI
+ * what version it was.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { CLI_VERSION } from '../src/index.ts';
+
+const CLI_PATH = resolve(process.cwd(), 'packages/cli/src/index.ts');
+const PACKAGE_JSON = resolve(process.cwd(), 'packages/cli/package.json');
+
+async function runAdr(args: string[]) {
+  const proc = Bun.spawn([process.execPath, CLI_PATH, ...args], { stdout: 'pipe', stderr: 'pipe' });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+describe('CLI_VERSION', () => {
+  test('matches the published package version', async () => {
+    const pkg = JSON.parse(await readFile(PACKAGE_JSON, 'utf8')) as { version: string };
+    expect(CLI_VERSION).toBe(pkg.version);
+  });
+});
+
+describe('adr --version (#42)', () => {
+  for (const flag of ['--version', '-V']) {
+    test(`${flag} prints the version to stdout and exits 0`, async () => {
+      const result = await runAdr([flag]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe(`${CLI_VERSION}\n`);
+      expect(result.stderr).toBe('');
+    });
+  }
+});
+
+describe('adr help (#42)', () => {
+  for (const invocation of [['--help'], ['-h'], ['help']]) {
+    test(`adr ${invocation.join(' ')} prints usage to stdout and exits 0`, async () => {
+      const result = await runAdr(invocation);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('Usage:');
+      expect(result.stdout).toContain('adr lint');
+    });
+  }
+
+  test('all three top-level help invocations print identical text', async () => {
+    const [dashDash, dash, bare] = await Promise.all([runAdr(['--help']), runAdr(['-h']), runAdr(['help'])]);
+
+    expect(dash.stdout).toBe(dashDash.stdout);
+    expect(bare.stdout).toBe(dashDash.stdout);
+  });
+
+  test('adr help <command> prints that command\u2019s usage', async () => {
+    const result = await runAdr(['help', 'migrate']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Usage: adr migrate --from madr');
+    expect(result.stdout).toContain('--rename');
+  });
+
+  test('adr <command> --help matches adr help <command>', async () => {
+    for (const command of ['lint', 'migrate', 'new', 'graph', 'explain', 'check', 'evaluate', 'queue']) {
+      const [viaFlag, viaHelp] = await Promise.all([runAdr([command, '--help']), runAdr(['help', command])]);
+
+      expect(viaFlag.exitCode).toBe(0);
+      expect(viaFlag.stderr).toBe('');
+      expect(viaFlag.stdout).toBe(viaHelp.stdout);
+    }
+  });
+
+  test('adr help <unknown> is still a usage error on stderr', async () => {
+    const result = await runAdr(['help', 'frobnicate']);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Unknown command "frobnicate"');
+  });
+
+  test('an inherited Object.prototype key is a usage error, not a crash', async () => {
+    for (const name of ['constructor', 'toString', '__proto__', 'valueOf', 'hasOwnProperty']) {
+      const viaHelp = await runAdr(['help', name]);
+      expect(viaHelp.exitCode).toBe(2);
+      expect(viaHelp.stdout).toBe('');
+      expect(viaHelp.stderr).toContain(`Unknown command "${name}"`);
+
+      const viaFlag = await runAdr([name, '--help']);
+      expect(viaFlag.exitCode).toBe(2);
+      expect(viaFlag.stdout).toBe('');
+    }
+  });
+});
+
+describe('unknown commands keep the old contract', () => {
+  test('an unknown command writes usage to stderr and exits 2', async () => {
+    const result = await runAdr(['frobnicate']);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Unknown command "frobnicate"');
+    expect(result.stderr).toContain('Usage:');
+  });
+
+  test('no arguments writes usage to stderr and exits 2', async () => {
+    const result = await runAdr([]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('Usage:');
+  });
+});

--- a/packages/core/src/check/index.ts
+++ b/packages/core/src/check/index.ts
@@ -1,5 +1,6 @@
-import type { Adr } from '../schema/adr.schema.ts';
-import { resolveAffects, type FiredMatcher, type ResolutionSnapshots } from '../affects/index.ts';
+import type { Adr, Status } from '../schema/adr.schema.ts';
+import { resolveAffects, type AffectsMatch, type FiredMatcher, type ResolutionSnapshots } from '../affects/index.ts';
+import { decisionBucketFor, type DecisionBucket } from '../status/bucket.ts';
 import { sortFindings, type Finding } from '../validate/findings.ts';
 
 /**
@@ -17,6 +18,15 @@ export interface CheckLintResult {
 export interface GoverningDecision {
   recordId: string;
   title: string;
+  /**
+   * The record's status. Present so no consumer has to assume a matched record is
+   * `accepted` — a `rejected` or `superseded` record can match a path just as easily.
+   */
+  status: Status;
+  /** Which of the three buckets this record falls into, per `decisionBucketFor`. */
+  bucket: DecisionBucket;
+  /** The successor, when this record was superseded. Lets a reader follow the chain. */
+  supersededBy?: string;
   firedMatchers: FiredMatcher[];
 }
 
@@ -26,7 +36,17 @@ export interface GoverningDecision {
  */
 export interface CheckOutcome {
   changedFiles: string[];
+  /**
+   * Every record whose matchers fired, regardless of status — the resolver's raw union.
+   * Retained for consumers written against the pre-bucketing shape; prefer `governing`.
+   */
   governedBy: GoverningDecision[];
+  /** `accepted` records only. These are the decisions that actually bind the change. */
+  governing: GoverningDecision[];
+  /** `draft`/`proposed` records that touch the change but have not been ratified. */
+  activeProposals: GoverningDecision[];
+  /** `rejected`/`superseded`/`deprecated` records that once covered the change. */
+  history: GoverningDecision[];
   changedRecords: string[];
   findings: Finding[];
   ok: boolean;
@@ -81,6 +101,44 @@ function uniqueSorted(values: readonly string[]): string[] {
 }
 
 /**
+ * Turn resolver matches into status-carrying decisions. A match whose record is not in
+ * `records` (dropped by lint as malformed) cannot be classified, so it is reported with
+ * the neutral `draft` status and lands in `activeProposals` rather than silently
+ * claiming to govern.
+ */
+export function toGoverningDecisions(
+  records: readonly Adr[],
+  matches: readonly AffectsMatch[],
+): GoverningDecision[] {
+  const byId = new Map(records.map((record) => [record.frontmatter.id, record]));
+  return matches.map((match) => {
+    const frontmatter = byId.get(match.recordId)?.frontmatter;
+    const status: Status = frontmatter?.status ?? 'draft';
+    return {
+      recordId: match.recordId,
+      title: frontmatter?.title ?? '',
+      status,
+      bucket: decisionBucketFor(status),
+      ...(frontmatter?.supersededBy ? { supersededBy: frontmatter.supersededBy } : {}),
+      firedMatchers: match.firedMatchers,
+    };
+  });
+}
+
+export interface BucketedDecisions {
+  governing: GoverningDecision[];
+  activeProposals: GoverningDecision[];
+  history: GoverningDecision[];
+}
+
+/** Partition decisions into the three buckets, preserving the input order within each. */
+export function bucketDecisions(decisions: readonly GoverningDecision[]): BucketedDecisions {
+  const buckets: BucketedDecisions = { governing: [], activeProposals: [], history: [] };
+  for (const decision of decisions) buckets[decision.bucket].push(decision);
+  return buckets;
+}
+
+/**
  * The single, neutral "resolve governing decisions + validate changed records"
  * implementation, called by both `adr check` (CLI) and the `@adrkit/ci` Action so
  * neither surface depends on the other. Pure: no clock, network, or fs traversal
@@ -99,14 +157,8 @@ export function checkChanges(input: CheckChangesInput): CheckOutcome {
     log: input.log,
   });
 
-  const titleById = new Map(
-    input.lint.records.map((record) => [record.frontmatter.id, record.frontmatter.title]),
-  );
-  const governedBy: GoverningDecision[] = resolution.matches.map((match) => ({
-    recordId: match.recordId,
-    title: titleById.get(match.recordId) ?? '',
-    firedMatchers: match.firedMatchers,
-  }));
+  const governedBy = toGoverningDecisions(input.lint.records, resolution.matches);
+  const buckets = bucketDecisions(governedBy);
 
   // Findings kept only for files lint attributes to a changed record. Errors on
   // unchanged records (A5) and corpus-level findings without a record path do not
@@ -117,5 +169,14 @@ export function checkChanges(input: CheckChangesInput): CheckOutcome {
   const findings = sortFindings([...resolution.findings, ...changedRecordFindings]);
   const ok = !changedRecordFindings.some((finding) => finding.severity === 'error');
 
-  return { changedFiles, governedBy, changedRecords, findings, ok };
+  return {
+    changedFiles,
+    governedBy,
+    governing: buckets.governing,
+    activeProposals: buckets.activeProposals,
+    history: buckets.history,
+    changedRecords,
+    findings,
+    ok,
+  };
 }

--- a/packages/core/src/import/index.ts
+++ b/packages/core/src/import/index.ts
@@ -246,11 +246,17 @@ export async function migrateMadr(input: MigrateMadrInput): Promise<MigrateMadrR
   const allocatedIds = new Map<string, string>(
     writable.map((entry) => [entry.sourceRef, allocateId(entry.source, classificationForSource.get(entry.sourceRef))]),
   );
+
+  // Built over *every* prepared source, not just the writable ones: in an incremental
+  // migration the successor a new record points at was often imported by an earlier run
+  // and is now `unchanged`. Its id is known from its classification, so the reference
+  // still resolves instead of being downgraded to an unrecognized status.
   const sourceNumberToId = new Map<string, string>();
-  for (const entry of writable) {
+  for (const entry of sorted) {
     const declared = rawId(entry.source) ?? fileNameId(entry.source.absolutePath);
-    const allocated = allocatedIds.get(entry.sourceRef);
-    if (declared && allocated && !sourceNumberToId.has(declared)) sourceNumberToId.set(declared, allocated);
+    if (!declared || sourceNumberToId.has(declared)) continue;
+    const resolved = allocatedIds.get(entry.sourceRef) ?? classificationForSource.get(entry.sourceRef)?.recordId;
+    if (resolved) sourceNumberToId.set(declared, resolved);
   }
   const resolveSupersededRef = (ref: string): string | undefined => sourceNumberToId.get(ref);
 

--- a/packages/core/src/import/index.ts
+++ b/packages/core/src/import/index.ts
@@ -1,9 +1,9 @@
-import { readFile, writeFile } from 'node:fs/promises';
-import { isAbsolute, resolve } from 'node:path';
+import { access, readFile, rename, writeFile } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { parseFrontmatter } from '../parse/frontmatter.ts';
-import { normalizeDisplayPath } from '../load/corpus.ts';
+import { isRecordFileName, normalizeDisplayPath } from '../load/corpus.ts';
 import { AdrFrontmatter, type Adr } from '../schema/adr.schema.ts';
-import { nextSequentialId } from '../scaffold/new.ts';
+import { nextSequentialId, slugifyTitle } from '../scaffold/new.ts';
 import { sortFindings, type Finding } from '../validate/findings.ts';
 import { validateImportIncomplete } from '../validate/import-incomplete.ts';
 import { classifyReimport, type ReimportBucket, type ReimportClassification } from './classify.ts';
@@ -14,7 +14,7 @@ import { MadrMergeError, mergeMadr, recordFromMerge } from './merge.ts';
 export { classifyReimport } from './classify.ts';
 export type { ReimportBucket, ReimportClassification, ReimportSourceEntry } from './classify.ts';
 export { fingerprintSourceBody, normalizeSourceBody } from './fingerprint.ts';
-export { readMadrFile, discoverMadrCandidateFiles } from './madr.ts';
+export { readMadrFile, discoverMadrCandidateFiles, extractMadrBodyFields, type MadrBodyFields } from './madr.ts';
 export { mapMadrStatus } from './status.ts';
 export { mergeMadr, renderMigratedContent } from './merge.ts';
 
@@ -27,12 +27,21 @@ export interface MigrateMadrInput {
   recordEdited?: (id: string) => boolean;
   cwd?: string;
   write?: boolean;
+  /**
+   * Rename each migrated file to `<id>-<slug>.md` so corpus discovery can see it.
+   * Off by default: ADR-0008 makes migration additive and in place, so existing MADR
+   * tooling and inbound links keep working. Opt in when the source corpus does not
+   * already use `NNNN-` filenames.
+   */
+  rename?: boolean;
 }
 
 export interface MigrateMadrResultItem {
   path: string;
   outcome: MigrateOutcome;
   frontmatter?: AdrFrontmatter;
+  /** Set when `rename` moved the record; the new repo-relative path. */
+  renamedTo?: string;
 }
 
 export interface MigrateMadrDivergenceItem {
@@ -56,6 +65,13 @@ function toAbsolutePath(path: string, cwd: string): string {
   return isAbsolute(path) ? path : resolve(cwd, path);
 }
 
+async function pathExists(path: string): Promise<boolean> {
+  return access(path).then(
+    () => true,
+    () => false,
+  );
+}
+
 function notMadrFinding(path: string, reason: string): Finding {
   return {
     rule: 'import-not-madr',
@@ -63,6 +79,37 @@ function notMadrFinding(path: string, reason: string): Finding {
     message: reason,
     path,
   };
+}
+
+/**
+ * A migrated record that corpus discovery cannot see is invisible to `lint`, `graph`,
+ * `check`, `explain`, and `queue` — migration reports success while governance covers
+ * nothing. Report it at the moment it happens (#41).
+ */
+function undiscoverableFinding(path: string, id: string, reason: string): Finding {
+  return {
+    rule: 'import-undiscoverable',
+    severity: 'warn',
+    message: `Migrated record is not discoverable: ${reason}. Until it is, lint, check, explain, graph, and queue will skip it`,
+    path,
+    id,
+    field: 'path',
+  };
+}
+
+const UNDISCOVERABLE_FILENAME =
+  'its filename does not match <id>-<slug>.md (four or more leading digits) — re-run with --rename, or rename it by hand';
+const UNDISCOVERABLE_NESTED =
+  'it is in a subdirectory of the corpus, and discovery reads only the top level of the corpus directory — move it up, or point --dir at its directory';
+
+/** Target filename for `--rename`: the corpus grammar, derived from the allocated id. */
+function discoverableFileName(id: string, title: string | undefined): string {
+  if (!title) return `${id}-record.md`;
+  try {
+    return `${id}-${slugifyTitle(title)}.md`;
+  } catch {
+    return `${id}-record.md`;
+  }
 }
 
 async function existingRecordsFromFiles(files: readonly string[], cwd: string): Promise<Adr[]> {
@@ -151,6 +198,7 @@ export async function migrateMadr(input: MigrateMadrInput): Promise<MigrateMadrR
   const cwd = input.cwd ?? process.cwd();
   const dir = input.dir ?? 'docs/adr';
   const write = input.write !== false;
+  const rename_ = input.rename === true;
   const files = input.files
     ? input.files.map((file) => toAbsolutePath(file, cwd)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)))
     : await discoverMadrCandidateFiles(dir, cwd);
@@ -186,7 +234,27 @@ export async function migrateMadr(input: MigrateMadrInput): Promise<MigrateMadrR
   ]);
   const recordsForIncomplete: Adr[] = [];
 
-  for (const entry of prepared.sort((a, b) => a.source.path.localeCompare(b.source.path))) {
+  const sorted = prepared.sort((a, b) => a.source.path.localeCompare(b.source.path));
+  const writable = sorted.filter((entry) => {
+    const bucket: ReimportBucket = classificationForSource.get(entry.sourceRef)?.bucket ?? 'new';
+    return bucket !== 'diverged' && bucket !== 'unchanged';
+  });
+
+  // Ids are allocated up front, in canonical order, so a `superseded by <ref>` status
+  // can be resolved into the id space this run is actually writing rather than the
+  // source project's numbering (which is a different namespace entirely).
+  const allocatedIds = new Map<string, string>(
+    writable.map((entry) => [entry.sourceRef, allocateId(entry.source, classificationForSource.get(entry.sourceRef))]),
+  );
+  const sourceNumberToId = new Map<string, string>();
+  for (const entry of writable) {
+    const declared = rawId(entry.source) ?? fileNameId(entry.source.absolutePath);
+    const allocated = allocatedIds.get(entry.sourceRef);
+    if (declared && allocated && !sourceNumberToId.has(declared)) sourceNumberToId.set(declared, allocated);
+  }
+  const resolveSupersededRef = (ref: string): string | undefined => sourceNumberToId.get(ref);
+
+  for (const entry of sorted) {
     const classification = classificationForSource.get(entry.sourceRef);
     const bucket: ReimportBucket = classification?.bucket ?? 'new';
 
@@ -206,20 +274,54 @@ export async function migrateMadr(input: MigrateMadrInput): Promise<MigrateMadrR
     }
 
     try {
-      const id = allocateId(entry.source, classification);
+      const id = allocatedIds.get(entry.sourceRef) ?? allocateId(entry.source, classification);
+
+      const sourceDir = dirname(entry.source.absolutePath);
+      // Discovery reads only the top level of the corpus directory, so a record in a
+      // subdirectory is invisible no matter what it is called — and renaming it in
+      // place would not help.
+      const isNested = resolve(sourceDir) !== resolve(toAbsolutePath(dir, cwd));
+      const targetAbsolutePath = join(sourceDir, discoverableFileName(id, entry.source.title));
+      const needsRename = !isNested && !isRecordFileName(basename(entry.source.absolutePath));
+      // Never clobber an unrelated file that already occupies the target name.
+      const targetTaken =
+        targetAbsolutePath !== entry.source.absolutePath && (await pathExists(targetAbsolutePath));
+      const willRename = rename_ && needsRename && !targetTaken;
+      const finalAbsolutePath = willRename ? targetAbsolutePath : entry.source.absolutePath;
+      const finalPath = willRename ? normalizeDisplayPath(finalAbsolutePath, cwd) : entry.source.path;
+
+      // Provenance records where the record ends up, not where it started, so the next
+      // run classifies a renamed record as `unchanged` instead of re-importing it.
       const merged = mergeMadr({
         source: entry.source,
         id,
-        sourceRef: entry.sourceRef,
+        sourceRef: finalPath,
         fingerprint: entry.fingerprint,
+        resolveSupersededRef,
       });
       findings.push(...merged.findings);
       const outcome = bucket === 'updated' ? 'updated' : 'migrated';
-      if (write && merged.content !== entry.source.source) {
+
+      if (write && (merged.content !== entry.source.source || willRename)) {
         await writeFile(entry.source.absolutePath, merged.content, 'utf8');
+        if (willRename) await rename(entry.source.absolutePath, finalAbsolutePath);
       }
-      results.push({ path: entry.source.path, outcome, frontmatter: merged.frontmatter });
-      recordsForIncomplete.push(recordFromMerge(merged, entry.source));
+
+      // Reported against the path the record actually ends up at, so a `--rename` run
+      // is clean and an in-place run points at the file the user has to fix.
+      if (isNested) {
+        findings.push(undiscoverableFinding(entry.source.path, id, UNDISCOVERABLE_NESTED));
+      } else if (needsRename && !willRename) {
+        findings.push(undiscoverableFinding(entry.source.path, id, UNDISCOVERABLE_FILENAME));
+      }
+
+      results.push({
+        path: entry.source.path,
+        outcome,
+        frontmatter: merged.frontmatter,
+        ...(willRename ? { renamedTo: finalPath } : {}),
+      });
+      recordsForIncomplete.push({ ...recordFromMerge(merged, entry.source), path: finalPath });
     } catch (error) {
       if (error instanceof MadrMergeError) {
         results.push({ path: entry.source.path, outcome: 'skipped' });

--- a/packages/core/src/import/madr.ts
+++ b/packages/core/src/import/madr.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { basename, isAbsolute, join, resolve } from 'node:path';
 import { FrontmatterError, parseFrontmatter } from '../parse/frontmatter.ts';
-import { normalizeDisplayPath } from '../load/corpus.ts';
+import { isConventionalNonRecordFileName, normalizeDisplayPath } from '../load/corpus.ts';
 
 export interface MadrSourceFile {
   kind: 'madr';
@@ -11,6 +11,12 @@ export interface MadrSourceFile {
   body: string;
   source: string;
   title?: string;
+  /**
+   * Fields recovered from the markdown body for MADR dialects that do not carry YAML
+   * frontmatter. Consulted only when the corresponding frontmatter key is absent, so
+   * frontmatter always wins and an already-migrated file re-migrates identically.
+   */
+  bodyFields: MadrBodyFields;
 }
 
 export interface NotMadrFile {
@@ -43,6 +49,83 @@ export function extractMadrTitle(frontmatter: Record<string, unknown>, body: str
   return title && title.length > 0 ? title : undefined;
 }
 
+/** Fields the body-dialect readers can recover when YAML frontmatter does not carry them. */
+export interface MadrBodyFields {
+  status?: string;
+  date?: string;
+}
+
+/**
+ * The MADR 2.x header-bullet region: everything before the first `##` section heading.
+ * Restricting the bullet scan to this region keeps a `Status:`-shaped line in ordinary
+ * prose (Context, Consequences, …) from being mistaken for the record's status.
+ */
+function headerRegion(body: string): string {
+  const heading = /^##[^\n]*$/m.exec(body);
+  return heading?.index === undefined ? body : body.slice(0, heading.index);
+}
+
+/**
+ * Upper bound on a field value before cleaning. Real `Status:`/`Date:` values are a few
+ * dozen characters; the cap keeps a pathological one-line file from driving the cleanup
+ * regexes over megabytes of attacker-supplied text.
+ */
+const MAX_FIELD_VALUE_LENGTH = 512;
+
+/**
+ * Strip the markdown decoration MADR corpora put around a field value — bold/italic
+ * runs, inline code, link syntax, and a trailing period — without touching the words.
+ * Every character class here is negated on both delimiters so no pattern can rescan the
+ * remainder of the string from each start position.
+ */
+function cleanFieldValue(value: string): string {
+  return value
+    .slice(0, MAX_FIELD_VALUE_LENGTH)
+    .replace(/`/g, '')
+    .replace(/\*\*|__/g, '')
+    .replace(/\[([^[\]]*)\]\([^()]*\)/g, '$1')
+    .replace(/^[[<]+|[\]>]+$/g, '')
+    .replace(/[.,;]+$/, '')
+    .trim();
+}
+
+/** `* Status: accepted`, `- Date: 2025-03-14`, `**Status:** accepted` — MADR 2.x. */
+function headerBulletValue(region: string, field: 'status' | 'date'): string | undefined {
+  const pattern = new RegExp(`^[ \\t]*(?:[*+-][ \\t]+)?\\*{0,2}_{0,2}${field}_{0,2}\\*{0,2}[ \\t]*:[ \\t]*(.+)$`, 'im');
+  const value = cleanFieldValue(pattern.exec(region)?.[1] ?? '');
+  return value.length > 0 ? value : undefined;
+}
+
+/** `## Status` followed by the value on its own line — the Nygard dialect. */
+function sectionValue(body: string, field: 'status' | 'date'): string | undefined {
+  const heading = new RegExp(`^#{2,6}[ \\t]+${field}[ \\t]*#*[ \\t]*$`, 'im').exec(body);
+  if (!heading) return undefined;
+
+  const rest = body.slice(heading.index + heading[0].length);
+  for (const line of rest.split('\n')) {
+    if (/^#{1,6}[ \t]/.test(line)) break;
+    const value = cleanFieldValue(line);
+    if (value.length > 0) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Recover `status` and `date` from the two widely deployed MADR dialects that keep them
+ * in the body rather than in YAML frontmatter: MADR 2.x header bullets and Nygard
+ * `## Status` sections. Without this, both dialects import as `proposed` dated
+ * `1970-01-01` — a silent downgrade of decisions that were already accepted (#40).
+ */
+export function extractMadrBodyFields(body: string): MadrBodyFields {
+  const region = headerRegion(body);
+  const status = headerBulletValue(region, 'status') ?? sectionValue(body, 'status');
+  const date = headerBulletValue(region, 'date') ?? sectionValue(body, 'date');
+  return {
+    ...(status !== undefined ? { status } : {}),
+    ...(date !== undefined ? { date } : {}),
+  };
+}
+
 function notMadr(path: string, absolutePath: string, reason: string): NotMadrFile {
   return { kind: 'not-madr', path, absolutePath, reason };
 }
@@ -65,6 +148,7 @@ export async function readMadrFile(path: string, cwd = process.cwd()): Promise<R
         body: parsed.body,
         source,
         title: extractMadrTitle(frontmatter, parsed.body),
+        bodyFields: extractMadrBodyFields(parsed.body),
       };
     } catch (error) {
       const reason = error instanceof FrontmatterError ? error.message : String(error);
@@ -85,6 +169,7 @@ export async function readMadrFile(path: string, cwd = process.cwd()): Promise<R
     body: source,
     source,
     title,
+    bodyFields: extractMadrBodyFields(source),
   };
 }
 
@@ -95,7 +180,10 @@ async function discoverMarkdownFilesInDir(dir: string): Promise<string[]> {
     const path = join(dir, entry.name);
     if (entry.isDirectory()) {
       files.push(...(await discoverMarkdownFilesInDir(path)));
-    } else if (entry.isFile() && entry.name.endsWith('.md') && entry.name !== '0000-template.md') {
+    } else if (entry.isFile() && entry.name.endsWith('.md') && !isConventionalNonRecordFileName(entry.name)) {
+      // Conventional corpus documentation (README, CONTRIBUTING, the template) is never
+      // a migration candidate: rewriting it would be wrong, and `--rename` would move
+      // it out from under every inbound link.
       files.push(path);
     }
   }

--- a/packages/core/src/import/merge.ts
+++ b/packages/core/src/import/merge.ts
@@ -19,6 +19,8 @@ export interface MergeMadrOptions {
   id: string;
   sourceRef: string;
   fingerprint: string;
+  /** See {@link MadrStatusContext.resolveSupersededRef}. */
+  resolveSupersededRef?: (ref: string) => string | undefined;
 }
 
 export interface MergeMadrResult {
@@ -141,6 +143,24 @@ function titleFinding(path: string, id?: string): Finding {
   };
 }
 
+const EPOCH_DATE = '1970-01-01';
+
+/**
+ * `date` is required by the schema, so a source that declares none gets the epoch
+ * sentinel. Report it rather than writing a plausible-looking but fabricated date —
+ * a record dated 1970-01-01 that nobody was told about is worse than a warning.
+ */
+function missingDateFinding(path: string, id?: string): Finding {
+  return {
+    rule: 'import-date-missing',
+    severity: 'warn',
+    message: `MADR source declares no date; using "${EPOCH_DATE}" as a placeholder — backfill the real decision date`,
+    path,
+    id,
+    field: 'date',
+  };
+}
+
 function importedAtFrom(value: unknown): string | undefined {
   if (!isRecord(value)) return undefined;
   const importedFrom = value.importedFrom;
@@ -171,13 +191,20 @@ function provenanceFrom(raw: MutableRecord, sourceRef: string, fingerprint: stri
 
 function initialCandidate(options: MergeMadrOptions, findings: Finding[]): MutableRecord {
   const raw = options.source.frontmatter;
+  const bodyFields = options.source.bodyFields ?? {};
   const id = isValidId(raw.id) ? raw.id : options.id;
   const title = options.source.title;
   if (!title || title.length < 3 || title.length > 120) {
     throw new MadrMergeError('MADR source is missing a usable title', [titleFinding(options.source.path, id)]);
   }
 
-  const status = mapMadrStatus(raw.status, { path: options.source.path, id });
+  // Frontmatter first; the body dialects (MADR 2.x bullets, Nygard sections) are the
+  // fallback so a migrated file re-migrates to exactly the same frontmatter (#40).
+  const status = mapMadrStatus(raw.status ?? bodyFields.status, {
+    path: options.source.path,
+    id,
+    ...(options.resolveSupersededRef ? { resolveSupersededRef: options.resolveSupersededRef } : {}),
+  });
   findings.push(...status.findings);
 
   const candidate: MutableRecord = {};
@@ -189,7 +216,12 @@ function initialCandidate(options: MergeMadrOptions, findings: Finding[]): Mutab
   candidate.id = id;
   candidate.title = title;
   candidate.status = status.status;
-  candidate.date = dateFrom(raw.date) ?? dateFrom(raw.created) ?? '1970-01-01';
+  const date = dateFrom(raw.date) ?? dateFrom(raw.created) ?? dateFrom(bodyFields.date);
+  if (date === undefined) findings.push(missingDateFinding(options.source.path, id));
+  candidate.date = date ?? EPOCH_DATE;
+  if (status.supersededBy !== undefined && candidate.supersededBy === undefined) {
+    candidate.supersededBy = status.supersededBy;
+  }
 
   for (const [key, value] of Object.entries(FALLBACKS)) {
     if (!(key in candidate) || candidate[key] === undefined || candidate[key] === null) {

--- a/packages/core/src/import/status.ts
+++ b/packages/core/src/import/status.ts
@@ -14,7 +14,22 @@ const STATUS_SET = new Set<string>(MADR_RECOGNIZED_STATUSES);
 
 export interface MadrStatusMapping {
   status: AdrFrontmatter['status'];
+  /** Set only when the source expressed status as `superseded by <ref>` (MADR 2.x). */
+  supersededBy?: string;
   findings: Finding[];
+}
+
+export interface MadrStatusContext {
+  path: string;
+  id?: string;
+  /**
+   * Maps a reference scraped from a `superseded by <ref>` status into the id space of
+   * the corpus being written. A scraped number belongs to the *source* project's
+   * numbering, which is not the numbering migration allocates, so without a resolver
+   * the form is treated as unrecognized rather than pointed at whatever record happens
+   * to hold that number. Return `undefined` to reject a reference.
+   */
+  resolveSupersededRef?: (ref: string) => string | undefined;
 }
 
 function rawStatusText(status: unknown): string | undefined {
@@ -23,11 +38,32 @@ function rawStatusText(status: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-export function mapMadrStatus(status: unknown, context: { path: string; id?: string }): MadrStatusMapping {
+/**
+ * MADR 2.x writes supersession into the status itself — `superseded by [ADR-0005](…)`.
+ * Recognize it only when a reference can be recovered *and* resolved, because the
+ * schema requires `supersededBy` whenever status is `superseded`; an unresolvable
+ * reference stays unrecognized and is reported rather than silently coerced into an
+ * edge that points at the wrong record.
+ */
+function supersededByRef(normalized: string, context: MadrStatusContext): string | undefined {
+  if (!/^superse(?:ded|des)\s+by\b/.test(normalized)) return undefined;
+  const scraped = /\b(\d{4,})\b/.exec(normalized)?.[1];
+  if (!scraped) return undefined;
+  const resolved = context.resolveSupersededRef?.(scraped);
+  // A record cannot supersede itself.
+  return resolved && resolved !== context.id ? resolved : undefined;
+}
+
+export function mapMadrStatus(status: unknown, context: MadrStatusContext): MadrStatusMapping {
   const raw = rawStatusText(status);
   const normalized = raw?.toLowerCase();
   if (normalized && STATUS_SET.has(normalized)) {
     return { status: normalized as AdrFrontmatter['status'], findings: [] };
+  }
+
+  if (normalized) {
+    const ref = supersededByRef(normalized, context);
+    if (ref) return { status: 'superseded', supersededBy: ref, findings: [] };
   }
 
   return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from './schema/index.ts';
 export * from './schema/ref.ts';
 export * from './parse/frontmatter.ts';
 export * from './load/corpus.ts';
+export * from './status/bucket.ts';
 export * from './validate/findings.ts';
 export * from './validate/contract.ts';
 export * from './validate/corpus-invariants.ts';

--- a/packages/core/src/load/corpus.ts
+++ b/packages/core/src/load/corpus.ts
@@ -6,6 +6,18 @@ import { parseFrontmatter } from '../parse/frontmatter.ts';
 export const RECORD_FILE_PATTERN = /^[0-9]{4,}-.+\.md$/;
 export const TEMPLATE_FILE_NAME = '0000-template.md';
 
+/**
+ * Conventional non-record markdown that legitimately lives alongside a corpus. These
+ * are not reported as skipped records, so the `corpus-file-skipped` warning stays
+ * signal rather than noise — and migration never rewrites or moves them.
+ */
+const NON_RECORD_FILE_NAMES = new Set(['readme.md', 'index.md', 'contributing.md', 'template.md']);
+
+/** Whether a markdown filename is conventional corpus documentation rather than a record. */
+export function isConventionalNonRecordFileName(fileName: string): boolean {
+  return fileName === TEMPLATE_FILE_NAME || NON_RECORD_FILE_NAMES.has(fileName.toLowerCase());
+}
+
 export interface ParsedAdrFile {
   data: unknown;
   body: string;
@@ -37,6 +49,28 @@ export async function discoverAdrFiles(dir = 'docs/adr', cwd = process.cwd()): P
   const entries = await readdir(absoluteDir, { withFileTypes: true });
   return entries
     .filter((entry) => entry.isFile() && isRecordFileName(entry.name))
+    .map((entry) => join(absoluteDir, entry.name))
+    .sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+}
+
+/**
+ * Markdown files in the corpus directory that {@link discoverAdrFiles} skipped because
+ * their filename does not match {@link RECORD_FILE_PATTERN}. Surfacing these is what
+ * keeps "checked 0 records" from being silently reported as a healthy corpus when a
+ * migrated or hand-authored record is simply misnamed (#41).
+ */
+export async function discoverSkippedMarkdownFiles(dir = 'docs/adr', cwd = process.cwd()): Promise<string[]> {
+  const absoluteDir = toAbsolutePath(dir, cwd);
+  const entries = await readdir(absoluteDir, { withFileTypes: true }).catch(() => []);
+  return entries
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        entry.name.endsWith('.md') &&
+        !entry.name.startsWith('.') &&
+        !isConventionalNonRecordFileName(entry.name) &&
+        !isRecordFileName(entry.name),
+    )
     .map((entry) => join(absoluteDir, entry.name))
     .sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
 }

--- a/packages/core/src/load/corpus.ts
+++ b/packages/core/src/load/corpus.ts
@@ -54,25 +54,60 @@ export async function discoverAdrFiles(dir = 'docs/adr', cwd = process.cwd()): P
 }
 
 /**
- * Markdown files in the corpus directory that {@link discoverAdrFiles} skipped because
- * their filename does not match {@link RECORD_FILE_PATTERN}. Surfacing these is what
- * keeps "checked 0 records" from being silently reported as a healthy corpus when a
- * migrated or hand-authored record is simply misnamed (#41).
+ * Why {@link discoverAdrFiles} did not pick a markdown file up: its filename does not
+ * match the record grammar, or it sits in a subdirectory that discovery never reads.
  */
-export async function discoverSkippedMarkdownFiles(dir = 'docs/adr', cwd = process.cwd()): Promise<string[]> {
-  const absoluteDir = toAbsolutePath(dir, cwd);
+export type SkippedMarkdownReason = 'filename' | 'nested';
+
+export interface SkippedMarkdownFile {
+  path: string;
+  reason: SkippedMarkdownReason;
+}
+
+/**
+ * Depth cap for the skipped-file scan. Corpora are flat by construction; this only
+ * bounds the walk over an unexpected tree so a deep or generated directory cannot turn
+ * a lint run into a full-repository traversal.
+ */
+const MAX_SKIP_SCAN_DEPTH = 8;
+
+async function collectSkippedMarkdown(
+  absoluteDir: string,
+  depth: number,
+  found: SkippedMarkdownFile[],
+): Promise<void> {
+  // Symlinked directories report `isDirectory() === false`, so the walk cannot loop.
   const entries = await readdir(absoluteDir, { withFileTypes: true }).catch(() => []);
-  return entries
-    .filter(
-      (entry) =>
-        entry.isFile() &&
-        entry.name.endsWith('.md') &&
-        !entry.name.startsWith('.') &&
-        !isConventionalNonRecordFileName(entry.name) &&
-        !isRecordFileName(entry.name),
-    )
-    .map((entry) => join(absoluteDir, entry.name))
-    .sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+  for (const entry of entries) {
+    const path = join(absoluteDir, entry.name);
+    if (entry.isDirectory()) {
+      if (!entry.name.startsWith('.') && depth < MAX_SKIP_SCAN_DEPTH) {
+        await collectSkippedMarkdown(path, depth + 1, found);
+      }
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.md') || entry.name.startsWith('.')) continue;
+    if (isConventionalNonRecordFileName(entry.name)) continue;
+    // Below the top level, discovery cannot see the file whatever it is called.
+    if (depth > 0) found.push({ path, reason: 'nested' });
+    else if (!isRecordFileName(entry.name)) found.push({ path, reason: 'filename' });
+  }
+}
+
+/**
+ * Markdown under the corpus directory that {@link discoverAdrFiles} skipped — either
+ * because the filename does not match {@link RECORD_FILE_PATTERN} or because the file
+ * is nested and discovery reads only the top level. Surfacing these is what keeps
+ * "checked 0 records" from being silently reported as a healthy corpus when a migrated
+ * or hand-authored record is simply misplaced or misnamed (#41).
+ */
+export async function discoverSkippedMarkdownFiles(
+  dir = 'docs/adr',
+  cwd = process.cwd(),
+): Promise<SkippedMarkdownFile[]> {
+  const found: SkippedMarkdownFile[] = [];
+  await collectSkippedMarkdown(toAbsolutePath(dir, cwd), 0, found);
+  return found.sort((a, b) => normalizeDisplayPath(a.path, cwd).localeCompare(normalizeDisplayPath(b.path, cwd)));
 }
 
 export async function expandRecordInputs(

--- a/packages/core/src/status/bucket.ts
+++ b/packages/core/src/status/bucket.ts
@@ -1,0 +1,23 @@
+/**
+ * @adrkit/core — the single definition of "does this record govern?".
+ *
+ * Every surface that answers that question — `adr check`, `adr explain`, the
+ * `@adrkit/ci` Action, and `@adrkit/mcp`'s `get_decision_context` — routes through
+ * this function, so the same corpus cannot be status-aware over one surface and
+ * status-blind over another.
+ *
+ * Only `accepted` records govern. `draft` and `proposed` are live proposals that have
+ * not been ratified; `rejected`, `superseded`, and `deprecated` are history, and
+ * reporting them as governing tells a reviewer that a decision the organization
+ * explicitly walked away from still binds their change.
+ */
+
+import type { Status } from '../schema/adr.schema.ts';
+
+export type DecisionBucket = 'governing' | 'activeProposals' | 'history';
+
+export function decisionBucketFor(status: Status | string): DecisionBucket {
+  if (status === 'accepted') return 'governing';
+  if (status === 'draft' || status === 'proposed') return 'activeProposals';
+  return 'history';
+}

--- a/packages/core/src/validate/findings.ts
+++ b/packages/core/src/validate/findings.ts
@@ -1,6 +1,8 @@
 export const IMPORT_FINDING_RULES = [
   'import-incomplete',
   'import-status-unrecognized',
+  'import-date-missing',
+  'import-undiscoverable',
   'import-not-madr',
 ] as const;
 

--- a/packages/core/src/validate/index.ts
+++ b/packages/core/src/validate/index.ts
@@ -1,4 +1,12 @@
-import { parseAdrFile, expandRecordInputs, discoverSkippedMarkdownFiles, normalizeDisplayPath } from '../load/corpus.ts';
+import { stat } from 'node:fs/promises';
+import { isAbsolute, resolve } from 'node:path';
+import {
+  parseAdrFile,
+  expandRecordInputs,
+  discoverSkippedMarkdownFiles,
+  normalizeDisplayPath,
+  type SkippedMarkdownFile,
+} from '../load/corpus.ts';
 import type { Adr } from '../schema/adr.schema.ts';
 import { FrontmatterError } from '../parse/frontmatter.ts';
 import { validateParsedAdr } from './contract.ts';
@@ -38,18 +46,51 @@ function parseErrorFinding(error: unknown, path: string): Finding {
 }
 
 /**
- * Warn about markdown in the corpus directory that discovery skipped. Without this a
- * corpus whose records are all misnamed lints as `checked 0 records, 0 errors` at exit
- * 0 — a false clean bill of health for a corpus that governs nothing (#41).
+ * Warn about markdown under a scanned corpus directory that discovery skipped. Without
+ * this a corpus whose records are all misnamed — or all tucked into a subdirectory —
+ * lints as `checked 0 records, 0 errors` at exit 0: a false clean bill of health for a
+ * corpus that governs nothing (#41).
  */
-function skippedFileFinding(path: string): Finding {
+function skippedFileFinding(skipped: SkippedMarkdownFile, cwd: string): Finding {
+  const message =
+    skipped.reason === 'nested'
+      ? 'Markdown file is in a subdirectory of the corpus, and discovery reads only the top level of the corpus directory; move it to the corpus root as <id>-<slug>.md for it to be linted and enforced'
+      : 'Markdown file in the corpus directory is not a discoverable ADR record and was skipped; rename it to <id>-<slug>.md (four or more leading digits) for it to be linted and enforced';
   return {
     rule: 'corpus-file-skipped',
     severity: 'warn',
-    message:
-      'Markdown file in the corpus directory is not a discoverable ADR record and was skipped; rename it to <id>-<slug>.md (four or more leading digits) for it to be linted and enforced',
-    path,
+    message,
+    path: normalizeDisplayPath(skipped.path, cwd),
   };
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  return stat(path).then(
+    (info) => info.isDirectory(),
+    () => false,
+  );
+}
+
+/**
+ * The directories a run actually scans: the corpus `dir` when no paths were given, and
+ * otherwise every positional that is a directory. `expandRecordInputs` expands those
+ * through `discoverAdrFiles`, which drops misnamed children — so `adr lint docs/adr`
+ * needs the same skipped-file reporting a bare `adr lint` gets. Explicit *file*
+ * positionals are the caller's own choice and are never reported as skipped.
+ */
+async function scannedDirectories(
+  paths: string[] | undefined,
+  dir: string,
+  cwd: string,
+): Promise<string[]> {
+  if (!paths || paths.length === 0) return [dir];
+
+  const directories = new Set<string>();
+  for (const path of paths) {
+    const absolutePath = isAbsolute(path) ? path : resolve(cwd, path);
+    if (await isDirectory(absolutePath)) directories.add(absolutePath);
+  }
+  return [...directories].sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
 }
 
 export async function lintCorpus(options: LintCorpusOptions = {}): Promise<LintCorpusResult> {
@@ -73,11 +114,12 @@ export async function lintCorpus(options: LintCorpusOptions = {}): Promise<LintC
     }
   }
 
-  // Only when scanning the corpus directory. Explicit paths are the caller's choice,
-  // so nothing there was "skipped".
-  if (!options.paths || options.paths.length === 0) {
-    for (const skipped of await discoverSkippedMarkdownFiles(dir, cwd)) {
-      findings.push(skippedFileFinding(normalizeDisplayPath(skipped, cwd)));
+  // Every directory this run scans, so an explicit directory positional gets the same
+  // reporting a bare corpus scan does.
+  const checkedPaths = new Set(files);
+  for (const scanned of await scannedDirectories(options.paths, dir, cwd)) {
+    for (const skipped of await discoverSkippedMarkdownFiles(scanned, cwd)) {
+      if (!checkedPaths.has(skipped.path)) findings.push(skippedFileFinding(skipped, cwd));
     }
   }
 

--- a/packages/core/src/validate/index.ts
+++ b/packages/core/src/validate/index.ts
@@ -1,4 +1,4 @@
-import { parseAdrFile, expandRecordInputs, normalizeDisplayPath } from '../load/corpus.ts';
+import { parseAdrFile, expandRecordInputs, discoverSkippedMarkdownFiles, normalizeDisplayPath } from '../load/corpus.ts';
 import type { Adr } from '../schema/adr.schema.ts';
 import { FrontmatterError } from '../parse/frontmatter.ts';
 import { validateParsedAdr } from './contract.ts';
@@ -37,9 +37,25 @@ function parseErrorFinding(error: unknown, path: string): Finding {
   };
 }
 
+/**
+ * Warn about markdown in the corpus directory that discovery skipped. Without this a
+ * corpus whose records are all misnamed lints as `checked 0 records, 0 errors` at exit
+ * 0 — a false clean bill of health for a corpus that governs nothing (#41).
+ */
+function skippedFileFinding(path: string): Finding {
+  return {
+    rule: 'corpus-file-skipped',
+    severity: 'warn',
+    message:
+      'Markdown file in the corpus directory is not a discoverable ADR record and was skipped; rename it to <id>-<slug>.md (four or more leading digits) for it to be linted and enforced',
+    path,
+  };
+}
+
 export async function lintCorpus(options: LintCorpusOptions = {}): Promise<LintCorpusResult> {
   const cwd = options.cwd ?? process.cwd();
-  const files = await expandRecordInputs(options.paths, options.dir ?? 'docs/adr', cwd);
+  const dir = options.dir ?? 'docs/adr';
+  const files = await expandRecordInputs(options.paths, dir, cwd);
   const records: Adr[] = [];
   const findings: Finding[] = [];
 
@@ -54,6 +70,14 @@ export async function lintCorpus(options: LintCorpusOptions = {}): Promise<LintC
       }
     } catch (error) {
       findings.push(parseErrorFinding(error, displayPath));
+    }
+  }
+
+  // Only when scanning the corpus directory. Explicit paths are the caller's choice,
+  // so nothing there was "skipped".
+  if (!options.paths || options.paths.length === 0) {
+    for (const skipped of await discoverSkippedMarkdownFiles(dir, cwd)) {
+      findings.push(skippedFileFinding(normalizeDisplayPath(skipped, cwd)));
     }
   }
 

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -40,3 +40,25 @@ ${extra}---
 # ADR-${id}: ${title}
 `;
 }
+
+/**
+ * An `accepted` record — the only status that governs. Accepted records need at least
+ * one decider unless they were imported, so one is supplied.
+ */
+export function acceptedRecordMarkdown(id: string, title = `Use test decision ${id}`, extra = ''): string {
+  return recordMarkdown(id, title, extra)
+    .replace('status: draft', 'status: accepted')
+    .replace('deciders: []', 'deciders: ["@tester"]');
+}
+
+/** A `superseded` record, which the schema requires to name its successor. */
+export function supersededRecordMarkdown(
+  id: string,
+  supersededBy: string,
+  title = `Use test decision ${id}`,
+  extra = '',
+): string {
+  return recordMarkdown(id, title, extra)
+    .replace('status: draft', `status: superseded\nsupersededBy: "${supersededBy}"`)
+    .replace('deciders: []', 'deciders: ["@tester"]');
+}

--- a/packages/core/test/migrate-dialects.test.ts
+++ b/packages/core/test/migrate-dialects.test.ts
@@ -155,6 +155,26 @@ describe('migrate --from madr across MADR dialects (#40)', () => {
     );
   });
 
+  test('resolves against a successor imported by an earlier run', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const dir = join(root, 'docs/adr');
+    await writeText(join(dir, '0005-new.md'), '# Use PostgreSQL\n\n* Status: accepted\n* Date: 2025-03-14\n');
+
+    // First run imports only the successor; it is `unchanged` on the second run.
+    await migrateMadr({ cwd: root, dir: 'docs/adr' });
+    await writeText(
+      join(dir, '0001-old.md'),
+      '# Use MySQL\n\n* Status: superseded by [ADR-0005](0005-new.md)\n* Date: 2024-01-02\n',
+    );
+    const second = await migrateMadr({ cwd: root, dir: 'docs/adr' });
+    const frontmatter = await migratedFrontmatter(root, '0001-old.md');
+
+    expect(second.results.find((r) => r.path.endsWith('0005-new.md'))?.outcome).toBe('unchanged');
+    expect(frontmatter.status).toBe('superseded');
+    expect(frontmatter.supersededBy).toBe('0005');
+    expect(second.findings.filter((f) => f.rule === 'import-status-unrecognized')).toEqual([]);
+  });
+
   test('`superseded by` with no recoverable id stays unrecognized rather than being coerced', async () => {
     const root = await resetTestDir(DIR_NAME);
     await writeText(join(root, 'docs/adr/0001-old.md'), '# Use MySQL\n\n* Status: superseded by a later decision\n');

--- a/packages/core/test/migrate-dialects.test.ts
+++ b/packages/core/test/migrate-dialects.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression tests for adrkit#40 — `migrate --from madr` read status and date only
+ * from YAML frontmatter, so MADR 2.x header bullets and Nygard `## Status` sections
+ * silently imported as `proposed` dated `1970-01-01`.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { extractMadrBodyFields, migrateMadr } from '../src/import/index.ts';
+import { parseFrontmatter } from '../src/parse/frontmatter.ts';
+import { cleanupTestDir, resetTestDir, writeText } from './helpers.ts';
+
+const DIR_NAME = 'migrate-dialects';
+
+async function migratedFrontmatter(root: string, file: string): Promise<Record<string, unknown>> {
+  const parsed = parseFrontmatter(await readFile(join(root, 'docs/adr', file), 'utf8'));
+  return parsed.data as Record<string, unknown>;
+}
+
+afterEach(async () => {
+  await cleanupTestDir(DIR_NAME);
+});
+
+describe('extractMadrBodyFields', () => {
+  test('reads the MADR 2.x header bullets', () => {
+    expect(extractMadrBodyFields('# Use PostgreSQL\n\n* Status: accepted\n* Date: 2025-03-14\n')).toEqual({
+      status: 'accepted',
+      date: '2025-03-14',
+    });
+  });
+
+  test('reads a dash bullet and bold field labels', () => {
+    expect(extractMadrBodyFields('# T\n\n- **Status**: accepted\n- **Date**: 2025-03-14\n')).toEqual({
+      status: 'accepted',
+      date: '2025-03-14',
+    });
+  });
+
+  test('reads the Nygard section form', () => {
+    expect(extractMadrBodyFields('# Use PostgreSQL\n\n## Status\n\nAccepted\n\n## Context\n\nx\n')).toEqual({
+      status: 'Accepted',
+    });
+  });
+
+  test('ignores a Status-shaped line in prose below the header region', () => {
+    const body = '# T\n\n## Context\n\n* Status: this sentence is not the record status\n';
+    expect(extractMadrBodyFields(body)).toEqual({});
+  });
+
+  test('an empty Status section yields nothing rather than an empty string', () => {
+    expect(extractMadrBodyFields('# T\n\n## Status\n\n## Context\n\nx\n')).toEqual({});
+  });
+
+  test('a pathological value is capped rather than driving the cleanup regexes', () => {
+    const body = `# T\n\n* Status: accepted ${'['.repeat(200_000)}\n`;
+    const started = performance.now();
+
+    const fields = extractMadrBodyFields(body);
+
+    expect(performance.now() - started).toBeLessThan(1000);
+    expect(fields.status).toBeDefined();
+    expect(fields.status!.length).toBeLessThanOrEqual(512);
+  });
+});
+
+describe('migrate --from madr across MADR dialects (#40)', () => {
+  test('preserves accepted status in all three dialects', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const dir = join(root, 'docs/adr');
+    await writeText(join(dir, '0001-yaml.md'), '---\nstatus: accepted\ndate: 2025-03-14\n---\n# Use PostgreSQL\n');
+    await writeText(join(dir, '0002-bullet.md'), '# Use PostgreSQL\n\n* Status: accepted\n* Date: 2025-03-14\n');
+    await writeText(join(dir, '0003-nygard.md'), '# Use PostgreSQL\n\n## Status\n\naccepted\n');
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr' });
+
+    expect((await migratedFrontmatter(root, '0001-yaml.md')).status).toBe('accepted');
+    expect((await migratedFrontmatter(root, '0002-bullet.md')).status).toBe('accepted');
+    expect((await migratedFrontmatter(root, '0003-nygard.md')).status).toBe('accepted');
+    expect(result.findings.filter((f) => f.rule === 'import-status-unrecognized')).toEqual([]);
+  });
+
+  test('reads the declared date from a header bullet instead of writing the epoch', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(
+      join(root, 'docs/adr/0001-bullet.md'),
+      '# Use PostgreSQL\n\n* Status: accepted\n* Date: 2025-03-14\n',
+    );
+
+    await migrateMadr({ cwd: root, dir: 'docs/adr' });
+
+    expect((await migratedFrontmatter(root, '0001-bullet.md')).date).toBe('2025-03-14');
+  });
+
+  test('a genuinely dateless source still gets the epoch, but is reported', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'docs/adr/0001-nodate.md'), '# Use PostgreSQL\n\n* Status: accepted\n');
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr' });
+
+    expect((await migratedFrontmatter(root, '0001-nodate.md')).date).toBe('1970-01-01');
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({ rule: 'import-date-missing', severity: 'warn', field: 'date' }),
+    );
+  });
+
+  test('`superseded by <ref>` resolves against the migrated corpus', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const dir = join(root, 'docs/adr');
+    await writeText(
+      join(dir, '0001-old.md'),
+      '# Use MySQL\n\n* Status: superseded by [ADR-0005](0005-use-postgresql.md)\n* Date: 2024-01-02\n',
+    );
+    await writeText(join(dir, '0005-new.md'), '# Use PostgreSQL\n\n* Status: accepted\n* Date: 2025-03-14\n');
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr' });
+    const frontmatter = await migratedFrontmatter(root, '0001-old.md');
+
+    expect(frontmatter.status).toBe('superseded');
+    expect(frontmatter.supersededBy).toBe('0005');
+    expect(result.findings.filter((f) => f.rule === 'import-status-unrecognized')).toEqual([]);
+  });
+
+  test('a reference to an id this run does not write is rejected, not pointed at a stranger', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    // The source corpus is unnumbered, so its "ADR-0001" is in a different id space
+    // than the ids migration allocates. Writing it verbatim would fabricate an edge.
+    await writeText(
+      join(root, 'docs/adr/drop-mysql.md'),
+      '# Drop MySQL\n\n* Status: superseded by [ADR-0001](use-postgres.md)\n',
+    );
+    await writeText(join(root, 'docs/adr/use-postgres.md'), '# Use PostgreSQL\n\n* Status: accepted\n');
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr' });
+    const frontmatter = await migratedFrontmatter(root, 'drop-mysql.md');
+
+    expect(frontmatter.status).toBe('proposed');
+    expect(frontmatter.supersededBy).toBeUndefined();
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({ rule: 'import-status-unrecognized', severity: 'warn' }),
+    );
+  });
+
+  test('a record never supersedes itself', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'docs/adr/0001-self.md'), '# Use MySQL\n\n* Status: superseded by ADR-0001\n');
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr' });
+    const frontmatter = await migratedFrontmatter(root, '0001-self.md');
+
+    expect(frontmatter.status).toBe('proposed');
+    expect(frontmatter.supersededBy).toBeUndefined();
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({ rule: 'import-status-unrecognized', severity: 'warn' }),
+    );
+  });
+
+  test('`superseded by` with no recoverable id stays unrecognized rather than being coerced', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'docs/adr/0001-old.md'), '# Use MySQL\n\n* Status: superseded by a later decision\n');
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr' });
+
+    expect((await migratedFrontmatter(root, '0001-old.md')).status).toBe('proposed');
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({ rule: 'import-status-unrecognized', severity: 'warn' }),
+    );
+  });
+
+  test('frontmatter status wins over a conflicting body bullet, so re-migration is a no-op', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const file = join(root, 'docs/adr/0001-bullet.md');
+    await writeText(file, '# Use PostgreSQL\n\n* Status: accepted\n* Date: 2025-03-14\n');
+
+    await migrateMadr({ cwd: root, dir: 'docs/adr' });
+    const afterFirst = await readFile(file, 'utf8');
+    await migrateMadr({ cwd: root, dir: 'docs/adr' });
+
+    expect(await readFile(file, 'utf8')).toBe(afterFirst);
+  });
+
+  test('the MADR 2.x template placeholder is not mistaken for a real status', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(
+      join(root, 'docs/adr/0001-placeholder.md'),
+      '# Use PostgreSQL\n\n* Status: [proposed | rejected | accepted | deprecated]\n',
+    );
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr' });
+
+    expect((await migratedFrontmatter(root, '0001-placeholder.md')).status).toBe('proposed');
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({ rule: 'import-status-unrecognized', severity: 'warn' }),
+    );
+  });
+});

--- a/packages/core/test/migrate-discoverability.test.ts
+++ b/packages/core/test/migrate-discoverability.test.ts
@@ -35,7 +35,23 @@ describe('discoverSkippedMarkdownFiles', () => {
 
     const skipped = await discoverSkippedMarkdownFiles(join(root, 'docs/adr'), root);
 
-    expect(skipped.map((p) => p.split('/').pop())).toEqual(['a-yaml.md', 'b-bullet.md', 'c-nygard.md']);
+    expect(skipped.map((s) => s.path.split('/').pop())).toEqual(['a-yaml.md', 'b-bullet.md', 'c-nygard.md']);
+    expect(skipped.every((s) => s.reason === 'filename')).toBe(true);
+  });
+
+  test('reports nested markdown regardless of filename, since discovery never reads it', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'docs/adr/0001-top.md'), SOURCE);
+    await writeText(join(root, 'docs/adr/nested/0002-deep.md'), SOURCE);
+    await writeText(join(root, 'docs/adr/nested/deeper/0003-deeper.md'), SOURCE);
+
+    const skipped = await discoverSkippedMarkdownFiles(join(root, 'docs/adr'), root);
+
+    expect(skipped.map((s) => s.path.split('/').slice(-2).join('/'))).toEqual([
+      'nested/0002-deep.md',
+      'deeper/0003-deeper.md',
+    ]);
+    expect(skipped.every((s) => s.reason === 'nested')).toBe(true);
   });
 
   test('does not report records, the template, or conventional companion files', async () => {
@@ -67,12 +83,43 @@ describe('lint visibility of skipped files (#41)', () => {
     expect(result.findings.every((f) => f.severity !== 'error')).toBe(true);
   });
 
-  test('explicit paths are the caller\u2019s choice and are never reported as skipped', async () => {
+  test('a corpus whose only records are nested is not reported as clean', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'docs/adr/nested/0001-decision.md'), SOURCE);
+
+    const result = await lintCorpus({ cwd: root, dir: 'docs/adr' });
+    const skipped = result.findings.filter((f) => f.rule === 'corpus-file-skipped');
+
+    expect(result.checked).toBe(0);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]?.message).toContain('subdirectory');
+  });
+
+  test('an explicit directory positional is scanned like a bare corpus run', async () => {
+    const root = await seedUndiscoverableCorpus();
+
+    const result = await lintCorpus({ cwd: root, dir: 'docs/adr', paths: [join(root, 'docs/adr')] });
+
+    expect(result.checked).toBe(0);
+    expect(result.findings.filter((f) => f.rule === 'corpus-file-skipped')).toHaveLength(3);
+  });
+
+  test('explicit file positionals are the caller\u2019s choice and are never reported as skipped', async () => {
     const root = await seedUndiscoverableCorpus();
 
     const result = await lintCorpus({ cwd: root, dir: 'docs/adr', paths: [join(root, 'docs/adr/a-yaml.md')] });
 
     expect(result.findings.filter((f) => f.rule === 'corpus-file-skipped')).toEqual([]);
+  });
+
+  test('a file that was explicitly checked is not also reported as skipped', async () => {
+    const root = await seedUndiscoverableCorpus();
+    const dir = join(root, 'docs/adr');
+
+    const result = await lintCorpus({ cwd: root, dir: 'docs/adr', paths: [dir, join(dir, 'a-yaml.md')] });
+    const skipped = result.findings.filter((f) => f.rule === 'corpus-file-skipped');
+
+    expect(skipped.map((f) => f.path)).toEqual(['docs/adr/b-bullet.md', 'docs/adr/c-nygard.md']);
   });
 });
 

--- a/packages/core/test/migrate-discoverability.test.ts
+++ b/packages/core/test/migrate-discoverability.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Regression tests for adrkit#41 — `migrate --from madr` wrote records under filenames
+ * corpus discovery cannot see, so migration reported success while `lint` reported
+ * `checked 0 records, 0 errors` at exit 0: a silent false bill of governance health.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { migrateMadr } from '../src/import/index.ts';
+import { discoverSkippedMarkdownFiles } from '../src/load/corpus.ts';
+import { lintCorpus } from '../src/validate/index.ts';
+import { cleanupTestDir, resetTestDir, writeText } from './helpers.ts';
+
+const DIR_NAME = 'migrate-discoverability';
+
+const SOURCE = '# Use PostgreSQL\n\n* Status: accepted\n* Date: 2025-03-14\n';
+
+async function seedUndiscoverableCorpus(): Promise<string> {
+  const root = await resetTestDir(DIR_NAME);
+  const dir = join(root, 'docs/adr');
+  for (const name of ['a-yaml.md', 'b-bullet.md', 'c-nygard.md']) {
+    await writeText(join(dir, name), SOURCE);
+  }
+  return root;
+}
+
+afterEach(async () => {
+  await cleanupTestDir(DIR_NAME);
+});
+
+describe('discoverSkippedMarkdownFiles', () => {
+  test('reports markdown that the record-filename grammar excludes', async () => {
+    const root = await seedUndiscoverableCorpus();
+
+    const skipped = await discoverSkippedMarkdownFiles(join(root, 'docs/adr'), root);
+
+    expect(skipped.map((p) => p.split('/').pop())).toEqual(['a-yaml.md', 'b-bullet.md', 'c-nygard.md']);
+  });
+
+  test('does not report records, the template, or conventional companion files', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const dir = join(root, 'docs/adr');
+    await writeText(join(dir, '0001-real.md'), SOURCE);
+    await writeText(join(dir, '0000-template.md'), SOURCE);
+    await writeText(join(dir, 'README.md'), '# Corpus readme\n');
+    await writeText(join(dir, 'index.md'), '# Index\n');
+
+    expect(await discoverSkippedMarkdownFiles(dir, root)).toEqual([]);
+  });
+
+  test('a missing directory yields no findings rather than throwing', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    expect(await discoverSkippedMarkdownFiles(join(root, 'nope'), root)).toEqual([]);
+  });
+});
+
+describe('lint visibility of skipped files (#41)', () => {
+  test('"checked 0 records" is never silent', async () => {
+    const root = await seedUndiscoverableCorpus();
+
+    const result = await lintCorpus({ cwd: root, dir: 'docs/adr' });
+
+    expect(result.checked).toBe(0);
+    expect(result.findings.filter((f) => f.rule === 'corpus-file-skipped')).toHaveLength(3);
+    // Warn, not error: a misnamed file is a gap to close, not a corpus that fails to parse.
+    expect(result.findings.every((f) => f.severity !== 'error')).toBe(true);
+  });
+
+  test('explicit paths are the caller\u2019s choice and are never reported as skipped', async () => {
+    const root = await seedUndiscoverableCorpus();
+
+    const result = await lintCorpus({ cwd: root, dir: 'docs/adr', paths: [join(root, 'docs/adr/a-yaml.md')] });
+
+    expect(result.findings.filter((f) => f.rule === 'corpus-file-skipped')).toEqual([]);
+  });
+});
+
+describe('migrate discoverability reporting (#41)', () => {
+  test('an in-place migration that produces an invisible record says so', async () => {
+    const root = await seedUndiscoverableCorpus();
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr' });
+
+    expect(result.results.filter((r) => r.outcome === 'migrated')).toHaveLength(3);
+    const undiscoverable = result.findings.filter((f) => f.rule === 'import-undiscoverable');
+    expect(undiscoverable).toHaveLength(3);
+    expect(undiscoverable[0]).toMatchObject({ severity: 'warn', field: 'path' });
+  });
+
+  test('a corpus that already uses record filenames reports nothing', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'docs/adr/0001-postgres.md'), SOURCE);
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr' });
+
+    expect(result.findings.filter((f) => f.rule === 'import-undiscoverable')).toEqual([]);
+  });
+
+  test('--rename writes <id>-<slug>.md and the corpus becomes visible', async () => {
+    const root = await seedUndiscoverableCorpus();
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr', rename: true });
+    const files = (await readdir(join(root, 'docs/adr'))).sort();
+    const lint = await lintCorpus({ cwd: root, dir: 'docs/adr' });
+
+    expect(files).toEqual(['0001-use-postgresql.md', '0002-use-postgresql.md', '0003-use-postgresql.md']);
+    expect(result.results.every((r) => r.renamedTo !== undefined)).toBe(true);
+    expect(result.findings.filter((f) => f.rule === 'import-undiscoverable')).toEqual([]);
+    expect(lint.checked).toBe(3);
+    expect(lint.findings.filter((f) => f.rule === 'corpus-file-skipped')).toEqual([]);
+  });
+
+  test('--rename leaves an already-discoverable filename untouched', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'docs/adr/0001-some-other-slug.md'), SOURCE);
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr', rename: true });
+
+    expect(await readdir(join(root, 'docs/adr'))).toEqual(['0001-some-other-slug.md']);
+    expect(result.results[0]?.renamedTo).toBeUndefined();
+  });
+
+  test('--dry-run with --rename does not touch the filesystem', async () => {
+    const root = await seedUndiscoverableCorpus();
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr', rename: true, write: false });
+
+    expect((await readdir(join(root, 'docs/adr'))).sort()).toEqual(['a-yaml.md', 'b-bullet.md', 'c-nygard.md']);
+    expect(result.results.every((r) => r.renamedTo !== undefined)).toBe(true);
+  });
+
+  test('--rename never clobbers a file already occupying the target name', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const dir = join(root, 'docs/adr');
+    // A source that pins its own id, so its rename target is predictable.
+    await writeText(
+      join(dir, 'a-source.md'),
+      '---\nid: "0001"\nstatus: accepted\ndate: 2025-03-14\n---\n# Use PostgreSQL\n',
+    );
+    await writeText(join(dir, '0001-use-postgresql.md'), '# Pre-existing unrelated record\n');
+
+    // Scoped to the one source, so the occupying file is not itself migrated.
+    const result = await migrateMadr({
+      cwd: root,
+      dir: 'docs/adr',
+      rename: true,
+      files: [join(dir, 'a-source.md')],
+    });
+
+    expect(await readFile(join(dir, '0001-use-postgresql.md'), 'utf8')).toContain('Pre-existing unrelated record');
+    expect((await readdir(dir)).sort()).toContain('a-source.md');
+    expect(result.results[0]?.renamedTo).toBeUndefined();
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({ rule: 'import-undiscoverable', severity: 'warn' }),
+    );
+  });
+
+  test('a record in a corpus subdirectory is reported as undiscoverable and is not renamed', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'docs/adr/nested/0001-deep.md'), SOURCE);
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr', rename: true });
+
+    expect(await readdir(join(root, 'docs/adr/nested'))).toEqual(['0001-deep.md']);
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        rule: 'import-undiscoverable',
+        severity: 'warn',
+        message: expect.stringContaining('subdirectory'),
+      }),
+    );
+  });
+
+  test('conventional corpus documentation is never migrated or moved', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const dir = join(root, 'docs/adr');
+    const readme = '# Architecture decision records\n\nSee [CONTRIBUTING.md](CONTRIBUTING.md).\n';
+    await writeText(join(dir, 'README.md'), readme);
+    await writeText(join(dir, 'CONTRIBUTING.md'), '# How to write an ADR\n');
+    await writeText(join(dir, 'index.md'), '# Index\n');
+    await writeText(join(dir, '0000-template.md'), '# Template\n');
+    await writeText(join(dir, '0001-real.md'), SOURCE);
+
+    const result = await migrateMadr({ cwd: root, dir: 'docs/adr', rename: true });
+
+    expect((await readdir(dir)).sort()).toEqual([
+      '0000-template.md',
+      '0001-real.md',
+      'CONTRIBUTING.md',
+      'README.md',
+      'index.md',
+    ]);
+    expect(await readFile(join(dir, 'README.md'), 'utf8')).toBe(readme);
+    expect(result.results.map((r) => r.path)).toEqual(['docs/adr/0001-real.md']);
+  });
+
+  test('--rename converges: the run after a rename reports unchanged, not a rewrite', async () => {
+    const root = await seedUndiscoverableCorpus();
+
+    const first = await migrateMadr({ cwd: root, dir: 'docs/adr', rename: true });
+    const second = await migrateMadr({ cwd: root, dir: 'docs/adr', rename: true });
+
+    expect(first.results.every((r) => r.outcome === 'migrated')).toBe(true);
+    expect(second.results.every((r) => r.outcome === 'unchanged')).toBe(true);
+  });
+
+  test('a --rename run leaves the corpus byte-stable on re-migration', async () => {
+    const root = await seedUndiscoverableCorpus();
+    const dir = join(root, 'docs/adr');
+
+    await migrateMadr({ cwd: root, dir: 'docs/adr', rename: true });
+    const after = await Promise.all(
+      (await readdir(dir)).sort().map(async (name) => [name, await readFile(join(dir, name), 'utf8')] as const),
+    );
+    await migrateMadr({ cwd: root, dir: 'docs/adr', rename: true });
+
+    for (const [name, content] of after) {
+      expect(await readFile(join(dir, name), 'utf8')).toBe(content);
+    }
+  });
+});

--- a/packages/core/test/status-governance.test.ts
+++ b/packages/core/test/status-governance.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Regression tests for adrkit#39 — `check`, `explain`, and the CI Action reported
+ * rejected, superseded, and deprecated records as governing, while `@adrkit/mcp`'s
+ * `get_decision_context` bucketed the same corpus correctly.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import { bucketDecisions, checkChanges, decisionBucketFor, lintCorpus, toGoverningDecisions } from '../src/index.ts';
+import { resolveAffects } from '../src/affects/index.ts';
+import { cleanupTestDir, recordMarkdown, resetTestDir, writeText } from './helpers.ts';
+
+const DIR_NAME = 'status-governance';
+const MATCHER = ['affects:', '  - type: path', '    pattern: "src/api/**"'].join('\n');
+
+function withMatcher(markdown: string): string {
+  return markdown.replace('affects: []', MATCHER);
+}
+
+/** One record per `Status` value, all matching the same path — the issue's fixture. */
+async function seedEveryStatus(): Promise<string> {
+  const root = await resetTestDir(DIR_NAME);
+  const dir = join(root, 'docs/adr');
+  const rows: readonly [string, string, string][] = [
+    ['0001', 'draft', 'Draft record'],
+    ['0002', 'proposed', 'Proposed record'],
+    ['0003', 'accepted', 'Accepted record'],
+    ['0004', 'rejected', 'Rejected record'],
+    ['0005', 'superseded', 'Superseded record'],
+    ['0006', 'deprecated', 'Deprecated record'],
+  ];
+
+  for (const [id, status, title] of rows) {
+    let markdown = withMatcher(recordMarkdown(id, title));
+    markdown =
+      status === 'superseded'
+        ? markdown.replace('status: draft', 'status: superseded\nsupersededBy: "0003"')
+        : markdown.replace('status: draft', `status: ${status}`);
+    if (status === 'accepted' || status === 'superseded') {
+      markdown = markdown.replace('deciders: []', 'deciders: ["@tester"]');
+    }
+    await writeText(join(dir, `${id}-${status}.md`), markdown);
+  }
+  return root;
+}
+
+afterEach(async () => {
+  await cleanupTestDir(DIR_NAME);
+});
+
+describe('decisionBucketFor', () => {
+  test('only accepted governs', () => {
+    expect(decisionBucketFor('accepted')).toBe('governing');
+    expect(decisionBucketFor('draft')).toBe('activeProposals');
+    expect(decisionBucketFor('proposed')).toBe('activeProposals');
+    expect(decisionBucketFor('rejected')).toBe('history');
+    expect(decisionBucketFor('superseded')).toBe('history');
+    expect(decisionBucketFor('deprecated')).toBe('history');
+  });
+
+  test('an unknown status is history, never governing', () => {
+    expect(decisionBucketFor('something-new')).toBe('history');
+  });
+});
+
+describe('checkChanges status awareness (#39)', () => {
+  test('buckets every status exactly as get_decision_context does', async () => {
+    const root = await seedEveryStatus();
+    const lint = await lintCorpus({ cwd: root, dir: 'docs/adr' });
+    const outcome = checkChanges({ lint, changedFiles: ['src/api/thing.ts'], dir: 'docs/adr' });
+
+    expect(outcome.governedBy).toHaveLength(6);
+    expect(outcome.governing.map((d) => d.recordId)).toEqual(['0003']);
+    expect(outcome.activeProposals.map((d) => d.recordId)).toEqual(['0001', '0002']);
+    expect(outcome.history.map((d) => d.recordId)).toEqual(['0004', '0005', '0006']);
+  });
+
+  test('every governedBy entry carries its status, so consumers can filter', async () => {
+    const root = await seedEveryStatus();
+    const lint = await lintCorpus({ cwd: root, dir: 'docs/adr' });
+    const outcome = checkChanges({ lint, changedFiles: ['src/api/thing.ts'], dir: 'docs/adr' });
+
+    expect(outcome.governedBy.map((d) => d.status)).toEqual([
+      'draft',
+      'proposed',
+      'accepted',
+      'rejected',
+      'superseded',
+      'deprecated',
+    ]);
+  });
+
+  test('a superseded record names the successor that replaced it', async () => {
+    const root = await seedEveryStatus();
+    const lint = await lintCorpus({ cwd: root, dir: 'docs/adr' });
+    const outcome = checkChanges({ lint, changedFiles: ['src/api/thing.ts'], dir: 'docs/adr' });
+
+    expect(outcome.history.find((d) => d.recordId === '0005')?.supersededBy).toBe('0003');
+    expect(outcome.governing[0]?.supersededBy).toBeUndefined();
+  });
+
+  test('the three buckets partition governedBy without loss or duplication', async () => {
+    const root = await seedEveryStatus();
+    const lint = await lintCorpus({ cwd: root, dir: 'docs/adr' });
+    const outcome = checkChanges({ lint, changedFiles: ['src/api/thing.ts'], dir: 'docs/adr' });
+
+    const bucketed = [...outcome.governing, ...outcome.activeProposals, ...outcome.history];
+    expect(bucketed).toHaveLength(outcome.governedBy.length);
+    expect(new Set(bucketed.map((d) => d.recordId)).size).toBe(outcome.governedBy.length);
+  });
+});
+
+describe('toGoverningDecisions', () => {
+  test('a match whose record lint dropped is never reported as governing', async () => {
+    const root = await seedEveryStatus();
+    const lint = await lintCorpus({ cwd: root, dir: 'docs/adr' });
+    const resolution = resolveAffects({ records: lint.records, changedFiles: ['src/api/thing.ts'] });
+
+    // Simulate the record being absent from `records` while its match survives.
+    const decisions = toGoverningDecisions([], resolution.matches);
+
+    expect(decisions.every((d) => d.bucket !== 'governing')).toBe(true);
+    expect(bucketDecisions(decisions).governing).toEqual([]);
+  });
+});

--- a/packages/mcp/src/tools/get-decision-context.ts
+++ b/packages/mcp/src/tools/get-decision-context.ts
@@ -8,7 +8,7 @@
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { resolveAffects, type Adr, type Finding, type FiredMatcher } from '@adrkit/core';
+import { decisionBucketFor, resolveAffects, type Adr, type Finding, type FiredMatcher } from '@adrkit/core';
 import { compareCodeUnits, sortFindingsCanonical } from '../corpus/ordering.ts';
 import { paginate, queryShapeHash } from '../pagination/cursor.ts';
 import {
@@ -37,10 +37,12 @@ interface GetDecisionContextArgs {
 
 type Bucket = 'governing' | 'activeProposals' | 'history';
 
+/**
+ * Delegates to `@adrkit/core`'s `decisionBucketFor` so this tool and the CLI/Action
+ * cannot drift apart on what counts as governing (#39).
+ */
 function bucketFor(status: string): Bucket {
-  if (status === 'accepted') return 'governing';
-  if (status === 'draft' || status === 'proposed') return 'activeProposals';
-  return 'history';
+  return decisionBucketFor(status);
 }
 
 function contextEntry(record: Adr, firedMatchers: readonly FiredMatcher[]): ContextEntry {

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -83,7 +83,10 @@ record with no `affects` is advisory only. See the
 
 ## Explain what governs a file — `adr explain`
 
-Print every decision governing a path, and the matcher that fired.
+Print every decision that matches a path, and the matcher that fired. Only
+`accepted` records are reported as governing; matched proposals and
+superseded, rejected, or deprecated records are listed under their own
+headings so a `rejected` decision is never presented as binding.
 
 ```sh
 bun run adr explain packages/core/src/schema/adr.schema.ts
@@ -108,11 +111,23 @@ Migrate a MADR corpus in place, additively and non-destructively. The migration
 is one-way; round-trip sync is deliberately unsupported
 ([ADR-0008](/adr/0008-import-and-migration-semantics/)).
 
+Status and date are read from MADR 3.x YAML frontmatter, MADR 2.x `* Status:`
+header bullets, and Nygard `## Status` sections, so an already-accepted corpus
+does not import as a backlog of proposals.
+
 ```sh
 # preview without writing
 bun run adr migrate --from madr --dry-run
 # apply
 bun run adr migrate --from madr --dir docs/adr
+```
+
+Corpus discovery requires `<id>-<slug>.md` filenames. If your MADR files use
+descriptive names, migration warns that the records will not be discoverable —
+pass `--rename` to move each file to a discoverable name as part of the run:
+
+```sh
+bun run adr migrate --from madr --dir docs/adr --rename
 ```
 
 ## Next steps

--- a/specs/002-affects-resolution/contracts/resolver-and-explain.md
+++ b/specs/002-affects-resolution/contracts/resolver-and-explain.md
@@ -60,12 +60,23 @@ interface CatalogPort {
 - **Input**: one repo-relative path.
 - **Behavior**: load the corpus; run `resolveAffects` with `changedFiles=[path]`
   and no snapshots (unless the environment later supplies them); print every
-  governing record and, for each, the matcher (type + pattern) that fired.
-- **Output (human)**: for each governing record: `id  title` then indented
-  `via <type>: <pattern>` lines. If none govern: `No decision governs <path>.`
+  matched record grouped by status, and, for each, the matcher (type + pattern)
+  that fired.
+- **Status awareness**: only `accepted` records govern. `draft`/`proposed` matches are
+  reported as **active proposals** and `rejected`/`superseded`/`deprecated` matches as
+  **history**, using `@adrkit/core`'s `decisionBucketFor` — the same function
+  `adr check`, the `@adrkit/ci` Action, and `@adrkit/mcp`'s `get_decision_context` use.
+- **Output (human)**: for each record: `id  [status] title` (plus
+  `(superseded by <id>)` when applicable) then indented `via <type>: <pattern>` lines,
+  under a heading per bucket. If none match: `No decision governs <path>.` If some match
+  but none are accepted: `No accepted decision governs <path>.`
   Inert/unresolved matchers relevant to the path are listed separately as info.
-- **Output (`--json`)**: `{ "path": "...", "governedBy": [{recordId, title,
-  firedMatchers:[{type,pattern}]}], "findings": Finding[] }`, stably sorted.
+- **Output (`--json`)**: `{ "path": "...", "governedBy": GoverningDecision[],
+  "governing": GoverningDecision[], "activeProposals": GoverningDecision[],
+  "history": GoverningDecision[], "findings": Finding[] }`, stably sorted.
+  `governedBy` is the full union across all statuses;
+  `GoverningDecision` is `{recordId, title, status, bucket, supersededBy?,
+  firedMatchers:[{type,pattern}]}`.
 - **Exit**: `0` normally (including "no decision governs"); `2` on usage error.
 - **Determinism**: identical corpus + path ⇒ identical output.
 

--- a/specs/004-ci-surface/contracts/check-and-comment.md
+++ b/specs/004-ci-surface/contracts/check-and-comment.md
@@ -13,8 +13,13 @@ or validation.
   sorted; otherwise print a human summary.
 - **Behavior**: load the corpus via `lintCorpus` (keeping its full findings, including
   those for malformed files it drops from `records`); call `checkChanges({ lint,
-  changedFiles, dir })`; print the governing decisions (id + title + fired matcher, like
-  `adr explain`) and the changed-record findings.
+  changedFiles, dir })`; print the governing decisions (id + status + title + fired
+  matcher, like `adr explain`) and the changed-record findings.
+- **Status awareness**: only `accepted` records are reported as **governing**. Matched
+  `draft`/`proposed` records are reported as **active proposals** and matched
+  `rejected`/`superseded`/`deprecated` records as **history**, under their own headings.
+  The bucketing is `@adrkit/core`'s `decisionBucketFor`, the same function
+  `@adrkit/mcp`'s `get_decision_context` uses, so the two surfaces cannot drift.
 - **Exit**: `0` on success; **non-zero** iff a **changed record** has an
   `error`-severity finding (FR-002); `2` on usage error. `info`/`warn` never fail.
 - **Purity/determinism**: identical `(lint result, changedFiles, snapshots)` → identical
@@ -25,12 +30,17 @@ or validation.
 
 ```text
 Decisions governing this change:
-  0007  Isolate integrations as optional adapters
+  0007  [accepted] Isolate integrations as optional adapters
     via path: packages/*/package.json
-  0009  Pin affects resolution semantics ...
+  0009  [accepted] Pin affects resolution semantics ...
     via path: packages/core/src/affects/**
-Changed records: 0
-checked: 3 governing, 0 changed-record errors
+Active proposals touching this change (not yet binding):
+  0015  [proposed] Adopt a shared cache layer
+    via path: packages/core/src/affects/**
+Historical records that once covered this change (not binding):
+  0003  [superseded] Old adapter policy (superseded by 0007)
+    via path: packages/*/package.json
+checked: 2 governing, 1 active proposals, 1 historical, 0 changed records, 0 changed-record errors
 ```
 
 `--json` output shape:
@@ -38,10 +48,24 @@ checked: 3 governing, 0 changed-record errors
 ```ts
 {
   changedFiles: string[];
-  governedBy: { recordId: string; title: string; firedMatchers: { type: string; pattern: string }[] }[];
+  // Every match, regardless of status — the resolver's raw union. Retained for
+  // consumers written against the pre-bucketing shape; prefer `governing`.
+  governedBy: GoverningDecision[];
+  governing: GoverningDecision[];        // accepted only — the decisions that bind
+  activeProposals: GoverningDecision[];  // draft | proposed
+  history: GoverningDecision[];          // rejected | superseded | deprecated
   changedRecords: string[];
   findings: Finding[];
   ok: boolean;
+}
+
+interface GoverningDecision {
+  recordId: string;
+  title: string;
+  status: Status;
+  bucket: 'governing' | 'activeProposals' | 'history';
+  supersededBy?: string;  // present only when status is `superseded`
+  firedMatchers: { type: string; pattern: string }[];
 }
 ```
 


### PR DESCRIPTION
Closes #39, closes #40, closes #41, closes #42.

Four defects found while dogfooding adrkit from an external consumer repo ([`mbeacom/adrkit-t018-dogfood`](https://github.com/mbeacom/adrkit-t018-dogfood)), each filed with a reproduction. All four reproductions are re-run below against this branch.

## #39 — status-blind governance

`check`, `explain`, and the CI Action reported **every** matched record as governing, regardless of status — while MCP's `get_decision_context` bucketed the same corpus correctly. That read as drift between surfaces rather than an intentional stance, so the fix removes the drift at its source: the bucketing rule now lives in one place, `@adrkit/core`'s `decisionBucketFor`, and all four surfaces call it.

- `GoverningDecision` gains `status`, `bucket`, and `supersededBy` (so a superseded record finally points at the successor that replaced it).
- `CheckOutcome` gains `governing` / `activeProposals` / `history`. `governedBy` is retained as the full union, so consumers written against the previous shape keep working.

```console
$ adr check src/api/thing.ts --dir docs/adr
Decisions governing this change:
  0003  [accepted] Accepted record
    via path: src/api/**
Active proposals touching this change (not yet binding):
  0001  [draft] Draft record
  0002  [proposed] Proposed record
Historical records that once covered this change (not binding):
  0004  [rejected] Rejected record
  0005  [superseded] Superseded record (superseded by 0003)
  0006  [deprecated] Deprecated record
checked: 1 governing, 2 active proposals, 3 historical, 0 changed records, 0 changed-record errors
```

The PR comment gets the same treatment — a reviewer is never told a rejected decision governs their change.

## #40 — MADR status parsing

`migrate --from madr` read `status`/`date` only from YAML frontmatter, so MADR 2.x header bullets and Nygard `## Status` sections imported as `proposed` dated `1970-01-01` — relabelling an entire accepted corpus as an ARB backlog, at exit 0.

Both dialects are now parsed, scoped to the header region above the first `##` so a `Status:`-shaped line in prose can't be mistaken for the field.

| Source form | Declared | Before | After |
|---|---|---|---|
| MADR 3.x YAML frontmatter | `accepted` | `accepted` | `accepted` |
| MADR 2.x `* Status:` bullet | `accepted` | `proposed` | `accepted` |
| Nygard `## Status` section | `accepted` | `proposed` | `accepted` |
| `* Date: 2025-03-14` | `2025-03-14` | `1970-01-01` | `2025-03-14` |

`superseded by <ref>` is recognized **only** when the reference resolves into the id space this run actually writes. A number scraped from the status belongs to the source project's numbering, which is not the numbering migration allocates; anything unresolvable — or self-referential — stays an unrecognized-status warning rather than a fabricated supersession edge. A genuinely dateless source still gets the epoch sentinel, but now says so via a new `import-date-missing` finding instead of writing 1970 silently.

## #41 — invisible migrated records

The silent false-coverage bug. Migration wrote records under filenames corpus discovery cannot see, so it reported success and `lint` then reported `checked 0 records, 0 errors` at exit 0.

Three changes, in order of how early they catch it:

- **`lint`** warns (`corpus-file-skipped`) when the corpus directory contains markdown that discovery skipped. `checked 0 records` is never silent again — and this also covers hand-authored records that are simply misnamed.
- **`migrate`** warns (`import-undiscoverable`) at the moment it writes a record that will be invisible, naming the file and how to fix it. It also catches records in corpus subdirectories, which discovery cannot see regardless of filename.
- **`migrate --rename`** (opt-in) writes `<id>-<slug>.md`.

ADR-0008's in-place, additive contract stays the default, so existing MADR tooling and inbound links keep working. `--rename` refuses to clobber a file already occupying the target name, never touches conventional corpus documentation (`README.md`, `CONTRIBUTING.md`, `index.md`, the template — these are also no longer migration candidates at all), and records post-rename provenance so the following run converges to `unchanged` rather than re-importing.

```console
$ adr migrate --from madr --dir docs/adr --rename
migrated  docs/adr/a-yaml.md -> docs/adr/0001-use-postgresql.md
...
$ adr lint --dir docs/adr
checked 3 records, 0 errors, 0 warnings
```

## #42 — `--help` / `--version`

All of `adr --help`, `-h`, `help`, `--version`, `-V` were unknown commands at exit 2, and there was no way to ask the CLI its version.

- `adr --help` / `-h` / `help` → usage on **stdout**, exit **0**
- `adr help <command>` and `adr <command> --help` → per-command usage, exit 0
- `adr --version` / `-V` → the `@adrkit/cli` version, exit 0
- a genuinely unknown command keeps stderr + exit 2

`CLI_VERSION` is a literal (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never locates `package.json` at runtime; a test asserts the two agree.

## Notes for review

- **Behavioral change worth knowing about:** this repo's own ADR-0009 is `proposed`, so `adr check` on `packages/core/src/affects/**` now reports it as an active proposal rather than as governing. That is the fix working.
- `packages/ci/dist/*.js` are regenerated `bun build` bundles — skip them in review.
- Contracts updated: `specs/002-affects-resolution/contracts/resolver-and-explain.md` and `specs/004-ci-surface/contracts/check-and-comment.md`. README, CLI README, and the site quickstart updated.

## Validation

`bun test` 739 pass / 0 fail (57 new), `bun run typecheck` and `bun run lint` clean, `bun run build` clean across all packages, and each issue's console transcript re-run by hand. A code review pass over the diff surfaced five further issues — a `supersededBy` id-namespace mismatch, `--rename` moving corpus READMEs, `--rename` non-idempotency, a quadratic regex over untrusted file content, and an `Object.prototype` key lookup crashing `adr help constructor` at exit 1 — all fixed here with regression tests.