### PR TITLE
docs: refresh post-release state for v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ different artifact from a heading convention. That is the whole thesis.
 
 Early, under active development, and deliberately honest about what is proven.
 
-- **Published — v0.2.1 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
+- **Published — v0.3.0 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
   the deterministic Pass 0 `@adrkit/evaluator`, and the read-only `@adrkit/mcp`
   server are all implemented and released; the MCP server passed real-session
   dogfood through the official MCP Inspector.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -5,7 +5,8 @@ the `@adrkit/*` CLI presence in the MCP and ADR-tooling ecosystems. It contains
 ready-to-paste content and exact procedures.
 
 > **Submission status.** The official MCP registry entry (§A) **has been published**
-> — `dev.adrkit/mcp` at `0.2.1`, status `active`, published 2026-07-28. Every other
+> — `dev.adrkit/mcp` at `0.3.0`, status `active` (first published 2026-07-28 at
+> `0.2.1`; re-published 2026-07-31 for the v0.3.0 release). Every other
 > venue below remains prepared but **not submitted**. Every outbound action —
 > publishing to a registry, opening a PR, filling a form, creating a git tag, or
 > posting anywhere — is performed by a human, never by tooling or an agent.
@@ -31,13 +32,13 @@ GitHub repo, so a small number of prerequisites unblock several venues at once.
 ### P1 — npm packages are published ✅
 
 **Satisfied.** `@adrkit/mcp`, `@adrkit/cli`, `@adrkit/core`, and `@adrkit/evaluator`
-are published at `0.2.1` — the exact version `server.json` names. The MCP registry
+are published at `0.3.0` — the exact version `server.json` names. The MCP registry
 hosts *metadata only*; the npm package must already exist at the version named in
-`server.json`. Verified with `npm view @adrkit/mcp@0.2.1 version` → `0.2.1`.
+`server.json`. Verified with `npm view @adrkit/mcp@0.3.0 version` → `0.3.0`.
 
 ### P2 — `mcpName` in the **published** `@adrkit/mcp` ✅
 
-**Satisfied.** `npm view @adrkit/mcp@0.2.1 mcpName` returns `dev.adrkit/mcp`,
+**Satisfied.** `npm view @adrkit/mcp@0.3.0 mcpName` returns `dev.adrkit/mcp`,
 matching `server.json` `name` exactly.
 
 The requirement, and why the ordering mattered: the official registry verifies npm
@@ -102,8 +103,9 @@ confusion in every listing:
 
 ## A. Official MCP registry (`registry.modelcontextprotocol.io`) — **PUBLISHED**
 
-**Status: published 2026-07-28** via the DNS namespace path. `dev.adrkit/mcp` is
-listed at `0.2.1` with status `active`; see §A4 for the verified response. The
+**Status: published.** First published 2026-07-28 via the DNS namespace path;
+re-published 2026-07-31 for v0.3.0. `dev.adrkit/mcp` is listed at `0.3.0` with
+status `active` and `isLatest: true`; see §A4 for the verified response. The
 subsections below are retained as the procedure to repeat on each release.
 
 This is the highest-leverage venue: **PulseMCP, mcp.so, Glama, and Smithery all
