### PR TITLE
docs(adr): ratify ADR-0016 and ADR-0017

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,32 @@ device. See
 `packages/adapters/*`. Integrations are optional, separately versioned, and
 allowed to break on upstream churn. The core is not.
 
+**3. A check does not count as coverage until you have watched it fail.**
+
+When you add or tighten an assertion, lint rule, or CI gate, build an input it is
+supposed to reject and confirm it actually fails on that input. "The suite still
+passes" only establishes that your assertion does not crash. Keep the failing
+input as a permanent negative case — the artifact that proves a check works is
+the case that makes it fail.
+
+Prefer asserting a specific observed value over a count or an absence. `0`, `[]`,
+and "no X found" render identically whether the tool looked and found nothing or
+could not look at all, which is why a green check can mean "I am blind" and be
+trusted anyway. Where a count or absence really is the right assertion, the
+negative case is mandatory rather than advisory.
+
+This extends past assertions to any claim of the form "X is not there." One
+negative observation of a default configuration is not evidence a capability is
+missing — check whether you looked in the only place it could be.
+
+If you defer the work, hand over the failing case, not the instruction. "Please
+verify this fires" transfers the whole cost of constructing the input and leaves
+the recipient unable to tell whether you ever built one.
+
+Aimed at checks guarding a corpus or an input the tool must not silently skip;
+applying it to every trivial equality assertion is cargo cult. See
+[ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md).
+
 ## Changing a decision
 
 This project governs itself. If your change contradicts an accepted record in

--- a/docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md
+++ b/docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md
@@ -2,7 +2,7 @@
 schemaVersion: 0.1.0
 id: "0016"
 title: Require every check to be observed failing before it counts as coverage
-status: proposed
+status: accepted
 date: 2026-07-25
 deciders: ["@mbeacom"]
 tags: [governance, testing, evidence, quality]
@@ -17,6 +17,7 @@ affects:
     pattern: "packages/core/src/validate/**"
 provenance:
   authoredBy: agent-drafted
+  ratifiedBy: "@mbeacom"
 review:
   tier: async
   tierReason: >-
@@ -178,6 +179,45 @@ when they were introduced, and each shipped a period of false assurance. The
 cost is not the fix; it is the interval during which governance silently covered
 nothing.
 
+## Instances inside this repository, after drafting
+
+Two more instances landed during the v0.3.0 release session (2026-07-28 →
+2026-08-01), both authored by an agent that had already read this record. They
+are kept because a rule about invisible failure is worth more with instances that
+survived the rule's own author than with hypotheticals.
+
+**The MCP Inspector.** ADR-0018's action item asked for a dogfood against both
+protocol eras. The Inspector was run with its default configuration, observed
+sending `initialize` on the wire, and the record concluded the tool "cannot reach
+the 2026 era" and that the item was "not satisfiable". The Inspector reaches it
+fine — the era is opt-in per server via a `protocolEra` key in its config, with no
+CLI flag. What was observed was a *default*, and it was rendered as a *capability
+boundary*. A release note was then cited as the cause, which turned a guess into
+something that read as a diagnosis; the mechanism it named was also wrong, and
+the eventual `auto`-mode test disproved it outright. Corrected in #71 after a
+human said "the new MCP inspector is under version 2.0.0" — a nudge, not a
+counter-example, which is the cheapest form this correction could have taken and
+still required a person.
+
+**The registry schema.** The same record then said there was "nowhere to put"
+supported protocol revisions in `server.json`. The check searched the schema for
+a *named* protocol field. There is a general publisher-provided `_meta` extension
+point, so the mechanism existed; only a first-class field did not. Corrected in
+the same pass as this record's ratification.
+
+Both are clause 3: an absence was asserted where a specific observed value was
+available. Neither was caught by the suite — nothing here can test a claim about
+a third-party tool. The first was caught by a human; the second by re-reading
+the artifact when the first proved the habit.
+
+Two properties are worth naming, because they bear on Option B and Option C
+respectively. First, both were committed by an author who had read this record in
+the same session, which is further evidence that vigilance is not the constraint.
+Second, neither is a *check* that reports a count — they are conclusions drawn
+from one negative observation. That is outside what mutation testing would catch,
+so they are not evidence for Option C; they are evidence that the clause-3 habit
+should extend past assertions to any claim of the form "X is not there."
+
 ## Known instances outside this repository
 
 `mbeacom/adrkit-t018-dogfood` carries an instance in its own validation scripts:
