### PR TITLE
docs: record the published MCP registry entry

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,21 +1,25 @@
-# Distribution & discoverability playbook (prepared, not submitted)
+# Distribution & discoverability playbook
 
 This document is a **prepared-submissions playbook** for giving `@adrkit/mcp` and
 the `@adrkit/*` CLI presence in the MCP and ADR-tooling ecosystems. It contains
 ready-to-paste content and exact procedures.
 
-> **Nothing here has been submitted.** Every outbound action — publishing to a
-> registry, opening a PR, filling a form, creating a git tag, or posting anywhere —
-> is left for a human to perform. This file only *prepares* those actions.
+> **Submission status.** The official MCP registry entry (§A) **has been published**
+> — `dev.adrkit/mcp` at `0.2.1`, status `active`, published 2026-07-28. Every other
+> venue below remains prepared but **not submitted**. Every outbound action —
+> publishing to a registry, opening a PR, filling a form, creating a git tag, or
+> posting anywhere — is performed by a human, never by tooling or an agent.
 
 ## Honesty guardrail (binding)
 
 Per [ADR-0014](./adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md),
 adrkit is **early**: phases 0–6 are *landed / reference-verified* (rungs 1–2), and
 rung-3 external/community validation is **openly not-yet-met**. A registry listing is
-**distribution, not adoption**. None of the copy below may state or imply that
-adrkit has external adopters, production users, or rung-3 validation. Listing copy
-describes *what the tool is and does*, never *who uses it*.
+**distribution, not adoption** — the §A publication below changes discoverability and
+nothing else; it is **not** evidence of external validation and does not move any
+rung. None of the copy below may state or imply that adrkit has external adopters,
+production users, or rung-3 validation. Listing copy describes *what the tool is and
+does*, never *who uses it*.
 
 ---
 
@@ -64,8 +68,8 @@ it now:
 3. ✅ Confirm **both** version fields in `packages/mcp/server.json` — the top-level
    `version` and `packages[0].version` — name that same published version. Both are
    `0.2.1`, and the document validates against the `2025-12-11` server schema.
-4. ⬜ Only then run `mcp-publisher publish`. **This is the one remaining step**, and
-   it is gated on namespace proof (P3/A3), not on anything above.
+4. ✅ Only then run `mcp-publisher publish`. **Done** — published 2026-07-28 via the
+   DNS namespace path (§A3); see §A4 for the verified registry response.
 
 Publishing against a `server.json` version that is not yet on npm will fail
 validation no matter what the working tree says.
@@ -96,7 +100,11 @@ confusion in every listing:
 
 ---
 
-## A. Official MCP registry (`registry.modelcontextprotocol.io`)
+## A. Official MCP registry (`registry.modelcontextprotocol.io`) — **PUBLISHED**
+
+**Status: published 2026-07-28** via the DNS namespace path. `dev.adrkit/mcp` is
+listed at `0.2.1` with status `active`; see §A4 for the verified response. The
+subsections below are retained as the procedure to repeat on each release.
 
 This is the highest-leverage venue: **PulseMCP, mcp.so, Glama, and Smithery all
 ingest or can ingest from it.** The registry is in public preview.