@@ -180,20 +182,24 @@ mcp-publisher publish
 curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=dev.adrkit/mcp"
 ```
 
-**Verified 2026-07-28.** The registry returns exactly one server:
+**Verified 2026-07-31** (the v0.3.0 re-publication; the entry first went live
+2026-07-28 at `0.2.1`). The registry returns the `0.3.0` record as latest:
 
 | Field | Value |
 |---|---|
 | `name` | `dev.adrkit/mcp` |
-| `version` | `0.2.1` |
-| `packages[0].identifier` / `version` | `@adrkit/mcp` / `0.2.1` |
+| `version` | `0.3.0` |
+| `packages[0].identifier` / `version` | `@adrkit/mcp` / `0.3.0` |
 | `transport.type` | `stdio` |
 | `_meta…/official.status` | `active` |
 | `_meta…/official.isLatest` | `true` |
-| `_meta…/official.publishedAt` | `2026-07-28T13:22:42.967034Z` |
+| `_meta…/official.publishedAt` | `2026-07-31T10:54:25.076965Z` |
+
+The registry retains the superseded `0.2.1` record alongside it; `isLatest` is the
+field that distinguishes them.
 
 `docs/RELEASING.md` step 7's exact assertion — the response containing both
-`dev.adrkit/mcp` and `0.2.1` — exits 0.
+`dev.adrkit/mcp` and `0.3.0` — exits 0.
 
 A subsequent release must re-run `mcp-publisher publish` with `server.json`'s two
 version fields bumped; the registry pins a specific npm version and does not track
@@ -207,7 +213,7 @@ version fields bumped; the registry pins a specific npm version and does not tra
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -219,7 +225,7 @@ version fields bumped; the registry pins a specific npm version and does not tra
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "runtimeHint": "npx",
       "transport": { "type": "stdio" },
       "environmentVariables": [
@@ -235,10 +241,10 @@ version fields bumped; the registry pins a specific npm version and does not tra
 > release you are publishing. If a new release (e.g. the SDK-CVE patch) bumps
 > `@adrkit/mcp`, bump both fields here before re-publishing.
 
-**Listing criteria met?** Yes once v0.2.1 is published — schema-valid, npm package
-exists at the manifest version, stdio transport, public repo. The remaining
-blockers are the human namespace proof and the v0.2.1 npm publication that carries
-`mcpName`.
+**Listing criteria met?** Yes — schema-valid, npm package exists at the manifest
+version, stdio transport, public repo. Both original blockers (the human namespace
+proof and an npm publication carrying `mcpName`) were cleared for v0.2.1 and remain
+satisfied at v0.3.0.
 
 ---
 
@@ -512,13 +518,17 @@ one-way (round-trip sync is out of scope per ADR-0008), and surfaces honest find
 
 ## D. The moving `queue@v0` tag (resolved by v0.2.1)
 
-**Status: resolved.** The v0.2.1 release moved the `v0` tag to `31bed03`, a commit
-that contains `packages/ci/queue/action.yml`, so adopters now reference the
+**Status: resolved.** The v0.2.1 release first moved the `v0` tag onto a commit
+containing `packages/ci/queue/action.yml` (`31bed03`), so adopters reference the
 ARB-queue Action from its moving major tag like any other:
 
 ```yaml
 uses: mbeacom/adrkit/packages/ci/queue@v0
 ```
+
+`v0` moves with every release, so it now peels to the v0.3.0 release commit
+(`3adefc7`) rather than to `31bed03`. That is the point of a moving major tag; the
+commit named below is the historical one that first made `@v0` resolve.
 
 The rest of this section is the historical record of why a full-commit pin was
 mandatory beforehand, and what it took to lift it.
@@ -605,8 +615,8 @@ itself, not a pin.
 
 No distribution-blocking source edits are currently delegated to another
 workstream. `packages/mcp/package.json` declares `"mcpName": "dev.adrkit/mcp"`
-(matching `server.json` `name`), v0.2.1 has been cut, and the registry entry is
-**published** (§A4). Nothing in this repository blocks any remaining venue; what is
+(matching `server.json` `name`), v0.3.0 has been cut, and the registry entry is
+**published** at that version (§A4). Nothing in this repository blocks any remaining venue; what is
 left is per-venue human submission, tracked in the readiness table above.
 
 `server.json` does **not** need to be added to `packages/mcp/package.json` `files`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,7 +9,7 @@ Action:
 | `@adrkit/evaluator` | npm |
 | `@adrkit/cli` (`adr`) | npm |
 | `@adrkit/mcp` (`adrkit-mcp`) | npm |
-| `packages/ci/action.yml` | Git tag (latest immutable release `v0.2.1`, moving `v0`) |
+| `packages/ci/action.yml` | Git tag (latest immutable release `v0.3.0`, moving `v0`) |
 
 `@adrkit/ci` stays private because GitHub executes the committed Action bundle
 directly from the referenced repository ref.
@@ -70,7 +70,7 @@ From a clean checkout:
 
 ```sh
 bun install --frozen-lockfile
-bun run release:pack -- --tag v0.2.1
+bun run release:pack -- --tag v0.3.0
 # With Node 22 selected in your Node version manager:
 node .release/smoke/smoke.mjs "$PWD"
 # Switch the same shell to Node 24, then run:
@@ -97,8 +97,8 @@ consumer_dir=$(mktemp -d)
   cd "$consumer_dir"
   npm init -y >/dev/null
   npm install --no-audit --no-fund \
