### PR TITLE
feat(release): release adapters on their own tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,13 @@ name: Release
 on:
   push:
     tags:
+      # Lockstep release: core, evaluator, CLI, MCP.
       - 'v*.*.*'
+      # Adapter release. Adapters are versioned independently (ADR-0007), so
+      # they release independently too — shipping a fix for an upstream change
+      # must not require republishing four unchanged packages under a new
+      # version.
+      - 'spec-kit-v*.*.*'
 
 concurrency:
   group: release-${{ github.repository }}
@@ -18,6 +24,25 @@ jobs:
       contents: write # gh release create + force-push the major Action tag
       id-token: write # npm Trusted Publishing (OIDC provenance)
     steps:
+      - name: Resolve release scope from the tag
+        id: scope
+        run: |
+          set -euo pipefail
+          case "$GITHUB_REF_NAME" in
+            v*.*.*)
+              echo "adapter=" >> "$GITHUB_OUTPUT"
+              echo "lockstep=true" >> "$GITHUB_OUTPUT"
+              ;;
+            spec-kit-v*.*.*)
+              echo "adapter=@adrkit/spec-kit" >> "$GITHUB_OUTPUT"
+              echo "lockstep=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unrecognized release tag: $GITHUB_REF_NAME" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Check out tagged source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -60,14 +85,24 @@ jobs:
           bun run adr lint
 
       - name: Pack release artifacts
-        run: bun run release:pack -- --tag "$GITHUB_REF_NAME" --skip-build
+        env:
+          ADAPTER: ${{ steps.scope.outputs.adapter }}
+        run: |
+          set -euo pipefail
+          if [ -n "$ADAPTER" ]; then
+            bun run release:pack -- --tag "$GITHUB_REF_NAME" --skip-build --only "$ADAPTER"
+          else
+            bun run release:pack -- --tag "$GITHUB_REF_NAME" --skip-build
+          fi
 
       - name: Set up Node 22 for installed-tarball smoke
+        if: steps.scope.outputs.lockstep == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
 
       - name: Smoke installed tarballs on Node 22
+        if: steps.scope.outputs.lockstep == 'true'
         run: node .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
 
       - name: Set up Node 24 for smoke and npm Trusted Publishing
@@ -77,9 +112,11 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Smoke installed tarballs on Node 24
+        if: steps.scope.outputs.lockstep == 'true'
         run: node .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
 
       - name: Smoke installed tarballs on Bun
+        if: steps.scope.outputs.lockstep == 'true'
         run: bun .release/smoke/smoke.mjs "$GITHUB_WORKSPACE"
 
       - name: Publish npm packages with provenance
@@ -103,6 +140,10 @@ jobs:
           fi
 
       - name: Update the major Action tag
+        # `packages/ci/queue@v0` tracks the lockstep surface. An adapter release
+        # neither builds nor changes it, and moving it would misreport which
+        # commit the Action points at.
+        if: steps.scope.outputs.lockstep == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@ Until `1.0.0`, minor releases may include breaking changes
   Workspace dependencies also now resolve against the dependency's own version
   rather than the depender's.
 
+- **Adapter releases.** Independently versioned packages now release on their own
+  tag (`spec-kit-v0.1.0`) rather than riding a lockstep release. Without this,
+  shipping an adapter fix would mean republishing core, evaluator, CLI, and MCP
+  under a new version despite no change to any of them — which would make
+  ADR-0007's "versioned independently" true of the number and false of everything
+  that matters. `release-pack` gains `--only`, the release manifest carries its
+  own `tag`, and the workflow derives scope from the tag: installed-tarball
+  smoke and the `packages/ci/queue@v0` Action tag are lockstep-only.
+
 ### Changed
 
 - ADR-0007's `core-has-no-adapter-deps` assertion is no longer vacuous. It had

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -121,6 +121,63 @@ being cut. An unrecorded advisory, or a recorded one whose observed version has
 moved, is a release blocker until the record is refreshed or the exposure is
 removed.
 
