### PR TITLE
docs: require agent runs to work in a worktree, not the main checkout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,3 +58,35 @@ them in sync when the tooling guidance changes:
 
 - Cursor: [`.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc`](./.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc)
 - GitHub Copilot / VS Code: [`.github/instructions/use-bun.instructions.md`](./.github/instructions/use-bun.instructions.md)
+
+## Agent working directories
+
+**Do not write to the maintainer's main checkout.** Agent runs work in a git
+worktree on their own branch, never in place on the primary clone.
+
+Before the first write in a session, check where you are:
+
+```bash
+git rev-parse --show-toplevel   # is this the main checkout?
+git worktree list               # the first entry is the main checkout
+git status --porcelain          # is someone else's work already here?
+```
+
+If the toplevel is the main checkout, stop and create a worktree instead:
+
+```bash
+git worktree add -b <branch> ../copilot-worktrees/adrkit/<name> origin/main
+```
+
+Two rules follow from this, and both have been violated in practice:
+
+- **A dirty main checkout is a hard stop**, not a state to work around. Staged
+  or modified files there are someone else's uncommitted work. Do not commit,
+  stash, reset, checkout, or "clean up" around them — the owning session may
+  still be running, and its work is invisible to `git worktree list`.
+- **Never `git worktree remove` or `git branch -D` on the strength of commit
+  ancestry alone.** Squash merges rewrite history, so a fully-merged branch is
+  *never* an ancestor of `main` and `git log main..<branch>` is not empty.
+  Compare *content* instead — `git diff <branch> origin/main -- <paths>` — and
+  gate the destructive command on that check actually passing, not merely on
+  having printed a warning.


### PR DESCRIPTION
## Summary

Adds an **Agent working directories** section to `CLAUDE.md`. Documentation only — no behavioural change to any package.

Each of the three rules was violated during a single working session, and each cost real recovery effort.

## The three rules

**1. Work in a worktree, with a pre-flight check before the first write.**

An agent run wrote ~1500 lines directly into the maintainer's main checkout. The failure mode is not untidiness — work in the main checkout is **invisible to `git worktree list`**, so an audit that specifically hunted for unrealized value across every worktree could not have surfaced it. It was found only because a routine `git status` caught it after a pull. Had any tree-mutating recovery run against `main` first, that work would have been destroyed while the operation reported success.

**2. A dirty main checkout is a hard stop.**

Staged files there belong to a session that may still be running — in the observed case the changeset grew by ~190 lines *while it was being examined*. `git stash create` is the safe way to snapshot such work, since it writes a commit object without touching the working tree or index. But the correct first move is not to touch it at all.

**3. Gate destructive operations on content, not ancestry.**

Squash merges rewrite history, so a fully-merged branch is **never** an ancestor of `main` and `git log main..<branch>` is not empty. In one session this produced three separate false "stranded work" alarms, twice after the trap had already been explicitly named. The reliable test is `git diff <branch> origin/main -- <paths>`.

Separately, a guard that *printed* a warning without gating the removal it guarded deleted a branch it had just declared unsafe. A check that does not gate the action is decoration. The content test happened to be satisfied, so nothing was lost — but that was luck covering a bug.

## Scope

- One file, `CLAUDE.md`, appended section only.
- No existing guidance modified.
- No package, spec, ADR, or workflow touched.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
