### PR TITLE
feat(mcp): adopt MCP SDK v2, serve protocol revision 2026-07-28, release v0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: bun run build
       - name: Pack and install publishable packages
         run: bun run release:pack -- --skip-build
-      - name: Smoke test built Node artifacts (core, evaluator, CLI incl. offline adr evaluate + adr queue, Action bundle)
+      - name: Smoke test built Node artifacts (core, evaluator, MCP on both protocol eras, CLI incl. offline adr evaluate + adr queue, Action bundle)
         run: node scripts/smoke-node.mjs
       - name: Smoke test committed queue Action bundle (corpus-load boundary, no network)
         run: node scripts/smoke-queue-node.mjs
@@ -74,9 +74,11 @@ jobs:
 
   audit:
     # Fail the build on high/critical advisories in this checkout's resolved
-    # workspace dependency tree after root package.json overrides are applied.
-    # This does not audit consumer installs of published @adrkit/* manifests; the
-    # gate output records the current known published-consumer exposure separately.
+    # workspace dependency tree as installed by `bun install --frozen-lockfile`.
+    # This does not audit consumer installs of published @adrkit/* manifests,
+    # which resolve from the published manifests and inherit no root overrides or
+    # workspace pins; the gate output records any known published-consumer
+    # exposure separately (there is none as of ADR-0018).
     # Kept a separate job because it needs network for the advisory database, so
     # it never entangles the no-network clean-clone guarantee (ADR-0007).
     # ADR-0016: observed failing on the pre-fix tree; the permanent negative case

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-31
+
 ### Added
 
 - `@adrkit/mcp` now serves **MCP protocol revision `2026-07-28`** alongside the
@@ -164,7 +166,8 @@ Until `1.0.0`, minor releases may include breaking changes
 - Node-targeted published distribution of all packages, smoke-tested under Node
   22 and 24.
 
-[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/mbeacom/adrkit/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/mbeacom/adrkit/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mbeacom/adrkit/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mbeacom/adrkit/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ Until `1.0.0`, minor releases may include breaking changes
   `resolvesWhen` clause ("...or adrkit removes that transitive path"), ahead of its
   `2026-10-31` expiry. `bun audit` is clean with no overrides in effect.
 
+### Fixed
+
+- The `adrkit-mcp` binary no longer fails silently when its stdio transport
+  breaks. `serveStdio` reports transport failures only through its `onerror`
+  callback — it consumes the rejected `start()` promise itself — so a client that
+  went away mid-session tore the connection down while the process still exited
+  `0`, a dead server reporting success. `createAdrkitMcpServer` now takes an
+  `onError` option (defaulting to a stderr diagnostic) and the binary wires it to
+  a stderr diagnostic plus a non-zero exit. stdout remains protocol-only.
+
 ## [0.2.1] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,54 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+### Added
+
+- `@adrkit/mcp` now serves **MCP protocol revision `2026-07-28`** alongside the
+  2025-era revision on the same stdio connection. The opening exchange selects the
+  era and pins it for the connection's lifetime: a `server/discover` call (or any
+  request carrying a 2026 `_meta` envelope) gets the stateless 2026 revision, while
+  an `initialize` handshake is served exactly as before. Tool names, schemas,
+  annotations, and structured results are identical on both eras, and 2025-era
+  responses are unchanged from 0.2.1 apart from `tools/list` ordering (see below).
+- `tools/list` and `server/discover` are served with SEP-2549 cache fields
+  (`ttlMs: 300000`, `cacheScope: "public"`) on the 2026 revision. The four-tool
+  surface is immutable for the life of the process and carries no corpus content or
+  caller identity, so a client can reuse it instead of re-listing. Corpus reads stay
+  uncacheable — every `tools/call` still loads a fresh projection.
+
+### Changed
+
+- Migrated `@adrkit/mcp` from `@modelcontextprotocol/sdk@1.29.0` to the MCP
+  TypeScript SDK v2 package split: `@modelcontextprotocol/server@2.0.0` in
+  production and `@modelcontextprotocol/client@2.0.0` as a development-only test
+  driver. `zod` tightened to `^4.2.0` — v2 converts schemas through the authoring
+  instance's `~standard.jsonSchema`, which zod added in 4.2.0. On zod 4.0–4.1 the
+  SDK falls back to its own bundled converter with a one-time stderr warning and
+  silently drops `.describe()` field descriptions from the advertised JSON Schema,
+  so the declared range excludes those versions rather than relying on the resolved
+  version happening to be new enough.
+- Tool `outputSchema`s are now explicit `z.object(...)` schemas rather than raw Zod
+  shapes (v2 deprecates the raw-shape overloads). The advertised JSON Schema is
+  unchanged: still a root object of `corpusHealth` + `result`.
+- `tools/list` advertises the four tools in lexicographic order, so the catalog is
+  deterministic across restarts (`2026-07-28` minor change 3). This is the one
+  2025-era wire change in this release: the SDK serves registration order on both
+  eras, so legacy clients see the new order too. MCP treats `tools` as an unordered
+  set, so no client behavior depends on it; the order is asserted unsorted on both
+  eras so it cannot drift unobserved.
+
+### Removed
+
+- The root `@hono/node-server` and `fast-uri` `overrides`, and the recorded
+  `@adrkit/mcp` consumer-advisory acceptance for
+  [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9). All
+  three are now dead: `@modelcontextprotocol/server@2.0.0` depends only on
+  `@modelcontextprotocol/core` and `zod`, so the SDK no longer drags Hono, Express,
+  Ajv, `cors`, or `zod-to-json-schema` into the tree, and neither `@hono/node-server`
+  nor `fast-uri` resolves anywhere in it. The advisory retired by its own recorded
+  `resolvesWhen` clause ("...or adrkit removes that transitive path"), ahead of its
+  `2026-10-31` expiry. `bun audit` is clean with no overrides in effect.
+
 ## [0.2.1] - 2026-07-27
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -70,17 +70,14 @@
       },
       "dependencies": {
         "@adrkit/core": "workspace:*",
-        "@modelcontextprotocol/sdk": "1.29.0",
-        "zod": "^4",
+        "@modelcontextprotocol/server": "2.0.0",
+        "zod": "^4.2.0",
       },
       "devDependencies": {
+        "@modelcontextprotocol/client": "2.0.0",
         "@types/bun": "latest",
       },
     },