+## Adapter releases (independently versioned packages)
+
+Adapters under `packages/adapters/*` are versioned independently — ADR-0007:
+"Their semver contract is with their upstream, not with our core." They release
+independently too, because the alternative is republishing four unchanged
+packages under a new version every time an adapter needs a fix for an upstream
+change, which makes "versioned independently" true of the number and false of
+everything that matters.
+
+| | Lockstep release | Adapter release |
+|---|---|---|
+| Tag | `v0.3.0` | `spec-kit-v0.1.0` |
+| Packages | core, evaluator, CLI, MCP (+ any adapter riding along) | exactly one adapter |
+| Installed-tarball smoke | runs | skipped — the smoke project imports the lockstep surface, and an adapter that ships no JavaScript has nothing for it to import |
+| `packages/ci/queue@v0` Action tag | updated | untouched |
+| GitHub release | created | created |
+
+The tag form is `<slug>-v<semver>`, where the slug is the package name after the
+scope. `@adrkit/spec-kit` → `spec-kit-v0.1.0`. The workflow derives the release
+scope from the tag and fails on an unrecognized one.
+
+To cut an adapter release:
+
+```sh
+# 1. Confirm the adapter's own version in its package.json is what you intend.
+#    It does not move with the repository version.
+git switch main && git pull
+
+# 2. Dry-run the exact pack the workflow will perform.
+bun run release:pack -- --only @adrkit/spec-kit --tag spec-kit-v0.1.0
+
+# 3. Tag and push. The Release workflow does the rest.
+git tag spec-kit-v0.1.0
+git push origin spec-kit-v0.1.0
+```
+
+`release-pack` validates **every** package's manifest regardless of scope — an
+adapter release is still a good moment to notice the lockstep surface drifted —
+but narrows what is packed, and requires the tag to match the adapter's own
+version. Publishing remains idempotent per artifact: an adapter already on the
+registry at matching integrity is skipped rather than republished.
+
+### First publish of a new adapter name
+
+npm Trusted Publishing cannot be configured for a package name that does not
+exist yet, so the very first publish needs a credential:
+
+1. Add `NPM_BOOTSTRAP_TOKEN` to the `npm` environment — a granular token with
+   publish rights for the `@adrkit` scope.
+2. Add the package name to `BOOTSTRAP_PACKAGES` in `scripts/release-publish.ts`.
+   It is scrubbed from every other package's environment.
+3. Release.
+4. Configure Trusted Publishing for the new name on npmjs.com.
+5. **Remove the name from `BOOTSTRAP_PACKAGES` and delete the secret.** Leaving
+   either in place hands a long-lived token to a package that no longer needs
+   one.
+
 ## One-time npm bootstrap (completed for v0.1.0)
 
 The npm scope and packages must exist before Trusted Publishers can be attached.

--- a/scripts/release-pack.test.ts
+++ b/scripts/release-pack.test.ts
@@ -3,6 +3,8 @@ import {
   RELEASE_PACKAGES,
   findWorkspaceProtocols,
   validatePackedManifest,
+  releaseTagFor,
+  resolveOnly,
   validateSourceManifests,
   versionFor,
   type PackageManifest,
@@ -86,6 +88,50 @@ describe('release package validation', () => {
         version: definition.versioning === 'lockstep' ? '0.1.0' : '9.9.9',
       });
     }
