### PR TITLE
docs(mcp): add registry manifests and a distribution playbook

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,484 @@
+# Distribution & discoverability playbook (prepared, not submitted)
+
+This document is a **prepared-submissions playbook** for giving `@adrkit/mcp` and
+the `@adrkit/*` CLI presence in the MCP and ADR-tooling ecosystems. It contains
+ready-to-paste content and exact procedures.
+
+> **Nothing here has been submitted.** Every outbound action — publishing to a
+> registry, opening a PR, filling a form, creating a git tag, or posting anywhere —
+> is left for a human to perform. This file only *prepares* those actions.
+
+## Honesty guardrail (binding)
+
+Per [ADR-0014](./adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md),
+adrkit is **early**: phases 0–6 are *landed / reference-verified* (rungs 1–2), and
+rung-3 external/community validation is **openly not-yet-met**. A registry listing is
+**distribution, not adoption**. None of the copy below may state or imply that
+adrkit has external adopters, production users, or rung-3 validation. Listing copy
+describes *what the tool is and does*, never *who uses it*.
+
+---
+
+## Shared prerequisites
+
+Most venues below ultimately read from the **official MCP registry** or from the
+GitHub repo, so a small number of prerequisites unblock several venues at once.
+
+### P1 — npm packages are published
+
+`@adrkit/mcp`, `@adrkit/cli`, `@adrkit/core`, `@adrkit/evaluator` are published at
+`0.2.0` (verify with `npm view @adrkit/mcp version`). The MCP registry hosts
+*metadata only*; the npm package must already exist at the version named in
+`server.json`.
+
+### P2 — `mcpName` marker in `packages/mcp/package.json` (REQUIRED, not yet present)
+
+The official registry verifies npm ownership by requiring an `mcpName` property in
+the package's `package.json` whose value **exactly** matches the `name` in
+`server.json`. Without it, `mcp-publisher publish` fails with
+`Registry validation failed for package`.
+
+**This file is owned by another workstream and has not been changed here.** The
+required edit (do not merge until the namespace decision in A1 is final):
+
+```jsonc
+// packages/mcp/package.json
+{
+  "name": "@adrkit/mcp",
+  "mcpName": "dev.adrkit/mcp",   // ← add; MUST equal server.json "name"
+  // ...
+}
+```
+
+`server.json` does **not** need to be added to the package's `files` allowlist —
+`mcp-publisher` reads it from the working directory at publish time and it is not
+required inside the npm tarball.
+
+### P3 — namespace decision (see A1)
+
+The registry namespace determines the ownership-verification method. This choice
+propagates to `server.json` `name`, the `package.json` `mcpName`, and every listing
+below. Decide A1 first.
+
+### P4 — `adr-kit` (PyPI) name collision — disambiguation
+
+An **unrelated** `adr-kit` package exists on PyPI (a different project). To avoid
+confusion in every listing:
+
+- Lead with the scoped npm name **`@adrkit/mcp`** / **`@adrkit/cli`** and the
+  registry namespace **`dev.adrkit/mcp`**, never the bare string "adrkit-kit" or
+  "adr-kit".
+- Where a venue has a one-line description, include "Node/npm" and link
+  `https://adrkit.dev` so it is unambiguous this is the JavaScript/TypeScript
+  project, not the Python `adr-kit`.
+- Recommended disambiguation clause (reuse verbatim): *"Node/npm project
+  (`@adrkit/*`); unrelated to the `adr-kit` package on PyPI."*
+
+---
+
+## A. Official MCP registry (`registry.modelcontextprotocol.io`)
+
+This is the highest-leverage venue: **PulseMCP, mcp.so, Glama, and Smithery all
+ingest or can ingest from it.** The registry is in public preview.
+
+The manifest is authored at [`packages/mcp/server.json`](../packages/mcp/server.json)
+and was validated against the published schema
+`https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
+(draft-07) with `ajv` → **VALID**.
+
+### A1 — choose a namespace (this drives everything)
+
+| Path | Namespace / `name` | Ownership proof | Notes |
+|---|---|---|---|
+| **DNS (recommended)** | `dev.adrkit/mcp` | DNS TXT on the **apex** of `adrkit.dev` | Brandable, matches the homepage, cleanly disambiguates from `adr-kit` on PyPI. **This is what `server.json` currently declares.** |
+| **GitHub (simpler)** | `io.github.mbeacom/adrkit-mcp` | GitHub device-flow login | No DNS needed. Requires **editing** `server.json` `name` **and** `package.json` `mcpName` to `io.github.mbeacom/adrkit-mcp`. |
+
+The rest of section A documents the DNS path (matching the committed `server.json`),
+then the GitHub fallback.
+
+### A2 — install `mcp-publisher` (human)
+
+```sh
+# macOS (Homebrew)
+brew install mcp-publisher
+# or a prebuilt binary:
+curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/
+mcp-publisher --help
+```
+
+### A3 — DNS namespace verification (human, DNS path only)
+
+The TXT record **must** sit on the **apex** of `adrkit.dev` (e.g. `adrkit.dev`),
+**not** a selector like `_mcp-auth.adrkit.dev` (MCP DNS auth uses SPF-style apex
+placement, not DKIM-style selectors).
+
+```sh
+# 1. Generate an Ed25519 keypair.
+#    NOTE: needs OpenSSL 3.0+. macOS system LibreSSL cannot do Ed25519 in genpkey —
+#    use `brew install openssl@3` and call that openssl explicitly.
+openssl genpkey -algorithm Ed25519 -out adrkit-mcp-key.pem
+PRIVATE_KEY=$(openssl pkey -in adrkit-mcp-key.pem -text -noout | grep -A3 'priv:' | tail -n +2 | tr -d ' :\n')
+PUBLIC_KEY=$(openssl pkey -in adrkit-mcp-key.pem -pubout -outform DER | tail -c 32 | xxd -p -c 32)
+
+# 2. Publish this TXT record at the apex of adrkit.dev via your DNS provider:
+echo "adrkit.dev. IN TXT \"v=MCPv1; k=ed25519; p=${PUBLIC_KEY}\""
+# Wait for propagation (minutes). If you ever rotate keys, DELETE the old TXT record.
+
+# 3. Authenticate, then publish (run from packages/mcp/, where server.json lives):
+mcp-publisher login dns --domain adrkit.dev --private-key "${PRIVATE_KEY}"
+cd packages/mcp && mcp-publisher publish
+```
+
+> HTTP fallback (if DNS is inconvenient): host
+> `https://adrkit.dev/.well-known/mcp-registry-auth` containing
+> `v=MCPv1; k=ed25519; p=<PUBLIC_KEY>` and use `mcp-publisher login http --domain adrkit.dev --private-key <key>`.
+
+### A3′ — GitHub namespace verification (human, fallback path)
+
+If using `io.github.mbeacom/adrkit-mcp` instead: first change `server.json` `name`
+and `package.json` `mcpName` to `io.github.mbeacom/adrkit-mcp` (an org namespace
+`io.github.<org>/…` requires you to be an **Owner** of that org; a personal
+namespace `io.github.mbeacom/…` always works). Then:
+
+```sh
+cd packages/mcp && mcp-publisher login github   # device flow at https://github.com/login/device
+mcp-publisher publish
+```
+
+### A4 — verify (human)
+
+```sh
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=dev.adrkit/mcp"
+```
+
+### A5 — the committed `server.json`
+
+```jsonc
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "dev.adrkit/mcp",
+  "title": "adrkit decision memory",
+  "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
+  "version": "0.2.0",
+  "websiteUrl": "https://adrkit.dev",
+  "repository": {
+    "url": "https://github.com/mbeacom/adrkit",
+    "source": "github",
+    "subfolder": "packages/mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@adrkit/mcp",
+      "version": "0.2.0",
+      "runtimeHint": "npx",
+      "transport": { "type": "stdio" },
+      "environmentVariables": [
+        { "name": "ADRKIT_MCP_CWD", "description": "Repository root to read (default: process.cwd()).", "isRequired": false, "isSecret": false },
+        { "name": "ADRKIT_MCP_DIR", "description": "ADR directory under the repo root (default: docs/adr).", "isRequired": false, "isSecret": false }
+      ]
+    }
+  ]
+}
+```
+
+> Keep `version` (top-level) and `packages[0].version` in lockstep with the npm
+> release you are publishing. If a new release (e.g. the SDK-CVE patch) bumps
+> `@adrkit/mcp`, bump both fields here before re-publishing.
+
+**Listing criteria met?** Yes — schema-valid, npm package exists, stdio transport,
+public repo. The only blocker is the human steps above (namespace proof + the P2
+`mcpName` edit).
+
+---
+
+## B. Directories that ingest the registry or crawl GitHub
+
+### B1 — mcp.so
+
+- **Process:** web form at <https://mcp.so/submit>. Free tier = queued review,
+  nofollow link, no badge; a $39 one-time tier gets immediate publish + verified
+  badge (not necessary).
+- **Fields:** Repository URL (`https://github.com/mbeacom/adrkit`), Name (`adrkit`).
+- **Ready-to-paste name / description:**
+  - Name: `adrkit`
+  - Repository URL: `https://github.com/mbeacom/adrkit`
+  - Description: *Deterministic, offline, read-only ADR (Architecture Decision
+    Record) memory for coding agents. Four read-only MCP tools —
+    `search_decisions`, `get_decision`, `get_decision_context`, `list_superseded` —
+    surface decisions you already made (and rejected) so agents stop re-proposing
+    them. No model or network calls. Node/npm project (`@adrkit/*`); unrelated to
+    the `adr-kit` package on PyPI.*
+- **Prerequisite:** none beyond a public repo.
+- **Criteria met?** Yes.
+
+### B2 — PulseMCP
+
+- **Process:** PulseMCP **ingests the official MCP registry daily and processes it
+  weekly** (<https://www.pulsemcp.com/submit>). The most reliable path is to
+  publish to the official registry (section A); adrkit then appears automatically.
+  For edits or to expedite, email <hello@pulsemcp.com> or use the submit form's URL
+  field (`https://github.com/mbeacom/adrkit`).
+- **Prerequisite:** official-registry listing (recommended) — so **A must land
+  first** for the automatic path.
+- **Criteria met?** Yes, once A is published. No separate machine format.
+
+### B3 — Smithery
+
+- **Process:** connect the GitHub repo at <https://smithery.ai/new> ("Deploy → From
+  GitHub"); Smithery reads a `smithery.yaml` at the **repo root**.
+- **Ready-to-paste `smithery.yaml`** (belongs at **repo root** — outside this
+  workstream's owned paths; hand to the root/CI owner):
+
+  ```yaml
+  # smithery.yaml (repo root)
+  startCommand:
+    type: stdio
+    commandFunction: |
+      (config) => ({
+        command: 'npx',
+        args: ['-y', '@adrkit/mcp', '--dir', config.dir || 'docs/adr'],
+        env: config.cwd ? { ADRKIT_MCP_CWD: config.cwd } : {}
+      })
+  configSchema:
+    type: object
+    properties:
+      cwd:
+        type: string
+        title: Repository root
+        description: Absolute path to the git repo whose ADRs to read (defaults to the launch cwd).
+      dir:
+        type: string
+        default: docs/adr
+        title: ADR directory
+        description: ADR directory under the repo root.
+    additionalProperties: false
+  exampleConfig:
+    dir: docs/adr
+  ```
+
+- **Prerequisite:** `smithery.yaml` at repo root (REPORT: not owned here).
+- **Criteria met?** Partially, with an honest caveat: adrkit is a **local** server
+  whose tools require a real on-disk ADR corpus in a git repo. Smithery's hosted
+  tool-playground has no such corpus, so the interactive "try in browser" surface
+  cannot meaningfully exercise the tools — the value is discovery/listing, and the
+  copy should say the server runs locally against the user's repo.
+
+### B4 — Glama
+
+- **Process:** Glama crawls GitHub for a `glama.json` at the **repo root** and
+  indexes within ~24h; the repo already signals MCP via name/topics.
+- **Ready-to-paste `glama.json`** (belongs at **repo root** — REPORT: not owned
+  here):
+
+  ```json
+  {
+    "$schema": "https://glama.ai/mcp/schemas/server.json",
+    "maintainers": ["mbeacom"]
+  }
+  ```
+
+- **Prerequisite:** `glama.json` at repo root; repo public with "mcp" in
+  topics/description.
+- **Criteria met?** Yes (public, documented, MCP server). Discovery-only listing.
+
+### B5 — `awesome-mcp-servers` (GitHub PR)
+
+- **Repo:** <https://github.com/punkpeye/awesome-mcp-servers> (PR to `README.md`).
+  Automated-agent PRs may append `🤖🤖🤖` to the PR title to fast-track; a human
+  must open it.
+- **Category:** `### 🧠 Knowledge & Memory` (best fit — decision memory). Alternate:
+  `### 💻 Developer Tools`. Maintain alphabetical order by repo path within the
+  section.
+- **Legend used:** `📇` TypeScript, `🏠` local service, `🍎 🪟 🐧` cross-platform.
+  (No `🎖️` — that is reserved for official Anthropic implementations.)
+- **Ready-to-paste entry line:**
+
+  ```markdown
+  - [mbeacom/adrkit](https://github.com/mbeacom/adrkit) 📇 🏠 🍎 🪟 🐧 - Deterministic, offline, read-only decision memory (ADRs) for coding agents. Four read-only tools surface prior and **superseded/rejected** decisions so agents stop re-proposing them. No model or network calls. Node/npm; unrelated to `adr-kit` on PyPI.
+  ```
+
+- **Prerequisite:** none beyond a public repo.
+- **Criteria met?** Yes.
+
+### B6 — `adr.github.io` "Decision Capturing Tools" (GitHub PR)
+
+- **Repo:** <https://github.com/adr/adr.github.io>; edit
+  `_posts/2024-10-28-adr-tooling.md`. CONTRIBUTING requires following the existing
+  format; entries are alphabetical.
+- **Best fit:** the **"MADR template"** table (adrkit consumes MADR via
+  `adr migrate --from madr`). It could alternatively sit under **"Tooling close to
+  the code"** (its `check`/`explain`/MCP surface binds decisions to code paths).
+- **Ready-to-paste table row** (insert alphabetically into the MADR-template table):
+
+  ```markdown
+  | [adrkit](https://github.com/mbeacom/adrkit) | 2.x / 3.x (one-way import) | Node CLI (`@adrkit/cli`) plus a read-only MCP server (`@adrkit/mcp`). Typed-frontmatter ADR format that is a superset of MADR: `adr migrate --from madr` imports MADR one-way and non-destructively; `adr lint`/`check`/`explain` enforce decisions and bind them to code paths in CI; the MCP server exposes decision memory (including superseded/rejected records) to coding agents. |
+  ```
+
+- **Prerequisite:** none beyond a public repo.
+- **Criteria met?** Yes. The MADR-version column is honest ("2.x / 3.x import"): the
+  importer reads both MADR 2.x header bullets and 3.x YAML frontmatter (see
+  `packages/core/src/import/madr.ts`). Confirm exact version wording before opening
+  the PR.
+
+### Venue readiness summary
+
+| Venue | Machine format | Prerequisite | Ready to submit? | What the human must do |
+|---|---|---|---|---|
+| Official MCP registry | `server.json` (validated) | P2 `mcpName` edit + namespace proof | **Blocked on P2 + namespace proof** | Add `mcpName`, add DNS TXT (or GitHub login), run `mcp-publisher publish` |
+| mcp.so | web form | public repo | **Yes** | Fill form at mcp.so/submit (free tier) |
+| PulseMCP | (ingests registry) | official-registry listing | **After A** | Publish A; optionally email hello@pulsemcp.com |
+| Smithery | `smithery.yaml` (root) | file at repo root | **Prepared; file not placed** | Add root `smithery.yaml`, connect repo at smithery.ai/new |
+| Glama | `glama.json` (root) | file at repo root | **Prepared; file not placed** | Add root `glama.json`; Glama auto-indexes |
+| awesome-mcp-servers | README PR | public repo | **Yes** | Open PR with the entry line |
+| adr.github.io tooling | Jekyll post PR | public repo | **Yes** | Open PR with the table row |
+
+---
+
+## C. Zero-install demo (`npx @adrkit/cli`) — actually run
+
+Both sequences below were **run end-to-end** against the published `@adrkit/cli@0.2.0`
+in a scratch directory outside the repo. The output is real, not aspirational.
+The binary published by `@adrkit/cli` is `adr`, so `npx -y @adrkit/cli <cmd>` works
+with no install.
+
+### C1 — scaffold and enforce a decision (offline, ~2 min)
+
+```sh
+mkdir adrkit-demo && cd adrkit-demo && git init -q
+
+# 1. Scaffold two decisions.
+npx -y @adrkit/cli new "Adopt PostgreSQL for the primary datastore"
+#   → docs/adr/0001-adopt-postgresql-for-the-primary-datastore.md
+npx -y @adrkit/cli new "Use connection pooling with PgBouncer"
+#   → docs/adr/0002-use-connection-pooling-with-pgbouncer.md
+
+# 2. In 0001's frontmatter set `status: accepted`, add a decider, and add an
+#    `affects` matcher binding the decision to code paths:
+#      deciders:
+#        - "you@example.com"
+#      affects:
+#        - type: path
+#          pattern: "src/db/**"
+
+# 3. Lint the corpus.
+npx -y @adrkit/cli lint
+#   → checked 2 records, 0 errors, 0 warnings
+
+# 4. Ask which decision governs a code file.
+npx -y @adrkit/cli explain src/db/pool.ts
+#   → 0001  Adopt PostgreSQL for the primary datastore
+#   →   via path: src/db/**
+
+# 5. The CI gate form — nonzero exit if a governed file changes without review.
+npx -y @adrkit/cli check src/db/pool.ts
+#   → Decisions governing this change:
+#   →   0001  Adopt PostgreSQL for the primary datastore
+#   →     via path: src/db/**
+#   → checked: 1 governing, 0 changed records, 0 changed-record errors
+#   (exit 0)
+
+# 6. Render the decision graph.
+npx -y @adrkit/cli graph --format dot
+#   → digraph adr {
+#   →   rankdir=LR;
+#   →   "0001" [label="0001: Adopt PostgreSQL for the primary datastore", status="accepted"];
+#   →   "0002" [label="0002: Use connection pooling with PgBouncer", status="draft"];
+#   → }
+```
+
+Before the decider was added, `lint` correctly failed with
+`accepted-requires-decider-unless-imported` (exit 1) — the enforcement is real, not
+cosmetic.
+
+### C2 — import a real MADR corpus (one-way, non-destructive)
+
+Run against the canonical MADR repository, `adr/madr` (`docs/decisions/`):
+
+```sh
+mkdir madr-demo && cd madr-demo && git init -q && mkdir -p docs/adr
+# Copy a few real MADR files from https://github.com/adr/madr/tree/main/docs/decisions
+#   into docs/adr/ (e.g. 0000-use-markdown-…, 0005-use-dashes-…, 0008-add-status-field.md)
+
+npx -y @adrkit/cli migrate --from madr --dry-run
+#   → migrated  docs/adr/0000-use-markdown-architectural-decision-records.md
+#   → migrated  docs/adr/0005-use-dashes-in-filenames.md
+#   → migrated  docs/adr/0008-add-status-field.md
+#   → summary: migrated 3, updated 0, unchanged 0, diverged 0, skipped 0
+#   → Divergence (report only):
+#   →   none
+#   → Findings:
+#   →   warn import-status-unrecognized 0000 status: MADR status is missing; using "proposed"
+#   →   warn import-status-unrecognized 0005 status: MADR status is missing; using "proposed"
+#   →   warn import-status-unrecognized 0008 status: MADR status is missing; using "proposed"
+
+npx -y @adrkit/cli migrate --from madr    # writes the typed frontmatter in place
+npx -y @adrkit/cli lint
+#   → checked 3 records, 0 errors, 0 warnings
+```
+
+The importer reads both MADR 2.x header bullets and 3.x YAML frontmatter, is
+one-way (round-trip sync is out of scope per ADR-0008), and surfaces honest findings
+(missing MADR status → `proposed`) rather than silently guessing.
+
+> These runs demonstrate the tool **works**. They are functional evidence only and
+> say nothing about external adoption (see the honesty guardrail).
+
+---
+
+## D. The moving `queue@v0` tag
+
+The README/plan pin the ARB-queue GitHub Action to a commit:
+
+```yaml
+uses: mbeacom/adrkit/packages/ci/queue@efef89b5d747ca175a1947f1ce2f4296dab54fa3
+```
+
+…"until a moving `queue@v0` tag is published." Here is what that actually requires.
+
+### D1 — current state (verified)
+
+- The queue Action (`packages/ci/queue/action.yml`) was added in commit
+  `efef89b5d747ca175a1947f1ce2f4296dab54fa3`, which landed **after** the `v0.2.0`
+  release.
+- The repo-wide `v0` tag currently points at the `v0.2.0` commit
+  (`66a1e7f…`), which does **not** contain `packages/ci/queue/action.yml`.
+- Therefore `mbeacom/adrkit/packages/ci/queue@v0` would currently **fail to
+  resolve** — which is exactly why the README pins the full commit SHA.
+
+### D2 — there is no separate `queue@v0` tag
+
+`queue@v0` is not its own tag. It is the **repo-wide `v0` major tag** plus the
+subpath `packages/ci/queue`. `scripts/update-action-tag.ts` force-moves the
+`v${major}` (= `v0`) tag to the release commit during a release, but **only** when a
+new stable `vX.Y.Z` tag is pushed and the new version is newer than the tag's
+current target (see `docs/RELEASING.md`, "Subsequent releases").
+
+### D3 — procedure to make `queue@v0` resolve (human; do NOT run here)
+
+1. Cut the next release (e.g. `v0.2.1` or `v0.3.0`) whose release commit **includes**
+   `packages/ci/queue/action.yml` — i.e. any release cut from current `main`.
+   Per `docs/RELEASING.md`: bump all four package manifests to the same version,
+   merge after CI is green, then push the annotated `vX.Y.Z` tag and approve the
+   `npm` deploy environment.
+2. The release workflow runs `scripts/update-action-tag.ts`, which **force-updates
+   the `v0` tag** to that release commit.
+3. `mbeacom/adrkit/packages/ci/queue@v0` then resolves to an Action tree that
+   contains `packages/ci/queue/action.yml`, and adopters can switch the pin from the
+   commit SHA to `@v0`.
+
+**Do not create or push any tag as part of this wave.** This is documentation of the
+procedure only; the release is a human action.
+
+---
+
+## E. Changes needed from other workstreams (report only)
+
+| File (not owned here) | Needed change | Why |
+|---|---|---|
+| `packages/mcp/package.json` | Add `"mcpName": "dev.adrkit/mcp"` (must equal `server.json` `name`). | Required for official MCP registry npm-ownership verification (P2). |
+| repo-root `smithery.yaml` | Create with the content in B3. | Smithery reads it from the repo root. |
+| repo-root `glama.json` | Create with the content in B4. | Glama crawls it from the repo root. |
+
+`server.json` does **not** need to be added to `packages/mcp/package.json` `files`.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -31,24 +31,42 @@ GitHub repo, so a small number of prerequisites unblock several venues at once.
 *metadata only*; the npm package must already exist at the version named in
 `server.json`.
 
-### P2 — `mcpName` marker in `packages/mcp/package.json` (REQUIRED, not yet present)
+### P2 — `mcpName` in the **published** `@adrkit/mcp` (REQUIRED, not yet satisfied)
 
-The official registry verifies npm ownership by requiring an `mcpName` property in
-the package's `package.json` whose value **exactly** matches the `name` in
+The official registry verifies npm ownership by reading `mcpName` from the
+package metadata of the **exact published version** named in `server.json` — not
+from the working tree. Its value must **exactly** match the `name` in
 `server.json`. Without it, `mcp-publisher publish` fails with
 `Registry validation failed for package`.
 
-**This file is owned by another workstream and has not been changed here.** The
-required edit (do not merge until the namespace decision in A1 is final):
+`@adrkit/mcp@0.2.0` was published **without** `mcpName` (verify:
+`npm view @adrkit/mcp@0.2.0 mcpName` returns nothing). Adding the field to the
+source manifest is therefore **not sufficient** — the registry would still read
+0.2.0's metadata and reject the claim.
+
+The manifest edit lands in the merge-gate branch (`packages/mcp/package.json`
+now declares `"mcpName": "dev.adrkit/mcp"`):
 
 ```jsonc
 // packages/mcp/package.json
 {
   "name": "@adrkit/mcp",
-  "mcpName": "dev.adrkit/mcp",   // ← add; MUST equal server.json "name"
+  "mcpName": "dev.adrkit/mcp",   // ← MUST equal server.json "name"
   // ...
 }
 ```
+
+**Publishing therefore requires, in order:**
+
+1. Merge the manifest change and cut a **new release** (e.g. `v0.2.1`) so a
+   published version of `@adrkit/mcp` carries `mcpName`.
+2. Confirm it landed: `npm view @adrkit/mcp@0.2.1 mcpName` → `dev.adrkit/mcp`.
+3. Bump **both** version fields in `packages/mcp/server.json` — the top-level
+   `version` and `packages[0].version` — to that same new version.
+4. Only then run `mcp-publisher publish`.
+
+Publishing against `server.json` as currently pinned (0.2.0) will fail
+ownership validation no matter what the working tree says.
 
 `server.json` does **not** need to be added to the package's `files` allowlist —
 `mcp-publisher` reads it from the working directory at publish time and it is not
@@ -113,12 +131,13 @@ The TXT record **must** sit on the **apex** of `adrkit.dev` (e.g. `adrkit.dev`),
 placement, not DKIM-style selectors).
 
 ```sh
-# 1. Generate an Ed25519 keypair.
+# 1. Generate an Ed25519 keypair. The TXT record carries the public key
+#    **base64-encoded** (the private key below is hex — the two encodings differ).
 #    NOTE: needs OpenSSL 3.0+. macOS system LibreSSL cannot do Ed25519 in genpkey —
 #    use `brew install openssl@3` and call that openssl explicitly.
 openssl genpkey -algorithm Ed25519 -out adrkit-mcp-key.pem
 PRIVATE_KEY=$(openssl pkey -in adrkit-mcp-key.pem -text -noout | grep -A3 'priv:' | tail -n +2 | tr -d ' :\n')
-PUBLIC_KEY=$(openssl pkey -in adrkit-mcp-key.pem -pubout -outform DER | tail -c 32 | xxd -p -c 32)
+PUBLIC_KEY=$(openssl pkey -in adrkit-mcp-key.pem -pubout -outform DER | tail -c 32 | base64)
 
 # 2. Publish this TXT record at the apex of adrkit.dev via your DNS provider:
 echo "adrkit.dev. IN TXT \"v=MCPv1; k=ed25519; p=${PUBLIC_KEY}\""
@@ -365,11 +384,16 @@ public repo. The only blocker is the human steps above (namespace proof + the P2
 ## C. Zero-install demo (`npx @adrkit/cli`) — actually run
 
 Both sequences below were **run end-to-end** against the published `@adrkit/cli@0.2.0`
-in a scratch directory outside the repo. The output is real, not aspirational.
-The binary published by `@adrkit/cli` is `adr`, so `npx -y @adrkit/cli <cmd>` works
-with no install.
+in a scratch directory outside the repo. The output is real, not aspirational, and
+is pinned to **0.2.0** — later versions change some rendering (`explain`/`check`
+gained a `[status]` token after 0.2.0), so re-capture these blocks when the pinned
+version moves. The binary published by `@adrkit/cli` is `adr`, so
+`npx -y @adrkit/cli <cmd>` works with no install.
 
-### C1 — scaffold and enforce a decision (offline, ~2 min)
+### C1 — scaffold and enforce a decision (~2 min)
+
+Needs network for the `npx` fetches; the CLI itself makes no network or model
+calls once resolved.
 
 ```sh
 mkdir adrkit-demo && cd adrkit-demo && git init -q
@@ -397,7 +421,10 @@ npx -y @adrkit/cli explain src/db/pool.ts
 #   → 0001  Adopt PostgreSQL for the primary datastore
 #   →   via path: src/db/**
 
-# 5. The CI gate form — nonzero exit if a governed file changes without review.
+# 5. The CI gate form — same resolution as `explain`, plus corpus findings.
+#    Note: `check` exits nonzero only when a *changed ADR record* carries an
+#    error-severity finding; a governed source file changing is reported, not
+#    failed (packages/core/src/check/index.ts).
 npx -y @adrkit/cli check src/db/pool.ts
 #   → Decisions governing this change:
 #   →   0001  Adopt PostgreSQL for the primary datastore
@@ -485,6 +512,15 @@ Re-confirmed against `origin` on 2026-07-25 with `git ls-remote --tags origin`,
 > (`@efef89b…`) is therefore **mandatory, not a nicety**, until §D3 is performed.
 > Any doc that presents `@v0` as an available option for the queue Action is wrong
 > as of this date and should keep pinning the SHA.
+>
+> **Repository sweep (done in this PR).** `README.md` and this document already
+> pinned the SHA, but two runnable references did not and have been corrected:
+> `specs/007-arb-queue/quickstart.md` (workflow YAML → SHA pin) and
+> `specs/007-arb-queue/contracts/github-action.md` (keeps `@v0` as the *intended*
+> contract, with an explicit not-yet-resolvable note). The remaining `@v0` strings
+> in `specs/007-arb-queue/research.md` and `tasks.md` are design rationale and a
+> completed task record, not copy-pasteable instructions; `tasks.md` T049 already
+> says to advertise `@v0` only after the tag moves.
 
 ### D2 — there is no separate `queue@v0` tag
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -228,49 +228,71 @@ public repo. The only blocker is the human steps above (namespace proof + the P2
 
 - **Process:** connect the GitHub repo at <https://smithery.ai/new> ("Deploy → From
   GitHub"); Smithery reads a `smithery.yaml` at the **repo root**.
-- **Ready-to-paste `smithery.yaml`** (belongs at **repo root** — outside this
-  workstream's owned paths; hand to the root/CI owner):
+- **Status:** ✅ **placed** at the repo root of this worktree as
+  [`smithery.yaml`](../smithery.yaml) (committed locally, **not** submitted). The
+  file below is the canonical content; edit the file, not this copy.
+- **Content** (verified 2026-07-25 against current real `smithery.yaml` files —
+  `HenkDz/selfhosted-supabase-mcp`, `isaac-levine/forage`, `sigvardt/linkedin-buddy`
+  — which all nest `configSchema`/`commandFunction`/`exampleConfig` **inside**
+  `startCommand`):
 
   ```yaml
   # smithery.yaml (repo root)
   startCommand:
     type: stdio
-    commandFunction: |
+    configSchema:
+      type: object
+      properties:
+        cwd:
+          type: string
+          title: Repository root
+          description: >-
+            Absolute path to the git repository whose ADRs to read. Must contain a
+            readable .git entry. Defaults to the launch working directory.
+        dir:
+          type: string
+          title: ADR directory
+          default: docs/adr
+          description: ADR directory, resolved against the repository root.
+      additionalProperties: false
+    commandFunction: |-
       (config) => ({
         command: 'npx',
-        args: ['-y', '@adrkit/mcp', '--dir', config.dir || 'docs/adr'],
-        env: config.cwd ? { ADRKIT_MCP_CWD: config.cwd } : {}
+        args: [
+          '-y',
+          '@adrkit/mcp',
+          ...(config.cwd ? ['--cwd', config.cwd] : []),
+          '--dir', config.dir || 'docs/adr'
+        ]
       })
-  configSchema:
-    type: object
-    properties:
-      cwd:
-        type: string
-        title: Repository root
-        description: Absolute path to the git repo whose ADRs to read (defaults to the launch cwd).
-      dir:
-        type: string
-        default: docs/adr
-        title: ADR directory
-        description: ADR directory under the repo root.
-    additionalProperties: false
-  exampleConfig:
-    dir: docs/adr
+    exampleConfig:
+      dir: docs/adr
   ```
 
-- **Prerequisite:** `smithery.yaml` at repo root (REPORT: not owned here).
-- **Criteria met?** Partially, with an honest caveat: adrkit is a **local** server
-  whose tools require a real on-disk ADR corpus in a git repo. Smithery's hosted
-  tool-playground has no such corpus, so the interactive "try in browser" surface
-  cannot meaningfully exercise the tools — the value is discovery/listing, and the
-  copy should say the server runs locally against the user's repo.
+- **Validation:** Smithery does **not** publish a referenced JSON Schema in the file
+  (there is no `$schema` key to `ajv` against), so a schema check is not possible.
+  Instead: the file parses as well-formed YAML (`Bun.YAML.parse`), its structure
+  matches the current real examples above, and the `commandFunction` was **executed**
+  — for empty/`dir`-only/`cwd`+`dir` configs it emits argv that the real binary's
+  strict `parseArgs` (`--cwd`/`--dir`, from `packages/mcp/src/main-module.ts`)
+  accepts. This is behavioural verification, not a schema assertion.
+- **Caveat (transport):** Smithery is steering **hosted** deployments from `stdio`
+  toward HTTP. adrkit is a **local** stdio server (its tools need a real on-disk ADR
+  corpus in a git repo), which is the still-supported local-server case; it is not a
+  hosted deployment. Smithery's hosted tool-playground has no corpus, so the
+  interactive "try in browser" surface cannot meaningfully exercise the tools — the
+  value is discovery/listing, and the copy should say the server runs locally against
+  the user's repo.
 
 ### B4 — Glama
 
 - **Process:** Glama crawls GitHub for a `glama.json` at the **repo root** and
   indexes within ~24h; the repo already signals MCP via name/topics.
-- **Ready-to-paste `glama.json`** (belongs at **repo root** — REPORT: not owned
-  here):
+- **Status:** ✅ **placed** at the repo root of this worktree as
+  [`glama.json`](../glama.json) (committed locally, **not** submitted).
+- **Content** (verified 2026-07-25 against two live upstream `glama.json` files —
+  `PipedreamHQ/pipedream` and `apify/apify-mcp-server` — and Glama's documented
+  format; only `$schema` + `maintainers` (GitHub usernames) are required):
 
   ```json
   {
@@ -279,8 +301,12 @@ public repo. The only blocker is the human steps above (namespace proof + the P2
   }
   ```
 
-- **Prerequisite:** `glama.json` at repo root; repo public with "mcp" in
-  topics/description.
+- **Validation:** the file is well-formed JSON with a string `$schema` and a
+  `string[]` `maintainers`, matching the live examples byte-for-byte in structure.
+  I could **not** run `ajv` against the live schema at
+  `https://glama.ai/mcp/schemas/server.json` — that URL times out from this
+  environment — so this is format-verified against real upstream examples, **not**
+  schema-validated. Stated honestly.
 - **Criteria met?** Yes (public, documented, MCP server). Discovery-only listing.
 
 ### B5 — `awesome-mcp-servers` (GitHub PR)
@@ -329,8 +355,8 @@ public repo. The only blocker is the human steps above (namespace proof + the P2
 | Official MCP registry | `server.json` (validated) | P2 `mcpName` edit + namespace proof | **Blocked on P2 + namespace proof** | Add `mcpName`, add DNS TXT (or GitHub login), run `mcp-publisher publish` |
 | mcp.so | web form | public repo | **Yes** | Fill form at mcp.so/submit (free tier) |
 | PulseMCP | (ingests registry) | official-registry listing | **After A** | Publish A; optionally email hello@pulsemcp.com |
-| Smithery | `smithery.yaml` (root) | file at repo root | **Prepared; file not placed** | Add root `smithery.yaml`, connect repo at smithery.ai/new |
-| Glama | `glama.json` (root) | file at repo root | **Prepared; file not placed** | Add root `glama.json`; Glama auto-indexes |
+| Smithery | `smithery.yaml` (root) | file at repo root | **Placed at repo root (not submitted)** | Connect the repo at smithery.ai/new |
+| Glama | `glama.json` (root) | file at repo root | **Placed at repo root (not submitted)** | Nothing — Glama auto-crawls once merged and public |
 | awesome-mcp-servers | README PR | public repo | **Yes** | Open PR with the entry line |
 | adr.github.io tooling | Jekyll post PR | public repo | **Yes** | Open PR with the table row |
 
@@ -437,15 +463,28 @@ uses: mbeacom/adrkit/packages/ci/queue@efef89b5d747ca175a1947f1ce2f4296dab54fa3
 
 …"until a moving `queue@v0` tag is published." Here is what that actually requires.
 
-### D1 — current state (verified)
+### D1 — current state (verified directly against the remote)
 
-- The queue Action (`packages/ci/queue/action.yml`) was added in commit
-  `efef89b5d747ca175a1947f1ce2f4296dab54fa3`, which landed **after** the `v0.2.0`
-  release.
-- The repo-wide `v0` tag currently points at the `v0.2.0` commit
-  (`66a1e7f…`), which does **not** contain `packages/ci/queue/action.yml`.
-- Therefore `mbeacom/adrkit/packages/ci/queue@v0` would currently **fail to
-  resolve** — which is exactly why the README pins the full commit SHA.
+Re-confirmed against `origin` on 2026-07-25 with `git ls-remote --tags origin`,
+`gh api repos/mbeacom/adrkit/git/ref/tags/v0`, and the GitHub contents API:
+
+- The `v0` tag is a **lightweight tag** (`"type":"commit"`) pointing at
+  `66a1e7f4accf503e88830ea6c1ea4fcee96168c9` — the exact commit that the annotated
+  `v0.2.0` tag peels to (`v0.2.0^{}` = `66a1e7f…`). So `v0` == the `v0.2.0` release
+  commit.
+- `GET /repos/mbeacom/adrkit/contents/packages/ci/queue/action.yml?ref=66a1e7f…`
+  returns **HTTP 404 (Not Found)**. The queue Action **does not exist at `v0`**.
+- The same path **does** exist at the pinned commit
+  `efef89b5d747ca175a1947f1ce2f4296dab54fa3` (861 bytes) and at `main` (861 bytes).
+  `66a1e7f…` (`v0`) is a git ancestor of `efef89b…`, i.e. the Action was added
+  **after** the `v0.2.0`/`v0` commit.
+
+> **⚠️ Documentation-severity finding.** Anyone who follows a `@v0` reference for the
+> queue Action **today** — `uses: mbeacom/adrkit/packages/ci/queue@v0` — gets a
+> **missing action** and the workflow fails to resolve it. The full-commit-SHA pin
+> (`@efef89b…`) is therefore **mandatory, not a nicety**, until §D3 is performed.
+> Any doc that presents `@v0` as an available option for the queue Action is wrong
+> as of this date and should keep pinning the SHA.
 
 ### D2 — there is no separate `queue@v0` tag
 
@@ -478,7 +517,11 @@ procedure only; the release is a human action.
 | File (not owned here) | Needed change | Why |
 |---|---|---|
 | `packages/mcp/package.json` | Add `"mcpName": "dev.adrkit/mcp"` (must equal `server.json` `name`). | Required for official MCP registry npm-ownership verification (P2). |
-| repo-root `smithery.yaml` | Create with the content in B3. | Smithery reads it from the repo root. |
-| repo-root `glama.json` | Create with the content in B4. | Glama crawls it from the repo root. |
 
 `server.json` does **not** need to be added to `packages/mcp/package.json` `files`.
+
+> **Update (2026-07-25):** the repo-root `smithery.yaml` and `glama.json` are now
+> **placed in this worktree** (B3/B4) — they are no longer pending on another
+> workstream. They are committed locally but **not submitted**; Smithery still needs
+> the human to connect the repo at smithery.ai/new, and Glama will auto-crawl once
+> the branch is merged and public.

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["mbeacom"]
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,15 +2,17 @@
 
 Git-native architecture decision record tooling from adrkit.
 
+Zero-install with `npx` (the published binary is `adr`):
+
 ```sh
-bun add --dev @adrkit/cli
-bunx adr lint
+npx @adrkit/cli lint
 ```
 
-For one-off use:
+Or add it as a dev dependency:
 
 ```sh
-bunx @adrkit/cli lint
+npm install --save-dev @adrkit/cli    # or: bun add --dev @adrkit/cli
+adr lint
 ```
 
 The `adr` binary includes `new`, `lint`, `graph`, `explain`, `check`, `queue`,
@@ -19,7 +21,12 @@ The `adr` binary includes `new`, `lint`, `graph`, `explain`, `check`, `queue`,
 Run `adr --help` for the command list, `adr help <command>` for one command's
 flags, and `adr --version` to print the installed version.
 
-The published ESM CLI runs on Node.js 22 or newer.
+The published ESM CLI runs on Node.js 22 or newer; development in the adrkit
+repository uses Bun.
+
+See also [`@adrkit/mcp`](../mcp/README.md) — a local, read-only Model Context
+Protocol server that exposes this corpus (including superseded/rejected
+decisions) to coding agents.
 
 Documentation: <https://adrkit.dev>
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,17 +2,20 @@
 
 Git-native architecture decision record tooling from adrkit.
 
-Zero-install with `npx` (the published binary is `adr`):
+Zero-install with `npx`, naming the package (the published binary is `adr`, but a
+bare `npx adr` resolves an unrelated `adr` package on npm):
 
 ```sh
 npx @adrkit/cli lint
 ```
 
-Or add it as a dev dependency:
+Or add it as a dev dependency and invoke it through your runner, which puts
+`node_modules/.bin` on PATH — a bare `adr` will not be on an interactive shell's
+PATH:
 
 ```sh
 npm install --save-dev @adrkit/cli    # or: bun add --dev @adrkit/cli
-adr lint
+npx adr lint                          # or: bunx adr lint, or an npm script
 ```
 
 The `adr` binary includes `new`, `lint`, `graph`, `explain`, `check`, `queue`,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,7 @@ decision records: parsing, schema validation, corpus invariants, MADR migration,
 graph construction, and `affects` resolution.
 
 ```sh
-bun add @adrkit/core
+npm install @adrkit/core      # or: bun add @adrkit/core
 ```
 
 ```ts
@@ -16,6 +16,10 @@ const findings = lintCorpus(records);
 
 The published ESM artifacts run on Node.js 22 or newer. Development in the
 adrkit repository uses Bun.
+
+See also [`@adrkit/mcp`](../mcp/README.md) — a local, read-only Model Context
+Protocol server that exposes this corpus (including superseded/rejected
+decisions) to coding agents.
 
 Documentation: <https://adrkit.dev>
 

--- a/packages/evaluator/README.md
+++ b/packages/evaluator/README.md
@@ -6,7 +6,7 @@ reports and schema-compatible patches, and routes proposals without approving
 or persisting them.
 
 ```sh
-bun add @adrkit/evaluator
+npm install @adrkit/evaluator     # or: bun add @adrkit/evaluator
 ```
 
 ```ts
@@ -16,7 +16,12 @@ const result = evaluatePass0(input);
 ```
 
 No model, network, clock, filesystem traversal, or database is used by the
-library. The published ESM artifacts run on Node.js 22 or newer.
+library. The published ESM artifacts run on Node.js 22 or newer; development in
+the adrkit repository uses Bun.
+
+See also [`@adrkit/mcp`](../mcp/README.md) — a local, read-only Model Context
+Protocol server that exposes the ADR corpus (including superseded/rejected
+decisions) to coding agents.
 
 Documentation: <https://adrkit.dev>
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -229,7 +229,7 @@ never opened.**
       "title": "Adopt Postgres",
       "status": "accepted",
       "sourcePath": "docs/adr/0007-adopt-postgres.md",
-      "firedMatchers": [ { "type": "glob", "pattern": "src/db/**" } ],
+      "firedMatchers": [ { "type": "path", "pattern": "src/db/**" } ],
       "relations": { "supersedes": [], "supersededBy": null, "relatesTo": [], "conflictsWith": [] }
     }
   ],

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,21 +1,125 @@
 # `@adrkit/mcp`
 
-A **local, read-only** [Model Context Protocol](https://modelcontextprotocol.io)
-server that exposes adrkit decision retrieval over stdio. It lets an agent harness
-ask "has this been decided?", "what governs these files?", and "what replaced this?"
-against one Git-backed ADR corpus — deterministically, offline, with no model,
-network, or write access.
+**Deterministic, offline, read-only decision memory for coding agents — including
+the decisions you already rejected.**
 
-> Part of [adrkit](https://adrkit.dev). The corpus lives in git as one Markdown
-> file per decision with typed YAML frontmatter (`@adrkit/core`); this server only
-> reads it.
+A local [Model Context Protocol](https://modelcontextprotocol.io) server that lets
+an agent harness query one Git-backed ADR (Architecture Decision Record) corpus
+over stdio: *"has this been decided?"*, *"what governs these files?"*, and *"what
+replaced this?"* It surfaces **superseded and rejected** decisions specifically so
+agents stop re-proposing paths the team already ruled out.
 
-## Install and run
+> **No model calls. No network calls. No writes.** The server reads Markdown files
+> from your repo and returns structured JSON. It never calls an LLM, never opens a
+> socket, and never mutates your corpus. Every tool is annotated
+> `readOnlyHint: true`, `openWorldHint: false`.
+
+Part of [adrkit](https://adrkit.dev). The corpus lives in git as one Markdown file
+per decision with typed YAML frontmatter (`@adrkit/core`); this server only reads
+it. Registry namespace: **`dev.adrkit/mcp`** (this is the Node/npm `@adrkit/mcp`
+package — unrelated to the `adr-kit` Python package on PyPI).
+
+## Maturity
+
+adrkit is **early**. Phases 0–6 are *landed / reference-verified* against
+[ADR-0014](https://github.com/mbeacom/adrkit/blob/main/docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md)
+rungs 1–2 (unit/contract/conformance plus maintainer-owned isolated
+reference-repository validation). It has **no external adopters or production users
+yet**, and rung-3 external/community validation is openly tracked as not-yet-met.
+The 4-tool surface is locked by a
+[surface test](https://github.com/mbeacom/adrkit/blob/main/packages/mcp/test/surface.test.ts).
+
+## Quick start
+
+The published binary is **`adrkit-mcp`**. Run it with `npx` (no install):
 
 ```sh
-bunx @adrkit/mcp                       # run the adrkit-mcp bin
-adrkit-mcp --cwd /path/to/repo --dir docs/adr
+npx -y @adrkit/mcp --cwd /path/to/your/repo --dir docs/adr
 ```
+
+It speaks JSON-RPC over stdio, so you normally point an MCP client at it rather than
+running it by hand. Copy-pasteable client configs follow.
+
+### Claude Desktop
+
+Edit `claude_desktop_config.json` (macOS:
+`~/Library/Application Support/Claude/claude_desktop_config.json`). Claude launches
+servers from an arbitrary working directory, so set `ADRKIT_MCP_CWD` to your repo's
+absolute path:
+
+```json
+{
+  "mcpServers": {
+    "adrkit": {
+      "command": "npx",
+      "args": ["-y", "@adrkit/mcp"],
+      "env": {
+        "ADRKIT_MCP_CWD": "/absolute/path/to/your/repo",
+        "ADRKIT_MCP_DIR": "docs/adr"
+      }
+    }
+  }
+}
+```
+
+### VS Code
+
+Create `.vscode/mcp.json` in your workspace (VS Code uses the `servers` key and
+substitutes `${workspaceFolder}`):
+
+```json
+{
+  "servers": {
+    "adrkit": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@adrkit/mcp", "--cwd", "${workspaceFolder}", "--dir", "docs/adr"]
+    }
+  }
+}
+```
+
+### Cursor
+
+Create `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "adrkit": {
+      "command": "npx",
+      "args": ["-y", "@adrkit/mcp"],
+      "env": {
+        "ADRKIT_MCP_CWD": "/absolute/path/to/your/repo",
+        "ADRKIT_MCP_DIR": "docs/adr"
+      }
+    }
+  }
+}
+```
+
+### GitHub Copilot CLI
+
+Add to `~/.copilot/mcp-config.json` (user-level) or `./.copilot/mcp-config.json`
+(per-repo). Copilot CLI runs servers from the trusted repo directory, so the default
+`cwd` usually resolves correctly:
+
+```json
+{
+  "mcpServers": {
+    "adrkit": {
+      "type": "local",
+      "command": "npx",
+      "args": ["-y", "@adrkit/mcp", "--dir", "docs/adr"],
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+You can also add it interactively with `/mcp add` inside a `copilot` session.
+
+### Configuration reference
 
 | Option | Env | Default | Meaning |
 |---|---|---|---|
@@ -26,6 +130,148 @@ Flags win over environment variables, which win over the defaults. An unusable
 configuration exits non-zero with a diagnostic on **stderr** (`2` for an
 unparseable flag, `1` for an invalid root/directory) and never starts a transport.
 **stdout is reserved for JSON-RPC protocol frames only.**
+
+## The four tools
+
+Exactly four tools, all read-only. Each shares fixed annotations
+(`readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`,
+`openWorldHint: false`), returns a deterministic human-readable summary line in
+`content[0].text`, and carries a `findings` page with the corpus's own
+parse/validation findings. Every substantive response also includes a
+`corpusHealth` sibling: `{ fingerprint, recordCount, excludedCount }`.
+
+Shapes below are the real input/output contracts (see
+[`packages/mcp/src/tools`](https://github.com/mbeacom/adrkit/tree/main/packages/mcp/src/tools)).
+Each tool's structured output is `{ corpusHealth?, result }`; the objects shown
+under "output" are the members of that discriminated `result` union (keyed on
+`outcome`). `findings` and every growing array are cursor-paginated (see
+[Pagination](#pagination-and-cursor-restart)); `findings` and repeated pagination
+fields are elided here for brevity.
+
+### `search_decisions`
+
+Normalized literal substring search over id, title, tags, and body (the graveyard of
+superseded/rejected records is included by default). Filters are ANDed:
+`status`/`scope` match any-of; `tags` matches all-of.
+
+```jsonc
+// input
+{
+  "query": "postgres",          // required, 1–256 code units, non-empty after trim
+  "status": ["accepted"],        // optional, ≤6, any-of
+  "tags": ["database"],          // optional, ≤32 tags × ≤64 chars, all-of
+  "scope": ["backend"]           // optional, ≤3, any-of
+}
+// output → single "results" branch (empty results use the same branch)
+{
+  "outcome": "results",
+  "items": [
+    {
+      "id": "0007",
+      "title": "Adopt Postgres",
+      "status": "accepted",
+      "sourcePath": "docs/adr/0007-adopt-postgres.md",
+      "matchedFields": ["title", "body"]   // subset of id | title | tag | body
+    }
+  ],
+  "cursor": null
+}
+```
+
+### `get_decision`
+
+The complete typed frontmatter + body for one ref.
+
+```jsonc
+// input
+{ "ref": "0007" }               // AdrRef, 1–128 chars (local id, or a "log:id" federated ref)
+// output → discriminated on "outcome"
+// found (the full record is nested under "decision"):
+{
+  "outcome": "found",
+  "decision": {
+    "requestedRef": "0007",
+    "id": "0007",
+    "title": "Adopt Postgres",
+    "status": "accepted",
+    "sourcePath": "docs/adr/0007-adopt-postgres.md",
+    "frontmatter": { /* typed YAML: status, tags, affects, relations, ... */ },
+    "body": "## Context\n..."
+  }
+}
+// other outcomes:
+// { "outcome": "not-found", "requestedRef": "9999" }
+// { "outcome": "ambiguous-local-id", "requestedRef": "0007", "candidates": [ /* DecisionSummary[] */ ] }
+// { "outcome": "federated-log-unavailable", "requestedRef": "core:12", "log": "core", "id": "12" }
+```
+
+A `log:id` federated ref is recognized but **never resolved or substituted** — this
+server reads exactly one local corpus.
+
+### `get_decision_context`
+
+Governing / active-proposal / historical decisions for repo-relative `files[]`, via
+each record's own `affects` matchers. **Paths are compared against patterns only —
+never opened.**
+
+```jsonc
+// input
+{
+  "files": ["src/db/pool.ts", "src/db/schema.sql"]
+  // 1–256 entries; each POSIX, 1–1024 chars; no leading "/", no "..", no drive, no "\"
+}
+// output → single "matches" branch (all three arrays; empty is the same branch)
+{
+  "outcome": "matches",
+  "governing": [
+    {
+      "id": "0007",
+      "title": "Adopt Postgres",
+      "status": "accepted",
+      "sourcePath": "docs/adr/0007-adopt-postgres.md",
+      "firedMatchers": [ { "type": "glob", "pattern": "src/db/**" } ],
+      "relations": { "supersedes": [], "supersededBy": null, "relatesTo": [], "conflictsWith": [] }
+    }
+  ],
+  "activeProposals": [],
+  "history": []
+}
+```
+
+### `list_superseded`
+
+Every superseded record with its **direct** local replacement state — the tool that
+keeps agents from re-proposing rejected paths.
+
+```jsonc
+// input (pagination only)
+{}
+// output → single "entries" branch
+{
+  "outcome": "entries",
+  "items": [
+    {
+      "id": "0003",
+      "title": "Use MySQL",
+      "status": "superseded",
+      "sourcePath": "docs/adr/0003-use-mysql.md",
+      "supersededBy": {            // one of four states:
+        "resolved": true,
+        "target": { "id": "0007", "title": "Adopt Postgres", "status": "accepted", "sourcePath": "docs/adr/0007-adopt-postgres.md" }
+      }
+      // unresolved states:
+      //   { "resolved": false, "targetRef": "0099", "reason": "dangling" }
+      //   { "resolved": false, "targetRef": "0007", "reason": "ambiguous", "candidateCount": 2 }
+      //   { "resolved": false, "targetRef": "core:1", "reason": "federated-unavailable", "log": "core", "id": "1" }
+    }
+  ],
+  "cursor": null
+}
+```
+
+Relation refs (`supersedes`, `supersededBy`, `relatesTo`, `conflictsWith`) are
+surfaced verbatim and never expanded — follow them with a second `get_decision`
+call. Supersession is reported one hop deep; there is no transitive traversal.
 
 ## Library surface
 
@@ -43,24 +289,6 @@ await server.close();
 
 `createAdrkitMcpServer(options?)` performs no filesystem access at construction and
 returns a frozen, null-prototype handle with exactly `start()` and `close()`.
-
-## The four tools
-
-All four share fixed annotations (`readOnlyHint: true`, `destructiveHint: false`,
-`idempotentHint: true`, `openWorldHint: false`), a `corpusHealth`
-(`fingerprint`/`recordCount`/`excludedCount`) sibling on every substantive
-response, and a `findings` page carrying the corpus's own parse/validation findings.
-
-| Tool | Answers | Notable outcomes |
-|---|---|---|
-| `search_decisions` | Normalized literal substring search over id, title, tags, and body (graveyard included by default). Filters: `status`/`scope` (any-of), `tags` (all-of), ANDed. | `results` (empty is the same branch) |
-| `get_decision` | The complete typed frontmatter + body for one ref. | `found`, `not-found`, `ambiguous-local-id` (duplicate ids), `federated-log-unavailable` (a `log:id` ref is recognized, never resolved or substituted) |
-| `get_decision_context` | Governing / active-proposal / historical decisions for repo-relative `files[]`, via the corpus's own `affects` matchers. Paths are compared against patterns only — never opened. | `matches` (all three arrays; empty is the same branch) |
-| `list_superseded` | Every superseded record with its **direct** local replacement state. | `entries` with `resolved` / `dangling` / `ambiguous` (`candidateCount` only) / `federated-unavailable` targets |
-
-Relation refs (`supersedes`, `supersededBy`, `relatesTo`, `conflictsWith`) are
-surfaced verbatim and never expanded — follow them with a second `get_decision`
-call.
 
 ## Limits
 
@@ -80,7 +308,8 @@ an unchanged corpus; otherwise the response is a non-error `invalid-cursor` outc
 (`corpus-changed`, `query-mismatch`, `wrong-channel`, `offset-out-of-range`,
 `cursor-not-applicable`, `version-unsupported`, or `decode-failed`) and you should
 restart the walk from no cursor. The primary-result and `findings` channels page
-independently.
+independently. A `corpus-unavailable` outcome is returned when the ADR directory
+cannot be read.
 
 ## Boundaries (out of scope by design)
 

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "dev.adrkit/mcp",
+  "title": "adrkit decision memory",
+  "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
+  "version": "0.2.0",
+  "websiteUrl": "https://adrkit.dev",
+  "repository": {
+    "url": "https://github.com/mbeacom/adrkit",
+    "source": "github",
+    "subfolder": "packages/mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@adrkit/mcp",
+      "version": "0.2.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "ADRKIT_MCP_CWD",
+          "description": "Repository root; must contain a readable .git entry. Defaults to the process working directory.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "ADRKIT_MCP_DIR",
+          "description": "ADR directory, resolved against the root and required to stay contained within it. Defaults to docs/adr.",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,36 @@
+# Smithery configuration file: https://smithery.ai/docs/build/project-config
+#
+# adrkit-mcp is a LOCAL, read-only, stdio MCP server. Its four tools require a
+# real on-disk ADR corpus inside a git repository, so it is distributed as a
+# local (stdio) server that runs against the user's own checkout — not a hosted
+# deployment. See packages/mcp/README.md.
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      cwd:
+        type: string
+        title: Repository root
+        description: >-
+          Absolute path to the git repository whose ADRs to read. Must contain a
+          readable .git entry. Defaults to the launch working directory.
+      dir:
+        type: string
+        title: ADR directory
+        default: docs/adr
+        description: ADR directory, resolved against the repository root.
+    additionalProperties: false
+  commandFunction: |-
+    (config) => ({
+      command: 'npx',
+      args: [
+        '-y',
+        '@adrkit/mcp',
+        ...(config.cwd ? ['--cwd', config.cwd] : []),
+        '--dir', config.dir || 'docs/adr'
+      ]
+    })
+  exampleConfig:
+    dir: docs/adr

--- a/specs/007-arb-queue/contracts/github-action.md
+++ b/specs/007-arb-queue/contracts/github-action.md
@@ -21,6 +21,12 @@ Users reference it as:
 - uses: mbeacom/adrkit/packages/ci/queue@v0
 ```
 
+> **Not yet resolvable.** `@v0` is the *intended* contract, but the moving `v0`
+> tag currently points at a commit that predates this Action, so a `@v0`
+> reference fails to resolve. Until a release containing `packages/ci/queue` is
+> cut and `v0` is moved, use the full-commit pin
+> `@efef89b5d747ca175a1947f1ce2f4296dab54fa3` (see `docs/DISTRIBUTION.md` §D).
+
 This is a separate YAML from the existing `packages/ci/action.yml` (the PR
 governing-decisions action). Each action has distinct triggers, permissions, and
 purposes.

--- a/specs/007-arb-queue/quickstart.md
+++ b/specs/007-arb-queue/quickstart.md
@@ -311,7 +311,10 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@v4
-      - uses: mbeacom/adrkit/packages/ci/queue@v0
+      # `@v0` does not resolve yet — the moving v0 tag predates this Action.
+      # Pin the commit until a release containing packages/ci/queue is cut
+      # (see docs/DISTRIBUTION.md §D).
+      - uses: mbeacom/adrkit/packages/ci/queue@efef89b5d747ca175a1947f1ce2f4296dab54fa3
         with:
           dir: docs/adr
 ```


### PR DESCRIPTION
Wave 2 of a three-part maturation pass. Prepares distribution; **submits nothing**.

## Why

`@adrkit/mcp` is absent from every registry where its users actually search — the official MCP registry, mcp.so, PulseMCP, Smithery, Glama, `awesome-mcp-servers` — and adrkit is missing from `adr.github.io/adr-tooling`. Meanwhile a model-driven competitor (`mcp-adr-analysis-server`) already ranks for "ADR MCP server" with the opposite philosophy. adrkit's wedge — deterministic, offline, read-only, and it surfaces the decisions you already **rejected** — is the better fit for an agent harness, but it is currently invisible.

## What changed

- **`packages/mcp/server.json`** — official MCP registry manifest. Validated with `ajv@8` + `ajv-formats@3` against the **actually fetched** published schema (`2025-12-11`) → `valid: true`.
- **`packages/mcp/README.md`** — rewritten as the registry/npm landing page: differentiator first, real client configs for Claude Desktop / VS Code / Cursor / Copilot CLI, and all four tools documented from the real source rather than from memory.
- **`smithery.yaml` + `glama.json`** at the repo root, both re-verified against current upstream examples before writing. A correction was found during that re-verification: `configSchema`/`exampleConfig` nest **inside** `startCommand` in current real files, not as top-level siblings.
- **`docs/DISTRIBUTION.md`** — ready-to-paste submission content for all seven venues, prerequisites, and an honest readiness column. Includes a disambiguation clause for the unrelated `adr-kit` PyPI package.
- Package READMEs for core/cli/evaluator now lead with `npx`/`npm` (published artifacts are Node-targeted; Bun is the dev toolchain).

## Finding: `packages/ci/queue@v0` is broken today

Verified directly against the remote:

| Ref | `packages/ci/action.yml` | `packages/ci/queue/action.yml` |
|---|---|---|
| `v0` → `66a1e7f` | 823 bytes ✅ | **404** ❌ |
| `efef89b` (documented pin) | — | 861 bytes ✅ |
| `main` | — | 861 bytes ✅ |

`uses: mbeacom/adrkit/packages/ci/queue@v0` resolves to a missing action. The full-SHA pin is **mandatory**, not merely recommended, until a release is cut from `main`. The PR-comment Action at `packages/ci@v0` is unaffected. Existing docs already use the SHA pin, so this is a latent trap rather than an active broken instruction — now documented with evidence in `docs/DISTRIBUTION.md` §D.

## Zero-install demo, actually run

The quickstart in §C was executed against published `@adrkit/cli@0.2.0` in scratch dirs, not written aspirationally. It includes an **observed negative case**: before a decider was added, `lint` failed with `accepted-requires-decider-unless-imported` (exit 1) — enforcement demonstrated, not asserted (ADR-0016 spirit).

## Honesty

Nothing here is adoption. Per ADR-0014, registry listings are **distribution**; rung-3 is satisfied only when a non-maintainer runs a surface in their own repo at a pinned ref. No copy implies external adopters exist. The venue table reads "Ready?", never "Submitted".

Two limits stated plainly: `glama.json` could **not** be schema-validated (the live schema URL times out; format-verified against two real upstream files instead), and Smithery publishes no referenced schema, so that file was verified structurally and behaviourally instead — its `commandFunction` was executed and its emitted argv checked against the real binary's `parseArgs`.

## Validation

`bun run typecheck` clean · `bun run build` exit 0 · `bun test packages/mcp` 167 pass / 0 fail · lockfile untouched.