### PR TITLE
feat(release): attach a catalog asset to adapter releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,14 +129,34 @@ jobs:
           NPM_BOOTSTRAP_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
         run: bun run release:publish
 
+      - name: Build the catalog release asset
+        # The Spec Kit community catalog installs an extension from a .zip
+        # attached to its GitHub release, so an adapter release must carry one.
+        if: steps.scope.outputs.lockstep != 'true'
+        run: bun scripts/pack-extension-zip.ts
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          ADAPTER: ${{ steps.scope.outputs.adapter }}
         run: |
+          set -euo pipefail
+          assets=()
+          if [ -n "$ADAPTER" ]; then
+            # Exactly one asset, produced by the step above.
+            while IFS= read -r zip; do assets+=("$zip"); done < <(find .release -maxdepth 1 -name '*.zip')
+            if [ "${#assets[@]}" -ne 1 ]; then
+              echo "Expected exactly one catalog asset, found ${#assets[@]}" >&2
+              exit 1
+            fi
+          fi
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             echo "GitHub release $GITHUB_REF_NAME already exists"
+            if [ "${#assets[@]}" -gt 0 ]; then
+              gh release upload "$GITHUB_REF_NAME" "${assets[@]}" --clobber
+            fi
           else
-            gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes
+            gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes "${assets[@]}"
           fi
 
       - name: Update the major Action tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,9 @@ Until `1.0.0`, minor releases may include breaking changes
   ADR-0007's "versioned independently" true of the number and false of everything
   that matters. `release-pack` gains `--only`, the release manifest carries its
   own `tag`, and the workflow derives scope from the tag: installed-tarball
