### PR TITLE
docs(releasing): audit all four published packages in the consumer advisory audit

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -89,19 +89,28 @@ The PR CI `bun audit` gate deliberately scopes itself to this workspace's
 resolved tree and does **not** audit consumer installs of the published
 `@adrkit/*` manifests
 ([ADR-0017](adr/0017-keep-dependency-audit-scope-explicit-and-release-scoped.md)).
-That audit is release evidence, so it runs here, against the packed tarballs:
+That audit is release evidence, so it runs here, against the packed tarballs —
+**all four of them**. `release:pack` already builds `.release/smoke/` with every
+artifact in the release manifest wired as a `file:` dependency, so auditing there
+covers the whole published set and cannot drift out of sync with what was packed:
 
 ```sh
-consumer_dir=$(mktemp -d)
 (
-  cd "$consumer_dir"
-  npm init -y >/dev/null
-  npm install --no-audit --no-fund \
-    "$OLDPWD/.release/npm/adrkit-core-0.3.0.tgz" \
-    "$OLDPWD/.release/npm/adrkit-mcp-0.3.0.tgz"
+  cd .release/smoke
+  npm install --no-audit --no-fund   # already installed by the step 2 smoke run
   npm audit
 )
 ```
+
+Audit **all four** packages, not a subset. `@adrkit/evaluator` is the only path to
+`jsonpath-rfc9535`, and `@adrkit/cli` is the only path to the evaluator, so an
+audit of `@adrkit/core` + `@adrkit/mcp` alone never sees that subtree at all
+(ADR-0017 action item 2).
+
+The `overrides` block in that project pins the `@adrkit/*` packages to the local
+tarballs — which is the point, since the release is not published yet. It does not
+affect third-party resolution, so the transitive tree `npm audit` examines is the
+genuine consumer tree.
 
 Root overrides are not published in package manifests, so a consumer resolves a
 different tree than this workspace does. Reconcile every advisory `npm audit`

--- a/docs/adr/0017-keep-dependency-audit-scope-explicit-and-release-scoped.md
+++ b/docs/adr/0017-keep-dependency-audit-scope-explicit-and-release-scoped.md
@@ -162,8 +162,16 @@ gap is visible instead of implied away.
 ## Action items
 
 1. [ ] Ratify or reject this proposed record.
-2. [ ] Add a release-time published-package consumer audit covering
+2. [x] Add a release-time published-package consumer audit covering
        `@adrkit/core`, `@adrkit/cli`, `@adrkit/evaluator`, and `@adrkit/mcp`.
+       **Done 2026-08-01.** `docs/RELEASING.md` had the audit but ran it over
+       `@adrkit/core` + `@adrkit/mcp` only, which never reaches
+       `jsonpath-rfc9535` — the evaluator's sole third-party dependency, and the
+       only package in the tree not already pulled in by core or mcp. The
+       procedure now audits `.release/smoke/`, which `release:pack` builds from
+       the release manifest with every artifact wired as a `file:` dependency, so
+       the audited set is derived from what was packed rather than hand-listed
+       and cannot drift when a fifth package is published.
 3. [x] Remove or renew the `GHSA-frvp-7c67-39w9` acceptance by 2026-10-31, or
        earlier if `@modelcontextprotocol/sdk` releases a range that reaches
        `@hono/node-server >=2.0.5`.


### PR DESCRIPTION
## What

Closes **ADR-0017 action item 2**, which asked for a release-time consumer audit covering `@adrkit/core`, `@adrkit/cli`, `@adrkit/evaluator` and `@adrkit/mcp`.

The procedure existed in `docs/RELEASING.md` but installed only **core** and **mcp** — so two of the four published packages were never audited.

## The gap is real, not cosmetic

`@adrkit/evaluator` is the only path to `jsonpath-rfc9535`, and `@adrkit/cli` is the only path to the evaluator. Verified by resolving both sets side by side against the published 0.3.0:

| documented scope (core + mcp) | ADR-0017 required scope (all four) |
| --- | --- |
| `@adrkit/core`, `@adrkit/mcp` | `@adrkit/core`, `@adrkit/mcp`, **`@adrkit/cli`**, **`@adrkit/evaluator`** |
| `@modelcontextprotocol/{core,server}` | `@modelcontextprotocol/{core,server}` |
| `picomatch`, `semver`, `yaml`, `zod` | `picomatch`, `semver`, `yaml`, `zod`, **`jsonpath-rfc9535`** |

A security gate that never looks at `jsonpath-rfc9535` cannot report an advisory in it.

## Fix

Rather than extend the hand-typed tarball list — which goes stale the next time a package is added — the procedure now audits **`.release/smoke/`**.

`release:pack` already generates that project from the release manifest with every artifact wired as a `file:` dependency, so the audited set is **derived from what was actually packed** and cannot drift. Step 2 of the runbook already installs it, so the audit costs one extra command:

```sh
(
  cd .release/smoke
  npm install --no-audit --no-fund   # already installed by the step 2 smoke run
  npm audit
)
```

## On the `overrides` caveat

That project's `overrides` block pins the `@adrkit/*` packages to the local tarballs — which is the point while the release is unpublished — and does not affect third-party resolution, so the transitive tree `npm audit` examines is the genuine consumer tree.

Called out inline, because ADR-0017 exists precisely because overrides can make an audit describe a tree nobody installs. It would be careless to fix a coverage gap by quietly reintroducing that confound.

## Evidence

Run against a real `v0.3.0` pack: `.release/smoke/` resolves all four packages plus `jsonpath-rfc9535`, and `npm audit` there reports **0 vulnerabilities**.

798 tests, typecheck, `adr lint` (18 records, 0 errors), `check:deps`, `audit:gate`.
