### PR TITLE
chore(release): retire the npm bootstrap credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+### Security
+
+- `BOOTSTRAP_PACKAGES` is empty again. `@adrkit/spec-kit` needed a credential for
+  its first publish because npm Trusted Publishing cannot be configured for a
+  name that does not exist yet; with the name established and Trusted Publishing
+  on, it publishes over OIDC and the `NPM_BOOTSTRAP_TOKEN` secret can be deleted.
+  A test asserts no package receives the credential, and was observed failing
+  against a name left in the set.
+
 ### Fixed
 
 - `@adrkit/spec-kit` **0.1.1** ships `LICENSE` and `NOTICE`. 0.1.0 did not: every

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -186,6 +186,11 @@ exist yet, so the very first publish needs a credential:
    either in place hands a long-lived token to a package that no longer needs
    one.
 
+An empty `BOOTSTRAP_PACKAGES` is the correct steady state, not an oversight. A
+name belongs in it only between "does not exist on the registry" and "Trusted
+Publishing is configured". `@adrkit/mcp` passed through it for 0.2.0 and
+`@adrkit/spec-kit` for 0.1.0; both publish over OIDC now.
+
 ## One-time npm bootstrap (completed for v0.1.0)
 
 The npm scope and packages must exist before Trusted Publishers can be attached.

--- a/docs/adr/0019-ship-the-spec-kit-extension-treating-the-spike-no-go-as-a-measurement-artifact.md
+++ b/docs/adr/0019-ship-the-spec-kit-extension-treating-the-spike-no-go-as-a-measurement-artifact.md
@@ -242,8 +242,8 @@ until it does not.
 2. [x] Enforce the read-only hook boundary with a test observed failing first
 3. [x] Re-verify the `speckit_version` pin against the next Spec Kit minor before widening it — done 2026-08-01, see the addendum above; widened to `<0.16.0`, verified at 0.13.0, 0.14.4, 0.15.1
 4. [x] Decide whether to publish `@adrkit/spec-kit` to npm, or install it from the repository — **both channels**, see the addendum below
-5. [ ] Submit the catalog entry to `github/spec-kit`'s `catalog.community.json` once a release asset exists
-6. [ ] Remove `@adrkit/spec-kit` from `BOOTSTRAP_PACKAGES` after its first publish, once Trusted Publishing is configured for the name
+5. [ ] Submit the catalog entry to `github/spec-kit` once a release asset exists — via the Extension Submission **issue template**; the publishing guide forbids editing `catalog.community.json` by PR
+6. [x] Remove `@adrkit/spec-kit` from `BOOTSTRAP_PACKAGES` after its first publish, once Trusted Publishing is configured for the name — done 2026-08-03; the set is now empty, which is its correct steady state. The `NPM_BOOTSTRAP_TOKEN` secret can be deleted.
 
 ### Addendum, 2026-08-02: distribution channels (action item 4)
 

--- a/scripts/release-publish.test.ts
+++ b/scripts/release-publish.test.ts
@@ -81,30 +81,25 @@ describe('release registry safety', () => {
     expect(environment).toEqual({ PATH: '/bin' });
   });
 
-  test('maps the bootstrap credential only to a package awaiting its first publish', () => {
-    const environment = publishEnvironment('@adrkit/spec-kit', {
-      NPM_BOOTSTRAP_TOKEN: 'bootstrap-token',
-      PATH: '/bin',
-    });
-
-    expect(environment).toEqual({
-      NODE_AUTH_TOKEN: 'bootstrap-token',
-      PATH: '/bin',
-    });
-  });
-
-  test('an already-published package never receives the bootstrap credential', () => {
-    // @adrkit/mcp bootstrapped in 0.2.0 and has used OIDC ever since. Leaving a
-    // published name in the bootstrap set would hand it a token it no longer
-    // needs, which is exactly the credential sprawl the set exists to bound.
-    for (const published of ['@adrkit/core', '@adrkit/cli', '@adrkit/evaluator', '@adrkit/mcp']) {
+  test('no package receives the bootstrap credential once all names exist', () => {
+    // The steady state. @adrkit/mcp bootstrapped for 0.2.0 and @adrkit/spec-kit
+    // for 0.1.0; both now publish over OIDC. A name left in the bootstrap set
+    // after Trusted Publishing is configured keeps receiving a long-lived token
+    // it no longer needs — exactly the credential sprawl the set bounds.
+    for (const name of [
+      '@adrkit/core',
+      '@adrkit/cli',
+      '@adrkit/evaluator',
+      '@adrkit/mcp',
+      '@adrkit/spec-kit',
+    ]) {
       expect({
-        published,
-        environment: publishEnvironment(published, {
+        name,
+        environment: publishEnvironment(name, {
           NPM_BOOTSTRAP_TOKEN: 'bootstrap-token',
           PATH: '/bin',
         }),
-      }).toEqual({ published, environment: { PATH: '/bin' } });
+      }).toEqual({ name, environment: { PATH: '/bin' } });
     }
   });
 

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -10,11 +10,16 @@ const REGISTRY = 'https://registry.npmjs.org';
  *
  * npm Trusted Publishing cannot be configured for a name that does not exist
  * yet, so the very first publish of a new package needs a credential. Every
- * subsequent publish uses OIDC. Remove a name from this set once it has been
- * published and Trusted Publishing is configured for it — leaving it here would
- * keep handing a token to a package that no longer needs one.
+ * subsequent publish uses OIDC.
+ *
+ * **This set is empty, and that is the correct steady state.** A name belongs
+ * here only between "the package does not exist on the registry" and "Trusted
+ * Publishing is configured for it". Leaving one here afterwards keeps handing a
+ * long-lived token to a package that no longer needs one — the credential
+ * sprawl the set exists to bound. `@adrkit/mcp` was bootstrapped for 0.2.0 and
+ * `@adrkit/spec-kit` for 0.1.0/0.1.1; both now publish over OIDC.
  */
-const BOOTSTRAP_PACKAGES: ReadonlySet<string> = new Set(['@adrkit/spec-kit']);
+const BOOTSTRAP_PACKAGES: ReadonlySet<string> = new Set();
 type RegistryFetch = (url: string) => Promise<Response>;
 
 function assert(condition: unknown, message: string): asserts condition {


### PR DESCRIPTION
`@adrkit/spec-kit` needed a credential for its first publish because npm Trusted Publishing cannot be configured for a name that does not exist yet. The name now exists and Trusted Publishing is enabled, so it publishes over OIDC like every other package.

`BOOTSTRAP_PACKAGES` is empty again — which is its **correct steady state**, not an oversight. A name belongs in it only between "does not exist on the registry" and "Trusted Publishing is configured". Leaving one there afterwards keeps handing a long-lived token to a package that no longer needs it: exactly the credential sprawl the set exists to bound.

## After merge

The `NPM_BOOTSTRAP_TOKEN` secret in the `npm` environment can be **deleted**.

## Verification

856 tests green; `adr lint` and `check:deps` clean. The test asserting no package receives the credential was observed failing against a name left in the set.