-  smoke and the `packages/ci/queue@v0` Action tag are lockstep-only.
+  smoke and the `packages/ci/queue@v0` Action tag are lockstep-only. An adapter
+  release also attaches a catalog `.zip` asset, derived from the packed tarball
+  so the npm and catalog artifacts cannot disagree.
 
 ### Changed
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -157,6 +157,14 @@ git tag spec-kit-v0.1.0
 git push origin spec-kit-v0.1.0
 ```
 
+An adapter release also attaches a catalog asset: `scripts/pack-extension-zip.ts`
+derives `<extension-id>.zip` from the already-packed, already-validated npm
+tarball — so the two artifacts cannot disagree about what the extension contains
+— drops `package.json`, and asserts `extension.yml` lands at the archive root,
+where Spec Kit looks first. That zip is what a
+[`catalog.community.json`](https://github.com/github/spec-kit/blob/main/extensions/catalog.community.json)
+entry's `download_url` points at.
+
 `release-pack` validates **every** package's manifest regardless of scope — an
 adapter release is still a good moment to notice the lockstep surface drifted —
 but narrows what is packed, and requires the tag to match the adapter's own

--- a/scripts/pack-extension-zip.test.ts
+++ b/scripts/pack-extension-zip.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { EXCLUDED_FROM_ASSET, assetNameFor } from './pack-extension-zip.ts';
+
+describe('catalog release asset', () => {
+  test('names the asset after the extension id, not the package name', () => {
+    // The catalog keys on `extension.id`. `@adrkit/spec-kit` is the npm name;
+    // `adrkit` is what a Spec Kit user types.
+    expect(assetNameFor('adrkit')).toBe('adrkit.zip');
+  });
+
+  test('rejects an id that is not catalog-safe', () => {
+    for (const bad of ['@adrkit/spec-kit', 'adrKit', 'adr kit', '../escape', '']) {
+      expect({ bad, threw: (() => { try { assetNameFor(bad); return false; } catch { return true; } })() })
+        .toEqual({ bad, threw: true });
+    }
+  });
+
+  test('excludes workspace metadata from what a catalog consumer receives', () => {
+    // npm always ships package.json; a Spec Kit consumer has no use for it, and
+    // the `--dev` install path already drops it via .extensionignore. The two
+    // install paths should hand over the same files.
+    expect(EXCLUDED_FROM_ASSET).toContain('package.json');
+    expect(EXCLUDED_FROM_ASSET.length).toBeGreaterThan(0);
+
+    // Guard the guard: the runtime files must never be excluded.
+    for (const shipped of ['extension.yml', 'commands', 'scripts', 'README.md']) {
+      expect({ shipped, excluded: EXCLUDED_FROM_ASSET.includes(shipped) }).toEqual({
+        shipped,
+        excluded: false,
+      });
+    }
+  });
+});

--- a/scripts/pack-extension-zip.ts
+++ b/scripts/pack-extension-zip.ts
@@ -1,0 +1,98 @@
+/**
+ * Build the catalog release asset for an adapter release.
+ *
+ * The Spec Kit community catalog installs an extension from a `.zip` attached to
+ * a GitHub release (143 of the 144 entries at the time of writing). This derives
+ * that zip from the already-packed, already-validated npm tarball rather than
+ * re-walking the source tree, so the two artifacts cannot disagree about what
+ * the extension contains.
+ *
+ * `package.json` is dropped: it exists for the Bun workspace and npm, and the
+ * `--dev` install path already excludes it via `.extensionignore`. Shipping it
+ * to a catalog consumer would put workspace metadata in their repository.
+ */
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import type { ReleaseManifest } from './release-pack.ts';
+
+const RELEASE_ROOT = new URL('..', import.meta.url).pathname;
+const RELEASE_DIR = join(RELEASE_ROOT, '.release');
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+/** The asset name for a scoped package: `@adrkit/spec-kit` -> `adrkit.zip`. */
+export function assetNameFor(extensionId: string): string {
+  assert(/^[a-z0-9-]+$/.test(extensionId), `Extension id ${extensionId} is not catalog-safe`);
+  return `${extensionId}.zip`;
+}
+
+/** Files the catalog consumer must never receive, even though npm ships them. */
+export const EXCLUDED_FROM_ASSET: readonly string[] = ['package.json'];
+
+async function run(command: readonly string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn([...command], { cwd, stdout: 'inherit', stderr: 'inherit' });
+  const exitCode = await proc.exited;
+  assert(exitCode === 0, `${command[0]} failed with exit ${exitCode}`);
+}
+
+export async function packExtensionZip(): Promise<string> {
+  const manifest = JSON.parse(
+    await Bun.file(join(RELEASE_DIR, 'npm', 'manifest.json')).text(),
+  ) as ReleaseManifest;
+
+  assert(
+    manifest.artifacts.length === 1,
+    `A catalog asset is built for a single-adapter release; this manifest has ${manifest.artifacts.length} artifacts`,
+  );
+  const artifact = manifest.artifacts[0];
+  assert(artifact, 'Release manifest has no artifact');
+
+  const tarball = join(RELEASE_DIR, 'npm', artifact.tarball);
+  const staging = await mkdtemp(join(tmpdir(), 'adrkit-asset-'));
+  try {
+    await run(['tar', '-xzf', tarball, '-C', staging], RELEASE_ROOT);
+    const root = join(staging, 'package');
+
+    const manifestYml = Bun.file(join(root, 'extension.yml'));
+    assert(await manifestYml.exists(), 'Packed adapter has no extension.yml at its root');
+
+    // Derive the id from the manifest the consumer will actually read.
+    const parsed = Bun.YAML.parse(await manifestYml.text()) as {
+      extension?: { id?: string };
+    } | null;
+    const id = parsed?.extension?.id;
+    assert(typeof id === 'string' && id.length > 0, 'extension.yml declares no extension.id');
+
+    for (const excluded of EXCLUDED_FROM_ASSET) {
+      await rm(join(root, excluded), { force: true });
+    }
+
+    const assetPath = join(RELEASE_DIR, assetNameFor(id));
+    await rm(assetPath, { force: true });
+    // Zip from inside `package/` so extension.yml lands at the archive root,
+    // which is where Spec Kit looks first.
+    await run(['zip', '-q', '-r', '-X', assetPath, '.'], root);
+
+    const entries = (
+      await new Response(Bun.spawn(['unzip', '-Z1', assetPath]).stdout).text()
+    )
+      .split('\n')
+      .filter(Boolean);
+    assert(entries.includes('extension.yml'), 'Asset does not carry extension.yml at its root');
+    for (const excluded of EXCLUDED_FROM_ASSET) {
+      assert(!entries.includes(excluded), `Asset leaked ${excluded}`);
+    }
+
+    console.log(`pack-extension-zip: ${basename(assetPath)} (${entries.length} entries)`);
+    return assetPath;
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+}
+
+if (import.meta.main) {
+  await packExtensionZip();
+}


### PR DESCRIPTION
The Spec Kit community catalog installs an extension from a `.zip` attached to its GitHub release — 143 of the 144 entries do this — so an adapter release that ships only an npm tarball cannot be listed.

## What this adds

`scripts/pack-extension-zip.ts`, wired into the release workflow for adapter releases only.

It derives the asset from the **already-packed, already-validated npm tarball** rather than re-walking the source tree, so the two artifacts cannot disagree about what the extension contains.

`package.json` is dropped. It exists for the Bun workspace and npm; the `--dev` install path already excludes it via `.extensionignore`, so both install paths now hand over exactly the same files.

## Verified, not assumed

The archive puts `extension.yml` at its root, which is where Spec Kit looks first (it falls back to a single top-level subdirectory). That layout was checked against upstream's extraction code and then proven by extracting the built zip and installing it into a real Spec Kit project:

```
✓ Extension installed successfully!
  • speckit.adrkit.context …
  • speckit.adrkit.check …
  • speckit.adrkit.draft …
```

Asset contents — no `package.json`, no dev files:

```
README.md  extension.yml
commands/{check,context,draft}.md
scripts/{adrkit-lib,check,context,draft}.sh
```

## Verification

855 tests green; typecheck, `adr lint`, `check:deps` clean. The packer asserts its own output: `extension.yml` at the root, and no excluded file leaked. Its tests guard the guard — the runtime files must never appear in the exclusion list.

Closes the remaining mechanical gap for [ADR-0019](docs/adr/0019-ship-the-spec-kit-extension-treating-the-spike-no-go-as-a-measurement-artifact.md) action item 5 (catalog submission).