+  });
+
+  test('lockstep packages release under the repository tag', () => {
+    for (const definition of RELEASE_PACKAGES.filter((d) => d.versioning === 'lockstep')) {
+      expect({ name: definition.name, tag: releaseTagFor(definition, '0.3.0') }).toEqual({
+        name: definition.name,
+        tag: 'v0.3.0',
+      });
+    }
+  });
+
+  test('an adapter releases under its own slugged tag', () => {
+    const adapters = RELEASE_PACKAGES.filter((d) => d.versioning === 'independent');
+    expect(adapters.length).toBeGreaterThan(0);
+    for (const definition of adapters) {
+      const slug = definition.name.split('/')[1];
+      expect({ name: definition.name, tag: releaseTagFor(definition, '0.1.0') }).toEqual({
+        name: definition.name,
+        tag: `${slug}-v0.1.0`,
+      });
+    }
+  });
+
+  test('--only accepts an adapter and rejects a lockstep package', () => {
+    const adapter = RELEASE_PACKAGES.find((d) => d.versioning === 'independent')!;
+    expect(resolveOnly(adapter.name)?.name).toBe(adapter.name);
+    expect(resolveOnly(undefined)).toBeUndefined();
+
+    const lockstep = RELEASE_PACKAGES.find((d) => d.versioning === 'lockstep')!;
+    expect(() => resolveOnly(lockstep.name)).toThrow('is lockstep');
+    expect(() => resolveOnly('@adrkit/does-not-exist')).toThrow('is not a release package');
+  });
+
+  test('the expected tag follows the release scope', () => {
+    const adapter = RELEASE_PACKAGES.find((d) => d.versioning === 'independent')!;
+    const manifests = alignedManifests('0.1.0');
+
+    // Scoped to the adapter: its own tag is required, the repository tag is not.
+    expect(validateSourceManifests(manifests, 'spec-kit-v9.9.9', adapter)).toBe('0.1.0');
+    expect(() => validateSourceManifests(manifests, 'v0.1.0', adapter)).toThrow('must be spec-kit-v9.9.9');
+
+    // Unscoped: the repository tag is required, the adapter's is not.
+    expect(validateSourceManifests(manifests, 'v0.1.0')).toBe('0.1.0');
+    expect(() => validateSourceManifests(manifests, 'spec-kit-v9.9.9')).toThrow('must be v0.1.0');
   });
 
   test('a package shipping no Node artifact may not publish dist', () => {

--- a/scripts/release-pack.ts
+++ b/scripts/release-pack.ts
@@ -58,7 +58,42 @@ export type ReleaseVersioning = 'lockstep' | 'independent';
 
 export interface ReleaseManifest {
   version: string;
+  /**
+   * The exact tag this release must be published from. Carried explicitly rather
+   * than rebuilt as `v${version}` downstream, because an independently versioned
+   * adapter releases under its own tag and that string is no longer derivable
+   * from the release version alone.
+   */
+  tag: string;
   artifacts: ReleaseArtifact[];
+}
+
+/**
+ * The tag a package releases under.
+ *
+ * Lockstep packages share the repository tag, `v0.3.0`. An adapter releases on
+ * its own, `spec-kit-v0.1.0`, so that shipping a fix for a Spec Kit change does
+ * not require republishing four unchanged packages under a new version — which
+ * would make "versioned independently" true of the number and false of
+ * everything that matters.
+ */
+export function releaseTagFor(definition: ReleasePackageDefinition, version: string): string {
+  if (definition.versioning === 'lockstep') return `v${version}`;
+  const slug = definition.name.split('/')[1];
+  assert(slug, `Cannot derive a release tag slug from ${definition.name}`);
+  return `${slug}-v${version}`;
+}
+
+/** Resolve `--only` to its definition, or undefined for a full lockstep release. */
+export function resolveOnly(only: string | undefined): ReleasePackageDefinition | undefined {
+  if (!only) return undefined;
+  const definition = RELEASE_PACKAGES.find((candidate) => candidate.name === only);
+  assert(definition, `--only ${only} is not a release package`);
+  assert(
+    definition.versioning === 'independent',
+    `--only is for independently versioned packages; ${only} is lockstep and releases with the repository tag`,
+  );
+  return definition;
 }
 
 export const RELEASE_PACKAGES: readonly ReleasePackageDefinition[] = [
@@ -185,6 +220,7 @@ export function findWorkspaceProtocols(value: unknown, path = 'package.json'): s
 export function validateSourceManifests(
   manifests: ReadonlyMap<string, PackageManifest>,
   tag?: string,
+  only?: ReleasePackageDefinition,
 ): string {
   const lockstepVersions = new Set<string>();
   let sawLockstep = false;
@@ -237,7 +273,16 @@ export function validateSourceManifests(
   );
   const [version] = lockstepVersions;
   assert(version, 'Release version is missing');
-  if (tag) assert(tag === `v${version}`, `Release tag ${tag} must match package version v${version}`);
+
+  // Every manifest is validated above regardless of scope — an adapter-only
+  // release is still a good moment to notice that the lockstep surface drifted.
+  // Only the tag expectation narrows.
+  if (tag) {
+    const expected = only
+      ? releaseTagFor(only, versionFor(only, manifests, version))
+      : `v${version}`;
+    assert(tag === expected, `Release tag ${tag} must be ${expected}`);
+  }
   return version;
 }
 
@@ -284,11 +329,13 @@ function parseArguments(args: readonly string[]): {
   skipBuild: boolean;
   skipSmokeInstall: boolean;
   tag?: string;
+  only?: string;
 } {
   let outputDir = DEFAULT_OUTPUT_DIR;
   let skipBuild = false;
   let skipSmokeInstall = false;
   let tag: string | undefined;
+  let only: string | undefined;
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === '--skip-build') {
@@ -299,6 +346,10 @@ function parseArguments(args: readonly string[]): {
       tag = args[index + 1];
       assert(tag, '--tag requires a value');
       index += 1;
+    } else if (argument === '--only') {
+      only = args[index + 1];
+      assert(only, '--only requires a value');
+      index += 1;
     } else if (argument === '--output') {
       const value = args[index + 1];
       assert(value, '--output requires a value');
@@ -308,7 +359,7 @@ function parseArguments(args: readonly string[]): {
       throw new Error(`Unknown release-pack argument: ${argument}`);
     }
   }
-  return { outputDir, skipBuild, skipSmokeInstall, tag };
+  return { outputDir, skipBuild, skipSmokeInstall, tag, only };
 }
 
 async function tarEntries(tarball: string): Promise<string[]> {
@@ -500,7 +551,11 @@ export async function packRelease(args = Bun.argv.slice(2)): Promise<ReleaseMani
       await readJson<PackageManifest>(join(RELEASE_ROOT, definition.directory, 'package.json')),
     );
   }
-  const version = validateSourceManifests(sourceManifests, options.tag);
+  const only = resolveOnly(options.only);
+  const version = validateSourceManifests(sourceManifests, options.tag, only);
+  // Scope narrows what is packed and published; it never narrows what is
+  // validated.
+  const selected = only ? [only] : RELEASE_PACKAGES;
 
   if (!options.skipBuild) {
     await run([process.execPath, 'run', 'build'], RELEASE_ROOT, 'building release packages');
@@ -513,7 +568,7 @@ export async function packRelease(args = Bun.argv.slice(2)): Promise<ReleaseMani
     return versionFor(definition, sourceManifests, version);
   };
 
-  for (const definition of RELEASE_PACKAGES) {
+  for (const definition of selected) {
     const packageVersion = versionFor(definition, sourceManifests, version);
     const filename = `${definition.name.slice(1).replace('/', '-')}-${packageVersion}.tgz`;
     const packageDir = join(RELEASE_ROOT, definition.directory);
@@ -550,10 +605,18 @@ export async function packRelease(args = Bun.argv.slice(2)): Promise<ReleaseMani
     });
   }
 
-  const manifest: ReleaseManifest = { version, artifacts };
+  const releaseVersion = only ? versionFor(only, sourceManifests, version) : version;
+  const tag = only ? releaseTagFor(only, releaseVersion) : `v${version}`;
+  const manifest: ReleaseManifest = { version: releaseVersion, tag, artifacts };
   await Bun.write(join(npmDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
-  if (!options.skipSmokeInstall) await prepareSmokeProject(options.outputDir, artifacts);
-  console.log(`release-pack: prepared ${artifacts.length} packages at v${version}`);
+
+  // The smoke project imports the lockstep surface, so it is meaningless for an
+  // adapter-only release — and an adapter that ships no JavaScript has nothing
+  // for it to import in the first place.
+  if (!options.skipSmokeInstall && !only) {
+    await prepareSmokeProject(options.outputDir, artifacts);
+  }
+  console.log(`release-pack: prepared ${artifacts.length} package(s) for ${tag}`);
   return manifest;
 }
 

--- a/scripts/release-publish.test.ts
+++ b/scripts/release-publish.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  assertPublishTag,
   existingIntegrity,
   publishEnvironment,
   shouldPublishArtifact,
@@ -53,6 +54,21 @@ describe('release registry safety', () => {
     expect(() => shouldPublishArtifact(artifact, 'sha512-other')).toThrow(
       'already exists with different integrity',
     );
+  });
+
+  test('requires the exact tag the manifest names, not one rebuilt from the version', () => {
+    // A lockstep manifest and an adapter manifest can carry the same version and
+    // still require different tags. Deriving the expectation from the version
+    // would accept the wrong tag for the adapter.
+    const lockstep = { version: '0.3.0', tag: 'v0.3.0', artifacts: [] };
+    const adapter = { version: '0.1.0', tag: 'spec-kit-v0.1.0', artifacts: [] };
+
+    expect(() => assertPublishTag(lockstep, 'v0.3.0')).not.toThrow();
+    expect(() => assertPublishTag(adapter, 'spec-kit-v0.1.0')).not.toThrow();
+
+    expect(() => assertPublishTag(adapter, 'v0.1.0')).toThrow('must match spec-kit-v0.1.0');
+    expect(() => assertPublishTag(lockstep, 'spec-kit-v0.3.0')).toThrow('must match v0.3.0');
+    expect(() => assertPublishTag(adapter, undefined)).toThrow('(missing)');
   });
 
   test('keeps bootstrap credentials out of existing package publishes', () => {

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -51,6 +51,20 @@ export function shouldPublishArtifact(
   return false;
 }
 
+/**
+ * The tag a manifest must be published from.
+ *
+ * Split out so it is testable: the assertion used to rebuild `v${version}`
+ * inline, which is right for a lockstep release and silently wrong for an
+ * adapter released under `spec-kit-v0.1.0`.
+ */
+export function assertPublishTag(manifest: ReleaseManifest, refName: string | undefined): void {
+  assert(
+    refName === manifest.tag,
+    `Tag ${refName ?? '(missing)'} must match ${manifest.tag}`,
+  );
+}
+
 export function publishEnvironment(
   packageName: string,
   source: Record<string, string | undefined> = Bun.env,
@@ -99,10 +113,10 @@ export async function publishRelease(args = Bun.argv.slice(2)): Promise<void> {
   if (!dryRun) {
     assert(Bun.env.GITHUB_ACTIONS === 'true', 'Real publication is restricted to GitHub Actions');
     assert(Bun.env.GITHUB_REF_TYPE === 'tag', 'Real publication requires a tag workflow');
-    assert(
-      Bun.env.GITHUB_REF_NAME === `v${manifest.version}`,
-      `Tag ${Bun.env.GITHUB_REF_NAME ?? '(missing)'} must match v${manifest.version}`,
-    );
+    // The manifest carries its own tag: a lockstep release publishes from
+    // `v0.3.0`, an adapter from `spec-kit-v0.1.0`. Rebuilding the expected tag
+    // from the version here would silently reintroduce the lockstep assumption.
+    assertPublishTag(manifest, Bun.env.GITHUB_REF_NAME);
   }
 
   for (const artifact of manifest.artifacts) {


### PR DESCRIPTION
Independent versioning without independent release is not independent versioning.

## Why

Publishing `@adrkit/spec-kit@0.1.0` through the lockstep path would have meant tagging a new repository version and republishing `@adrkit/core`, `@adrkit/evaluator`, `@adrkit/cli`, and `@adrkit/mcp` — **none of which changed since v0.3.0** — purely to carry one adapter along. That would make ADR-0007's "adapters are versioned independently" true of the number and false of everything that matters.

## What changes

Adapters release under `<slug>-v<semver>`, e.g. `spec-kit-v0.1.0`.

| | Lockstep (`v0.3.0`) | Adapter (`spec-kit-v0.1.0`) |
|---|---|---|
| Packages | core, evaluator, CLI, MCP | exactly one adapter |
| Installed-tarball smoke | runs | skipped — the smoke project imports the lockstep surface, and an adapter shipping no JavaScript has nothing for it to import |
| `packages/ci/queue@v0` Action tag | updated | untouched |

- `release-pack` gains `--only`, which narrows what is **packed** but never what is **validated** — an adapter release is still a good moment to notice the lockstep surface drifted.
- The release manifest now carries its own `tag`. Downstream used to rebuild `v${version}`, which is correct for lockstep and silently wrong for an adapter.
- The publish-side tag assertion was extracted to `assertPublishTag` so that distinction is testable — a mutation rebuilding the tag from the version went undetected until this existed.
- The workflow derives scope from the tag shape and fails closed on an unrecognized tag.

## Verification

852 tests green; typecheck, `adr lint`, `check:deps` clean. Both release paths exercised locally:

```
release-pack: prepared 5 package(s) for v0.3.0
release-pack: prepared 1 package(s) for spec-kit-v0.1.0
```

All five tag/scope guards observed rejecting bad input (adapter tag on a full release, lockstep tag on an adapter release, `--only` on a lockstep package, `--only` on an unknown package, wrong adapter version), and all four new test guards observed failing under deliberate defects before being trusted ([ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).

Also documents the path and the first-publish bootstrap lifecycle in `docs/RELEASING.md`, including removing the token and the `BOOTSTRAP_PACKAGES` entry afterwards.