@@ -240,14 +280,14 @@ equality assertion would be cargo cult.
 
 ## Action items
 
-1. [ ] Ratify or reject — this record is `proposed` and agent-drafted; it binds
-       nothing until a human accepts it.
+1. [x] Ratify or reject — this record is `proposed` and agent-drafted; it binds
+       nothing until a human accepts it. **Ratified by @mbeacom, 2026-08-01.**
 2. [x] Carry both directions for the two checks that motivated this. The tests
        accompanying `corpus-file-skipped` and `corpus.file-skipped` already
        assert both that they fire on a skipped file and that they stay silent on
        a clean corpus, and both were observed distinguishing the two before the
        fix landed.
-3. [ ] Fold the rule into `CONTRIBUTING.md` if accepted.
+3. [x] Fold the rule into `CONTRIBUTING.md` if accepted. **Done 2026-08-01**, on ratification.
 
 Every item above is completable from inside this repository. The external
 instance is recorded under "Known instances outside this repository" and is

--- a/docs/adr/0017-keep-dependency-audit-scope-explicit-and-release-scoped.md
+++ b/docs/adr/0017-keep-dependency-audit-scope-explicit-and-release-scoped.md
@@ -2,7 +2,7 @@
 schemaVersion: 0.1.0
 id: "0017"
 title: Keep dependency audit scope explicit and release-scoped
-status: proposed
+status: accepted
 date: 2026-07-25
 deciders: ["@mbeacom"]
 tags: [security, ci, dependencies, release, evidence]
@@ -21,6 +21,7 @@ affects:
     pattern: "packages/*/package.json"
 provenance:
   authoredBy: agent-drafted
+  ratifiedBy: "@mbeacom"
 review:
   tier: async
   tierReason: >-
@@ -37,10 +38,6 @@ reviewBy: 2026-10-31
 ---
 
 # ADR-0017: Keep dependency audit scope explicit and release-scoped
-
-> **Status: `proposed`. This record is for maintainer review and is not
-> ratified.** It records the proposed interpretation of the audit gate, but it
-> does not become project law until a human accepts it.
 
 ## Context
 
@@ -161,7 +158,7 @@ gap is visible instead of implied away.
 
 ## Action items
 
-1. [ ] Ratify or reject this proposed record.
+1. [x] Ratify or reject this proposed record. **Ratified by @mbeacom, 2026-08-01.**
 2. [x] Add a release-time published-package consumer audit covering
        `@adrkit/core`, `@adrkit/cli`, `@adrkit/evaluator`, and `@adrkit/mcp`.
        **Done 2026-08-01.** `docs/RELEASING.md` had the audit but ran it over

--- a/docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md
+++ b/docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md
@@ -339,15 +339,41 @@ directly against the same binary and reported `negotiated era: modern` with
 server identity `{"name":"@adrkit/mcp","version":"0.3.0"}` and the same four
 outcomes.
 
-### `server.json` cannot advertise protocol revisions yet
+### `server.json` will not advertise protocol revisions
+
+> **Corrected 2026-08-01.** This section first said there was "nowhere to put the
+> claim". That is false — there is an extension point. The first check looked for
+> a *named* protocol field, found none, and concluded no mechanism existed. The
+> conclusion below is unchanged; the reason for it is not.
 
 `2025-12-11` remains the only published registry schema
 (`https://static.modelcontextprotocol.io/schemas/2026-01-01/…` and `…/latest/…`
-both 404), and it defines no `protocolVersion`, `protocolVersions`,
-`supportedVersions`, or `revision` field anywhere. There is nowhere to put the
-claim, so `server.json` stays as it is.
+both 404), and it defines no first-class `protocolVersion` / `protocolVersions` /
+`supportedVersions` / `revision` field.
 