-  },
-  "overrides": {
-    "@hono/node-server": "^2.0.5",
-    "fast-uri": "^3.1.4",
   },
   "packages": {
     "@actions/core": ["@actions/core@3.0.1", "", { "dependencies": { "@actions/exec": "^3.0.0", "@actions/http-client": "^4.0.0" } }, "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA=="],
@@ -103,9 +100,11 @@
 
     "@adrkit/mcp": ["@adrkit/mcp@workspace:packages/mcp"],
 
-    "@hono/node-server": ["@hono/node-server@2.0.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA=="],
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
+
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
     "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
@@ -135,185 +134,39 @@
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
-
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
-
-    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
-
-    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
-
-    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
-
-    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
-
-    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
-
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
-
-    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+    "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
-
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
-    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
-
-    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
-
-    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
-
-    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
-
-    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
-
-    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
-
-    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
-
-    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
-
-    "express-rate-limit": ["express-rate-limit@8.6.0", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA=="],
-
-    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
-
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
-
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
-
-    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
-
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
-
-    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
-
-    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
-
-    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
-
-    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
-
-    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
-
-    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
-
-    "hono": ["hono@4.12.30", "", {}, "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog=="],
-
-    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
-
-    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
-
-    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
-
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
-
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
-
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
-
-    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-with-bigint": ["json-with-bigint@3.5.10", "", {}, "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w=="],
 
     "jsonpath-rfc9535": ["jsonpath-rfc9535@1.3.0", "", {}, "sha512-3jFHya7oZ45aDxIIdx+/zQARahHXxFSMWBkcBUldfXpLS9VCXDJyTKt35kQfEXLqh0K3Ixw/9xFnvcDStaxh7Q=="],
 
-    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
-
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
-
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
-    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
-
-    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
-    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
-    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
-
-    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
-    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
-    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
-
-    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
-
-    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
-
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
-    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
-
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
-
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
-
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
-
-    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
-
-    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
-
-    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
-
-    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
-
-    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
-
-    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
@@ -323,26 +176,12 @@
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
-    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
-    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
-
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
-
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
     "@actions/github/@actions/http-client": ["@actions/http-client@3.0.2", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^6.23.0" } }, "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA=="],
-
-    "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
-
-    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
-
-    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "bin": {
         "adr": "./dist/index.js",
       },
@@ -38,7 +38,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -53,7 +53,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -64,7 +64,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/docs/adr/0017-keep-dependency-audit-scope-explicit-and-release-scoped.md
+++ b/docs/adr/0017-keep-dependency-audit-scope-explicit-and-release-scoped.md
@@ -9,7 +9,7 @@ tags: [security, ci, dependencies, release, evidence]
 scope: org
 reversibility: two-way-door
 blastRadius: team
-relatesTo: ["0007", "0014", "0016"]
+relatesTo: ["0007", "0014", "0016", "0018"]
 affects:
   - type: path
     pattern: "scripts/audit-gate.ts"
@@ -164,6 +164,31 @@ gap is visible instead of implied away.
 1. [ ] Ratify or reject this proposed record.
 2. [ ] Add a release-time published-package consumer audit covering
        `@adrkit/core`, `@adrkit/cli`, `@adrkit/evaluator`, and `@adrkit/mcp`.
-3. [ ] Remove or renew the `GHSA-frvp-7c67-39w9` acceptance by 2026-10-31, or
+3. [x] Remove or renew the `GHSA-frvp-7c67-39w9` acceptance by 2026-10-31, or
        earlier if `@modelcontextprotocol/sdk` releases a range that reaches
        `@hono/node-server >=2.0.5`.
+       **Removed 2026-07-29**, ahead of expiry, by the second limb of the
+       recorded resolution condition — adrkit removed the transitive path rather
+       than waiting for upstream to widen its range. See the update below.
+
+## Update: 2026-07-29 — the recorded consumer exposure is resolved
+
+The `GHSA-frvp-7c67-39w9` acceptance recorded above has been removed from
+`scripts/audit-gate.ts`, along with the root `@hono/node-server` and `fast-uri`
+`overrides` this record's Context quotes.
+
+Neither the Context nor the Decision above is amended: both describe the situation
+that held while `@adrkit/mcp` depended on `@modelcontextprotocol/sdk@1.29.0`, and
+the scope discipline they establish still stands. What changed is the underlying
+fact. `@adrkit/mcp` migrated to `@modelcontextprotocol/server@2.0.0`
+([ADR-0018](0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md)),
+whose only runtime dependencies are `@modelcontextprotocol/core` and `zod`. The
+SDK no longer pulls Hono, Express, or Ajv into the graph, so neither
+`@hono/node-server` nor `fast-uri` resolves anywhere in the tree and a published
+consumer can no longer reach either. `bun audit` is clean with no overrides in
+effect.
+
+The acceptance list is now empty rather than deleted, and the expiry machinery
+that would fail CI closed remains under test through an injected synthetic
+acceptance — so the next real acceptance is recorded and expires exactly as this
+record requires.

--- a/docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md
+++ b/docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md
@@ -2,7 +2,7 @@
 schemaVersion: 0.1.0
 id: "0018"
 title: Adopt MCP SDK v2 and serve protocol revision 2026-07-28 dual-era
-status: proposed
+status: accepted
 date: 2026-07-29
 deciders: ["@mbeacom"]
 tags: [mcp, dependencies, protocol, compatibility, security]
@@ -19,6 +19,7 @@ affects:
     pattern: "scripts/check-deps.ts"
 provenance:
   authoredBy: agent-drafted
+  ratifiedBy: "@mbeacom"
 review:
   tier: async
   tierReason: >-
@@ -40,10 +41,6 @@ reviewBy: 2027-07-28
 ---
 
 # ADR-0018: Adopt MCP SDK v2 and serve protocol revision 2026-07-28 dual-era
-
-> **Status: `proposed`. This record is for maintainer review and is not
-> ratified.** It records the proposed migration and its compatibility posture,
-> but it does not become project law until a human accepts it.
 
 ## Context
 
@@ -260,7 +257,7 @@ migration. The constraint expires on its own and blocks nothing in the meantime.
 
 ## Action items
 
-1. [ ] Ratify or reject this proposed record.
+1. [x] Ratify or reject this proposed record. **Ratified by @mbeacom, 2026-07-31.**
 2. [ ] Re-run MCP Inspector dogfood against both eras before release, as Phase 5
        did for the 2025 era.
 3. [ ] Decide whether `packages/mcp/server.json` should advertise the supported

--- a/docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md
+++ b/docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md
@@ -228,14 +228,40 @@ Any such change must revisit the hint.
   `cacheScope: "public"`), or the MCP registry begins advertising a server's
   supported revisions, which `packages/mcp/server.json` should then declare.
 
+## The `minimumReleaseAge` window
+
+`bunfig.toml` sets `minimumReleaseAge = 259200` (three days). The v2 packages
+published 2026-07-27T23:55Z, so they cannot be freshly **resolved** until
+2026-07-30T23:55Z. `bun.lock` was therefore generated with a one-off
+`bun install --minimum-release-age=0`.
+
+Measured, not assumed — with the lockfile committed and `node_modules` deleted:
+
+| Command | Result |
+|---|---|
+| `bun install --frozen-lockfile` (CI) | succeeds |
+| `bun install` (contributor, no flag) | succeeds; leaves `bun.lock` byte-identical |
+| `bun update @modelcontextprotocol/*`, or resolving without a lockfile | blocked until 2026-07-30T23:55Z |
+
+The gate applies at **resolution**, not to entries a lockfile already pins. So the
+committed lockfile is exactly what a normal-policy resolution produces, nothing in
+the documented clean-clone flow is blocked, and the lockfile does not need
+regenerating.
+
+We considered adding a standing
+`minimumReleaseAgeExcludes = ["@modelcontextprotocol/server", ...]` to
+`bunfig.toml` (verified working on Bun 1.3.14) and rejected it. The key is a
+permanent waiver, not a one-time one: it would exempt every future
+`@modelcontextprotocol/*` release from the soak, including releases nobody has
+reviewed yet. A compromised MCP SDK executes inside every agent harness that
+installs `@adrkit/mcp`, which makes these the packages the soak is most worth
+keeping on — a poor thing to trade away permanently to save one day on one
+migration. The constraint expires on its own and blocks nothing in the meantime.
+
 ## Action items
 
 1. [ ] Ratify or reject this proposed record.
-2. [ ] Hold the merge until `@modelcontextprotocol/{server,client,core}@2.0.0`
-       clear `bunfig.toml`'s three-day `minimumReleaseAge`, then regenerate
-       `bun.lock` under the normal policy rather than the `--minimum-release-age=0`
-       bypass used to develop the change.
-3. [ ] Re-run MCP Inspector dogfood against both eras before release, as Phase 5
+2. [ ] Re-run MCP Inspector dogfood against both eras before release, as Phase 5
        did for the 2025 era.
-4. [ ] Decide whether `packages/mcp/server.json` should advertise the supported
+3. [ ] Decide whether `packages/mcp/server.json` should advertise the supported
        protocol revisions once the registry schema supports it.

--- a/docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md
+++ b/docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md
@@ -1,0 +1,241 @@
+---
+schemaVersion: 0.1.0
+id: "0018"
+title: Adopt MCP SDK v2 and serve protocol revision 2026-07-28 dual-era
+status: proposed
+date: 2026-07-29
+deciders: ["@mbeacom"]
+tags: [mcp, dependencies, protocol, compatibility, security]
+scope: component
+reversibility: two-way-door
+blastRadius: team
+relatesTo: ["0007", "0010", "0014", "0017"]
+affects:
+  - type: path
+    pattern: "packages/mcp/**"
+  - type: path
+    pattern: "scripts/audit-gate.ts"
+  - type: path
+    pattern: "scripts/check-deps.ts"
+provenance:
+  authoredBy: agent-drafted
+review:
+  tier: async
+  tierReason: >-
+    Replaces the MCP server's only third-party runtime dependency with a new
+    upstream major line and changes what `@adrkit/mcp` puts on the wire for
+    clients that ask for the new revision. The tool surface, schemas, and 2025-era
+    bytes are unchanged, so no published API contract moves, but the dependency
+    and protocol commitments affect every consumer of the published package.
+externalRefs:
+  - type: other
+    id: mcp-2026-07-28
+    url: "https://modelcontextprotocol.io/specification/2026-07-28/changelog"
+    label: MCP specification revision 2026-07-28 changelog
+  - type: other
+    id: GHSA-frvp-7c67-39w9
+    url: "https://github.com/advisories/GHSA-frvp-7c67-39w9"
+    label: Node.js Adapter for Hono serve-static path traversal on Windows
+reviewBy: 2027-07-28
+---
+
+# ADR-0018: Adopt MCP SDK v2 and serve protocol revision 2026-07-28 dual-era
+
+> **Status: `proposed`. This record is for maintainer review and is not
+> ratified.** It records the proposed migration and its compatibility posture,
+> but it does not become project law until a human accepts it.
+
+## Context
+
+On 2026-07-28 the Model Context Protocol published specification revision
+`2026-07-28`. Its headline change is a **stateless protocol core**: the
+`initialize` / `notifications/initialized` handshake and the `Mcp-Session-Id`
+header are gone, every request carries its own protocol version and client
+capabilities in `_meta`, a new `server/discover` RPC advertises capabilities up
+front, and every result carries a `resultType`. Server-initiated requests are
+replaced by the Multi Round-Trip Request pattern; `ping`, `logging/setLevel`, and
+`resources/subscribe` are removed; Roots, Sampling, and Logging are deprecated
+under a new twelve-month deprecation policy.
+
+The day before, the TypeScript SDK shipped v2 as a **package split**. The single
+`@modelcontextprotocol/sdk@1.x` became `@modelcontextprotocol/core`, `/client`,
+`/server`, and framework adapters. `@modelcontextprotocol/sdk@1.29.0` — the exact
+pin research §R0 chose in Phase 5, when v2 was still beta — is now the end of the
+v1 line.
+
+Three forces make this a decision rather than a routine bump.
+
+**The dependency surface is not equivalent.** `@modelcontextprotocol/sdk@1.29.0`
+declares thirteen runtime dependencies, including Express, Hono,
+`@hono/node-server`, Ajv, `cors`, `jose`, and `zod-to-json-schema` — an HTTP and
+auth stack that a local stdio server never executes but always installs.
+`@modelcontextprotocol/server@2.0.0` declares two: `@modelcontextprotocol/core`
+and `zod`. That difference is the direct cause of the consumer exposure
+[ADR-0017](0017-keep-dependency-audit-scope-explicit-and-release-scoped.md)
+recorded and accepted until 2026-10-31: a consumer installing `@adrkit/mcp@0.2.1`
+resolved a vulnerable `@hono/node-server` through the SDK, which adrkit could not
+fix because the SDK ranged it below the patched major.
+
+**Upgrading the SDK does not, by itself, change the wire.** v2 keeps speaking the
+2025-era protocol unless a server opts in. A hand-wired
+`server.connect(new StdioServerTransport())` — what `@adrkit/mcp` does today —
+serves only the 2025 era no matter which SDK version is installed. Serving
+`2026-07-28` on stdio requires the connection-pinned `serveStdio(factory)` entry.
+So "update the dependency" and "support the new revision" are two decisions, and
+only the second is visible to agents.
+
+**Most deployed clients are still 2025-era.** The revision is one day old.
+Choosing modern-only would strand every client that has not migrated.
+
+adrkit's exposure to the spec's breaking changes is unusually small: the server is
+local, read-only, stdio-only, and uses none of what changed — no sessions, no
+roots, sampling, logging, prompts, resources, subscriptions, tasks, HTTP, or auth.
+Its entire surface is four read-only tools.
+
+## Decision
+
+We will migrate `@adrkit/mcp` to `@modelcontextprotocol/server@2.0.0` and serve
+**both protocol eras on the same stdio connection**, with the client choosing.
+
+- `start()` hands a closure-private server factory to `serveStdio(...)` with the
+  default `legacy: 'serve'`. The opening exchange selects the era and pins one
+  factory instance for the connection's lifetime: `server/discover` (or any
+  request carrying a 2026 `_meta` envelope) gets `2026-07-28`; an `initialize`
+  handshake is served exactly as before.
+- The four tools are registered once and served identically to both eras. Names,
+  input and output schemas, annotations, structured results, cursor semantics, and
+  rendered text do not vary by era. **The 2025-era wire is unchanged from 0.2.1
+  except for `tools/list` ordering** (next bullet) — asserted directly against a
+  real spawned subprocess, unsorted.
+- `@modelcontextprotocol/client@2.0.0` is a **development-only** dependency. It
+  drives the in-process and real-stdio conformance harnesses and is never imported
+  by shipped code; `scripts/check-deps.ts` enforces that split.
+- `zod` tightens from `^4` to `^4.2.0`. v2 converts schemas through the authoring
+  instance's `~standard.jsonSchema`, added in zod 4.2.0. A `^4` range still
+  satisfies v2's peer and installs, and zod 4.0–4.1 does not fail outright — the
+  SDK falls back to its own bundled `z.toJSONSchema()` with a one-time `[mcp-sdk]`
+  stderr warning. But `.describe()` field descriptions live in the *authoring*
+  zod's registry, so the fallback silently drops them from the advertised JSON
+  Schema. A degraded tool catalog that still returns `0` is exactly the fail-quiet
+  shape ADR-0016 rejects, so the declared range excludes the versions that take
+  that path rather than relying on the resolved version happening to be new enough.
+- We adopt SEP-2549 cache fields deliberately rather than accepting the SDK's
+  conservative `ttlMs: 0` default: `tools/list` and `server/discover` are served
+  with `ttlMs: 300000, cacheScope: "public"`. Both are immutable for the life of
+  the process and carry no corpus content or caller identity. Corpus reads are
+  never cacheable — every `tools/call` still loads a fresh projection.
+- `tools/list` advertises the four tools in lexicographic order, satisfying the
+  revision's deterministic-order SHOULD without relying on registration accident.
+  The SDK serves registration order on **both** eras, so this is the one 2025-era
+  wire change in this migration. MCP models `tools` as an unordered set, so no
+  client behavior depends on it — but the previous order was an artifact of the
+  order the four `registerX` calls happened to be written in, and nothing observed
+  it. It is now asserted unsorted on both eras.
+
+We will also **retire the ADR-0017 consumer-advisory acceptance and the root
+overrides it stood behind**, because this migration satisfies that acceptance's
+own recorded `resolvesWhen` clause ("...or adrkit removes that transitive path").
+Neither `@hono/node-server` nor `fast-uri` resolves anywhere in the tree after the
+swap, so the `overrides` block and the acceptance entry both describe an exposure
+that no longer exists. Leaving them in place would be the inverse of ADR-0016's
+concern: a gate reporting a finding it can no longer observe.
+
+## Options considered
+
+### Option A: SDK v2 + `serveStdio` serving both eras (chosen)
+
+| Dimension | Assessment |
+|---|---|
+| Client compatibility | Widest. 2025-era clients are unaffected; 2026-era clients get the stateless revision. The client decides, per connection. |
+| Consumer security | Removes the Express/Hono/Ajv/auth stack from the published dependency graph, closing GHSA-frvp-7c67-39w9 for consumers ahead of its accepted expiry. |
+| Migration cost | Contained. Import paths, `outputSchema` wrapping, one lifecycle rewrite, and a test-client strictness flag. The tool logic is untouched. |
+| Cost | Carries two wire eras in one binary for as long as the SDK supports both, and the era-selection logic is upstream code we do not own. |
+
+### Option B: SDK v2, stay on the 2025 era
+
+**Pros:** Strictly smaller change; captures the entire dependency-surface and
+security win, which is the more urgent half. No new wire behavior to validate.
+
+**Cons:** Silently misleading. The package would ship the SDK that speaks
+`2026-07-28` while answering `server/discover` with a method-not-found, so a
+2026-era agent harness sees a server that looks migrated and is not. It also
+defers, rather than avoids, the `serveStdio` work — the 2025 era is on a
+twelve-month deprecation clock.
+
+### Option C: SDK v2, `legacy: 'reject'` (2026-07-28 only)
+
+**Pros:** One wire era to reason about and test; no legacy surface to carry.
+
+**Cons:** Breaks every currently deployed client on a one-day-old revision, for a
+package whose maturity section openly states it has no external adopters yet. The
+compatibility cost is real and immediate; the simplification is speculative.
+
+### Option D: Do nothing — stay on `@modelcontextprotocol/sdk@1.29.0`
+
+**Pros:** No work, no risk of regression.
+
+**Cons:** Pins the package to a frozen v1 line that will not receive the new
+revision, and keeps shipping consumers a thirteen-dependency HTTP/auth stack the
+server never runs — including the advisory ADR-0017 could only accept, not fix.
+The accepted exposure expires 2026-10-31 and would then fail CI closed with no
+upstream remedy available.
+
+## Trade-offs
+
+We take on an upstream major-version migration one day after it shipped, against a
+specification one day old. That is early. The mitigations are that adrkit's MCP
+surface is four read-only tools that touch none of the changed features, that the
+2025-era wire is asserted unchanged apart from `tools/list` ordering — so the blast
+radius of a v2 regression is bounded to clients that explicitly opt into the new era
+— and that the migration strictly shrinks the third-party attack surface rather than
+growing it.
+
+That ordering caveat is deliberate and worth naming rather than rounding off, since
+it is the single exception to an otherwise unchanged legacy wire. MCP models `tools`
+as an unordered set, so it is not a compatibility surface; the risk is not that a
+client breaks but that "unchanged" gets read as absolute. Both eras now assert the
+order unsorted, so the exception is enforced rather than asserted.
+
+We also carry two wire eras. The era-selection logic lives in `serveStdio`, not in
+adrkit, so a defect there is upstream and not directly fixable by us — which is
+why both eras are exercised against a real spawned subprocess rather than only
+in-process.
+
+Finally, the `cacheScope: "public"` hint asserts that the tool catalog is safe for
+shared caches. That is true today because the catalog is static package metadata,
+and it stops being true if a future tool surface ever varies by caller or corpus.
+Any such change must revisit the hint.
+
+## Consequences
+
+- **Easier:** Consumers install two transitive packages instead of a web framework
+  stack. `bun audit` is clean with no `overrides` in effect, and the audit gate
+  reports no known consumer exposure because there is none.
+- **Easier:** 2026-era agent harnesses reach the corpus with no handshake, and can
+  cache the tool catalog instead of re-listing it.
+- **Harder:** Two wire eras must stay covered. Era coverage cannot be asserted
+  in-process — `InMemoryTransport.createLinkedPair()` links 2025-era instances
+  only — so the 2026-era evidence requires spawning the real bin.
+- **How we would know this was wrong:** a 2025-era client that worked against
+  `@adrkit/mcp@0.2.1` fails or observes a changed response against this build; a
+  `tools/call` returns stale corpus data because something cacheable leaked a
+  corpus read; or `@modelcontextprotocol/server@2.x` proves less stable than the
+  frozen v1 line it replaced, measured by regressions traced to SDK behavior
+  rather than adrkit code.
+- **Revisit if:** the SDK removes 2025-era serving (at which point
+  `legacy: 'serve'` becomes moot and Option C becomes the only option), a fifth
+  tool or any caller-varying tool metadata is introduced (which invalidates
+  `cacheScope: "public"`), or the MCP registry begins advertising a server's
+  supported revisions, which `packages/mcp/server.json` should then declare.
+
+## Action items
+
+1. [ ] Ratify or reject this proposed record.
+2. [ ] Hold the merge until `@modelcontextprotocol/{server,client,core}@2.0.0`
+       clear `bunfig.toml`'s three-day `minimumReleaseAge`, then regenerate
+       `bun.lock` under the normal policy rather than the `--minimum-release-age=0`
+       bypass used to develop the change.
+3. [ ] Re-run MCP Inspector dogfood against both eras before release, as Phase 5
+       did for the 2025 era.
+4. [ ] Decide whether `packages/mcp/server.json` should advertise the supported
+       protocol revisions once the registry schema supports it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Decision memory for human and agent-authored plans — machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -40,9 +40,5 @@
     "@types/bun": "latest",
     "typescript": "^6",
     "zod": "^4"
-  },
-  "overrides": {
-    "@hono/node-server": "^2.0.5",
-    "fast-uri": "^3.1.4"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,7 +30,7 @@ import { isMainModule } from './main-module.ts';
  * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
  * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
  */
-export const CLI_VERSION = '0.2.1';
+export const CLI_VERSION = '0.3.0';
 
 function writeStdout(text: string): void {
   process.stdout.write(text);

--- a/packages/cli/test/lint.test.ts
+++ b/packages/cli/test/lint.test.ts
@@ -23,7 +23,7 @@ describe('adr lint CLI', () => {
   test('passes on this repository corpus', async () => {
     const result = await runAdr(['lint']);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('checked 17 records, 0 errors');
+    expect(result.stdout).toContain('checked 18 records, 0 errors');
     expect(result.stderr).toBe('');
   });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -316,6 +316,12 @@ await server.close();
 `createAdrkitMcpServer(options?)` performs no filesystem access at construction and
 returns a frozen, null-prototype handle with exactly `start()` and `close()`.
 
+Transport failures — a transport that fails to start, or a background stream error
+such as the `EPIPE` from a client that has gone away — are reported through the
+optional `onError` option, which defaults to a stderr diagnostic. The `adrkit-mcp`
+binary additionally exits non-zero. Nothing is written to stdout: that is reserved
+for protocol frames.
+
 ## Limits
 
 `query` 1–256 code units (non-empty after trimming); `ref` 1–128; `files[]` 1–256

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -42,6 +42,30 @@ npx -y @adrkit/mcp --cwd /path/to/your/repo --dir docs/adr
 It speaks JSON-RPC over stdio, so you normally point an MCP client at it rather than
 running it by hand. Copy-pasteable client configs follow.
 
+### Protocol revisions
+
+The server speaks **both** MCP protocol eras on the same stdio connection, and the
+client picks. The opening exchange selects the era and pins it for the connection's
+lifetime:
+
+| Client opens with                                     | Server serves                                     |
+| ----------------------------------------------------- | ------------------------------------------------- |
+| `server/discover`, or any request carrying a 2026 `_meta` envelope | **`2026-07-28`** — stateless, no handshake |
+| `initialize` / `notifications/initialized`            | the 2025-era revision it negotiates               |
+
+On `2026-07-28` there is no `initialize` handshake and no session id: every request
+carries its own protocol version and client capabilities in `_meta`, and every result
+is self-describing (`resultType`, plus server identity in `_meta`). `tools/list` and
+`server/discover` are cacheable (SEP-2549) and are served with `ttlMs: 300000,
+cacheScope: "public"` — the four-tool surface is immutable for the life of the process
+and carries no corpus content, so a client may reuse it instead of re-listing. Corpus
+reads are never cacheable: every `tools/call` loads a fresh projection.
+
+Nothing else about the tools changes between eras — same names, same schemas, same
+annotations, same structured results. The server uses none of the features the
+`2026-07-28` revision deprecated (roots, sampling, logging) or removed (sessions,
+`ping`, `resources/subscribe`).
+
 ### Claude Desktop
 
 Edit `claude_desktop_config.json` (macOS:
@@ -284,7 +308,7 @@ the underlying SDK server, its registrations, or its transport:
 import { createAdrkitMcpServer } from '@adrkit/mcp';
 
 const server = createAdrkitMcpServer({ cwd: process.cwd(), dir: 'docs/adr' });
-await server.start();   // validates the root, connects exactly one stdio transport
+await server.start();   // validates the root, then serves one stdio connection
 // ... later:
 await server.close();
 ```
@@ -325,6 +349,6 @@ traversal.
 
 Developed and tested with Bun; published artifacts are ESM targeting Node.js `>=22`
 and are verified on Node 22 and 24. Runtime dependencies are exactly `@adrkit/core`,
-`@modelcontextprotocol/sdk`, and `zod`.
+`@modelcontextprotocol/server` (MCP TypeScript SDK v2), and `zod`.
 
 Apache-2.0.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adrkit/mcp",
   "mcpName": "dev.adrkit/mcp",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -46,10 +46,11 @@
   },
   "dependencies": {
     "@adrkit/core": "workspace:*",
-    "@modelcontextprotocol/sdk": "1.29.0",
-    "zod": "^4"
+    "@modelcontextprotocol/server": "2.0.0",
+    "zod": "^4.2.0"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "2.0.0",
     "@types/bun": "latest"
   },
   "files": [

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,8 +7,7 @@
  * construction time (data-model.md §8, contracts/tools.md §1).
  */
 
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { serveStdio, type StdioServerHandle } from '@modelcontextprotocol/server/stdio';
 import { resolve } from 'node:path';
 import { buildRegisteredServer } from './server.ts';
 import { resolveCanonicalRoots, MAX_SOURCE_BYTES } from './corpus/projection.ts';
@@ -26,9 +25,15 @@ export interface AdrkitMcpServerHandle {
 
 /**
  * The public stdio lifecycle factory. Performs NO filesystem access at construction;
- * `start()` validates the configured root, builds the closure-private server, creates
- * exactly one `StdioServerTransport`, and connects it. The concrete server, its
+ * `start()` validates the configured root, then hands a closure-private server factory
+ * to the SDK's connection-pinned `serveStdio` entry. The concrete server, its
  * registrations, and its transport remain unreachable to the caller.
+ *
+ * `serveStdio` — not a hand-wired `StdioServerTransport` — is what makes this server
+ * speak protocol revision 2026-07-28. The opening exchange selects the connection's
+ * era and pins one factory instance to it; `legacy: 'serve'` (the default) keeps
+ * 2025-era clients working unchanged. The four tools are registered once and served
+ * identically to both eras.
  */
 export function createAdrkitMcpServer(
   options?: Partial<AdrkitMcpServerOptions>,
@@ -36,7 +41,7 @@ export function createAdrkitMcpServer(
   const cwd = resolve(options?.cwd ?? process.cwd());
   const dir = options?.dir ?? 'docs/adr';
 
-  let server: McpServer | undefined;
+  let connection: StdioServerHandle | undefined;
   let startPromise: Promise<void> | undefined;
   let closePromise: Promise<void> | undefined;
   let closed = false;
@@ -48,7 +53,6 @@ export function createAdrkitMcpServer(
     if (startPromise) return startPromise;
 
     startPromise = (async () => {
-      let nextServer: McpServer | undefined;
       try {
         const roots = await resolveCanonicalRoots({ cwd, dir });
         const config: ToolConfig = {
@@ -57,19 +61,9 @@ export function createAdrkitMcpServer(
           expectedCanonicalCwd: roots.canonicalCwd,
           maxSourceBytes: MAX_SOURCE_BYTES,
         };
-        nextServer = buildRegisteredServer(config);
-        server = nextServer;
-        await nextServer.connect(new StdioServerTransport());
+        connection = serveStdio(() => buildRegisteredServer(config));
       } catch (error) {
-        server = undefined;
-        if (nextServer) {
-          try {
-            await nextServer.close();
-          } catch (closeError) {
-            startPromise = undefined;
-            throw new AggregateError([error, closeError], 'MCP server startup and cleanup failed');
-          }
-        }
+        connection = undefined;
         startPromise = undefined;
         throw error;
       }
@@ -82,8 +76,8 @@ export function createAdrkitMcpServer(
     closed = true;
     closePromise = (async () => {
       if (startPromise) await startPromise;
-      const current = server;
-      server = undefined;
+      const current = connection;
+      connection = undefined;
       if (current) await current.close();
     })();
     return closePromise;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -16,11 +16,31 @@ import type { ToolConfig } from './tools/shared.ts';
 export interface AdrkitMcpServerOptions {
   readonly cwd: string;
   readonly dir: string;
+  /**
+   * Called for out-of-band transport failures: a transport that fails to start,
+   * and every background error the connection reports afterwards (an stdin or
+   * stdout stream error, such as the EPIPE from a client that has gone away).
+   *
+   * This is not optional plumbing. `serveStdio` reports these **only** through
+   * its `onerror` callback — it consumes the rejected `start()` promise
+   * deliberately — so without a callback a broken transport tears the connection
+   * down while the process still exits 0. That is a dead server reporting
+   * success, the fail-quiet shape ADR-0016 rejects, so the default writes a
+   * diagnostic to stderr rather than staying silent. `main-module.ts` supplies a
+   * reporter that also fails the exit status.
+   *
+   * Never writes to stdout: that is reserved for protocol frames.
+   */
+  readonly onError: (error: Error) => void;
 }
 
 export interface AdrkitMcpServerHandle {
   start(): Promise<void>;
   close(): Promise<void>;
+}
+
+function writeTransportDiagnostic(error: Error): void {
+  process.stderr.write(`adrkit-mcp: transport error: ${error.message}\n`);
 }
 
 /**
@@ -40,6 +60,7 @@ export function createAdrkitMcpServer(
 ): Readonly<AdrkitMcpServerHandle> {
   const cwd = resolve(options?.cwd ?? process.cwd());
   const dir = options?.dir ?? 'docs/adr';
+  const onError = options?.onError ?? writeTransportDiagnostic;
 
   let connection: StdioServerHandle | undefined;
   let startPromise: Promise<void> | undefined;
@@ -61,7 +82,7 @@ export function createAdrkitMcpServer(
           expectedCanonicalCwd: roots.canonicalCwd,
           maxSourceBytes: MAX_SOURCE_BYTES,
         };
-        connection = serveStdio(() => buildRegisteredServer(config));
+        connection = serveStdio(() => buildRegisteredServer(config), { onerror: onError });
       } catch (error) {
         connection = undefined;
         startPromise = undefined;

--- a/packages/mcp/src/main-module.ts
+++ b/packages/mcp/src/main-module.ts
@@ -37,6 +37,25 @@ export function reportUnhandledRejection(
   fail();
 }
 
+/**
+ * Out-of-band transport failures reach the bin here.
+ *
+ * `serveStdio` reports them only through its `onerror` callback — it consumes
+ * the rejected `start()` promise itself — so this is the only path by which a
+ * broken transport can reach stderr and a non-zero exit status. Without it the
+ * connection tears down while the process still exits 0 (ADR-0016).
+ */
+export function reportTransportError(
+  error: Error,
+  write: (text: string) => void = writeStderr,
+  fail: () => void = () => {
+    process.exitCode = 1;
+  },
+): void {
+  write(`adrkit-mcp: transport error: ${error.message}\n`);
+  fail();
+}
+
 export async function main(
   argv: string[],
   env: Record<string, string | undefined>,
@@ -68,7 +87,7 @@ export async function main(
     throw error;
   }
 
-  const handle = createAdrkitMcpServer({ cwd, dir });
+  const handle = createAdrkitMcpServer({ cwd, dir, onError: (error) => reportTransportError(error) });
 
   const shutdown = (): void => {
     void handle.close().finally(() => process.exit(0));

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -7,7 +7,7 @@
  * `package.json#exports` and every public subpath.
  */
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer, type ServerOptions } from '@modelcontextprotocol/server';
 import { registerSearchDecisions } from './tools/search-decisions.ts';
 import { registerGetDecision } from './tools/get-decision.ts';
 import { registerGetDecisionContext } from './tools/get-decision-context.ts';
@@ -16,12 +16,45 @@ import type { ToolConfig } from './tools/shared.ts';
 
 export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.2.1' } as const;
 
-/** Package-internal: build the concrete server with exactly the four ratified tools. */
+/**
+ * The MCP protocol revision this server serves through `serveStdio`'s modern era.
+ *
+ * The SDK keeps the revision string internal (`LATEST_PROTOCOL_VERSION` names the
+ * latest *legacy*-era version, `2025-11-25`), so the modern revision is stated here
+ * once and asserted against the wire in `test/bin.test.ts`.
+ */
+export const MODERN_PROTOCOL_VERSION = '2026-07-28' as const;
+
+/**
+ * SEP-2549 cache hints for the two cacheable results this server can answer.
+ *
+ * Both are immutable for the lifetime of the process and carry no corpus content,
+ * caller identity, or per-request state: `tools/list` is the four ratified tools with
+ * their fixed schemas and annotations, and `server/discover` is the supported
+ * revisions plus the tools capability. They are therefore honestly `public` and safe
+ * to cache, which spares an agent a round trip per re-list. Corpus reads are NOT
+ * cacheable and are unaffected — every `tools/call` still loads a fresh projection.
+ *
+ * Without this the SDK falls back to the conservative `{ ttlMs: 0, cacheScope:
+ * 'private' }`. 2025-era responses never carry these fields either way.
+ */
+const CACHE_HINTS = {
+  'tools/list': { ttlMs: 300_000, cacheScope: 'public' },
+  'server/discover': { ttlMs: 300_000, cacheScope: 'public' },
+} as const satisfies ServerOptions['cacheHints'];
+
+/**
+ * Package-internal: build the concrete server with exactly the four ratified tools.
+ *
+ * Registration order is lexicographic by tool name so `tools/list` answers in a
+ * deterministic, self-evidently stable order (2026-07-28 minor change 3 — servers
+ * SHOULD do this so clients can cache catalogs and keep upstream prompt caches warm).
+ */
 export function buildRegisteredServer(config: ToolConfig): McpServer {
-  const server = new McpServer(SERVER_INFO);
-  registerSearchDecisions(server, config);
+  const server = new McpServer(SERVER_INFO, { cacheHints: CACHE_HINTS });
   registerGetDecision(server, config);
   registerGetDecisionContext(server, config);
   registerListSuperseded(server, config);
+  registerSearchDecisions(server, config);
   return server;
 }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetDecisionContext } from './tools/get-decision-context.ts';
 import { registerListSuperseded } from './tools/list-superseded.ts';
 import type { ToolConfig } from './tools/shared.ts';
 
-export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.2.1' } as const;
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.3.0' } as const;
 
 /**
  * The MCP protocol revision this server serves through `serveStdio`'s modern era.

--- a/packages/mcp/src/tools/get-decision-context.ts
+++ b/packages/mcp/src/tools/get-decision-context.ts
@@ -7,7 +7,7 @@
  * page is partitioned by status.
  */
 
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { decisionBucketFor, resolveAffects, type Adr, type Finding, type FiredMatcher } from '@adrkit/core';
 import { compareCodeUnits, sortFindingsCanonical } from '../corpus/ordering.ts';
 import { paginate, queryShapeHash } from '../pagination/cursor.ts';

--- a/packages/mcp/src/tools/get-decision.ts
+++ b/packages/mcp/src/tools/get-decision.ts
@@ -7,7 +7,7 @@
  * ambiguous-local-id. Relation refs are surfaced verbatim, never expanded.
  */
 
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { parseAdrRef, type Adr } from '@adrkit/core';
 import { paginate, queryShapeHash, checkInapplicablePrimaryCursor } from '../pagination/cursor.ts';
 import {

--- a/packages/mcp/src/tools/list-superseded.ts
+++ b/packages/mcp/src/tools/list-superseded.ts
@@ -7,7 +7,7 @@
  * finding templates.
  */
 
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { parseAdrRef, type Adr, type Finding } from '@adrkit/core';
 import { sortFindingsCanonical } from '../corpus/ordering.ts';
 import { paginate, queryShapeHash } from '../pagination/cursor.ts';

--- a/packages/mcp/src/tools/search-decisions.ts
+++ b/packages/mcp/src/tools/search-decisions.ts
@@ -7,7 +7,7 @@
  * only — never a body, ranking score, or hidden index.
  */
 
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Adr } from '@adrkit/core';
 import { compareCodeUnits } from '../corpus/ordering.ts';
 import { normalize } from '../search/normalize.ts';

--- a/packages/mcp/src/tools/shared.ts
+++ b/packages/mcp/src/tools/shared.ts
@@ -7,7 +7,7 @@
 
 import { z } from 'zod';
 import { AdrFrontmatter, AdrRef, Status, Scope, type Finding, type FiredMatcher } from '@adrkit/core';
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import {
   loadCorpusProjection,
   CorpusUnavailableError,
@@ -265,7 +265,7 @@ export function renderResponseText(spec: TextSpec): string {
  * ------------------------------------------------------------------ */
 
 export type ToolInputSchema = z.ZodType;
-export type ToolOutputSchema = z.ZodRawShape;
+export type ToolOutputSchema = z.ZodType;
 
 const uniqueArray = <T>(schema: z.ZodType<T>, min: number, max: number) =>
   z
@@ -392,7 +392,7 @@ export function searchDecisionsOutputSchema(): ToolOutputSchema {
     sourcePath: z.string(),
     matchedFields: z.array(z.enum(['id', 'title', 'tag', 'body'])),
   });
-  return {
+  return z.object({
     corpusHealth: corpusHealthSchema().optional(),
     result: z.discriminatedUnion('outcome', [
       z.object({
@@ -404,7 +404,7 @@ export function searchDecisionsOutputSchema(): ToolOutputSchema {
       invalidCursorSchema(),
       corpusUnavailableSchema(),
     ]),
-  };
+  });
 }
 
 export function getDecisionOutputSchema(): ToolOutputSchema {
@@ -417,7 +417,7 @@ export function getDecisionOutputSchema(): ToolOutputSchema {
     frontmatter: AdrFrontmatter,
     body: z.string(),
   });
-  return {
+  return z.object({
     corpusHealth: corpusHealthSchema().optional(),
     result: z.discriminatedUnion('outcome', [
       z.object({ outcome: z.literal('found'), decision: fullDecision, findings: findingsPageSchema() }),
@@ -439,7 +439,7 @@ export function getDecisionOutputSchema(): ToolOutputSchema {
       invalidCursorSchema(),
       corpusUnavailableSchema(),
     ]),
-  };
+  });
 }
 
 export function getDecisionContextOutputSchema(): ToolOutputSchema {
@@ -451,7 +451,7 @@ export function getDecisionContextOutputSchema(): ToolOutputSchema {
     firedMatchers: z.array(z.object({ type: z.string(), pattern: z.string() })),
     relations: relationRefsSchema(),
   });
-  return {
+  return z.object({
     corpusHealth: corpusHealthSchema().optional(),
     result: z.discriminatedUnion('outcome', [
       z.object({
@@ -465,7 +465,7 @@ export function getDecisionContextOutputSchema(): ToolOutputSchema {
       invalidCursorSchema(),
       corpusUnavailableSchema(),
     ]),
-  };
+  });
 }
 
 export function listSupersededOutputSchema(): ToolOutputSchema {
@@ -493,7 +493,7 @@ export function listSupersededOutputSchema(): ToolOutputSchema {
     sourcePath: z.string(),
     supersededBy,
   });
-  return {
+  return z.object({
     corpusHealth: corpusHealthSchema().optional(),
     result: z.discriminatedUnion('outcome', [
       z.object({
@@ -505,7 +505,7 @@ export function listSupersededOutputSchema(): ToolOutputSchema {
       invalidCursorSchema(),
       corpusUnavailableSchema(),
     ]),
-  };
+  });
 }
 
 /* ------------------------------------------------------------------ *

--- a/packages/mcp/test/bin.test.ts
+++ b/packages/mcp/test/bin.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import { main, reportUnhandledRejection } from '../src/main-module.ts';
+import { MODERN_PROTOCOL_VERSION, SERVER_INFO } from '../src/server.ts';
 import { createRepo, repoFromFixture, type TempRepo } from './helpers.ts';
 
 const BIN_SRC = resolve(dirname(fileURLToPath(import.meta.url)), '../src/bin.ts');
@@ -135,7 +136,10 @@ describe('adrkit-mcp bin — real stdio subprocess', () => {
     cleanups.push(repo.cleanup);
     const client = await spawnClient(repo);
     const list = await client.listTools();
-    expect(list.tools.map((t) => t.name).sort()).toEqual([
+    // Asserted UNSORTED: tools/list order is wire-visible on this era too, so the
+    // deterministic lexicographic order has to be observable here or nothing
+    // enforces it for 2025-era clients (ADR-0016).
+    expect(list.tools.map((t) => t.name)).toEqual([
       'get_decision',
       'get_decision_context',
       'list_superseded',
@@ -174,5 +178,123 @@ describe('adrkit-mcp bin — real stdio subprocess', () => {
     }
     expect(ids.has(2)).toBe(true);
     expect(ids.has(3)).toBe(true);
+  });
+});
+
+describe('adrkit-mcp bin — protocol revision 2026-07-28 over real stdio', () => {
+  async function spawnPinnedModernClient(repo: TempRepo): Promise<Client> {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [BIN_SRC, '--cwd', repo.root],
+    });
+    const client = new Client(
+      { name: 'bin-test-modern', version: '0.0.0' },
+      { versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } } },
+    );
+    await client.connect(transport);
+    cleanups.push(() => client.close());
+    return client;
+  }
+
+  test('a client pinned to 2026-07-28 negotiates the modern era and lists the four tools', async () => {
+    const repo = await repoFromFixture('edge-corpus');
+    cleanups.push(repo.cleanup);
+    const client = await spawnPinnedModernClient(repo);
+
+    expect(client.getProtocolEra()).toBe('modern');
+
+    const list = await client.listTools();
+    expect(list.tools.map((t) => t.name).sort()).toEqual([
+      'get_decision',
+      'get_decision_context',
+      'list_superseded',
+      'search_decisions',
+    ]);
+  });
+
+  test('tools/call answers the same structured result on the modern era as on the legacy era', async () => {
+    const repo = await repoFromFixture('edge-corpus');
+    cleanups.push(repo.cleanup);
+    const client = await spawnPinnedModernClient(repo);
+
+    const call = await client.callTool({ name: 'list_superseded', arguments: {} });
+    expect((call.structuredContent as { result: { outcome: string } }).result.outcome).toBe('entries');
+  });
+
+  test('a raw 2026-07-28 exchange needs no initialize handshake and carries its version in _meta', async () => {
+    const repo = await repoFromFixture('status-corpus');
+    cleanups.push(repo.cleanup);
+    const proc = Bun.spawn([process.execPath, BIN_SRC, '--cwd', repo.root], {
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const envelope = {
+      'io.modelcontextprotocol/protocolVersion': MODERN_PROTOCOL_VERSION,
+      'io.modelcontextprotocol/clientCapabilities': {},
+      'io.modelcontextprotocol/clientInfo': { name: 'raw-modern', version: '0.0.0' },
+    };
+    const frames = [
+      { jsonrpc: '2.0', id: 1, method: 'server/discover', params: { _meta: envelope } },
+      { jsonrpc: '2.0', id: 2, method: 'tools/list', params: { _meta: envelope } },
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'get_decision', arguments: { ref: '0001' }, _meta: envelope },
+      },
+    ];
+    proc.stdin.write(frames.map((f) => `${JSON.stringify(f)}\n`).join(''));
+    await proc.stdin.end();
+    const out = await new Response(proc.stdout).text();
+    proc.kill();
+    await proc.exited;
+
+    const byId = new Map<number, Record<string, unknown>>();
+    for (const line of out.split('\n').filter((l) => l.length > 0)) {
+      const message = JSON.parse(line) as { id?: number; error?: unknown; result?: Record<string, unknown> };
+      if (typeof message.id === 'number') {
+        expect(message.error).toBeUndefined();
+        byId.set(message.id, message.result as Record<string, unknown>);
+      }
+    }
+
+    const discover = byId.get(1) as {
+      supportedVersions?: string[];
+      capabilities?: Record<string, unknown>;
+      resultType?: string;
+      _meta?: Record<string, unknown>;
+    };
+    expect(discover?.supportedVersions).toEqual([MODERN_PROTOCOL_VERSION]);
+    expect(discover?.capabilities?.tools).toBeDefined();
+    expect(discover?.resultType).toBe('complete');
+    expect(discover?._meta?.['io.modelcontextprotocol/serverInfo']).toMatchObject({ name: SERVER_INFO.name });
+
+    // Every 2026-era result is self-describing: `resultType` plus server identity in
+    // _meta; the cacheable list results additionally carry our SEP-2549 hints.
+    const list = byId.get(2) as {
+      resultType?: string;
+      ttlMs?: number;
+      cacheScope?: string;
+      tools?: { name: string }[];
+      _meta?: Record<string, unknown>;
+    };
+    expect(list?.resultType).toBe('complete');
+    expect(list?.ttlMs).toBe(300_000);
+    expect(list?.cacheScope).toBe('public');
+    // Advertised in deterministic (lexicographic) order — asserted unsorted.
+    expect(list?.tools?.map((t) => t.name)).toEqual([
+      'get_decision',
+      'get_decision_context',
+      'list_superseded',
+      'search_decisions',
+    ]);
+    expect(list?._meta?.['io.modelcontextprotocol/serverInfo']).toMatchObject({ name: SERVER_INFO.name });
+
+    const call = byId.get(3) as { resultType?: string; ttlMs?: number; structuredContent?: { result: { outcome: string } } };
+    expect(call?.resultType).toBe('complete');
+    // tools/call is not a cacheable result — a corpus read never carries cache fields.
+    expect(call?.ttlMs).toBeUndefined();
+    expect(call?.structuredContent?.result.outcome).toBe('found');
   });
 });

--- a/packages/mcp/test/bin.test.ts
+++ b/packages/mcp/test/bin.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from 'bun:test';
+import { spawn } from 'node:child_process';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/client';
 import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
-import { main, reportUnhandledRejection } from '../src/main-module.ts';
+import { main, reportTransportError, reportUnhandledRejection } from '../src/main-module.ts';
 import { MODERN_PROTOCOL_VERSION, SERVER_INFO } from '../src/server.ts';
 import { createRepo, repoFromFixture, type TempRepo } from './helpers.ts';
 
@@ -116,6 +117,74 @@ describe('adrkit-mcp bin — startup validation and exit codes', () => {
     );
     expect(diagnostic).toContain('unhandled rejection: background transport failed');
     expect(failed).toBe(true);
+  });
+
+  test('a transport error emits a stderr diagnostic and sets failure status', () => {
+    let diagnostic = '';
+    let failed = false;
+    reportTransportError(
+      new Error('EPIPE: broken pipe, write'),
+      (text) => {
+        diagnostic += text;
+      },
+      () => {
+        failed = true;
+      },
+    );
+    expect(diagnostic).toContain('transport error: EPIPE: broken pipe, write');
+    expect(failed).toBe(true);
+  });
+});
+
+describe('adrkit-mcp bin — transport failures are never silent', () => {
+  test('a client that dies mid-session produces a stderr diagnostic and a non-zero exit', async () => {
+    const repo = await repoFromFixture('status-corpus');
+    cleanups.push(repo.cleanup);
+
+    // `serveStdio` reports transport failures ONLY through its `onerror` callback
+    // (it consumes the rejected `start()` promise itself). Without that callback
+    // wired through to the bin, this exact sequence tears the connection down and
+    // still exits 0 — a dead server reporting success (ADR-0016).
+    const proc = spawn(process.execPath, [BIN_SRC, '--cwd', repo.root], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    let stdout = '';
+    proc.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    proc.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+
+    const initialize = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 't', version: '0' } },
+    };
+    proc.stdin.write(`${JSON.stringify(initialize)}\n`);
+
+    const deadline = Date.now() + 5000;
+    while (!stdout.includes('"id":1') && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    expect(stdout).toContain('"id":1'); // the server is live before we break the pipe
+
+    proc.stdout.destroy(); // the client goes away
+    proc.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' })}\n`); // forces a write to a dead pipe
+
+    const exitCode = await new Promise<number | 'timeout'>((resolve) => {
+      const timer = setTimeout(() => resolve('timeout'), 5000);
+      proc.on('exit', (code) => {
+        clearTimeout(timer);
+        resolve(code ?? -1);
+      });
+    });
+    proc.kill();
+
+    expect(stderr).toContain('transport error');
+    expect(exitCode).toBe(1);
   });
 });
 

--- a/packages/mcp/test/bin.test.ts
+++ b/packages/mcp/test/bin.test.ts
@@ -196,6 +196,36 @@ describe('adrkit-mcp bin — protocol revision 2026-07-28 over real stdio', () =
     return client;
   }
 
+  /** A 2025-era client against the same bin, for era-equivalence comparison. */
+  async function spawnLegacyClient(repo: TempRepo): Promise<Client> {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [BIN_SRC, '--cwd', repo.root],
+    });
+    const client = new Client({ name: 'bin-test-legacy', version: '0.0.0' });
+    await client.connect(transport);
+    cleanups.push(() => client.close());
+    return client;
+  }
+
+  /** Drive a paginated tool channel to exhaustion, collecting every item once. */
+  async function walkTool(
+    client: Client,
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<{ id: string }[]> {
+    const all: { id: string }[] = [];
+    let cursor: string | undefined;
+    for (let guard = 0; guard < 100; guard += 1) {
+      const call = await client.callTool({ name, arguments: { ...args, ...(cursor ? { cursor } : {}) } });
+      const result = (call.structuredContent as { result: { items: { id: string }[]; cursor: string | null } }).result;
+      all.push(...result.items);
+      if (result.cursor == null) return all;
+      cursor = result.cursor;
+    }
+    throw new Error('walkTool exceeded its page guard');
+  }
+
   test('a client pinned to 2026-07-28 negotiates the modern era and lists the four tools', async () => {
     const repo = await repoFromFixture('edge-corpus');
     cleanups.push(repo.cleanup);
@@ -212,13 +242,60 @@ describe('adrkit-mcp bin — protocol revision 2026-07-28 over real stdio', () =
     ]);
   });
 
-  test('tools/call answers the same structured result on the modern era as on the legacy era', async () => {
+  test('every tool answers byte-equal structured content and text on both eras', async () => {
     const repo = await repoFromFixture('edge-corpus');
     cleanups.push(repo.cleanup);
-    const client = await spawnPinnedModernClient(repo);
+    const modern = await spawnPinnedModernClient(repo);
+    const legacy = await spawnLegacyClient(repo);
 
-    const call = await client.callTool({ name: 'list_superseded', arguments: {} });
-    expect((call.structuredContent as { result: { outcome: string } }).result.outcome).toBe('entries');
+    // ADR-0018's central claim: results do not vary by era. Asserted per tool
+    // over the whole payload, not one field — the 2026 codec is a distinct
+    // encode seam, so anything it reshapes has to show up here.
+    const calls: Array<[string, Record<string, unknown>]> = [
+      ['search_decisions', { query: 'a' }],
+      ['get_decision', { ref: '0010' }], // duplicate id -> ambiguous-local-id + candidates
+      ['get_decision_context', { files: ['docs/adr/0001.md'] }],
+      ['list_superseded', {}], // dangling / ambiguous / federated supersededBy states
+    ];
+
+    for (const [name, args] of calls) {
+      const [m, l] = await Promise.all([
+        modern.callTool({ name, arguments: args }),
+        legacy.callTool({ name, arguments: args }),
+      ]);
+      expect(m.structuredContent, `${name} structuredContent`).toEqual(l.structuredContent);
+      expect(m.content, `${name} content`).toEqual(l.content);
+    }
+  });
+
+  test('a cursor minted on the modern era resumes on it, and the walk matches the legacy era', async () => {
+    const repo = await repoFromFixture('edge-corpus');
+    cleanups.push(repo.cleanup);
+    const modern = await spawnPinnedModernClient(repo);
+    const legacy = await spawnLegacyClient(repo);
+
+    // limit:1 forces a cursor to be minted, returned, and fed back through the
+    // 2026 codec on every hop — the round trip a single-page call never exercises.
+    const modernWalk = await walkTool(modern, 'list_superseded', { limit: 1 });
+    const legacyWalk = await walkTool(legacy, 'list_superseded', { limit: 1 });
+
+    expect(modernWalk.map((e) => e.id)).toEqual(['0011', '0012', '0013', '0014']);
+    expect(modernWalk).toEqual(legacyWalk);
+  });
+
+  test('an invalid cursor stays a structured outcome on the modern era, not a JSON-RPC error', async () => {
+    const repo = await repoFromFixture('edge-corpus');
+    cleanups.push(repo.cleanup);
+    const modern = await spawnPinnedModernClient(repo);
+
+    // The 2026 revision tightened result validation; a non-error outcome must not
+    // get promoted into a protocol error by the stricter codec.
+    const call = await modern.callTool({ name: 'list_superseded', arguments: { cursor: 'not-a-real-cursor' } });
+    expect(call.isError).toBeFalsy();
+    const result = (call.structuredContent as { result: { outcome: string; reason: string; message: string } }).result;
+    expect(result.outcome).toBe('invalid-cursor');
+    expect(result.reason).toBe('decode-failed');
+    expect(result.message).toBe('Cursor could not be decoded.');
   });
 
   test('a raw 2026-07-28 exchange needs no initialize handshake and carries its version in _meta', async () => {

--- a/packages/mcp/test/boundary.test.ts
+++ b/packages/mcp/test/boundary.test.ts
@@ -3,8 +3,8 @@ import { mkdir, mkdtemp, writeFile, rm, realpath } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import { buildRegisteredServer } from '../src/server.ts';
 import {
   connectServer,

--- a/packages/mcp/test/helpers.ts
+++ b/packages/mcp/test/helpers.ts
@@ -7,10 +7,9 @@
  * here is local, offline, model-free, and credential-free.
  */
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { McpServer, InMemoryTransport } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import { createHash } from 'node:crypto';
 import { mkdtemp, mkdir, writeFile, readdir, readFile, rm, realpath, stat, cp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -35,7 +34,12 @@ export interface OpenServer {
 /** Connect an already-built McpServer to an in-process client. */
 export async function connectServer(server: McpServer): Promise<OpenServer> {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  const client = new Client({ name: 'adrkit-mcp-test-client', version: '0.0.0' });
+  // v2 clients return an empty result for an unadvertised capability instead of
+  // sending the request; strict mode restores the v1 throw the surface tests assert.
+  const client = new Client(
+    { name: 'adrkit-mcp-test-client', version: '0.0.0' },
+    { enforceStrictCapabilities: true },
+  );
   await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
   return {
     server,

--- a/packages/mcp/test/shared-contracts.test.ts
+++ b/packages/mcp/test/shared-contracts.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
 import {
   ANNOTATIONS,
   LIMITS,
@@ -162,9 +163,10 @@ describe('root-object output schemas with a nested discriminated union', () => {
     ['get_decision_context', getDecisionContextOutputSchema],
     ['list_superseded', listSupersededOutputSchema],
   ] as const) {
-    test(`${name} output raw shape has corpusHealth + result (union nested under result)`, () => {
-      const shape = builder();
-      expect(Object.keys(shape).sort()).toEqual(['corpusHealth', 'result']);
+    test(`${name} output schema is a root object of corpusHealth + result (union nested under result)`, () => {
+      const schema = builder();
+      expect(schema).toBeInstanceOf(z.ZodObject);
+      expect(Object.keys((schema as z.ZodObject).shape).sort()).toEqual(['corpusHealth', 'result']);
     });
   }
 });

--- a/packages/mcp/test/side-effect-denial.test.ts
+++ b/packages/mcp/test/side-effect-denial.test.ts
@@ -3,8 +3,8 @@ import { mkdtemp, readFile, readdir, writeFile, rm, realpath } from 'node:fs/pro
 import { tmpdir } from 'node:os';
 import { dirname, extname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import * as ts from 'typescript';
 import { repoFromFixture, snapshotTree, diffSnapshots, type TempRepo } from './helpers.ts';
 

--- a/scripts/audit-gate.test.ts
+++ b/scripts/audit-gate.test.ts
@@ -7,6 +7,28 @@ const FIXTURES = resolve(import.meta.dir, '__fixtures__', 'audit');
 const readFixture = (name: string) => Bun.file(resolve(FIXTURES, name)).text();
 const ACTIVE_ACCEPTANCE_AS_OF = '2026-07-25';
 
+/**
+ * A synthetic acceptance used to keep the expiry and reporting machinery under test
+ * while the real acceptance list is empty. Injected via `evaluateAudit`'s test-only
+ * `acceptances` option, so it never claims a real exposure.
+ */
+const SAMPLE_ACCEPTANCE = {
+  advisoryId: 'GHSA-example-0000-0000',
+  url: 'https://github.com/advisories/GHSA-example-0000-0000',
+  title: 'Example advisory used only to exercise the acceptance machinery',
+  severity: 'moderate',
+  package: 'example-transitive',
+  observedVersion: '1.0.0',
+  vulnerableVersions: '<2.0.0',
+  affectedPublishedPackage: '@adrkit/example',
+  affectedPublishedVersion: '0.0.0',
+  dependencyPath: ['@adrkit/example', 'example-upstream@1.0.0', 'example-transitive'],
+  acceptedUntil: '2026-10-31',
+  whyNotFixed: 'synthetic fixture; upstream range cannot resolve the patched version.',
+  consequence: 'synthetic fixture; no real consumer exposure.',
+  resolvesWhen: 'synthetic fixture; never.',
+} as const;
+
 describe('audit-gate — evaluateAudit', () => {
   // ADR-0016 permanent negative case. `prefix-high.json` is the real, unedited
   // `bun audit --json` output captured from this repository's tree BEFORE the
@@ -53,39 +75,58 @@ describe('audit-gate — evaluateAudit', () => {
     const rendered = formatEvaluation(evaluation);
 
     expect(rendered).toContain('scope: workspace-resolved-dependency-tree');
-    expect(rendered).toContain('after root package.json overrides');
+    expect(rendered).toContain('as resolved by `bun install --frozen-lockfile`');
     expect(rendered).toContain('does not audit consumer installs of published @adrkit/* packages');
   });
 
-  test('records the known upstream-blocked @adrkit/mcp consumer advisory without hiding the scope gap', async () => {
+  test('records no known published-consumer exposure now that the MCP SDK v2 split removed the path', async () => {
     const evaluation = evaluateAudit(await readFixture('clean.json'), { asOf: ACTIVE_ACCEPTANCE_AS_OF });
+
+    expect(evaluation.ok).toBe(true);
+    // The @hono/node-server acceptance retired when @adrkit/mcp moved to
+    // @modelcontextprotocol/server v2 (deps: @modelcontextprotocol/core + zod only).
+    expect(evaluation.knownConsumerAdvisories).toEqual([]);
+    expect(formatEvaluation(evaluation)).not.toContain('known published-consumer exposure');
+    // Guard against a stale acceptance outliving the exposure it describes: the
+    // manifest this repo is about to ship no longer reaches the vulnerable package.
+    expect(mcpManifest.dependencies).not.toHaveProperty('@modelcontextprotocol/sdk');
+  });
+
+  test('reports an active acceptance in full, without hiding the scope gap', async () => {
+    const evaluation = evaluateAudit(await readFixture('clean.json'), {
+      asOf: ACTIVE_ACCEPTANCE_AS_OF,
+      acceptances: [SAMPLE_ACCEPTANCE],
+    });
     const known = evaluation.knownConsumerAdvisories?.[0];
 
     expect(evaluation.ok).toBe(true);
-    expect(known?.package).toBe('@hono/node-server');
-    expect(known?.url).toBe('https://github.com/advisories/GHSA-frvp-7c67-39w9');
-    expect(known?.affectedPublishedPackage).toBe('@adrkit/mcp');
-    // Pinned to the manifest, not a literal: the recorded exposure must name the
-    // version this repository is about to ship, or the gate reports a consumer
-    // exposure for a version nobody installs and reads as false safety for the
-    // current one.
-    expect(known?.affectedPublishedVersion).toBe(mcpManifest.version);
+    expect(known?.package).toBe('example-transitive');
+    expect(known?.expired).toBe(false);
     expect(known?.acceptedUntil).toBe('2026-10-31');
 
     const rendered = formatEvaluation(evaluation);
     expect(rendered).toContain('known published-consumer exposure');
-    expect(rendered).toContain('GHSA-frvp-7c67-39w9');
-    expect(rendered).toContain('@modelcontextprotocol/sdk@1.29.0');
-    expect(rendered).toContain('@hono/node-server >=2.0.5');
-    expect(rendered).toContain('stdio MCP server does not use Hono serve-static');
+    expect(rendered).toContain('GHSA-example-0000-0000');
+    expect(rendered).toContain('accepted until 2026-10-31');
+    expect(rendered).toContain('why not fixed:');
+    expect(rendered).toContain('resolves when:');
   });
 
-  test('fails closed once the known consumer advisory acceptance expires', async () => {
-    const evaluation = evaluateAudit(await readFixture('clean.json'), { asOf: '2026-11-01' });
+  test('fails closed once a known consumer advisory acceptance expires', async () => {
+    const evaluation = evaluateAudit(await readFixture('clean.json'), {
+      asOf: '2026-11-01',
+      acceptances: [SAMPLE_ACCEPTANCE],
+    });
 
     expect(evaluation.ok).toBe(false);
     expect(evaluation.reason).toBe('consumer-advisory-acceptance-expired');
     expect(formatEvaluation(evaluation)).toContain('consumer advisory acceptance expired');
+  });
+
+  test('a clean tree with no recorded acceptances cannot expire', async () => {
+    const evaluation = evaluateAudit(await readFixture('clean.json'), { asOf: '2099-01-01' });
+    expect(evaluation.ok).toBe(true);
+    expect(evaluation.reason).toBeUndefined();
   });
 
   // The core ADR-0016 distinction: absence of output is "could not look", which

--- a/scripts/audit-gate.ts
+++ b/scripts/audit-gate.ts
@@ -97,33 +97,29 @@ const BLOCKING: ReadonlySet<AdvisorySeverity> = new Set(['critical', 'high']);
 const WORKSPACE_AUDIT_SCOPE: AuditScope = {
   id: 'workspace-resolved-dependency-tree',
   examined:
-    'the current checkout after root package.json overrides are applied by `bun install --frozen-lockfile`',
+    'the current checkout as resolved by `bun install --frozen-lockfile`, including any root package.json overrides in effect',
   notExamined:
-    'consumer installs of published @adrkit/* packages, whose manifests do not publish the root overrides',
+    'consumer installs of published @adrkit/* packages, which resolve from the published manifests and inherit no root overrides or workspace pins',
 };
 
-const KNOWN_CONSUMER_ADVISORY_ACCEPTANCES: readonly Omit<KnownConsumerAdvisory, 'expired'>[] = [
-  {
-    advisoryId: 'GHSA-frvp-7c67-39w9',
-    url: 'https://github.com/advisories/GHSA-frvp-7c67-39w9',
-    title:
-      'Node.js Adapter for Hono: Path traversal in `serve-static` on Windows via encoded backslash (`%5C`)',
-    severity: 'moderate',
-    package: '@hono/node-server',
-    observedVersion: '1.19.17',
-    vulnerableVersions: '<2.0.5',
-    affectedPublishedPackage: '@adrkit/mcp',
-    affectedPublishedVersion: '0.2.1',
-    dependencyPath: ['@adrkit/mcp', '@modelcontextprotocol/sdk@1.29.0', '@hono/node-server'],
-    acceptedUntil: '2026-10-31',
-    whyNotFixed:
-      '@modelcontextprotocol/sdk@1.29.0 is the latest release and still ranges @hono/node-server as ^1.19.9; adrkit root overrides do not constrain consumer installs.',
-    consequence:
-      'adrkit is a local stdio MCP server; the stdio MCP server does not use Hono serve-static or expose HTTP static files, so this Windows serve-static path traversal is low-consequence here.',
-    resolvesWhen:
-      'an @modelcontextprotocol/sdk release updates its @hono/node-server range so consumers resolve @hono/node-server >=2.0.5, or adrkit removes that transitive path.',
-  },
-];
+/**
+ * Narrow, expiring acceptances for advisories that reach a *published consumer* of an
+ * `@adrkit/*` package but not this workspace's audited tree (ADR-0017). Recorded here
+ * rather than suppressed, so the gate reports them and fails closed on expiry.
+ *
+ * Currently empty. The one entry this list has ever held —
+ * [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9), a
+ * vulnerable `@hono/node-server` reached through
+ * `@adrkit/mcp › @modelcontextprotocol/sdk@1.29.0` — was retired by its own recorded
+ * `resolvesWhen` clause ("...or adrkit removes that transitive path"): the MCP SDK v2
+ * package split moved `@adrkit/mcp` onto `@modelcontextprotocol/server`, whose only
+ * runtime dependencies are `@modelcontextprotocol/core` and `zod`. Neither
+ * `@hono/node-server` nor `fast-uri` appears anywhere in the resolved tree now, so a
+ * consumer install can no longer reach either.
+ *
+ * The expiry machinery stays exercised through the injectable `acceptances` option.
+ */
+const KNOWN_CONSUMER_ADVISORY_ACCEPTANCES: readonly Omit<KnownConsumerAdvisory, 'expired'>[] = [];
 
 function emptySeverityTally(): Record<AdvisorySeverity, number> {
   return { critical: 0, high: 0, moderate: 0, low: 0, info: 0 };
@@ -191,6 +187,12 @@ function findShapeError(value: unknown): string | undefined {
 
 export interface AuditEvaluationOptions {
   readonly asOf?: string;
+  /**
+   * Override the recorded acceptance list. Test-only seam: it keeps the expiry and
+   * reporting machinery under test while the real list
+   * (`KNOWN_CONSUMER_ADVISORY_ACCEPTANCES`) is empty. Production callers omit it.
+   */
+  readonly acceptances?: readonly Omit<KnownConsumerAdvisory, 'expired'>[];
 }
 
 const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
@@ -213,8 +215,11 @@ function normalizeAsOf(value: string | undefined): { asOf: string; error?: strin
   return { asOf };
 }
 
-function buildKnownConsumerAdvisories(asOf: string): KnownConsumerAdvisory[] {
-  return KNOWN_CONSUMER_ADVISORY_ACCEPTANCES.map((advisory) => ({
+function buildKnownConsumerAdvisories(
+  asOf: string,
+  acceptances: readonly Omit<KnownConsumerAdvisory, 'expired'>[] = KNOWN_CONSUMER_ADVISORY_ACCEPTANCES,
+): KnownConsumerAdvisory[] {
+  return acceptances.map((advisory) => ({
     ...advisory,
     expired: asOf > advisory.acceptedUntil,
   }));
@@ -241,7 +246,7 @@ export function evaluateAudit(raw: string, options: AuditEvaluationOptions = {})
     return blind('invalid-as-of', normalizedAsOf.asOf, [], normalizedAsOf.error);
   }
   const { asOf } = normalizedAsOf;
-  const knownConsumerAdvisories = buildKnownConsumerAdvisories(asOf);
+  const knownConsumerAdvisories = buildKnownConsumerAdvisories(asOf, options.acceptances);
 
   const trimmed = raw.trim();
   if (trimmed.length === 0) {

--- a/scripts/check-deps.test.ts
+++ b/scripts/check-deps.test.ts
@@ -235,7 +235,7 @@ describe('evaluator dependency boundary (Phase 4)', () => {
 });
 
 describe('mcp dependency boundary (Phase 5)', () => {
-  test('allows exactly core, the pinned SDK, and zod, plus @types/bun in dev', async () => {
+  test('allows exactly core, the pinned SDK server, and zod, plus the dev-only SDK client and @types/bun', async () => {
     const root = await resetTestDir(DIR_NAME);
     await writeText(
       join(root, 'packages/mcp/package.json'),
@@ -243,8 +243,8 @@ describe('mcp dependency boundary (Phase 5)', () => {
         {
           name: '@adrkit/mcp',
           version: '0.1.0',
-          dependencies: { '@adrkit/core': 'workspace:*', '@modelcontextprotocol/sdk': '1.29.0', zod: '^4' },
-          devDependencies: { '@types/bun': 'latest' },
+          dependencies: { '@adrkit/core': 'workspace:*', '@modelcontextprotocol/server': '2.0.0', zod: '^4' },
+          devDependencies: { '@modelcontextprotocol/client': '2.0.0', '@types/bun': 'latest' },
         },
         null,
         2,
@@ -267,7 +267,7 @@ describe('mcp dependency boundary (Phase 5)', () => {
           version: '0.1.0',
           dependencies: {
             '@adrkit/core': 'workspace:*',
-            '@modelcontextprotocol/sdk': '1.29.0',
+            '@modelcontextprotocol/server': '2.0.0',
             zod: '^4',
             '@adrkit/adapter-example': 'workspace:*',
             undici: '^6',
@@ -302,7 +302,7 @@ describe('mcp dependency boundary (Phase 5)', () => {
         {
           name: '@adrkit/mcp',
           version: '0.1.0',
-          dependencies: { '@adrkit/core': 'workspace:*', '@modelcontextprotocol/sdk': '1.29.0', zod: '^4', '@modelcontextprotocol/server-everything': '^1' },
+          dependencies: { '@adrkit/core': 'workspace:*', '@modelcontextprotocol/server': '2.0.0', zod: '^4', '@modelcontextprotocol/server-everything': '^1' },
         },
         null,
         2,
@@ -318,7 +318,7 @@ describe('mcp dependency boundary (Phase 5)', () => {
     await writeText(
       join(root, 'packages/mcp/package.json'),
       JSON.stringify(
-        { name: '@adrkit/mcp', version: '0.1.0', dependencies: { '@adrkit/core': 'workspace:*', '@modelcontextprotocol/sdk': '1.29.0', zod: '^4', '@actions/github': '^6' } },
+        { name: '@adrkit/mcp', version: '0.1.0', dependencies: { '@adrkit/core': 'workspace:*', '@modelcontextprotocol/server': '2.0.0', zod: '^4', '@actions/github': '^6' } },
         null,
         2,
       ),

--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -125,11 +125,13 @@ function allowedDependenciesFor(packageName: string): Record<DependencySection, 
 
   if (packageName === '@adrkit/mcp') {
     // The MCP server surface may depend on core, the pinned Model Context Protocol
-    // SDK, and zod only — never an adapter, GitHub toolkit, network/auth/model/
-    // embedding/database/cache client, native addon, or worker helper (R2/R10).
+    // SDK server package, and zod only — never an adapter, GitHub toolkit, network/
+    // auth/model/embedding/database/cache client, native addon, or worker helper
+    // (R2/R10). The SDK client package is development-only: it drives the in-process
+    // and real-stdio conformance harnesses and is never imported by shipped code.
     return {
-      dependencies: new Set(['@adrkit/core', '@modelcontextprotocol/sdk', 'zod']),
-      devDependencies: new Set(['@types/bun']),
+      dependencies: new Set(['@adrkit/core', '@modelcontextprotocol/server', 'zod']),
+      devDependencies: new Set(['@modelcontextprotocol/client', '@types/bun']),
       peerDependencies: new Set(),
       optionalDependencies: new Set(),
     };

--- a/scripts/release-pack.ts
+++ b/scripts/release-pack.ts
@@ -274,13 +274,19 @@ if (JSON.stringify(Object.getOwnPropertyNames(handle).sort()) !== JSON.stringify
 }
 if (mcp.buildRegisteredServer !== undefined) throw new Error('Installed @adrkit/mcp must not export its internal builder');
 
-async function runMcpStdio(bin, cwd) {
+const MCP_MODERN_META = {
+  'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+  'io.modelcontextprotocol/clientCapabilities': {},
+  'io.modelcontextprotocol/clientInfo': { name: 'smoke', version: '0' },
+};
+
+async function runMcpStdio(bin, cwd, era) {
   const proc = spawn(bin, ['--cwd', cwd], { stdio: ['pipe', 'pipe', 'inherit'] });
   const messages = new Map();
   const wanted = [2, 3, 4, 5, 6];
   let buffer = '';
   await new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error('MCP stdio smoke timed out')), 20000);
+    const timer = setTimeout(() => reject(new Error('MCP stdio smoke timed out (' + era + ' era)')), 20000);
     proc.on('error', reject);
     proc.stdout.on('data', (chunk) => {
       buffer += chunk.toString('utf8');
@@ -298,31 +304,56 @@ async function runMcpStdio(bin, cwd) {
         }
       }
     });
-    const frames = [
-      { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'smoke', version: '0' } } },
-      { jsonrpc: '2.0', method: 'notifications/initialized' },
-      { jsonrpc: '2.0', id: 2, method: 'tools/list' },
-      { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'search_decisions', arguments: { query: 'git' } } },
-      { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'get_decision', arguments: { ref: '0001' } } },
-      { jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'get_decision_context', arguments: { files: ['README.md'] } } },
-      { jsonrpc: '2.0', id: 6, method: 'tools/call', params: { name: 'list_superseded', arguments: {} } },
-    ];
+    const _meta = era === 'modern' ? MCP_MODERN_META : undefined;
+    const call = (id, name, args) => ({ jsonrpc: '2.0', id, method: 'tools/call', params: _meta ? { name, arguments: args, _meta } : { name, arguments: args } });
+    const frames = era === 'modern'
+      ? [
+          { jsonrpc: '2.0', id: 1, method: 'server/discover', params: { _meta } },
+          { jsonrpc: '2.0', id: 2, method: 'tools/list', params: { _meta } },
+        ]
+      : [
+          { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'smoke', version: '0' } } },
+          { jsonrpc: '2.0', method: 'notifications/initialized' },
+          { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+        ];
+    frames.push(
+      call(3, 'search_decisions', { query: 'git' }),
+      call(4, 'get_decision', { ref: '0001' }),
+      call(5, 'get_decision_context', { files: ['README.md'] }),
+      call(6, 'list_superseded', {}),
+    );
     proc.stdin.write(frames.map((f) => JSON.stringify(f) + '\\n').join(''));
   });
   proc.stdin.end();
   proc.kill();
+  for (const id of [1, 2, 3, 4, 5, 6]) {
+    const error = messages.get(id)?.error;
+    if (error) throw new Error('Installed adrkit-mcp answered id ' + id + ' with an error (' + era + ' era): ' + JSON.stringify(error));
+  }
   const list = messages.get(2);
-  const names = (list?.result?.tools ?? []).map((t) => t.name).sort();
+  // Asserted UNSORTED: tools/list order is wire-visible and deterministic.
+  const names = (list?.result?.tools ?? []).map((t) => t.name);
   const expected = ['get_decision', 'get_decision_context', 'list_superseded', 'search_decisions'];
-  if (JSON.stringify(names) !== JSON.stringify(expected)) throw new Error('Installed adrkit-mcp did not list the four tools: ' + names);
+  if (JSON.stringify(names) !== JSON.stringify(expected)) throw new Error('Installed adrkit-mcp did not list the four tools in order (' + era + ' era): ' + names);
+  if (era === 'modern') {
+    const supported = messages.get(1)?.result?.supportedVersions ?? [];
+    if (!supported.includes('2026-07-28')) throw new Error('Installed adrkit-mcp did not advertise 2026-07-28: ' + JSON.stringify(supported));
+  }
+  const outcomes = {};
   for (const id of [3, 4, 5, 6]) {
     const outcome = messages.get(id)?.result?.structuredContent?.result?.outcome;
-    if (!outcome) throw new Error('Installed adrkit-mcp tool call ' + id + ' did not return a structured outcome');
+    if (!outcome) throw new Error('Installed adrkit-mcp tool call ' + id + ' did not return a structured outcome (' + era + ' era)');
+    outcomes[id] = outcome;
   }
+  return outcomes;
 }
 
 const mcpBin = join(import.meta.dirname, 'node_modules', '.bin', process.platform === 'win32' ? 'adrkit-mcp.cmd' : 'adrkit-mcp');
-await runMcpStdio(mcpBin, repoRoot);
+const legacyOutcomes = await runMcpStdio(mcpBin, repoRoot, 'legacy');
+const modernOutcomes = await runMcpStdio(mcpBin, repoRoot, 'modern');
+if (JSON.stringify(legacyOutcomes) !== JSON.stringify(modernOutcomes)) {
+  throw new Error('Installed adrkit-mcp tool outcomes differ by protocol era: ' + JSON.stringify(legacyOutcomes) + ' vs ' + JSON.stringify(modernOutcomes));
+}
 
 const bin = join(import.meta.dirname, 'node_modules', '.bin', process.platform === 'win32' ? 'adr.cmd' : 'adr');
 const lint = spawnSync(bin, ['lint', join(repoRoot, 'docs/adr')], { cwd: repoRoot, encoding: 'utf8' });

--- a/scripts/smoke-node.mjs
+++ b/scripts/smoke-node.mjs
@@ -62,7 +62,39 @@ if (JSON.stringify(Object.getOwnPropertyNames(mcpHandle).sort()) !== JSON.string
 const mcpBinPath = fileURLToPath(new URL('../packages/mcp/dist/bin.js', import.meta.url));
 const mcpPreloadPath = fileURLToPath(new URL('../packages/mcp/test/side-effect-denial-preload.mjs', import.meta.url));
 
-async function runBuiltMcpStdio() {
+// Both protocol eras are exercised against the BUILT artifact under Node, not just
+// against src/ under Bun: the 2026-07-28 revision is a distinct encode seam, and it
+// is the reason this release exists (ADR-0018).
+const MCP_TOOL_CALLS = [
+  { id: 3, name: 'search_decisions', arguments: { query: 'git' } },
+  { id: 4, name: 'get_decision', arguments: { ref: '0001' } },
+  { id: 5, name: 'get_decision_context', arguments: { files: ['README.md'] } },
+  { id: 6, name: 'list_superseded', arguments: {} },
+];
+
+function mcpFrames(era) {
+  if (era === 'legacy') {
+    return [
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'smoke', version: '0' } } },
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+      ...MCP_TOOL_CALLS.map(({ id, name, arguments: args }) => ({ jsonrpc: '2.0', id, method: 'tools/call', params: { name, arguments: args } })),
+    ];
+  }
+  // 2026-07-28: no handshake; every request carries its own envelope in _meta.
+  const _meta = {
+    'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+    'io.modelcontextprotocol/clientCapabilities': {},
+    'io.modelcontextprotocol/clientInfo': { name: 'smoke', version: '0' },
+  };
+  return [
+    { jsonrpc: '2.0', id: 1, method: 'server/discover', params: { _meta } },
+    { jsonrpc: '2.0', id: 2, method: 'tools/list', params: { _meta } },
+    ...MCP_TOOL_CALLS.map(({ id, name, arguments: args }) => ({ jsonrpc: '2.0', id, method: 'tools/call', params: { name, arguments: args, _meta } })),
+  ];
+}
+
+async function runBuiltMcpStdio(era) {
   const proc = spawn(process.execPath, ['--import', mcpPreloadPath, mcpBinPath, '--cwd', repoRoot], {
     stdio: ['pipe', 'pipe', 'inherit'],
   });
@@ -70,7 +102,7 @@ async function runBuiltMcpStdio() {
   const wanted = [2, 3, 4, 5, 6];
   let buffer = '';
   await new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error('Built MCP stdio smoke timed out')), 20000);
+    const timer = setTimeout(() => reject(new Error(`Built MCP stdio smoke timed out (${era} era)`)), 20000);
     proc.on('error', reject);
     proc.stdout.on('data', (chunk) => {
       buffer += chunk.toString('utf8');
@@ -81,7 +113,7 @@ async function runBuiltMcpStdio() {
         if (!line.trim()) continue;
         const message = JSON.parse(line);
         if (message.jsonrpc !== '2.0') {
-          reject(new Error('Built adrkit-mcp emitted a non-JSON-RPC stdout line'));
+          reject(new Error(`Built adrkit-mcp emitted a non-JSON-RPC stdout line (${era} era)`));
           return;
         }
         if (typeof message.id === 'number') messages.set(message.id, message);
@@ -91,31 +123,48 @@ async function runBuiltMcpStdio() {
         }
       }
     });
-    const frames = [
-      { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'smoke', version: '0' } } },
-      { jsonrpc: '2.0', method: 'notifications/initialized' },
-      { jsonrpc: '2.0', id: 2, method: 'tools/list' },
-      { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'search_decisions', arguments: { query: 'git' } } },
-      { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'get_decision', arguments: { ref: '0001' } } },
-      { jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'get_decision_context', arguments: { files: ['README.md'] } } },
-      { jsonrpc: '2.0', id: 6, method: 'tools/call', params: { name: 'list_superseded', arguments: {} } },
-    ];
+    const frames = mcpFrames(era);
     proc.stdin.write(frames.map((f) => JSON.stringify(f) + '\n').join(''));
   });
   proc.stdin.end();
   proc.kill();
-  const names = (messages.get(2)?.result?.tools ?? []).map((t) => t.name).sort();
+  for (const id of [1, 2, ...MCP_TOOL_CALLS.map((c) => c.id)]) {
+    const error = messages.get(id)?.error;
+    if (error) throw new Error(`Built adrkit-mcp answered id ${id} with an error (${era} era): ${JSON.stringify(error)}`);
+  }
+  // Asserted UNSORTED: tools/list order is wire-visible and deterministic.
+  const names = (messages.get(2)?.result?.tools ?? []).map((t) => t.name);
   const expected = ['get_decision', 'get_decision_context', 'list_superseded', 'search_decisions'];
   if (JSON.stringify(names) !== JSON.stringify(expected)) {
-    throw new Error(`Built adrkit-mcp did not list the four tools: ${names}`);
+    throw new Error(`Built adrkit-mcp did not list the four tools in order (${era} era): ${names}`);
   }
-  for (const id of [3, 4, 5, 6]) {
+  const outcomes = {};
+  for (const { id, name } of MCP_TOOL_CALLS) {
     const outcome = messages.get(id)?.result?.structuredContent?.result?.outcome;
-    if (!outcome) throw new Error(`Built adrkit-mcp tool call ${id} did not return a structured outcome`);
+    if (!outcome) throw new Error(`Built adrkit-mcp tool call ${id} did not return a structured outcome (${era} era)`);
+    outcomes[name] = outcome;
   }
+  if (era === 'modern') {
+    const discover = messages.get(1)?.result ?? {};
+    if (!(discover.supportedVersions ?? []).includes('2026-07-28')) {
+      throw new Error(`Built adrkit-mcp did not advertise 2026-07-28 from server/discover: ${JSON.stringify(discover.supportedVersions)}`);
+    }
+    if (messages.get(2)?.result?.resultType !== 'complete') {
+      throw new Error('Built adrkit-mcp omitted the required 2026-07-28 resultType on tools/list');
+    }
+  }
+  return outcomes;
 }
 
-await runBuiltMcpStdio();
+// Serve both eras from the same built binary and require identical tool outcomes:
+// ADR-0018's claim is that results do not vary by era.
+const legacyOutcomes = await runBuiltMcpStdio('legacy');
+const modernOutcomes = await runBuiltMcpStdio('modern');
+if (JSON.stringify(legacyOutcomes) !== JSON.stringify(modernOutcomes)) {
+  throw new Error(
+    `Built adrkit-mcp tool outcomes differ by protocol era: legacy=${JSON.stringify(legacyOutcomes)} modern=${JSON.stringify(modernOutcomes)}`,
+  );
+}
 
 const cli = spawnSync(process.execPath, [cliPath, 'lint', 'docs/adr'], {
   cwd: repoRoot,
@@ -202,5 +251,5 @@ if (!action.stdout.includes('not a pull_request event')) {
   throw new Error('Expected the Action bundle to no-op outside a pull_request event');
 }
 
-console.log('smoke-node: built core import, evaluator import, MCP sealed handle + stdio tools, CLI lint, offline `adr evaluate`, `adr queue`, and Action bundle passed');
+console.log('smoke-node: built core import, evaluator import, MCP sealed handle + stdio tools on both protocol eras (2025 + 2026-07-28), CLI lint, offline `adr evaluate`, `adr queue`, and Action bundle passed');
 

--- a/site/src/content/docs/mcp.mdx
+++ b/site/src/content/docs/mcp.mdx
@@ -40,6 +40,33 @@ root. `--dir` (env `ADRKIT_MCP_DIR`, default `docs/adr`) is resolved and
 contained within it. Flags win over environment variables. stdout carries only
 JSON-RPC frames; all diagnostics go to stderr.
 
+## Protocol revisions
+
+The server speaks **both** MCP protocol eras on the same stdio connection, and
+the client picks. The opening exchange selects the era and pins it for the
+connection's lifetime:
+
+- A `server/discover` call — or any request carrying a `2026-07-28` `_meta`
+  envelope — gets the **`2026-07-28`** revision: no `initialize` handshake, no
+  session id, every request self-describing and every result carrying a
+  `resultType`.
+- An `initialize` handshake is served as the 2025-era revision it negotiates,
+  unchanged from 0.2.1 apart from `tools/list` now listing the four tools in
+  lexicographic order.
+
+Tool names, schemas, annotations, and structured results are identical on both.
+`tools/list` and `server/discover` carry SEP-2549 cache hints
+(`ttlMs: 300000`, `cacheScope: "public"`) on the 2026 revision — the four-tool
+surface is immutable for the life of the process and holds no corpus content, so
+a client can reuse it instead of re-listing. Corpus reads are never cacheable:
+every `tools/call` re-reads the corpus.
+
+<Aside type="note">
+adrkit uses none of the features `2026-07-28` deprecated (roots, sampling,
+logging) or removed (sessions, `ping`, `resources/subscribe`). Upgrading a client
+to the new revision changes how it talks to the server, not what it gets back.
+</Aside>
+
 ## Client configuration
 
 <Tabs>

--- a/specs/006-mcp-server/research.md
+++ b/specs/006-mcp-server/research.md
@@ -16,6 +16,17 @@ knowledge would have been formed.
 
 ## R0 — SDK package and version: stable `@modelcontextprotocol/sdk@1.29.0`; v2 is a separate, beta, split-package line
 
+> **Amended 2026-07-29 — this decision has been superseded.** Everything below was
+> true and correctly sourced on 2026-07-20. It stopped being true on 2026-07-27,
+> when the SDK published `@modelcontextprotocol/{core,client,server}@2.0.0` as
+> stable, and on 2026-07-28, when the MCP `2026-07-28` specification revision
+> shipped. `@adrkit/mcp` now depends on `@modelcontextprotocol/server@2.0.0` in
+> production and `@modelcontextprotocol/client@2.0.0` in development, and serves
+> both protocol eras over stdio. The reasoning that follows — prefer the stable,
+> production-recommended line and avoid pre-1.0 churn (ADR-0007) — is unchanged;
+> it now points at v2, because v2 is that line. See
+> [ADR-0018](../../docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md).
+
 **Decision**: depend on the single, unified, stable `@modelcontextprotocol/sdk`
 package at **exact `1.29.0`**, imported only via its `server/mcp.js`, `server/stdio.js`,
 `inMemory.js`, and (test-only) `client/index.js` subpaths. Do **not** depend on the

--- a/specs/006-mcp-server/spec.md
+++ b/specs/006-mcp-server/spec.md
@@ -1052,6 +1052,16 @@ exercised paths, not that raw native syscalls or future unenumerated APIs are im
 
 ## Assumptions
 
+> **Amended 2026-07-29.** A5 below named `@modelcontextprotocol/sdk@1.29.0` because
+> that was the stable line on 2026-07-20 and the SDK's v2 was then in beta. Both
+> facts changed on 2026-07-27/28. `@adrkit/mcp` now depends on
+> `@modelcontextprotocol/server@2.0.0` (plus a development-only
+> `@modelcontextprotocol/client@2.0.0`), and SC-013's "the pinned
+> `@modelcontextprotocol/sdk`" should be read as "the pinned MCP TypeScript SDK
+> server package" — the allow-list check it describes is unchanged and still
+> enforced, against the v2 package names. See
+> [ADR-0018](../../docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md).
+
 Documented, ADR-consistent defaults chosen so this spec stays testable without
 prescribing implementation; none is presented as a one-way door, and no
 maintainer-facing product decision remains open after the 2026-07-20 scope


### PR DESCRIPTION
## What

Migrates `@adrkit/mcp` to the MCP TypeScript SDK v2 package split and adopts protocol revision **`2026-07-28`**, serving both eras on the same stdio connection. Cuts **v0.3.0**.

The [spec](https://modelcontextprotocol.io/specification/2026-07-28/changelog) shipped 2026-07-28 with a stateless core (no `initialize` handshake, no `Mcp-Session-Id`, `server/discover`, MRTR, `resultType`, cacheable list results). The [SDK](https://github.com/modelcontextprotocol/typescript-sdk) shipped v2 the day before, splitting `@modelcontextprotocol/sdk@1.x` into `@modelcontextprotocol/{core,client,server}`.

**The load-bearing detail:** upgrading the SDK does *not* change the wire. A hand-wired `server.connect(new StdioServerTransport())` — what we did — serves only the 2025 era regardless of SDK version. Serving `2026-07-28` on stdio requires the connection-pinned `serveStdio(factory)` entry. Those are two decisions, recorded in **[ADR-0018](docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md)**.

## Compatibility

Both eras are served from one binary; the client picks, and the opening exchange pins the era for the connection's lifetime.

| Client opens with | Server serves |
| --- | --- |
| `server/discover`, or any request with a 2026 `_meta` envelope | `2026-07-28` |
| `initialize` / `notifications/initialized` | the 2025-era revision it negotiates |

Tool names, schemas, annotations, and structured results are identical on both. The 2025-era wire is unchanged from 0.2.1 **except** `tools/list` ordering, which is now lexicographic — the SDK serves registration order on both eras. MCP models `tools` as an unordered set so nothing depends on it, but it's a real wire change and is called out rather than rounded off. It's asserted unsorted on both eras so it can't drift unobserved.

adrkit uses none of what the revision deprecated (roots, sampling, logging) or removed (sessions, `ping`, `resources/subscribe`).

## Security: the ADR-0017 exposure is closed

`@modelcontextprotocol/sdk@1.29.0` declared thirteen runtime dependencies including Express, Hono, `@hono/node-server`, Ajv and `cors`. `@modelcontextprotocol/server@2.0.0` declares two: `@modelcontextprotocol/core` and `zod`.

That retires [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) — the exposure [ADR-0017](docs/adr/0017-keep-dependency-audit-scope-explicit-and-release-scoped.md) could only *accept*, not fix — by its own recorded `resolvesWhen` clause ("…or adrkit removes that transitive path"), three months ahead of its `2026-10-31` expiry. Neither `@hono/node-server` nor `fast-uri` resolves anywhere in the tree now, so both root `overrides` and the acceptance entry were removed.

A real consumer install of the packed tarballs:

```
└─┬ @adrkit/mcp@0.3.0
  ├─┬ @modelcontextprotocol/server@2.0.0
  │ └─┬ @modelcontextprotocol/core@2.0.0
  └── zod@4.4.3

npm audit --omit=dev → found 0 vulnerabilities
```

The acceptance list is now empty rather than deleted, and the fail-closed expiry machinery stays under test via an injected synthetic acceptance.

## Also

- **SEP-2549 cache hints** on `tools/list` and `server/discover` (`ttlMs: 300000`, `cacheScope: "public"`) instead of the SDK's conservative `ttlMs: 0`. Both are immutable per-process and carry no corpus content or caller identity. Corpus reads stay uncacheable — every `tools/call` loads a fresh projection.
- **`zod` → `^4.2.0`.** Below that the SDK falls back to its bundled converter and silently drops `.describe()` descriptions from the advertised schema — a degraded catalog that still returns `0`, which is the fail-quiet shape ADR-0016 rejects.
- Tool `outputSchema`s wrapped in `z.object()` (v2 deprecates raw Zod shapes). Advertised JSON Schema unchanged.

## Evidence

The in-process conformance suite (~150 tests) **cannot** reach the 2026 era: `InMemoryTransport` links 2025-era instances only and the SDK ships no in-memory 2026 entry. Rather than duplicate the suite, the new coverage targets the encode seam:

- **Era equivalence** — all four tools called on both eras against one corpus, comparing whole `structuredContent` and `content` payloads.
- **Cursor round trip** — `limit: 1` walk so a cursor is minted, returned and re-fed through the 2026 codec every hop; must match the legacy walk.
- **Non-error outcomes survive** — an invalid cursor stays a structured `invalid-cursor` result, not a JSON-RPC error.
- **Both Node smoke paths** (built dist *and* installed npm tarball) now run both eras and fail if outcomes diverge by era.

Per [ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md), every new assertion was **observed failing** before being counted — five targeted mutations, including the smoke exiting 1 with `tool outcomes differ by protocol era: … get_decision:"found" vs "not-found"`.

Green: 796 tests, typecheck, lint, `adr lint`, `check:deps`, `audit:gate`, clean-clone frozen install, both-era smoke on Node 22, `release:pack` (manifest all-0.3.0), installed-tarball smoke.

## Release notes for the reviewer

- **Minor, not patch:** the MCP server's runtime dependency moved to a different upstream line and it answers a protocol revision it previously did not. Pre-1.0, minor is where that belongs (ADR-0002).
- `@adrkit/ci` stays at `0.1.0` — versioned independently, distributed by git tag.
- `bun.lock` records workspace versions, and neither `bun install` nor `--force` refreshes them; only full regeneration does, which drifts three unrelated dev transitives (`@types/node`, `jose`, `undici`) and would rewrite the committed `packages/ci/dist` bundles. The four workspace version lines were updated directly instead. Verified: frozen install clean, CI bundles rebuild byte-identically, pins unchanged.
- Historical `0.2.1` references are deliberately untouched — the RELEASING cutover runbook, DISTRIBUTION's registry record, "unchanged from 0.2.1" prose, and the "Published — v0.2.1 on npm" badges, which stay true until v0.3.0 publishes.
- `docs/RELEASING.md` wants the version bump to be the last thing merged before tagging. It's bundled here on request; if anything lands ahead of it, refresh the changelog and re-run the local simulation before cutting the tag.

## Not done

- MCP Inspector dogfood against both eras (ADR-0018 action item 2).
- Whether `server.json` should advertise supported protocol revisions once the registry schema allows it (action item 3).