-    "$OLDPWD/.release/npm/adrkit-core-0.2.1.tgz" \
-    "$OLDPWD/.release/npm/adrkit-mcp-0.2.1.tgz"
+    "$OLDPWD/.release/npm/adrkit-core-0.3.0.tgz" \
+    "$OLDPWD/.release/npm/adrkit-mcp-0.3.0.tgz"
   npm audit
 )
 ```
@@ -150,7 +150,7 @@ bootstrap described below.
    inter-package expectations and run `bun install` with stable Bun 1.3.14 when
    the lockfile changes.
 2. Merge the version change only after CI passes.
-3. Create and push the matching annotated tag, such as `v0.2.1`.
+3. Create and push the matching annotated tag, such as `v0.3.0`.
 4. Approve the protected `npm` environment deployment.
 5. Confirm the workflow published all packages, created the immutable GitHub
    release, and moved `v0` to the released commit.
@@ -158,20 +158,33 @@ bootstrap described below.
 Never move an immutable `vX.Y.Z` tag. The release workflow may force-update only
 the moving major Action tag (`v0`, later `v1`, and so on).
 
-## v0.2.1 cutover runbook — **COMPLETE**
+## v0.3.0 cutover runbook — **COMPLETE**
 
-**All eight steps are done.** v0.2.1 published on 2026-07-27 (npm, GitHub release,
-`v0` moved to `31bed03`); the MCP registry entry went live 2026-07-28; the queue
-Action examples were de-pinned to `@v0` in #65. This section is retained as the
-worked template for the next cutover — substitute the new version throughout.
+**All eight steps are done.** v0.3.0 published on 2026-07-31 from `3adefc7` (npm:
+`@adrkit/core`, `@adrkit/evaluator`, `@adrkit/cli`, `@adrkit/mcp`; GitHub release;
+`v0` moved to the release commit); the MCP registry entry was re-published at
+`0.3.0` the same day. Step 8 needed no work — the queue Action examples were
+already de-pinned to `@v0` during the v0.2.1 cutover (#65), and the one surviving
+full-commit pin is in `specs/007-arb-queue/checklists/reference-verification-evidence.md`,
+which is deliberately immutable because it records reproducible evidence.
+
+This section is retained as the worked template for the next cutover — substitute
+the new version throughout.
 
 Run these steps only after the version-bump PR is the last change merged to
-`main`. The three branches this runbook originally waited on —
-`wave3-toward-1-0` (#60), `audit-gate-published-scope` (#62), and
-`adr-0015-decision` (#61) — plus `ratifier-gate` (#64) have all landed, and the
-v0.2.1 changelog was refreshed to cover them. If anything else merges ahead of
-the version bump, refresh the changelog and re-run the local simulation before
-tagging.
+`main`; for v0.3.0 that was #68. If anything else merges ahead of the version
+bump, refresh the changelog and re-run the local simulation before tagging.
+
+Two notes worth carrying forward from the v0.3.0 cutover:
+
+- `bun run release:pack` triggers a **non-frozen** `bun install`, which can pull
+  transitive drift into the committed `packages/ci/dist` bundles. Check
+  `git status` after step 2; it was clean for v0.3.0.
+- The published-consumer advisory audit reported **0 vulnerabilities** at v0.3.0,
+  and `KNOWN_CONSUMER_ADVISORY_ACCEPTANCES` is now empty
+  ([ADR-0018](adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md)
+  removed the last entry). Any advisory appearing in a future run is therefore an
+  unrecorded exposure and a release blocker until reconciled.
 
 1. Start from the final release commit on `main`.
 
@@ -181,40 +194,40 @@ tagging.
    git log -1 --oneline
    ```
 
-   Verify that the last commit is the intended v0.2.1 release-prep commit.
+   Verify that the last commit is the intended v0.3.0 release-prep commit.
 
 2. Re-run the local release simulation.
 
    ```sh
    bun install --frozen-lockfile
-   bun run release:pack -- --tag v0.2.1
+   bun run release:pack -- --tag v0.3.0
    # With Node 22 selected:
    node .release/smoke/smoke.mjs "$PWD"
    # With Node 24 selected:
    node .release/smoke/smoke.mjs "$PWD"
    bun .release/smoke/smoke.mjs "$PWD"
    bun run release:publish -- --dry-run
-   bun -e "const m = await Bun.file('.release/npm/manifest.json').json(); if (m.version !== '0.2.1' || m.artifacts.length !== 4 || !m.artifacts.every((a) => a.version === '0.2.1')) throw new Error('release manifest is not entirely 0.2.1');"
+   bun -e "const m = await Bun.file('.release/npm/manifest.json').json(); if (m.version !== '0.3.0' || m.artifacts.length !== 4 || !m.artifacts.every((a) => a.version === '0.3.0')) throw new Error('release manifest is not entirely 0.3.0');"
    ```
 
    Verify that all commands exit 0; the final assertion fails if the release
