### PR TITLE
chore(governance): queue this repo's own ARB backlog and de-pin queue@v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,7 @@ answer where the next decision is actually being made.
 
 It never approves anything. It routes, and humans decide.
 
-Use the CI Action from its moving major tag; pin the queue Action to a commit until
-a moving `queue@v0` tag exists (see [Use in CI](https://adrkit.dev/ci/)):
+Use both CI Actions from their moving major tag (see [Use in CI](https://adrkit.dev/ci/)):
 
 ```yaml
 permissions:

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -482,17 +482,20 @@ one-way (round-trip sync is out of scope per ADR-0008), and surfaces honest find
 
 ---
 
-## D. The moving `queue@v0` tag
+## D. The moving `queue@v0` tag (resolved by v0.2.1)
 
-The README/plan pin the ARB-queue GitHub Action to a commit:
+**Status: resolved.** The v0.2.1 release moved the `v0` tag to `31bed03`, a commit
+that contains `packages/ci/queue/action.yml`, so adopters now reference the
+ARB-queue Action from its moving major tag like any other:
 
 ```yaml
-uses: mbeacom/adrkit/packages/ci/queue@efef89b5d747ca175a1947f1ce2f4296dab54fa3
+uses: mbeacom/adrkit/packages/ci/queue@v0
 ```
 
-…"until a moving `queue@v0` tag is published." Here is what that actually requires.
+The rest of this section is the historical record of why a full-commit pin was
+mandatory beforehand, and what it took to lift it.
 
-### D1 — current state (verified directly against the remote)
+### D1 — pre-release state (verified directly against the remote, 2026-07-25)
 
 Re-confirmed against `origin` on 2026-07-25 with `git ls-remote --tags origin`,
 `gh api repos/mbeacom/adrkit/git/ref/tags/v0`, and the GitHub contents API:
@@ -508,21 +511,24 @@ Re-confirmed against `origin` on 2026-07-25 with `git ls-remote --tags origin`,
   `66a1e7f…` (`v0`) is a git ancestor of `efef89b…`, i.e. the Action was added
   **after** the `v0.2.0`/`v0` commit.
 
-> **⚠️ Documentation-severity finding.** Anyone who follows a `@v0` reference for the
-> queue Action **today** — `uses: mbeacom/adrkit/packages/ci/queue@v0` — gets a
-> **missing action** and the workflow fails to resolve it. The full-commit-SHA pin
-> (`@efef89b…`) is therefore **mandatory, not a nicety**, until §D3 is performed.
-> Any doc that presents `@v0` as an available option for the queue Action is wrong
-> as of this date and should keep pinning the SHA.
+> **⚠️ Documentation-severity finding (historical — resolved by v0.2.1).** As of
+> 2026-07-25, anyone who followed a `@v0` reference for the queue Action —
+> `uses: mbeacom/adrkit/packages/ci/queue@v0` — got a **missing action** and the
+> workflow failed to resolve it. The full-commit-SHA pin (`@efef89b…`) was
+> therefore **mandatory, not a nicety**, until §D3 was performed. Since the
+> v0.2.1 release moved `v0` to `31bed03`, `@v0` resolves and the copy-pasteable
+> examples have been de-pinned to it.
 >
-> **Repository sweep (done in this PR).** `README.md` and this document already
-> pinned the SHA, but two runnable references did not and have been corrected:
+> **Repository sweep (done in the PR that recorded this finding).** `README.md` and
+> this document already pinned the SHA, but two runnable references did not and were
+> corrected at the time:
 > `specs/007-arb-queue/quickstart.md` (workflow YAML → SHA pin) and
-> `specs/007-arb-queue/contracts/github-action.md` (keeps `@v0` as the *intended*
-> contract, with an explicit not-yet-resolvable note). The remaining `@v0` strings
+> `specs/007-arb-queue/contracts/github-action.md` (kept `@v0` as the *intended*
+> contract, with an explicit not-yet-resolvable note). Both have since been
+> de-pinned back to `@v0` now that it resolves. The remaining `@v0` strings
 > in `specs/007-arb-queue/research.md` and `tasks.md` are design rationale and a
 > completed task record, not copy-pasteable instructions; `tasks.md` T049 already
-> says to advertise `@v0` only after the tag moves.
+> said to advertise `@v0` only after the tag moves.
 
 ### D2 — there is no separate `queue@v0` tag
 
@@ -532,7 +538,7 @@ subpath `packages/ci/queue`. `scripts/update-action-tag.ts` force-moves the
 new stable `vX.Y.Z` tag is pushed and the new version is newer than the tag's
 current target (see `docs/RELEASING.md`, "Subsequent releases").
 
-### D3 — procedure to make `queue@v0` resolve (human; do NOT run here)
+### D3 — procedure that made `queue@v0` resolve (performed by the v0.2.1 release)
 
 1. Cut the next release (e.g. `v0.2.1` or `v0.3.0`) whose release commit **includes**
    `packages/ci/queue/action.yml` — i.e. any release cut from current `main`.
@@ -545,8 +551,14 @@ current target (see `docs/RELEASING.md`, "Subsequent releases").
    contains `packages/ci/queue/action.yml`, and adopters can switch the pin from the
    commit SHA to `@v0`.
 
-**Do not create or push any tag as part of this wave.** This is documentation of the
-procedure only; the release is a human action.
+**Done.** v0.2.1 executed exactly this: `v0` and `v0.2.1^{}` both peel to
+`31bed03a179b6bfa4a62f7e69008c7441c62598f`, and
+`GET /repos/mbeacom/adrkit/contents/packages/ci/queue/action.yml?ref=v0` returns the
+861-byte blob. The copy-pasteable examples were de-pinned to `@v0` as
+`docs/RELEASING.md` step 8 requires; immutable SHA pins are kept only where the
+surrounding text is teaching reproducibility (the §D1 record above,
+`specs/007-arb-queue/checklists/reference-verification-evidence.md`, ADR-0014, and
+`plan.md`).
 
 ---
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -555,10 +555,21 @@ current target (see `docs/RELEASING.md`, "Subsequent releases").
 `31bed03a179b6bfa4a62f7e69008c7441c62598f`, and
 `GET /repos/mbeacom/adrkit/contents/packages/ci/queue/action.yml?ref=v0` returns the
 861-byte blob. The copy-pasteable examples were de-pinned to `@v0` as
-`docs/RELEASING.md` step 8 requires; immutable SHA pins are kept only where the
-surrounding text is teaching reproducibility (the §D1 record above,
-`specs/007-arb-queue/checklists/reference-verification-evidence.md`, ADR-0014, and
-`plan.md`).
+`docs/RELEASING.md` step 8 requires.
+
+Immutable `@efef89b…` pins are kept only where the surrounding text is teaching
+reproducibility or recording history. That set is exhaustively:
+
+- §D1 above (the pre-release verified state)
+- `specs/007-arb-queue/checklists/reference-verification-evidence.md`
+- `specs/007-arb-queue/contracts/github-action.md` (the historical resolvability note)
+- `specs/007-arb-queue/tasks.md` (the completed T018 record)
+- `docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md`
+- `plan.md`
+
+The SHA also appears once more in `docs/RELEASING.md` step 8, as the argument to
+the `rg` command that verifies the de-pin actually happened. That is the check
+itself, not a pin.
 
 ---
 

--- a/docs/adr/0003-ship-as-spec-kit-extension.md
+++ b/docs/adr/0003-ship-as-spec-kit-extension.md
@@ -21,6 +21,8 @@ provenance:
 review:
   tier: arb
   tierReason: Determines distribution strategy and primary adoption channel.
+  queuedAt: 2026-07-28T00:00:00Z
+  slaDays: 30
 externalRefs:
   - type: doc
     url: https://github.github.com/spec-kit/

--- a/docs/adr/0006-license-apache-2-and-single-monorepo.md
+++ b/docs/adr/0006-license-apache-2-and-single-monorepo.md
@@ -21,6 +21,8 @@ provenance:
 review:
   tier: arb
   tierReason: Licensing is effectively irreversible once external contributions land.
+  queuedAt: 2026-07-28T00:00:00Z
+  slaDays: 30
 ---
 
 # ADR-0006: License Apache-2.0 with a DCO and develop in a single monorepo

--- a/docs/adr/0007-adapter-isolation-and-public-surface-build.md
+++ b/docs/adr/0007-adapter-isolation-and-public-surface-build.md
@@ -25,6 +25,8 @@ review:
   tierReason: >-
     Sets the dependency boundary for every future integration and the IP
     boundary for the repository. Expensive to reverse once adapters exist.
+  queuedAt: 2026-07-28T00:00:00Z
+  slaDays: 30
 assertions:
   - id: core-has-no-adapter-deps
     description: >-

--- a/docs/adr/0008-import-and-migration-semantics.md
+++ b/docs/adr/0008-import-and-migration-semantics.md
@@ -23,6 +23,8 @@ review:
   tierReason: >-
     Determines whether imported records carry governance authority they never
     earned. Low technical risk, high governance risk.
+  queuedAt: 2026-07-28T00:00:00Z
+  slaDays: 30
 ---
 
 # ADR-0008: Migrate MADR corpora in place and treat all other imports as one-way with a re-import diff

--- a/docs/adr/0009-affects-resolution-and-catalog-binding.md
+++ b/docs/adr/0009-affects-resolution-and-catalog-binding.md
@@ -23,6 +23,8 @@ review:
   tierReason: >-
     Every consumer depends on these semantics; changing them later silently
     changes which decisions govern which code.
+  queuedAt: 2026-07-28T00:00:00Z
+  slaDays: 30
 assertions:
   - id: resolution-is-pure
     description: >-

--- a/docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md
+++ b/docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md
@@ -2,9 +2,9 @@
 schemaVersion: 0.1.0
 id: "0016"
 title: Require every check to be observed failing before it counts as coverage
-status: draft
+status: proposed
 date: 2026-07-25
-deciders: []
+deciders: ["@mbeacom"]
 tags: [governance, testing, evidence, quality]
 scope: org
 reversibility: two-way-door
@@ -23,6 +23,8 @@ review:
     Changes how contributors are expected to write and review checks across every
     package, but is a reversible process convention rather than a schema or
     interface commitment. No external consumer depends on it.
+  queuedAt: 2026-07-28T00:00:00Z
+  slaDays: 30
 ---
 
 # ADR-0016: Require every check to be observed failing before it counts as coverage

--- a/docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md
+++ b/docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md
@@ -240,7 +240,7 @@ equality assertion would be cargo cult.
 
 ## Action items
 
-1. [ ] Ratify or reject — this record is `draft` and agent-drafted; it binds
+1. [ ] Ratify or reject — this record is `proposed` and agent-drafted; it binds
        nothing until a human accepts it.
 2. [x] Carry both directions for the two checks that motivated this. The tests
        accompanying `corpus-file-skipped` and `corpus.file-skipped` already

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -67,16 +67,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mbeacom/adrkit/packages/ci/queue@efef89b5d747ca175a1947f1ce2f4296dab54fa3
+      - uses: mbeacom/adrkit/packages/ci/queue@v0
         # with:
         #   dir: docs/adr
         #   issue-title: ADR ARB Queue
 ```
 
-<Aside type="caution" title="Pin the queue Action to a commit">
-	The queue Action does **not** yet have a moving `queue@v0` tag. Until one is
-	published, pin it to the immutable commit
-	`efef89b5d747ca175a1947f1ce2f4296dab54fa3`, exactly as shown. Phase 6 is
+<Aside type="note" title="Pinning the queue Action">
+	`queue@v0` resolves as of the v0.2.1 release, which moved the `v0` tag to a
+	commit containing `packages/ci/queue/action.yml`. `@v0` is a moving tag; pin
+	the full commit SHA instead if you need a byte-immutable reference. Phase 6 is
 	landed and maintainer reference-verified; external validation
 	([ADR-0014](/adr/) rung 3) remains open.
 </Aside>
@@ -84,17 +84,17 @@ jobs:
 The managed issue's body is the same report you get locally:
 
 ```text
-# ARB Queue — 2026-07-25
+# ARB Queue — 2026-07-28
 
-Corpus fingerprint: `96e7f31…903cb00`
-7 item(s) | 0 corpus finding(s) | 0 item(s) with findings
+Corpus fingerprint: `0cd56b8…10e3eb6`
+8 item(s) | 0 corpus finding(s) | 0 item(s) with findings
 
 ## Queue Items
 
 | # | ID | Title | Tier | SLA State | Deadline | Approvals | Objections |
 |---|----|-------|------|-----------|----------|-----------|------------|
-| 1 | 0005 | Gate proposals with a deterministic-first evaluator … | arb | within-sla | 2027-01-18 | 0/- | 0 |
-| 2 | 0015 | Validate descriptors against Backstage field formats … | arb | within-sla | 2027-01-25 | 0/- | 0 |
+| 1 | 0003 | Ship as a Spec Kit extension plus a standalone CLI … | arb | within-sla | 2026-08-27 | 0/- | 0 |
+| 2 | 0006 | License Apache-2.0 with a DCO and develop in a single … | arb | within-sla | 2026-08-27 | 0/- | 0 |
 ```
 
 Identical inputs produce byte-for-byte identical output, so a re-run only

--- a/specs/007-arb-queue/contracts/github-action.md
+++ b/specs/007-arb-queue/contracts/github-action.md
@@ -21,11 +21,12 @@ Users reference it as:
 - uses: mbeacom/adrkit/packages/ci/queue@v0
 ```
 
-> **Not yet resolvable.** `@v0` is the *intended* contract, but the moving `v0`
-> tag currently points at a commit that predates this Action, so a `@v0`
-> reference fails to resolve. Until a release containing `packages/ci/queue` is
-> cut and `v0` is moved, use the full-commit pin
-> `@efef89b5d747ca175a1947f1ce2f4296dab54fa3` (see `docs/DISTRIBUTION.md` §D).
+> **Resolvable since v0.2.1.** The v0.2.1 release moved the `v0` tag to a commit
+> containing `packages/ci/queue`, so `@v0` now resolves as intended. Historical
+> note: before that release, `v0` pointed at a commit predating this Action and
+> `@v0` failed to resolve, so the full-commit pin
+> `@efef89b5d747ca175a1947f1ce2f4296dab54fa3` was mandatory (see
+> `docs/DISTRIBUTION.md` §D).
 
 This is a separate YAML from the existing `packages/ci/action.yml` (the PR
 governing-decisions action). Each action has distinct triggers, permissions, and

--- a/specs/007-arb-queue/quickstart.md
+++ b/specs/007-arb-queue/quickstart.md
@@ -311,10 +311,7 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@v4
-      # `@v0` does not resolve yet — the moving v0 tag predates this Action.
-      # Pin the commit until a release containing packages/ci/queue is cut
-      # (see docs/DISTRIBUTION.md §D).
-      - uses: mbeacom/adrkit/packages/ci/queue@efef89b5d747ca175a1947f1ce2f4296dab54fa3
+      - uses: mbeacom/adrkit/packages/ci/queue@v0
         with:
           dir: docs/adr
 ```


### PR DESCRIPTION
Two things that were quietly overdue: the ARB queue this project ships could not route this project's own decisions, and `docs/RELEASING.md` step 8 was left unfinished after v0.2.1.

## Governance — the corpus was not being governed

Five `arb`-tier ADRs (0003, 0006, 0007, 0008, 0009) sat in the `not-queued` SLA state since 2026-07-18 — no `queuedAt`, no deadline, invisible to any SLA. ADR-0016 had never left `draft` after it was written in #54.

All six are now queued with `review.queuedAt: 2026-07-28T00:00:00Z` and `review.slaDays: 30`, rather than a bare `reviewBy`. That matters: `queuedAt` + `slaDays` is the only path that exercises the kernel's `addCalendarDays` deadline arithmetic against the real corpus and populates `Queued At` in the report. A bare `reviewBy` short-circuits it and leaves `Queued At` as `-`.

ADR-0016 also picks up `deciders: ["@mbeacom"]` so it does not trip `item.deciders-empty` once queued. It needs no `provenance.ratifiedBy` — that invariant (`adr.schema.ts:290`) only fires at `accepted`, and this moves `draft` → `proposed`.

**Observed failing first**, per ADR-0016's own rule — the pre-change run reported five `not-queued` rows:

| before | after |
|---|---|
| 7 items, 5 `not-queued` | 8 items, 0 `not-queued` |
| deadline `-` for those 5 | derived `2026-08-27` for all six |

`adr queue` now exits 0 with 8 items, zero corpus findings, zero item findings, all `within-sla`.

## `docs/RELEASING.md` step 8 — de-pin `queue@v0`

`queue@v0` resolves now: v0.2.1 moved the `v0` tag to `31bed03`, and `GET /repos/mbeacom/adrkit/contents/packages/ci/queue/action.yml?ref=v0` returns the 861-byte blob. Five places still asserted the opposite, which is worse than a stale pin — they actively told adopters that `@v0` fails.

De-pinned (copy-pasteable):
- `site/src/content/docs/ci.mdx` — workflow YAML, plus the `caution` Aside whose premise was false
- `specs/007-arb-queue/quickstart.md` — workflow YAML and its explanatory comment
- `specs/007-arb-queue/contracts/github-action.md` — the "Not yet resolvable" note
- `README.md` — "pin the queue Action to a commit until a moving `queue@v0` tag exists"
- `docs/DISTRIBUTION.md` §D — the whole section existed to track this; D1's documentation-severity finding and D3's "do NOT run here" procedure are now marked resolved/performed, with the pre-release state preserved as the historical record

Kept pinned, per step 8's "keep immutable pins where the text is explicitly teaching reproducibility": the §D1 pre-release record, `specs/007-arb-queue/checklists/reference-verification-evidence.md`, `specs/007-arb-queue/tasks.md`, ADR-0014, and `plan.md`.

The sample queue output in `ci.mdx` was also refreshed — it claimed 7 items and listed ADR-0015, which is `accepted` and therefore not in the queue at all.

## Verification

- `adr lint` — 17 records, 0 errors, 0 warnings
- `adr queue` — exit 0, 8 items, 0 findings
- `bun test` — 789 pass, 0 fail
- `bun run typecheck` — clean
- `bun run check:deps` — `core-has-no-adapter-deps: ok`
- `site` build — 26 pages, clean

## Not in scope

`docs/RELEASING.md` **step 7** is still open: the official MCP registry has no `dev.adrkit/mcp` entry (`registry.modelcontextprotocol.io` search returns `count: 0`). Its prerequisites are met — `@adrkit/mcp@0.2.1` is published with `mcpName: dev.adrkit/mcp` — but `mcp-publisher publish` is an outbound action `docs/DISTRIBUTION.md` reserves for a human, so it is left alone here. `DISTRIBUTION.md` §P1/§P2/§E still describe that release as pending and will need a pass when step 7 runs.

The 30-day SLA window is a maintainer choice, not a derived value. Overdue is a visible state only — it does not change the `adr queue` exit code or fail the managed-issue Action.