### PR TITLE
fix(spec-kit): keep extension.yml and package.json versions in sync (0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ### Fixed
 
+- `@adrkit/spec-kit` **0.1.2** reports its own version correctly. 0.1.1 shipped
+  with `extension.yml` still saying `0.1.0`, so `specify extension info` and
+  `specify extension list` told every user they had 0.1.0. Two version fields —
+  `package.json` for npm, `extension.yml` for Spec Kit — with nothing keeping
+  them in sync. A test now asserts they match, and was observed failing against
+  the exact 0.1.1 state.
+
 - `@adrkit/spec-kit` **0.1.1** ships `LICENSE` and `NOTICE`. 0.1.0 did not: every
   sibling package copies them into `dist` at build time, and this package has no
   build, so nothing carried them. The files are committed rather than generated

--- a/packages/adapters/spec-kit/extension.yml
+++ b/packages/adapters/spec-kit/extension.yml
@@ -12,7 +12,7 @@ schema_version: "1.0"
 extension:
   id: "adrkit"
   name: "adrkit — decision memory for spec-driven development"
-  version: "0.1.0"
+  version: "0.1.2"
   description: "Pulls the decisions governing this work into agent context, checks produced plans against them, and drafts an ADR from a plan artifact."
   author: "Mark Beacom (@mbeacom)"
   repository: "https://github.com/mbeacom/adrkit"

--- a/packages/adapters/spec-kit/package.json
+++ b/packages/adapters/spec-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/spec-kit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Spec Kit extension that injects adrkit's governing decisions into the spec-driven plan loop.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/adapters/spec-kit/test/manifest.test.ts
+++ b/packages/adapters/spec-kit/test/manifest.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { loadManifest } from './manifest-fixture.ts';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { loadManifest, packageRoot } from './manifest-fixture.ts';
 
 /**
  * The upstream validation rules from Spec Kit's EXTENSION-API-REFERENCE at the
@@ -25,6 +27,26 @@ describe('extension manifest', () => {
 
   test('extension version is a bare semver triple', () => {
     expect(manifest.extension.version).toMatch(SEMVER_PATTERN);
+  });
+
+  test('the manifest version matches the package version', () => {
+    // Two version fields, one artifact. `package.json` decides what npm
+    // publishes; `extension.yml` decides what `specify extension info` and the
+    // catalog report. 0.1.1 shipped with these out of sync and told every user
+    // it was 0.1.0 — nothing was watching, so nothing complained.
+    const packageJson = JSON.parse(
+      readFileSync(join(packageRoot, 'package.json'), 'utf8'),
+    ) as { version?: string };
+
+    // Assert presence before comparing: two missing versions are equal, and
+    // that is exactly the vacuous pass this guard must not have.
+    expect(typeof packageJson.version).toBe('string');
+    const packageVersion = packageJson.version ?? '(absent)';
+
+    expect({ source: 'extension.yml', version: manifest.extension.version }).toEqual({
+      source: 'extension.yml',
+      version: packageVersion,
+    });
   });
 
   test('description stays under the 200-character upstream limit', () => {


### PR DESCRIPTION
`@adrkit/spec-kit@0.1.1` published with `extension.yml` still saying `0.1.0`. Anyone who installed it saw:

```
✓ adrkit — decision memory for spec-driven development (v0.1.0)
```

## Root cause

The package has **two** version fields and nothing kept them together:

| File | Consumed by |
|---|---|
| `package.json` | npm |
| `extension.yml` | `specify extension info` / `list`, and the community catalog |

Bumping the first for the LICENSE fix silently left the second behind. No test looked.

## The guard

A test now asserts they match. It was observed failing against the exact 0.1.1 state.

It also asserts the package version is *present* before comparing — two absent versions are equal, and that is precisely the vacuous pass this guard must not have ([ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).

## How it surfaced

While assembling the Spec Kit catalog submission, which reports the version to every consumer. A wrong number there would have propagated well past this repository — the catalog entry, the docs table, and every `specify extension info` call.

## Verification

857 tests green; typecheck, `adr lint`, `check:deps` clean.