### PR TITLE
ci: make audit gate scope explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,10 @@ jobs:
         run: node .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
 
   audit:
-    # Fail the build on high/critical advisories in the resolved dependency tree.
+    # Fail the build on high/critical advisories in this checkout's resolved
+    # workspace dependency tree after root package.json overrides are applied.
+    # This does not audit consumer installs of published @adrkit/* manifests; the
+    # gate output records the current known published-consumer exposure separately.
     # Kept a separate job because it needs network for the advisory database, so
     # it never entangles the no-network clean-clone guarantee (ADR-0007).
     # ADR-0016: observed failing on the pre-fix tree; the permanent negative case

--- a/docs/adr/0017-keep-dependency-audit-scope-explicit-and-release-scoped.md
+++ b/docs/adr/0017-keep-dependency-audit-scope-explicit-and-release-scoped.md
@@ -1,0 +1,169 @@
+---
+schemaVersion: 0.1.0
+id: "0017"
+title: Keep dependency audit scope explicit and release-scoped
+status: proposed
+date: 2026-07-25
+deciders: ["@mbeacom"]
+tags: [security, ci, dependencies, release, evidence]
+scope: org
+reversibility: two-way-door
+blastRadius: team
+relatesTo: ["0007", "0014", "0016"]
+affects:
+  - type: path
+    pattern: "scripts/audit-gate.ts"
+  - type: path
+    pattern: "scripts/audit-gate.test.ts"
+  - type: path
+    pattern: ".github/workflows/ci.yml"
+  - type: path
+    pattern: "packages/*/package.json"
+provenance:
+  authoredBy: agent-drafted
+review:
+  tier: async
+  tierReason: >-
+    Changes how dependency-audit evidence is described and where published-package
+    consumer resolution should be verified. It does not change a public API, but
+    it does affect the meaning of a CI security gate across every published
+    package.
+externalRefs:
+  - type: other
+    id: GHSA-frvp-7c67-39w9
+    url: "https://github.com/advisories/GHSA-frvp-7c67-39w9"
+    label: Node.js Adapter for Hono serve-static path traversal on Windows
+reviewBy: 2026-10-31
+---
+
+# ADR-0017: Keep dependency audit scope explicit and release-scoped
+
+> **Status: `proposed`. This record is for maintainer review and is not
+> ratified.** It records the proposed interpretation of the audit gate, but it
+> does not become project law until a human accepts it.
+
+## Context
+
+The `audit` CI job runs `bun audit --json` through `scripts/audit-gate.ts` and
+blocks only high- or critical-severity advisories. That gate was observed
+failing against a real pre-fix workspace tree under ADR-0016, and it now fails
+closed on blind states such as no output, unparseable output, and unexpected
+JSON shape.
+
+The gate's scope was still ambiguous. It audited the repository's resolved
+workspace tree after root `package.json` overrides:
+
+```json
+"overrides": { "@hono/node-server": "^2.0.5", "fast-uri": "^3.1.4" }
+```
+
+Those overrides are not published in package manifests. A consumer installing
+`@adrkit/mcp@0.2.0` resolves a different tree:
+
+```text
+bun audit v1.3.14
+@hono/node-server  <2.0.5
+  @adrkit/mcp › @modelcontextprotocol/sdk › @hono/node-server
+  moderate: Node.js Adapter for Hono: Path traversal in `serve-static` on Windows via encoded backslash (`%5C`) - https://github.com/advisories/GHSA-frvp-7c67-39w9
+
+1 vulnerabilities (1 moderate)
+```
+
+The high-severity `fast-uri` advisory is genuinely closed for consumers because
+the SDK already resolves `fast-uri@3.1.4`. The remaining exposure is moderate,
+upstream-blocked, and low-consequence for adrkit: `@modelcontextprotocol/sdk`
+`1.29.0` is the latest release and still ranges `@hono/node-server` as
+`^1.19.9`, while adrkit's MCP server is a local stdio server that does not use
+Hono `serve-static` or expose HTTP static files.
+
+## Decision
+
+We will keep the PR CI audit as a **workspace resolved dependency tree** gate,
+and the gate must state that scope in its output. A reader must see that it
+examines this checkout after root overrides and does **not** audit consumer
+installs of published `@adrkit/*` package manifests.
+
+We will record the known `@adrkit/mcp@0.2.0` consumer exposure in the gate
+output rather than hiding it behind the workspace override. The record is narrow:
+it names `@hono/node-server`, `GHSA-frvp-7c67-39w9`, the observed published
+package and version, the upstream dependency path, why adrkit cannot currently
+fix the transitive range, why the consequence is low for a stdio server, and the
+condition that resolves it: an `@modelcontextprotocol/sdk` release whose
+`@hono/node-server` range lets consumers resolve `@hono/node-server >=2.0.5`.
+
+The acceptance expires on 2026-10-31. After that date the gate fails closed until
+the exposure is removed, the evidence is refreshed, or a human deliberately
+renews the narrow acceptance.
+
+Published-artifact consumer audits belong in release evidence, not every PR CI
+run. They require network, a real install of already-published package versions,
+and currently audit `@adrkit/mcp@0.2.0` while the repository is ahead of npm.
+That shape is valuable before or immediately after publishing, but it is a poor
+merge gate for ordinary source changes because it is slower, flakier, and can
+report on an artifact the PR did not produce.
+
+## Options considered
+
+### Option A: State workspace scope, record known consumer exposure, and move published audits to release evidence (chosen)
+
+| Dimension | Assessment |
+|---|---|
+| Honesty | The CI output says exactly what tree it examined and names the known tree it did not examine. |
+| Fail-closed behavior | Blind `bun audit` states still fail, and the known consumer acceptance fails after a fixed date. |
+| Cost | PR CI stays close to its current cost; release evidence absorbs the network-heavy published install. |
+| Gap | The PR gate does not discover new consumer-only advisories by itself. |
+
+### Option B: Audit published package consumer installs on every PR
+
+**Pros:** The PR check would continuously exercise the consumer resolution path.
+
+**Cons:** The check needs network and fresh installs of all four published
+packages (`@adrkit/core`, `@adrkit/cli`, `@adrkit/evaluator`, `@adrkit/mcp`).
+It also audits the package versions currently on npm, not necessarily the source
+tree under review. While the repo is ahead of the latest publication, this makes
+the PR gate noisy evidence about a different artifact.
+
+### Option C: Treat the root override audit as sufficient
+
+**Pros:** No code or process change.
+
+**Cons:** This is the false-assurance failure ADR-0016 describes: "clean" would
+mean "the workspace tree is clean after unpublished overrides" while readers
+could reasonably infer "published consumers are clean."
+
+### Option D: Fail every PR on the known moderate consumer advisory
+
+**Pros:** Conservative.
+
+**Cons:** There is no adrkit-side dependency bump available today: the latest
+SDK still ranges `@hono/node-server` below the patched major. Failing every PR
+would block unrelated work on an upstream moderate advisory that the stdio MCP
+server does not exercise.
+
+## Trade-offs
+
+This decision makes the CI output longer and leaves consumer-only discovery to
+release evidence rather than continuous PR evidence. It buys a more precise
+claim: the workspace gate is still a real gate, and the known published-consumer
+gap is visible instead of implied away.
+
+## Consequences
+
+- **Easier:** Reading the audit job output without over-interpreting it.
+- **Harder:** Maintaining the known-exposure record until the upstream SDK range
+  changes or the exposure is otherwise removed.
+- **How we would know this was wrong:** a consumer-only high or critical
+  advisory ships because release evidence did not run, or the acceptance expires
+  without prompting a real review.
+- **Revisit if:** published-artifact audits become cheap and deterministic
+  enough to run on every PR, or adrkit adds a release workflow that can make them
+  mandatory at the correct artifact boundary.
+
+## Action items
+
+1. [ ] Ratify or reject this proposed record.
+2. [ ] Add a release-time published-package consumer audit covering
+       `@adrkit/core`, `@adrkit/cli`, `@adrkit/evaluator`, and `@adrkit/mcp`.
+3. [ ] Remove or renew the `GHSA-frvp-7c67-39w9` acceptance by 2026-10-31, or
+       earlier if `@modelcontextprotocol/sdk` releases a range that reaches
+       `@hono/node-server >=2.0.5`.

