### PR TITLE
docs(adr-0018): record post-release dogfood evidence for both protocol eras

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,18 @@
 
 Decision memory for human- and agent-authored plans — machine-readable ADRs
 that are enforceable in CI and legible to agents, without leaving git.
-Status: early — phases 0–6 landed and v0.2.0 is public. `@adrkit/core`,
+Status: early — phases 0–6 landed and v0.3.0 is public. `@adrkit/core`,
 `@adrkit/evaluator`, `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
 `check`, `migrate --from madr`, `evaluate`) are published on npm; the
 repository-backed CI Action is available at `mbeacom/adrkit/packages/ci@v0`.
-The published `@adrkit/mcp` server has exactly four local stdio tools and passed
-real-session dogfood through the official MCP Inspector. Phase 6 ARB queue is
+The published `@adrkit/mcp` server has exactly four local stdio tools and serves
+**both** MCP protocol eras over one stdio connection — `2026-07-28` (stateless;
+opened by `server/discover` or a 2026 `_meta` envelope) and the 2025 era (opened
+by `initialize`) — via the SDK v2 `serveStdio` entry
+([ADR-0018](./docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md)).
+It passed real-session dogfood against the published artifact on each era: the
+official MCP Inspector for the 2025 era, and a conforming SDK v2 client pinned to
+`2026-07-28` for the modern era, which the Inspector cannot yet negotiate. Phase 6 ARB queue is
 implemented under `specs/007-arb-queue/` (see [`plan.md`](./plan.md)): the pure
 `buildQueueReport` kernel and canonical JSON/Markdown formatters live in
 `@adrkit/core`, the `adr queue` CLI subcommand ships in `@adrkit/cli`, and a

--- a/README.md
+++ b/README.md
@@ -189,8 +189,12 @@ Early, under active development, and deliberately honest about what is proven.
 
 - **Published — v0.3.0 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
   the deterministic Pass 0 `@adrkit/evaluator`, and the read-only `@adrkit/mcp`
-  server are all implemented and released; the MCP server passed real-session
-  dogfood through the official MCP Inspector.
+  server are all implemented and released. The MCP server speaks both protocol
+  eras and passed real-session dogfood against the published artifact on each:
+  the official MCP Inspector for the 2025 era, and a conforming SDK v2 client
+  pinned to `2026-07-28` for the modern era — the Inspector cannot yet negotiate
+  that revision
+  ([ADR-0018](docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md)).
 - **Landed, maintainer reference-verified — not yet externally validated.** The
   Phase 6 ARB queue (`adr queue` plus the managed-issue Action) is verified on
   rungs 1–2 of the

--- a/docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md
+++ b/docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md
@@ -258,7 +258,74 @@ migration. The constraint expires on its own and blocks nothing in the meantime.
 ## Action items
 
 1. [x] Ratify or reject this proposed record. **Ratified by @mbeacom, 2026-07-31.**
-2. [ ] Re-run MCP Inspector dogfood against both eras before release, as Phase 5
-       did for the 2025 era.
-3. [ ] Decide whether `packages/mcp/server.json` should advertise the supported
-       protocol revisions once the registry schema supports it.
+2. [x] Re-run MCP Inspector dogfood against both eras before release, as Phase 5
+       did for the 2025 era. **Done 2026-08-01, with a finding: the Inspector
+       cannot reach the 2026 era.** See the post-release verification below.
+3. [x] Decide whether `packages/mcp/server.json` should advertise the supported
+       protocol revisions once the registry schema supports it. **Decided
+       2026-08-01: not yet possible.** See below.
+
+## Post-release verification (2026-08-01, against published `@adrkit/mcp@0.3.0`)
+
+Both eras were exercised against the **published npm artifact** — not the working
+tree — over real stdio, against this repository's own 18-record corpus.
+
+### The Inspector validates the 2025 era only
+
+Official MCP Inspector `2.0.0` (published 2026-07-28, the first release built on
+SDK v2) connects and drives all four tools correctly:
+
+| Tool | Outcome |
+|---|---|
+| `search_decisions` (`query: "bun"`) | `results` — 5 decisions |
+| `get_decision` (`ref: "0018"`) | `found` — this record, `accepted` |
+| `get_decision_context` (`packages/mcp/src/server.ts`) | `matches` — 1 governing |
+| `list_superseded` | `entries` — 0 |
+
+But it does so on the **2025 era**. Teeing the client's frames into a log shows
+the Inspector opening with `initialize` offering `2025-11-25`, then
+`notifications/initialized` — never `server/discover`, and never a `2026-07-28`
+`_meta` envelope on any request.
+
+This is not a configuration miss. The Inspector CLI exposes no era or
+negotiation option, and its `--metadata` flag cannot help: `serveStdio` pins the
+era on the *opening* exchange, and the Inspector's opening message is always
+`initialize`. The likely upstream cause is its dependency pin — Inspector 2.0.0
+depends on `@modelcontextprotocol/client@2.0.0-beta.5`, which predates the final
+2.0.0 alignment of the `DiscoverResult` wire (spec PR #3002 moved `serverInfo`
+from the body into result `_meta`); a pre-final client hard-rejects a conforming
+server's discover result and falls back to the handshake.
+
+So the action item as originally written — "Inspector dogfood against both eras"
+— is **not satisfiable with today's Inspector**. Recording that rather than
+quietly downgrading it: the Inspector evidence covers the 2025 era, which is
+still the era virtually every deployed client speaks, and it does prove the SDK
+v2 migration did not break existing clients.
+
+### The 2026 era, validated by a conforming client instead
+
+Substituted evidence for the era the Inspector cannot reach: a client on the
+final `@modelcontextprotocol/client@2.0.0` pinned to `{ pin: '2026-07-28' }`,
+against the same published binary.
+
+```
+negotiated era : modern
+server identity: {"name":"@adrkit/mcp","version":"0.3.0"}
+tools/list     : get_decision, get_decision_context, list_superseded, search_decisions
+```
+
+All four tools returned the **same outcomes and byte-identical rendered text** as
+the Inspector's 2025-era session above — which is this record's central claim,
+now observed against the published artifact rather than only in the test suite.
+
+### `server.json` cannot advertise protocol revisions yet
+
+`2025-12-11` remains the only published registry schema
+(`https://static.modelcontextprotocol.io/schemas/2026-01-01/…` and `…/latest/…`
+both 404), and it defines no `protocolVersion`, `protocolVersions`,
+`supportedVersions`, or `revision` field anywhere. There is nowhere to put the
+claim, so `server.json` stays as it is.
+
+Re-check when the registry publishes a schema revision later than `2025-12-11`.
+Until then a server's supported revisions are discoverable only at runtime, via
+the `server/discover` RPC this server already answers.