-Re-check when the registry publishes a schema revision later than `2025-12-11`.
-Until then a server's supported revisions are discoverable only at runtime, via
-the `server/discover` RPC this server already answers — which the Inspector's
-`auto` probe above demonstrates working end to end.
+It does, however, define a general extension point on `ServerDetail`:
+`_meta["io.modelcontextprotocol.registry/publisher-provided"]`, an
+`additionalProperties: true` object described as "publisher-provided metadata for
+downstream registries". A `dev.adrkit/...` key could physically carry the
+revisions today.
+
+We will not use it, for three reasons:
+
+1. **No consumer and no convention.** The key would be ours alone. Nothing reads
+   it, and inventing a private spelling for a protocol-level fact invites a
+   different spelling to win later.
+2. **It creates a second source of truth that can go stale.** The registry record
+   is republished per release; the served revisions are a property of the running
+   binary. Drop legacy-era serving in some future version and the blob keeps
+   asserting two eras until someone remembers to republish. `server/discover`
+   cannot drift, because it *is* the server answering for itself.
+3. **Verifying the registry preserves and returns the field would require
+   republishing**, which `docs/DISTRIBUTION.md` binds to a human action. Claiming
+   it works without that check would be the same unverified-assertion shape this
+   record already had to correct once.
+
+Re-check when the registry defines a **first-class** field for supported
+revisions — at which point the claim has an agreed spelling and a consumer.
+Until then supported revisions are discoverable at runtime via the
+`server/discover` RPC this server already answers, which the Inspector's `auto`
+probe above demonstrates working end to end.


### PR DESCRIPTION
## What

Ratifies **ADR-0016** and **ADR-0017**, and corrects a factual error in **ADR-0018** that this review surfaced.

Both ratified records are `agent-drafted`, so the schema's refine requires a named human ratifier — `provenance.ratifiedBy: "@mbeacom"`. ADR-0017's not-ratified callout is removed. Both drop out of the ARB queue, which is the observable effect of acceptance.

Two commits, independently revertable.

---

## 1. `106e60e` — ADR-0018: correct the registry reason

The record said there was **"nowhere to put the claim"** for supported protocol revisions in `server.json`. That is false.

The `2025-12-11` schema defines `ServerDetail._meta["io.modelcontextprotocol.registry/publisher-provided"]` — `additionalProperties: true`, "publisher-provided metadata for downstream registries". A `dev.adrkit/...` key could carry the revisions today. The original check searched for a *named* protocol field, found none, and read that absence as impossibility.

**The conclusion is unchanged — we still won't use it — but now for reasons rather than a non-existent constraint:**

1. **No consumer, no convention.** The key would be ours alone; inventing a private spelling for a protocol-level fact invites a different spelling to win later.
2. **Second source of truth that can go stale.** The registry record is republished per release; served revisions are a property of the running binary. Drop legacy-era serving later and the blob keeps asserting two eras until someone republishes. `server/discover` can't drift — it *is* the server answering for itself.
3. **Verifying the registry preserves it requires republishing**, which `docs/DISTRIBUTION.md` binds to a human. Claiming it works without that check would repeat the shape this record already had to correct once.

Re-check when the registry defines a **first-class** field, not merely a place to put one.

---

## 2. `d2e5f3a` — ratify ADR-0016 and ADR-0017

**ADR-0017 is ratified unchanged.** Its action items closed on their own terms: the GHSA-frvp-7c67-39w9 acceptance was removed early by the SDK v2 migration (#68), and the release-time consumer audit now covers all four published packages (#72).

**ADR-0016 gains a section before ratification** — two instances of its own pattern that landed during the v0.3.0 release session, both authored by an agent that had already read the record:

- **The Inspector.** Ran with default config, saw `initialize` on the wire, concluded the tool "cannot reach the 2026 era". A *default* read as a *capability boundary*. A release note was then cited as the cause, turning a guess into something that read as a diagnosis — and the mechanism it named was wrong too, disproved later by testing `auto` mode. Corrected in #71, prompted by a human remark.
- **The registry schema.** Searched for a named field, missed the general `_meta` extension point. Corrected in commit 1 above.

Both are **clause 3** — an absence asserted where a specific observed value was available. Neither was catchable by the suite; nothing here can test a claim about a third-party tool.

They're recorded rather than quietly fixed because they bear on two options the record already weighs:

- **Against Option B** (rely on review): further evidence that vigilance isn't the constraint — the author had the rule in context and committed the defect anyway.
- **Not evidence for Option C** (mutation testing): neither is a check reporting a count. They're conclusions from a single negative observation, which mutation testing wouldn't catch. What they argue for is extending the clause-3 habit past assertions to *any* claim of the form "X is not there."

**Action item 3 is now live and done:** the rule is folded into `CONTRIBUTING.md` as a third numbered rule alongside clean-clone and adapter-isolation — including the "one negative observation of a default is not evidence of absence" extension those instances motivated.

---

## Evidence

798 tests, typecheck, `adr lint` (18 records, 0 errors), `check:deps`. `adr queue` no longer lists 0016 or 0017.