--- a/packages/cli/test/lint.test.ts
+++ b/packages/cli/test/lint.test.ts
@@ -23,7 +23,7 @@ describe('adr lint CLI', () => {
   test('passes on this repository corpus', async () => {
     const result = await runAdr(['lint']);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('checked 16 records, 0 errors');
+    expect(result.stdout).toContain('checked 17 records, 0 errors');
     expect(result.stderr).toBe('');
   });
 

--- a/scripts/audit-gate.test.ts
+++ b/scripts/audit-gate.test.ts
@@ -4,6 +4,7 @@ import { evaluateAudit, formatEvaluation, main } from '../scripts/audit-gate.ts'
 
 const FIXTURES = resolve(import.meta.dir, '__fixtures__', 'audit');
 const readFixture = (name: string) => Bun.file(resolve(FIXTURES, name)).text();
+const ACTIVE_ACCEPTANCE_AS_OF = '2026-07-25';
 
 describe('audit-gate — evaluateAudit', () => {
   // ADR-0016 permanent negative case. `prefix-high.json` is the real, unedited
@@ -38,12 +39,48 @@ describe('audit-gate — evaluateAudit', () => {
   });
 
   test('passes a clean audit ({} — audit ran, found nothing)', async () => {
-    const evaluation = evaluateAudit(await readFixture('clean.json'));
+    const evaluation = evaluateAudit(await readFixture('clean.json'), { asOf: ACTIVE_ACCEPTANCE_AS_OF });
     expect(evaluation.ok).toBe(true);
     expect(evaluation.reason).toBeUndefined();
     expect(evaluation.blocking).toEqual([]);
     expect(evaluation.examinedPackages).toBe(0);
     expect(formatEvaluation(evaluation)).toContain('PASSED');
+  });
+
+  test('states that the live gate audits the workspace resolved tree, not published consumer installs', async () => {
+    const evaluation = evaluateAudit(await readFixture('clean.json'), { asOf: ACTIVE_ACCEPTANCE_AS_OF });
+    const rendered = formatEvaluation(evaluation);
+
+    expect(rendered).toContain('scope: workspace-resolved-dependency-tree');
+    expect(rendered).toContain('after root package.json overrides');
+    expect(rendered).toContain('does not audit consumer installs of published @adrkit/* packages');
+  });
+
+  test('records the known upstream-blocked @adrkit/mcp consumer advisory without hiding the scope gap', async () => {
+    const evaluation = evaluateAudit(await readFixture('clean.json'), { asOf: ACTIVE_ACCEPTANCE_AS_OF });
+    const known = evaluation.knownConsumerAdvisories?.[0];
+
+    expect(evaluation.ok).toBe(true);
+    expect(known?.package).toBe('@hono/node-server');
+    expect(known?.url).toBe('https://github.com/advisories/GHSA-frvp-7c67-39w9');
+    expect(known?.affectedPublishedPackage).toBe('@adrkit/mcp');
+    expect(known?.affectedPublishedVersion).toBe('0.2.0');
+    expect(known?.acceptedUntil).toBe('2026-10-31');
+
+    const rendered = formatEvaluation(evaluation);
+    expect(rendered).toContain('known published-consumer exposure');
+    expect(rendered).toContain('GHSA-frvp-7c67-39w9');
+    expect(rendered).toContain('@modelcontextprotocol/sdk@1.29.0');
+    expect(rendered).toContain('@hono/node-server >=2.0.5');
+    expect(rendered).toContain('stdio MCP server does not use Hono serve-static');
+  });
+
+  test('fails closed once the known consumer advisory acceptance expires', async () => {
+    const evaluation = evaluateAudit(await readFixture('clean.json'), { asOf: '2026-11-01' });
+
+    expect(evaluation.ok).toBe(false);
+    expect(evaluation.reason).toBe('consumer-advisory-acceptance-expired');
+    expect(formatEvaluation(evaluation)).toContain('consumer advisory acceptance expired');
   });
 
   // The core ADR-0016 distinction: absence of output is "could not look", which
@@ -74,7 +111,7 @@ describe('audit-gate — evaluateAudit', () => {
         },
       ],
     });
-    const evaluation = evaluateAudit(moderateOnly);
+    const evaluation = evaluateAudit(moderateOnly, { asOf: ACTIVE_ACCEPTANCE_AS_OF });
     expect(evaluation.ok).toBe(true);
     expect(evaluation.examinedBySeverity.moderate).toBe(1);
     expect(evaluation.blocking).toEqual([]);
@@ -157,10 +194,10 @@ describe('audit-gate — schema shape (fail-closed on anything unrecognized)', (
   });
 
   test('still accepts the real clean and dirty shapes', async () => {
-    expect(evaluateAudit(await readFixture('clean.json')).ok).toBe(true);
+    expect(evaluateAudit(await readFixture('clean.json'), { asOf: ACTIVE_ACCEPTANCE_AS_OF }).ok).toBe(true);
     expect(evaluateAudit(await readFixture('prefix-high.json')).reason).toBe('blocking-advisories');
     // An empty advisory array for a package is legitimate, not a shape error.
-    expect(evaluateAudit(JSON.stringify({ 'some-pkg': [] })).ok).toBe(true);
+    expect(evaluateAudit(JSON.stringify({ 'some-pkg': [] }), { asOf: ACTIVE_ACCEPTANCE_AS_OF }).ok).toBe(true);
   });
 });
 

