### PR TITLE
fix(core): require ratifiers for agent-drafted ADRs

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -143,10 +143,10 @@ the record contract. `schema/adr.schema.ts` is only a compatibility re-export.
   differs from a fresh emit (`schema-emit-matches`). The JSON Schema MUST NOT be
   hand-edited.
 - Cross-field invariants (e.g. `superseded` requires `supersededBy`; an accepted
-  decision names a decider unless imported; an agent-authored record cannot reach
-  `accepted` without a named human ratifier; one-way-door decisions cannot take
-  the auto tier) are enforced by code and covered by tests — never by an ad-hoc
-  script.
+  decision names a decider unless imported; a machine-originated record
+  (`agent` or `agent-drafted`) cannot reach `accepted` without a named human
+  ratifier; one-way-door decisions cannot take the auto tier) are enforced by
+  code and covered by tests — never by an ad-hoc script.
 - The schema is versioned independently of the tooling and is treated as a
   one-way door: consumers pin it, so breaking changes require an explicit,
   superseding decision.

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -47390,8 +47390,8 @@ var AdrFrontmatter = strictObject2({
 }).refine((a) => a.status !== "accepted" || a.deciders.length > 0 || Boolean(a.provenance?.importedFrom), {
   message: "an accepted decision must name at least one decider, unless it was imported",
   path: ["deciders"]
-}).refine((a) => a.status !== "accepted" || a.provenance?.authoredBy !== "agent" || Boolean(a.provenance?.ratifiedBy), {
-  message: 'an agent-authored record cannot reach "accepted" without a named human ratifier',
+}).refine((a) => a.status !== "accepted" || a.provenance?.authoredBy !== "agent" && a.provenance?.authoredBy !== "agent-drafted" || Boolean(a.provenance?.ratifiedBy), {
+  message: 'a machine-originated record cannot reach "accepted" without a named human ratifier',
   path: ["provenance", "ratifiedBy"]
 }).refine((a) => !(a.reversibility === "one-way-door" && a.review?.tier === "auto"), {
   message: "one-way-door decisions may not take the auto-approve fast path",
@@ -47610,7 +47610,7 @@ function ruleForIssue(issue3) {
     if (issue3.message === "an accepted decision must name at least one decider, unless it was imported") {
       return "accepted-requires-decider-unless-imported";
     }
-    if (issue3.message === 'an agent-authored record cannot reach "accepted" without a named human ratifier') {
+    if (issue3.message === 'a machine-originated record cannot reach "accepted" without a named human ratifier') {
       return "agent-accepted-requires-ratifier";
     }
     if (issue3.message === "one-way-door decisions may not take the auto-approve fast path") {

--- a/packages/ci/dist/queue-action.js
+++ b/packages/ci/dist/queue-action.js
@@ -45721,8 +45721,8 @@ var AdrFrontmatter = strictObject2({
 }).refine((a) => a.status !== "accepted" || a.deciders.length > 0 || Boolean(a.provenance?.importedFrom), {
   message: "an accepted decision must name at least one decider, unless it was imported",
   path: ["deciders"]
-}).refine((a) => a.status !== "accepted" || a.provenance?.authoredBy !== "agent" || Boolean(a.provenance?.ratifiedBy), {
-  message: 'an agent-authored record cannot reach "accepted" without a named human ratifier',
+}).refine((a) => a.status !== "accepted" || a.provenance?.authoredBy !== "agent" && a.provenance?.authoredBy !== "agent-drafted" || Boolean(a.provenance?.ratifiedBy), {
+  message: 'a machine-originated record cannot reach "accepted" without a named human ratifier',
   path: ["provenance", "ratifiedBy"]
 }).refine((a) => !(a.reversibility === "one-way-door" && a.review?.tier === "auto"), {
   message: "one-way-door decisions may not take the auto-approve fast path",
@@ -45933,7 +45933,7 @@ function ruleForIssue(issue3) {
     if (issue3.message === "an accepted decision must name at least one decider, unless it was imported") {
       return "accepted-requires-decider-unless-imported";
     }
-    if (issue3.message === 'an agent-authored record cannot reach "accepted" without a named human ratifier') {
+    if (issue3.message === 'a machine-originated record cannot reach "accepted" without a named human ratifier') {
       return "agent-accepted-requires-ratifier";
     }
     if (issue3.message === "one-way-door decisions may not take the auto-approve fast path") {

--- a/packages/core/src/schema/adr.schema.ts
+++ b/packages/core/src/schema/adr.schema.ts
@@ -290,11 +290,12 @@ export const AdrFrontmatter = strictObject({
   .refine(
     (a) =>
       a.status !== 'accepted' ||
-      a.provenance?.authoredBy !== 'agent' ||
+      (a.provenance?.authoredBy !== 'agent' &&
+        a.provenance?.authoredBy !== 'agent-drafted') ||
       Boolean(a.provenance?.ratifiedBy),
     {
       message:
-        'an agent-authored record cannot reach "accepted" without a named human ratifier',
+        'a machine-originated record cannot reach "accepted" without a named human ratifier',
       path: ['provenance', 'ratifiedBy'],
     },
   )

--- a/packages/core/src/validate/contract.ts
+++ b/packages/core/src/validate/contract.ts
@@ -37,7 +37,7 @@ function ruleForIssue(issue: z.core.$ZodIssue): string {
     }
     if (
       issue.message ===
-      'an agent-authored record cannot reach "accepted" without a named human ratifier'
+      'a machine-originated record cannot reach "accepted" without a named human ratifier'
     ) {
       return 'agent-accepted-requires-ratifier';
     }

--- a/packages/core/test/invariants.test.ts
+++ b/packages/core/test/invariants.test.ts
@@ -54,25 +54,37 @@ describe('intra-record contract invariants', () => {
     );
   });
 
-  test('agent-authored accepted records need a human ratifier', () => {
+  test('machine-originated accepted records need a human ratifier', () => {
+    for (const authoredBy of ['agent', 'agent-drafted']) {
+      expect(
+        rulesFor(
+          base({
+            status: 'accepted',
+            deciders: ['@mbeacom'],
+            provenance: { authoredBy, ratifiedBy: '@mbeacom' },
+          }),
+        ),
+      ).toEqual([]);
+      expect(
+        rulesFor(
+          base({
+            status: 'accepted',
+            deciders: ['@mbeacom'],
+            provenance: { authoredBy },
+          }),
+        ),
+      ).toContain('agent-accepted-requires-ratifier');
+    }
+
     expect(
       rulesFor(
         base({
           status: 'accepted',
           deciders: ['@mbeacom'],
-          provenance: { authoredBy: 'agent', ratifiedBy: '@mbeacom' },
+          provenance: { authoredBy: 'human' },
         }),
       ),
     ).toEqual([]);
-    expect(
-      rulesFor(
-        base({
-          status: 'accepted',
-          deciders: ['@mbeacom'],
-          provenance: { authoredBy: 'agent' },
-        }),
-      ),
-    ).toContain('agent-accepted-requires-ratifier');
   });
 
   test('one-way-door decisions may not take the auto tier', () => {

--- a/site/src/content/docs/schema.mdx
+++ b/site/src/content/docs/schema.mdx
@@ -98,7 +98,7 @@ These are what make a record enforceable and routable rather than advisory.
 | `reversibility` | `two-way-door`, `one-way-door`, or `unknown`. A `one-way-door` decision may not take the auto-approve fast path. |
 | `blastRadius` | `component`, `team`, `cross-team`, or `org`. |
 | `supersedes` / `supersededBy` | Links the supersession graph. |
-| `provenance` | Who (or what agent) authored the record, and who ratified it. An agent-authored record cannot reach `accepted` without a named human ratifier. |
+| `provenance` | Who (or what agent) authored the record, and who ratified it. A machine-originated record (`agent` or `agent-drafted`) cannot reach `accepted` without a named human ratifier. |
 
 The schema is `additionalProperties: false` — unknown frontmatter keys are a hard
 error, so a typo fails validation instead of silently doing nothing.

--- a/specs/001-schema-and-core/data-model.md
+++ b/specs/001-schema-and-core/data-model.md
@@ -39,7 +39,7 @@ A parsed record. Composed of:
 
 1. `status = superseded` ⇒ `supersededBy` present, and its converse.
 2. `status = accepted` ⇒ ≥1 `deciders`, unless `provenance.importedFrom` present.
-3. `provenance.authoredBy = agent` & `status = accepted` ⇒ `provenance.ratifiedBy`.
+3. `provenance.authoredBy = agent | agent-drafted` & `status = accepted` ⇒ `provenance.ratifiedBy`.
 4. `reversibility = one-way-door` ⇒ `review.tier ≠ auto`.
 5. Strict object: unknown frontmatter keys are rejected.
 


### PR DESCRIPTION
## Defect

The accepted-record ratification refine only checked `provenance.authoredBy === "agent"`. Because the schema also allows `agent-drafted`, a machine-originated `agent-drafted` ADR could become `accepted` with no `provenance.ratifiedBy`, even though the governance rule says accepted machine-originated records need a named human ratifier.

## Reproduction

The reported corpus reproduction was: copy `docs/adr/`, flip an `agent-drafted` record such as ADR-0015 to `status: accepted`, remove `ratifiedBy`, then run lint. Before this fix, that produced:

```text
checked 16 records, 0 errors, 0 warnings
exit=0
```

## Observed failing test before fix

After adding the regression test but before changing the schema refine, the targeted test failed as required by ADR-0016:

```text
$ bun test packages/core/test/invariants.test.ts
bun test v1.3.14 (0d9b296a)

packages/core/test/invariants.test.ts:
(pass) intra-record contract invariants > status superseded requires supersededBy [2.58ms]
(pass) intra-record contract invariants > supersededBy requires status superseded [0.11ms]
(pass) intra-record contract invariants > accepted records need a decider unless imported [0.30ms]
71 |             status: 'accepted',
72 |             deciders: ['@mbeacom'],
73 |             provenance: { authoredBy },
74 |           }),
75 |         ),
76 |       ).toContain('agent-accepted-requires-ratifier');
             ^
error: expect(received).toContain(expected)

Expected to contain: "agent-accepted-requires-ratifier"
Received: []

      at <anonymous> (/Users/markbeacom/github/mbeacom/copilot-worktrees/adrkit/ratifier-gate/packages/core/test/invariants.test.ts:76:9)
(fail) intra-record contract invariants > machine-originated accepted records need a human ratifier [0.24ms]
(pass) intra-record contract invariants > one-way-door decisions may not take the auto tier [0.28ms]
(pass) intra-record contract invariants > unknown keys are rejected by the strict contract [0.14ms]
(pass) intra-record contract invariants > unknown nested keys are rejected by the strict contract [0.08ms]

 6 pass
 1 fail
 16 expect() calls
Ran 7 tests across 1 file. [24.00ms]
```

## Fix / guarantee

- Treat both `agent` and `agent-drafted` as machine-originated authorship for the accepted-record ratification gate.
- Keep `human` accepted records unaffected.
- Preserve the existing finding rule (`agent-accepted-requires-ratifier`) while updating the human-readable message to match the enforced rule.
- Rebuild the committed CI action bundles so repository CI uses the tightened gate too.
- Clarify docs/constitution/spec wording to name `agent` and `agent-drafted` explicitly.

Now, `accepted` + (`agent` or `agent-drafted`) + no `ratifiedBy` is rejected; the same records with a ratifier are accepted; `human` accepted records are unaffected.

## Schema emit / validation

`bun run schema:emit` was run, followed by `git diff --exit-code schema/adr.schema.json`. The JSON Schema artifact stayed byte-identical because this is a refine-only invariant and is not represented in the emitted JSON Schema.

Validation passed:

```text
bun run schema:emit && git diff --exit-code schema/adr.schema.json && bun run typecheck && bun test && bun run lint && bun run adr lint
```

Corpus cleanliness:

```text
$ bun run adr lint
checked 17 records, 0 errors, 0 warnings
```

## `agent` vs `agent-drafted`

I searched the codebase for differentiated handling. The only meaningful code paths treat both values as the same machine-originated class (for example evaluator routing already checks `agent || agent-drafted`), and the current corpus uses `agent-drafted` or `human`, not `agent`. I recommend a follow-up ADR/migration discussion on simplifying the enum if external consumers do not need both values; this PR intentionally does not change the enum.