-   manifest is missing or names any package version other than `0.2.1`. Then run
+   manifest is missing or names any package version other than `0.3.0`. Then run
    the [published-consumer advisory audit](#published-consumer-advisory-audit)
    against the tarballs just packed, and confirm every reported advisory is
    already recorded in `scripts/audit-gate.ts` at `affectedPublishedVersion:
-   '0.2.1'` with an unexpired acceptance.
+   '0.3.0'` with an unexpired acceptance.
 
 3. Create and push the immutable release tag.
 
    ```sh
-   git tag -a v0.2.1 -m "adrkit v0.2.1"
-   git push origin v0.2.1
+   git tag -a v0.3.0 -m "adrkit v0.3.0"
+   git push origin v0.3.0
    ```
 
    Verify the release workflow started:
 
    ```sh
-   release_sha=$(git rev-list -n 1 v0.2.1)
+   release_sha=$(git rev-list -n 1 v0.3.0)
    release_run_id=$(
      gh run list \
        --workflow release.yml \
@@ -233,7 +246,7 @@ tagging.
    Verify the exact release workflow run succeeds:
 
    ```sh
-   release_sha=$(git rev-list -n 1 v0.2.1)
+   release_sha=$(git rev-list -n 1 v0.3.0)
    release_run_id=$(
      gh run list \
        --workflow release.yml \
@@ -251,9 +264,9 @@ tagging.
 
    ```sh
    for package in @adrkit/core @adrkit/evaluator @adrkit/cli @adrkit/mcp; do
-     test "$(npm view "${package}@0.2.1" version)" = "0.2.1"
+     test "$(npm view "${package}@0.3.0" version)" = "0.3.0"
    done
-   test "$(npm view @adrkit/mcp@0.2.1 mcpName)" = "dev.adrkit/mcp"
+   test "$(npm view @adrkit/mcp@0.3.0 mcpName)" = "dev.adrkit/mcp"
    ```
 
    Verify the command exits 0; any missing package, wrong version, or missing
@@ -262,9 +275,9 @@ tagging.
 6. Confirm the GitHub release and moving major Action tag.
 
    ```sh
-   gh release view v0.2.1
-   release_sha=$(git rev-list -n 1 v0.2.1)
-   remote_release_sha=$(git ls-remote --tags origin 'refs/tags/v0.2.1^{}' | awk '{print $1}')
+   gh release view v0.3.0
+   release_sha=$(git rev-list -n 1 v0.3.0)
+   remote_release_sha=$(git ls-remote --tags origin 'refs/tags/v0.3.0^{}' | awk '{print $1}')
    remote_major_sha=$(git ls-remote --tags origin refs/tags/v0 | awk '{print $1}')
    test "$remote_release_sha" = "$release_sha"
    test "$remote_major_sha" = "$release_sha"
@@ -282,11 +295,11 @@ tagging.
    curl --fail --silent --show-error \
      'https://registry.modelcontextprotocol.io/v0.1/servers?search=dev.adrkit/mcp' \
      | grep -F 'dev.adrkit/mcp' \
-     | grep -F '0.2.1'
+     | grep -F '0.3.0'
    ```
 
    Verify the command exits 0; the grep pipeline fails if the registry response
-   does not include both `dev.adrkit/mcp` and package version `0.2.1`. If
+   does not include both `dev.adrkit/mcp` and package version `0.3.0`. If
    namespace proof has not been completed yet, follow
    [`docs/DISTRIBUTION.md`](./DISTRIBUTION.md) section A before publishing.
 

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -39,7 +39,7 @@ jobs:
         #   token: ${{ github.token }}
 ```
 
-`v0` is a moving major tag. Pin the immutable `v0.2.1` tag or a commit SHA for
+`v0` is a moving major tag. Pin the immutable `v0.3.0` tag or a commit SHA for
 maximum reproducibility.
 
 ## Publish the ARB operations queue

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
 <div class="adr-home">
 	<section class="adr-status-band" aria-label="Project status">
 		<div class="adr-status-band__item">
-			<span class="adr-status adr-status--current">Published · v0.2.1</span>
+			<span class="adr-status adr-status--current">Published · v0.3.0</span>
 			<p>
 				<code>@adrkit/core</code>, <code>@adrkit/cli</code>,
 				<code>@adrkit/evaluator</code>, and <code>@adrkit/mcp</code> are on npm;

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -10,7 +10,7 @@ decisions govern a file, renders the decision graph, migrates an existing MADR
 corpus in place, emits the ARB operations queue, and runs the deterministic
 evaluator.
 
-<Aside type="tip" title="Published on npm (v0.2.1)">
+<Aside type="tip" title="Published on npm (v0.3.0)">
 	`@adrkit/cli` is live. Consumers install it with your Node package manager and
 	run the `adr` binary — no clone required. Published artifacts are Node-targeted
 	([ADR-0010](/adr/0010-bun-toolchain/)); Bun is used for developing adrkit


### PR DESCRIPTION
## What

v0.3.0 published 2026-07-31 from `3adefc7`. This refreshes the documentation that asserts **what is published now**, and re-templates the release runbook.

Verified live before writing any of it:

| Check | Result |
| --- | --- |
| npm — all four packages at 0.3.0 | ✅ |
| `npm view @adrkit/mcp@0.3.0 mcpName` | `dev.adrkit/mcp` |
| `v0.3.0^{}` peels to release commit | ✅ `3adefc7` |
| `v0` moved to release commit | ✅ `3adefc7` |
| `queue/action.yml` resolvable at `@v0` | ✅ |
| GitHub release `v0.3.0` | published, not draft/prerelease |
| MCP registry | `dev.adrkit/mcp` @ `0.3.0`, `active`, `isLatest: true` |

## Updated — these assert current state

- "Published … v0.2.1" badges in `README.md`, the site index, and quickstart.
- `site/.../ci.mdx` immutable-tag pinning advice.
- `docs/DISTRIBUTION.md`: submission-status header, P1/P2 prerequisites (they assert npm matches the version `server.json` names), §A status, the §A4 verified-response table, the embedded `server.json` sample, listing-criteria framing (both original blockers are cleared), and §E.

## Left alone — historical record, not current state

- §A's registry bootstrap checklist (what was done to first get listed).
- §D's account of how `queue@v0` came to resolve.

§D did get one addition: a note that `v0` now peels to the v0.3.0 commit rather than the `31bed03` it first moved to. The old text was true but read as a current-state claim.

Also unchanged: `site/.../mcp.mdx` "unchanged from 0.2.1" — that describes the previous release's wire and is still correct — and the full-commit pin in `specs/007-arb-queue/checklists/reference-verification-evidence.md`, which is immutable on purpose (RELEASING step 8: "keep immutable pins where the text is explicitly teaching reproducibility").

## Runbook re-templated

`docs/RELEASING.md` cutover section says it is "the worked template for the next cutover — substitute the new version throughout", so it is now the **v0.3.0** runbook.

Step 8 needed no work: examples were already de-pinned to `@v0` during v0.2.1 (#65).

Two lessons carried forward in the preamble:

- `bun run release:pack` triggers a **non-frozen** `bun install` that can drift the committed `packages/ci/dist` bundles — check `git status` after step 2. It was clean for v0.3.0.
- The consumer advisory audit is now effectively zero-tolerance: it reported **0 vulnerabilities**, and `KNOWN_CONSUMER_ADVISORY_ACCEPTANCES` is empty after ADR-0018, so any future advisory is unrecorded by definition and blocks the release.

## Evidence

Every updated runbook assertion was **executed against the live release**, not assumed — step 5 (npm versions + `mcpName`), step 6 (both tag comparisons), step 7 (registry grep) all exit 0.

That caught two bugs in my own bulk substitution: double-quoted `"0.2.1"` literals survived in the step 2 assertion message and the step 5 version comparison, so the runbook would have compared 0.3.0 against 0.2.1 and always failed.

798 tests, typecheck, `adr lint`, `check:deps`, and a clean Astro build (27 pages).