--- a/scripts/audit-gate.ts
+++ b/scripts/audit-gate.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 // CI gate: fail the build on high- or critical-severity dependency advisories
-// reported by `bun audit --json`.
+// reported by `bun audit --json` for this checkout's resolved workspace tree.
 //
 // ADR-0016 ("require every check to be observed failing before it counts as
 // coverage") governs this file directly. A naive gate would run `bun audit`,
@@ -35,6 +35,30 @@ export interface BlockingAdvisory extends Advisory {
   readonly package: string;
 }
 
+export interface AuditScope {
+  readonly id: 'workspace-resolved-dependency-tree';
+  readonly examined: string;
+  readonly notExamined: string;
+}
+
+export interface KnownConsumerAdvisory {
+  readonly advisoryId: string;
+  readonly url: string;
+  readonly title: string;
+  readonly severity: AdvisorySeverity;
+  readonly package: string;
+  readonly observedVersion: string;
+  readonly vulnerableVersions: string;
+  readonly affectedPublishedPackage: string;
+  readonly affectedPublishedVersion: string;
+  readonly dependencyPath: readonly string[];
+  readonly acceptedUntil: string;
+  readonly expired: boolean;
+  readonly whyNotFixed: string;
+  readonly consequence: string;
+  readonly resolvesWhen: string;
+}
+
 export interface AuditEvaluation {
   /** True only when the audit was read AND contained no high/critical advisory. */
   readonly ok: boolean;
@@ -42,33 +66,82 @@ export interface AuditEvaluation {
    * Why the gate could not pass. `undefined` means it was read successfully.
    * 'no-output' / 'unparseable' / 'unexpected-shape' are blind states: the audit
    * could not be read, which ADR-0016 requires we surface rather than render as a
-   * clean pass.
+   * clean pass. Expired consumer acceptances also fail closed: the record was
+   * understood, but the accepted risk window has ended.
    */
-  readonly reason?: 'blocking-advisories' | 'no-output' | 'unparseable' | 'unexpected-shape';
+  readonly reason?:
+    | 'blocking-advisories'
+    | 'no-output'
+    | 'unparseable'
+    | 'unexpected-shape'
+    | 'invalid-as-of'
+    | 'consumer-advisory-acceptance-expired';
   /** High- and critical-severity advisories that block the gate. */
   readonly blocking: BlockingAdvisory[];
+  /** What dependency tree was actually audited. */
+  readonly scope: AuditScope;
+  /** Known consumer-install exposures outside `bun audit`'s workspace scope. */
+  readonly knownConsumerAdvisories: KnownConsumerAdvisory[];
+  /** UTC date used to decide whether known consumer advisory acceptances expired. */
+  readonly asOf: string;
   /** What was examined: advisory count per severity across every package. */
   readonly examinedBySeverity: Record<AdvisorySeverity, number>;
   /** Number of distinct packages carrying at least one advisory. */
   readonly examinedPackages: number;
-  /** Set only when `reason` is 'unexpected-shape': which field did not match. */
+  /** Set only when `reason` is 'unexpected-shape' or 'invalid-as-of'. */
   readonly shapeError?: string;
 }
 
 const BLOCKING: ReadonlySet<AdvisorySeverity> = new Set(['critical', 'high']);
+
+const WORKSPACE_AUDIT_SCOPE: AuditScope = {
+  id: 'workspace-resolved-dependency-tree',
+  examined:
+    'the current checkout after root package.json overrides are applied by `bun install --frozen-lockfile`',
+  notExamined:
+    'consumer installs of published @adrkit/* packages, whose manifests do not publish the root overrides',
+};
+
+const KNOWN_CONSUMER_ADVISORY_ACCEPTANCES: readonly Omit<KnownConsumerAdvisory, 'expired'>[] = [
+  {
+    advisoryId: 'GHSA-frvp-7c67-39w9',
+    url: 'https://github.com/advisories/GHSA-frvp-7c67-39w9',
+    title:
+      'Node.js Adapter for Hono: Path traversal in `serve-static` on Windows via encoded backslash (`%5C`)',
+    severity: 'moderate',
+    package: '@hono/node-server',
+    observedVersion: '1.19.15',
+    vulnerableVersions: '<2.0.5',
+    affectedPublishedPackage: '@adrkit/mcp',
+    affectedPublishedVersion: '0.2.0',
+    dependencyPath: ['@adrkit/mcp', '@modelcontextprotocol/sdk@1.29.0', '@hono/node-server'],
+    acceptedUntil: '2026-10-31',
+    whyNotFixed:
+      '@modelcontextprotocol/sdk@1.29.0 is the latest release and still ranges @hono/node-server as ^1.19.9; adrkit root overrides do not constrain consumer installs.',
+    consequence:
+      'adrkit is a local stdio MCP server; the stdio MCP server does not use Hono serve-static or expose HTTP static files, so this Windows serve-static path traversal is low-consequence here.',
+    resolvesWhen:
+      'an @modelcontextprotocol/sdk release updates its @hono/node-server range so consumers resolve @hono/node-server >=2.0.5, or adrkit removes that transitive path.',
+  },
+];
 
 function emptySeverityTally(): Record<AdvisorySeverity, number> {
   return { critical: 0, high: 0, moderate: 0, low: 0, info: 0 };
 }
 
 function blind(
-  reason: 'no-output' | 'unparseable' | 'unexpected-shape',
+  reason: 'no-output' | 'unparseable' | 'unexpected-shape' | 'invalid-as-of',
+  asOf: string,
+  knownConsumerAdvisories: KnownConsumerAdvisory[],
   shapeError?: string,
 ): AuditEvaluation {
   return {
     ok: false,
     reason,
     blocking: [],
+    scope: WORKSPACE_AUDIT_SCOPE,
+    knownConsumerAdvisories,
+    asOf,
     examinedBySeverity: emptySeverityTally(),
     examinedPackages: 0,
     ...(shapeError === undefined ? {} : { shapeError }),
@@ -116,28 +189,77 @@ function findShapeError(value: unknown): string | undefined {
   return undefined;
 }
 
+export interface AuditEvaluationOptions {
+  readonly asOf?: string;
+}
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function normalizeAsOf(value: string | undefined): { asOf: string; error?: string } {
+  const asOf = value ?? todayUtc();
+  if (!DATE_ONLY.test(asOf)) {
+    return { asOf, error: `expected asOf to be a UTC YYYY-MM-DD date, got ${JSON.stringify(asOf)}` };
+  }
+
+  const parsed = new Date(`${asOf}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== asOf) {
+    return { asOf, error: `expected asOf to be a real UTC calendar date, got ${JSON.stringify(asOf)}` };
+  }
+
+  return { asOf };
+}
+
+function buildKnownConsumerAdvisories(asOf: string): KnownConsumerAdvisory[] {
+  return KNOWN_CONSUMER_ADVISORY_ACCEPTANCES.map((advisory) => ({
+    ...advisory,
+    expired: asOf > advisory.acceptedUntil,
+  }));
+}
+
+function chooseReason(
+  blocking: readonly BlockingAdvisory[],
+  knownConsumerAdvisories: readonly KnownConsumerAdvisory[],
+): AuditEvaluation['reason'] {
+  if (blocking.length > 0) return 'blocking-advisories';
+  if (knownConsumerAdvisories.some((advisory) => advisory.expired)) {
+    return 'consumer-advisory-acceptance-expired';
+  }
+  return undefined;
+}
+
 /**
  * Evaluate raw `bun audit --json` stdout. Pure: no process, no I/O. Distinguishes
  * "read the audit and it was clean" from "could not read the audit at all".
  */
-export function evaluateAudit(raw: string): AuditEvaluation {
+export function evaluateAudit(raw: string, options: AuditEvaluationOptions = {}): AuditEvaluation {
+  const normalizedAsOf = normalizeAsOf(options.asOf);
+  if (normalizedAsOf.error !== undefined) {
+    return blind('invalid-as-of', normalizedAsOf.asOf, [], normalizedAsOf.error);
+  }
+  const { asOf } = normalizedAsOf;
+  const knownConsumerAdvisories = buildKnownConsumerAdvisories(asOf);
+
   const trimmed = raw.trim();
   if (trimmed.length === 0) {
     // ADR-0016: an absent report is "could not look", not "looked, found nothing".
-    return blind('no-output');
+    return blind('no-output', asOf, knownConsumerAdvisories);
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(trimmed);
   } catch {
-    return blind('unparseable');
+    return blind('unparseable', asOf, knownConsumerAdvisories);
   }
 
   // Valid JSON is not enough: a report we do not recognize must fail closed,
   // otherwise an envelope change renders as "examined 0 packages — PASSED".
   const shapeError = findShapeError(parsed);
-  if (shapeError !== undefined) return blind('unexpected-shape', shapeError);
+  if (shapeError !== undefined) return blind('unexpected-shape', asOf, knownConsumerAdvisories, shapeError);
 
   const examinedBySeverity = emptySeverityTally();
   const blocking: BlockingAdvisory[] = [];
@@ -154,28 +276,66 @@ export function evaluateAudit(raw: string): AuditEvaluation {
     }
   }
 
+  const reason = chooseReason(blocking, knownConsumerAdvisories);
   return {
-    ok: blocking.length === 0,
-    reason: blocking.length === 0 ? undefined : 'blocking-advisories',
+    ok: reason === undefined,
+    reason,
     blocking,
+    scope: WORKSPACE_AUDIT_SCOPE,
+    knownConsumerAdvisories,
+    asOf,
     examinedBySeverity,
     examinedPackages,
   };
 }
 
+function formatScope(scope: AuditScope): string {
+  return `audit-gate: scope: ${scope.id} — examines ${scope.examined}; does not audit ${scope.notExamined}.`;
+}
+
+function formatKnownConsumerAdvisories(advisories: readonly KnownConsumerAdvisory[], asOf: string): string {
+  if (advisories.length === 0) return '';
+
+  const lines = advisories.map((advisory) => {
+    const dependencyPath = advisory.dependencyPath.join(' › ');
+    const state = advisory.expired
+      ? `EXPIRED on ${advisory.acceptedUntil} (as-of ${asOf})`
+      : `accepted until ${advisory.acceptedUntil}`;
+    return [
+      `  - ${advisory.severity.toUpperCase()} ${advisory.affectedPublishedPackage}@${advisory.affectedPublishedVersion} consumer install: ${dependencyPath} resolves ${advisory.package}@${advisory.observedVersion} (${advisory.advisoryId}, ${advisory.url}; vulnerable ${advisory.vulnerableVersions}; ${state}).`,
+      `    why not fixed: ${advisory.whyNotFixed}`,
+      `    consequence: ${advisory.consequence}`,
+      `    resolves when: ${advisory.resolvesWhen}`,
+    ].join('\n');
+  });
+
+  return (
+    'audit-gate: known published-consumer exposure(s) outside this audit scope (recorded, not suppressed):\n' +
+    lines.join('\n')
+  );
+}
+
 /** Human-readable summary of what the gate examined and why it passed or failed. */
 export function formatEvaluation(evaluation: AuditEvaluation): string {
+  const scope = formatScope(evaluation.scope);
+  const known = formatKnownConsumerAdvisories(evaluation.knownConsumerAdvisories, evaluation.asOf);
+  const suffix = known.length === 0 ? '' : `\n${known}`;
+
+  if (evaluation.reason === 'invalid-as-of') {
+    return `${scope}\naudit-gate: FAILED — invalid audit-gate as-of date; refusing to evaluate acceptance expiry: ${evaluation.shapeError}.${suffix}`;
+  }
   if (evaluation.reason === 'no-output') {
-    return 'audit-gate: FAILED — `bun audit --json` produced no output; the audit could not be read (blind), not a clean tree.';
+    return `${scope}\naudit-gate: FAILED — \`bun audit --json\` produced no output; the audit could not be read (blind), not a clean tree.${suffix}`;
   }
   if (evaluation.reason === 'unparseable') {
-    return 'audit-gate: FAILED — `bun audit --json` output was not valid JSON; the audit could not be read (blind).';
+    return `${scope}\naudit-gate: FAILED — \`bun audit --json\` output was not valid JSON; the audit could not be read (blind).${suffix}`;
   }
   if (evaluation.reason === 'unexpected-shape') {
     return (
+      `${scope}\n` +
       'audit-gate: FAILED — `bun audit --json` output parsed but did not match the expected schema, ' +
       `so the audit could not be read (blind): ${evaluation.shapeError}. ` +
-      'If bun legitimately changed its output, update scripts/audit-gate.ts and its fixtures together.'
+      `If bun legitimately changed its output, update scripts/audit-gate.ts and its fixtures together.${suffix}`
     );
   }
 
@@ -185,16 +345,19 @@ export function formatEvaluation(evaluation: AuditEvaluation): string {
     `(critical=${s.critical}, high=${s.high}, moderate=${s.moderate}, low=${s.low}, info=${s.info}).`;
 
   if (evaluation.ok) {
-    return `${examined}\naudit-gate: PASSED — no high- or critical-severity advisories.`;
+    return `${scope}\n${examined}\naudit-gate: PASSED — no high- or critical-severity advisories.${suffix}`;
   }
 
-  const lines = evaluation.blocking.map(
-    (a) => `  - ${a.severity.toUpperCase()} ${a.package}: ${a.title} (${a.url})`,
-  );
+  const lines = evaluation.blocking.map((a) => `  - ${a.severity.toUpperCase()} ${a.package}: ${a.title} (${a.url})`);
+  const blockingMessage =
+    evaluation.blocking.length > 0
+      ? `audit-gate: FAILED — ${evaluation.blocking.length} high/critical advisory(ies) must be resolved:\n${lines.join('\n')}`
+      : 'audit-gate: FAILED — consumer advisory acceptance expired; refresh the published-consumer audit evidence, remove the exposure, or renew the narrow acceptance before this gate can pass.';
   return (
+    `${scope}\n` +
     `${examined}\n` +
-    `audit-gate: FAILED — ${evaluation.blocking.length} high/critical advisory(ies) must be resolved:\n` +
-    lines.join('\n')
+    blockingMessage +
+    suffix
   );
 }
 


### PR DESCRIPTION
## Problem

The current audit gate was true but over-broad in the assurance it appeared to give. `scripts/audit-gate.ts` reads `bun audit --json` for this repository's resolved workspace tree after the root `package.json` overrides are applied. Those overrides are not published in `@adrkit/*` package manifests, so a clean workspace audit is not evidence that a consumer install of the published packages is clean.

I re-verified the consumer gap with a real install of the published MCP package:

```text
$ mkdir .consumer-audit-probe && cd .consumer-audit-probe
$ printf '{"name":"adrkit-consumer-audit-probe","private":true}\n' > package.json
$ bun add @adrkit/mcp@0.2.0 >/dev/null
Resolving dependencies
Resolved, downloaded and extracted [86]
Saved lockfile
$ bun audit
bun audit v1.3.14 (0d9b296a)
@hono/node-server  <2.0.5
  @adrkit/mcp › @modelcontextprotocol/sdk › @hono/node-server
  moderate: Node.js Adapter for Hono: Path traversal in `serve-static` on Windows via encoded backslash (`%5C`) - https://github.com/advisories/GHSA-frvp-7c67-39w9

1 vulnerabilities (1 moderate)
```

`fast-uri` is genuinely closed for consumers because the SDK resolves `3.1.4`. The remaining exposure is the moderate `GHSA-frvp-7c67-39w9`; `@modelcontextprotocol/sdk@1.29.0` is latest and still ranges `@hono/node-server` as `^1.19.9`, so adrkit cannot fix this by bumping the SDK today. The stdio MCP server does not use Hono `serve-static` or expose HTTP static files, so the advisory is low-consequence for adrkit, but it should not be invisible.

## Design

- Keep the PR CI gate as a workspace resolved dependency tree audit, but make that scope explicit in the output and workflow comment.
- Preserve fail-closed parsing behavior for no output, unparseable JSON, and unexpected report shapes.
- Record the known `@adrkit/mcp@0.2.0` consumer exposure in `audit-gate` output with exact package, GHSA, published package/version, upstream path, why it is upstream-blocked, why it is low-consequence here, and the condition that resolves it.
- Make the acceptance narrow and expiring: after `2026-10-31`, `evaluateAudit` fails closed with `consumer-advisory-acceptance-expired` until the exposure is removed, evidence is refreshed, or a human deliberately renews it.
- Add proposed ADR-0017 (not accepted) documenting why published-artifact consumer audits are release evidence rather than ordinary PR CI.

## Alternatives rejected

- **Audit published package consumer installs on every PR.** This needs network and fresh installs of all four published packages (`@adrkit/core`, `@adrkit/cli`, `@adrkit/evaluator`, `@adrkit/mcp`), and it audits the versions already on npm rather than the source tree under review. The repo is currently ahead of `@adrkit/mcp@0.2.0`, so this would be slow/flaky evidence about a different artifact.
- **Treat the root override audit as sufficient.** That is the false-assurance failure ADR-0016 warns about: "clean" would mean only "workspace clean after unpublished overrides."
- **Fail every PR on this known moderate advisory.** There is no adrkit-side dependency bump available today, and the stdio server does not exercise the vulnerable `serve-static` path.

## ADR-0016 observed-failing output

Before implementing the fix, I added the new assertions and ran them against the unfixed code:

```text
$ bun test scripts/audit-gate.test.ts
bun test v1.3.14 (0d9b296a)

scripts/audit-gate.test.ts:
(pass) audit-gate — evaluateAudit > rejects the pre-fix tree and names the exact high-severity advisories [0.54ms]
(pass) audit-gate — evaluateAudit > passes a clean audit ({} — audit ran, found nothing) [0.10ms]
48 | 
49 |   test('states that the live gate audits the workspace resolved tree, not published consumer installs', async () => {
50 |     const evaluation = evaluateAudit(await readFixture('clean.json'), { asOf: '2026-07-25' });
51 |     const rendered = formatEvaluation(evaluation);
52 | 
53 |     expect(rendered).toContain('scope: workspace-resolved-dependency-tree');
                          ^
error: expect(received).toContain(expected)

Expected to contain: "scope: workspace-resolved-dependency-tree"
Received: "audit-gate: examined 0 package(s) with advisories (critical=0, high=0, moderate=0, low=0, info=0).\naudit-gate: PASSED — no high- or critical-severity advisories."

      at <anonymous> (/Users/markbeacom/github/mbeacom/copilot-worktrees/adrkit/audit-gate-published-scope/scripts/audit-gate.test.ts:53:22)
(fail) audit-gate — evaluateAudit > states that the live gate audits the workspace resolved tree, not published consumer installs [0.15ms]
58 |   test('records the known upstream-blocked @adrkit/mcp consumer advisory without hiding the scope gap', async () => {
59 |     const evaluation = evaluateAudit(await readFixture('clean.json'), { asOf: '2026-07-25' });
60 |     const known = evaluation.knownConsumerAdvisories?.[0];
61 | 
62 |     expect(evaluation.ok).toBe(true);
63 |     expect(known?.package).toBe('@hono/node-server');
                                ^
error: expect(received).toBe(expected)

Expected: "@hono/node-server"
Received: undefined

      at <anonymous> (/Users/markbeacom/github/mbeacom/copilot-worktrees/adrkit/audit-gate-published-scope/scripts/audit-gate.test.ts:63:28)
(fail) audit-gate — evaluateAudit > records the known upstream-blocked @adrkit/mcp consumer advisory without hiding the scope gap [0.12ms]
75 |   });
76 | 
77 |   test('fails closed once the known consumer advisory acceptance expires', async () => {
78 |     const evaluation = evaluateAudit(await readFixture('clean.json'), { asOf: '2026-11-01' });
79 | 
80 |     expect(evaluation.ok).toBe(false);
                               ^
error: expect(received).toBe(expected)

Expected: false
Received: true

      at <anonymous> (/Users/markbeacom/github/mbeacom/copilot-worktrees/adrkit/audit-gate-published-scope/scripts/audit-gate.test.ts:80:27)
(fail) audit-gate — evaluateAudit > fails closed once the known consumer advisory acceptance expires [0.11ms]

 16 pass
 3 fail
 50 expect() calls
Ran 19 tests across 1 file. [14.00ms]
```

## What this does and does not guarantee

This PR guarantees that the existing gate says what it actually audited, keeps blind `bun audit` states failing closed, and makes the known `@adrkit/mcp@0.2.0` consumer exposure visible with an expiry.

It does **not** continuously discover new consumer-only advisories for published packages on every PR. That should be added as release-time evidence at the artifact boundary, where the real published package versions are the intended subject.

## Validation

```text
$ bun test scripts/audit-gate.test.ts packages/cli/test/lint.test.ts
22 pass
0 fail
73 expect() calls

$ bun run typecheck && bun test && bun run lint
784 pass
0 fail
3495 expect() calls

$ bun run adr lint
checked 17 records, 0 errors, 0 warnings

$ bun run audit:gate
# passed; output now states scope and records GHSA-frvp-7c67-39w9 as known published-consumer exposure
```