@@ -166,11 +174,30 @@ cd packages/mcp && mcp-publisher login github   # device flow at https://github.
 mcp-publisher publish
 ```
 
-### A4 — verify (human)
+### A4 — verify (human) ✅
 
 ```sh
 curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=dev.adrkit/mcp"
 ```
+
+**Verified 2026-07-28.** The registry returns exactly one server:
+
+| Field | Value |
+|---|---|
+| `name` | `dev.adrkit/mcp` |
+| `version` | `0.2.1` |
+| `packages[0].identifier` / `version` | `@adrkit/mcp` / `0.2.1` |
+| `transport.type` | `stdio` |
+| `_meta…/official.status` | `active` |
+| `_meta…/official.isLatest` | `true` |
+| `_meta…/official.publishedAt` | `2026-07-28T13:22:42.967034Z` |
+
+`docs/RELEASING.md` step 7's exact assertion — the response containing both
+`dev.adrkit/mcp` and `0.2.1` — exits 0.
+
+A subsequent release must re-run `mcp-publisher publish` with `server.json`'s two
+version fields bumped; the registry pins a specific npm version and does not track
+`latest` on its own.
 
 ### A5 — the committed `server.json`
 
@@ -374,9 +401,9 @@ blockers are the human namespace proof and the v0.2.1 npm publication that carri
 
 | Venue | Machine format | Prerequisite | Ready to submit? | What the human must do |
 |---|---|---|---|---|
-| Official MCP registry | `server.json` (validated) | P2 `mcpName` edit + namespace proof | **Blocked on P2 + namespace proof** | Add `mcpName`, add DNS TXT (or GitHub login), run `mcp-publisher publish` |
+| Official MCP registry | `server.json` (validated) | P2 `mcpName` edit + namespace proof | **Published 2026-07-28** | Nothing — re-publish on each release with `server.json` bumped |
 | mcp.so | web form | public repo | **Yes** | Fill form at mcp.so/submit (free tier) |
-| PulseMCP | (ingests registry) | official-registry listing | **After A** | Publish A; optionally email hello@pulsemcp.com |
+| PulseMCP | (ingests registry) | official-registry listing | **Yes — A is published** | Nothing required; optionally email hello@pulsemcp.com |
 | Smithery | `smithery.yaml` (root) | file at repo root | **Placed at repo root (not submitted)** | Connect the repo at smithery.ai/new |
 | Glama | `glama.json` (root) | file at repo root | **Placed at repo root (not submitted)** | Nothing — Glama auto-crawls once merged and public |
 | awesome-mcp-servers | README PR | public repo | **Yes** | Open PR with the entry line |
@@ -578,10 +605,9 @@ itself, not a pin.
 
 No distribution-blocking source edits are currently delegated to another
 workstream. `packages/mcp/package.json` declares `"mcpName": "dev.adrkit/mcp"`
-(matching `server.json` `name`), and v0.2.1 has been cut, so that field exists in
-npm metadata. Nothing in this repository now blocks the registry submission — the
-only remaining gate is the namespace proof in A3, which is a DNS change plus a
-human-run `mcp-publisher` invocation.
+(matching `server.json` `name`), v0.2.1 has been cut, and the registry entry is
+**published** (§A4). Nothing in this repository blocks any remaining venue; what is
+left is per-venue human submission, tracked in the readiness table above.
 
 `server.json` does **not** need to be added to `packages/mcp/package.json` `files`.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -158,7 +158,12 @@ bootstrap described below.
 Never move an immutable `vX.Y.Z` tag. The release workflow may force-update only
 the moving major Action tag (`v0`, later `v1`, and so on).
 
-## v0.2.1 cutover runbook
+## v0.2.1 cutover runbook — **COMPLETE**
+
+**All eight steps are done.** v0.2.1 published on 2026-07-27 (npm, GitHub release,
+`v0` moved to `31bed03`); the MCP registry entry went live 2026-07-28; the queue
+Action examples were de-pinned to `@v0` in #65. This section is retained as the
+worked template for the next cutover — substitute the new version throughout.
 
 Run these steps only after the version-bump PR is the last change merged to
 `main`. The three branches this runbook originally waited on —

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -16,8 +16,10 @@ agents stop re-proposing paths the team already ruled out.
 
 Part of [adrkit](https://adrkit.dev). The corpus lives in git as one Markdown file
 per decision with typed YAML frontmatter (`@adrkit/core`); this server only reads
-it. Registry namespace: **`dev.adrkit/mcp`** (this is the Node/npm `@adrkit/mcp`
-package — unrelated to the `adr-kit` Python package on PyPI).
+it. Listed in the [official MCP registry](https://registry.modelcontextprotocol.io)
+as **`dev.adrkit/mcp`** (this is the Node/npm `@adrkit/mcp` package — unrelated to
+the `adr-kit` Python package on PyPI). A registry listing is distribution, not
+adoption; see Maturity below.
 
 ## Maturity
 


### PR DESCRIPTION
`dev.adrkit/mcp` is live in the official MCP registry, which closes the last open step in the v0.2.1 cutover runbook. Several documents were still describing it as pending.

## Verified before writing

```
GET https://registry.modelcontextprotocol.io/v0.1/servers?search=dev.adrkit/mcp
```

| Field | Value |
|---|---|
| `name` | `dev.adrkit/mcp` |
| `version` | `0.2.1` |
| `packages[0].identifier` / `version` | `@adrkit/mcp` / `0.2.1` |
| `transport.type` | `stdio` |
| `official.status` | `active` |
| `official.isLatest` | `true` |
| `official.publishedAt` | `2026-07-28T13:22:42.967034Z` |

`metadata.count` is `1`, and step 7's own assertion — the response containing both `dev.adrkit/mcp` and `0.2.1` — exits 0.

## Changes

**`docs/DISTRIBUTION.md`**
- Title and banner no longer claim "nothing here has been submitted", which was false the moment §A went live. The banner now states precisely what shipped and what did not: §A published, every other venue still prepared-but-unsubmitted.
- §A marked **PUBLISHED**, with the subsections kept as the repeat-on-each-release procedure.
- §A4 records the verified registry response rather than just the command, and notes that a future release must re-publish with `server.json` bumped — the registry pins a specific npm version and does not follow `latest`.
- §P2 step 4 flipped from ⬜ to ✅.
- Venue table: MCP registry → **Published 2026-07-28**; PulseMCP → unblocked, since it ingests from the registry.
- §E no longer describes the submission as the outstanding gate.

**`docs/RELEASING.md`** — the v0.2.1 cutover runbook is marked **COMPLETE** (all eight steps), retained as the worked template for the next cutover.

**`packages/mcp/README.md`** — this is what npm and registry visitors read. "Registry namespace: `dev.adrkit/mcp`" was forward-looking; it now says the server is listed, and links the registry.

## Honesty guardrail

The guardrail was strengthened, not relaxed. It now says explicitly that the §A publication "changes discoverability and nothing else; it is **not** evidence of external validation and does not move any rung." The `packages/mcp/README.md` addition carries the same qualifier inline, immediately above the existing Maturity section that states adrkit has no external adopters or production users yet.

**No rung, phase, or outcome-ladder claim changes in this PR.** ADR-0014 rung 3 remains open. Phases 0–6 remain landed / reference-verified.

`adr lint` — 17 records, 0 errors, 0 warnings. `bun test` — 789 pass, 0 fail. Docs-only change.