### PR DESCRIPTION
## What

Closes ADR-0018 action items 2 and 3 — both with **findings**, not clean ticks.

## Item 2: the Inspector cannot reach the 2026 era

The action item said "re-run MCP Inspector dogfood against both eras". It is **not satisfiable with today's Inspector**.

Inspector `2.0.0` (published 2026-07-28, its first SDK v2 release) connects to published `@adrkit/mcp@0.3.0` and drives all four tools correctly:

| Tool | Outcome |
| --- | --- |
| `search_decisions` (`query: "bun"`) | `results` — 5 decisions |
| `get_decision` (`ref: "0018"`) | `found` — this record, `accepted` |
| `get_decision_context` (`packages/mcp/src/server.ts`) | `matches` — 1 governing |
| `list_superseded` | `entries` — 0 |

But on the **2025 era**. Teeing its frames into a log:

```
method='initialize'                protocolVersion in _meta = None   (offered 2025-11-25)
method='notifications/initialized' protocolVersion in _meta = None
method='tools/list'                protocolVersion in _meta = None
```

Never `server/discover`, never a 2026 `_meta` envelope.

**Not a configuration miss.** The CLI exposes no era or negotiation option, and `--metadata` cannot help — `serveStdio` pins the era on the *opening* exchange, and the Inspector always opens with `initialize`. Likely upstream cause: Inspector 2.0.0 pins `@modelcontextprotocol/client@2.0.0-beta.5`, which predates the final 2.0.0 `DiscoverResult` alignment (spec PR #3002 moved `serverInfo` from the body into result `_meta`); a pre-final client hard-rejects a conforming discover result and falls back to the handshake.

Rather than quietly downgrade the item, the record states what the Inspector evidence covers — the 2025 era, which is still what virtually every deployed client speaks, and which proves the SDK v2 migration didn't break existing clients.

### Substituted evidence for the era it can't reach

A final `@modelcontextprotocol/client@2.0.0` pinned to `{ pin: '2026-07-28' }`, same published binary:

```
negotiated era : modern
server identity: {"name":"@adrkit/mcp","version":"0.3.0"}
tools/list     : get_decision, get_decision_context, list_superseded, search_decisions
```

All four tools returned the **same outcomes and byte-identical rendered text** as the Inspector's 2025-era session. That is ADR-0018's central claim — results do not vary by era — now observed against the **published artifact**, not only in the test suite.

## Item 3: `server.json` cannot advertise revisions yet

Decided: not possible. `2025-12-11` is still the only published registry schema —

```
2025-12-11 -> HTTP 200
2026-01-01 -> HTTP 404
latest     -> HTTP 404
```

— and it defines no `protocolVersion`, `protocolVersions`, `supportedVersions`, or `revision` field anywhere. There is nowhere to put the claim. Re-check on the next schema revision; until then supported revisions are discoverable at runtime via the `server/discover` RPC this server already answers.

## Claims scoped as a result

- **`README.md`** said the MCP server "passed real-session dogfood through the official MCP Inspector" without naming an era — which now reads as covering both. Scoped, with the Inspector limitation named.
- **`CLAUDE.md`** carried the same claim *and* still said "v0.2.0 is public". Now records v0.3.0 and dual-era serving.

## Evidence

All of the above was run against the **published npm artifact** over real stdio, against this repository's own 18-record corpus — not the working tree.

798 tests, typecheck, `adr lint` (18 records, 0 errors), `check:deps`.
