### PR TITLE
docs: sync the docs to v0.3.0 and document the Spec Kit extension

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: adrkit version
       description: Output of `adr --version` (or the package version you installed).
-      placeholder: '0.2.0'
+      placeholder: '0.3.0'
     validations:
       required: true
   - type: dropdown
@@ -43,6 +43,7 @@ body:
         - '@adrkit/core'
         - '@adrkit/evaluator'
         - '@adrkit/mcp'
+        - '@adrkit/spec-kit (Spec Kit extension)'
         - 'CI Action (packages/ci)'
         - 'Docs / website'
         - 'Not sure'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,32 @@ against live Spec Kit, rather than reasoning about it:
   into the consuming project's `.specify/extensions/adrkit/`. Now excluded via
   `.extensionignore`, which upstream supports across the whole pinned range.
 
+### Documentation
+
+- **adrkit.dev documents the Spec Kit extension.** It had shipped, been released
+  three times, and existed nowhere on the site — no page, no sidebar entry, and
+  absent from the homepage's own list of published packages. A new
+  [Spec Kit extension](https://adrkit.dev/spec-kit/) guide joins "Use in CI" and
+  "MCP setup", covering the three commands, the optional hook and why `draft` is
+  unreachable from it, the environment-variable configuration, the tested
+  guarantees, and the honest ADR-0014 rung-2 status.
+
+- Stale versions swept out of the docs. The homepage hero still advertised
+  v0.2.1 two releases after v0.3.0 shipped; the roadmap still said "shipped in
+  v0.2.0"; the `queue@v0` pinning note explained the tag as of the v0.2.1
+  release though it has since moved to the v0.3.0 commit; and the bug-report
+  template suggested `0.2.0` as the version to report and offered no
+  `@adrkit/spec-kit` surface to file against.
+
+- `MANIFEST.md` is an inventory again rather than a seed-bundle snapshot. It had
+  not been touched since ADR-0013 and still claimed "13 records, ids 0001–0013"
+  with statuses six records out of date, no `packages/` tree, and a "not
+  included — add at repo creation" list of files that have existed for months.
+
+- `CLAUDE.md` documents `packages/adapters/spec-kit`, including the constraints
+  that have already been broken once each: the two version fields that must
+  agree, the independent release tag, and the no-dependencies/no-`dist` rule.
+
 ## [0.3.0] - 2026-07-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@ Decision memory for human- and agent-authored plans — machine-readable ADRs
 that are enforceable in CI and legible to agents, without leaving git.
 Status: early — phases 0–6 landed and v0.3.0 is public. `@adrkit/core`,
 `@adrkit/evaluator`, `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
-`check`, `migrate --from madr`, `evaluate`) are published on npm; the
+`check`, `queue`, `migrate --from madr`, `evaluate`) are published on npm, as is
+the independently versioned `@adrkit/spec-kit` Spec Kit extension (0.1.2); the
 repository-backed CI Action is available at `mbeacom/adrkit/packages/ci@v0`.
 The published `@adrkit/mcp` server has exactly four local stdio tools and serves
 **both** MCP protocol eras over one stdio connection — `2026-07-28` (stateless;
@@ -28,6 +29,42 @@ evidence ladder — unit/contract/conformance plus maintainer-owned isolated
 reference-repository validation ([`adrkit-t018-dogfood`](https://github.com/mbeacom/adrkit-t018-dogfood),
 queue Action pinned at `efef89b`). It is **not** yet externally validated; the
 rung-3 external/community signal is tracked honestly as open.
+
+## The Spec Kit extension (`packages/adapters/spec-kit`)
+
+`@adrkit/spec-kit` is the first package under `packages/adapters/*` and the
+second distribution surface
+([ADR-0003](./docs/adr/0003-ship-as-spec-kit-extension.md)). It adds three
+namespaced commands to a [Spec Kit](https://github.com/github/spec-kit) project
+— `/speckit.adrkit.context`, `/speckit.adrkit.check`, `/speckit.adrkit.draft` —
+plus one **optional** `after_plan` hook that offers to run the check. Pinned to
+Spec Kit `>=0.13.0,<0.16.0`, verified against 0.13.0, 0.14.4, and 0.15.1.
+Authorized by
+[ADR-0019](./docs/adr/0019-ship-the-spec-kit-extension-treating-the-spike-no-go-as-a-measurement-artifact.md).
+**Landed / reference-verified** on ADR-0014 rungs 1–2; rung 3 open.
+
+Things that are load-bearing and easy to break:
+
+- **It is versioned independently** of the lockstep surface, per
+  [ADR-0007](./docs/adr/0007-adapter-isolation-and-public-surface-build.md) — its
+  semver contract is with Spec Kit, not with `@adrkit/core`. It releases on its
+  own `spec-kit-v<semver>` tag (see [`docs/RELEASING.md`](./docs/RELEASING.md)),
+  currently **0.1.2**, and does **not** move with the repository version.
+- **Two version fields must agree**: `package.json` (npm) and `extension.yml`
+  (Spec Kit). A test asserts they match — 0.1.1 shipped with them diverged and
+  told every user the wrong version.
+- **It ships no `dist` and declares no dependencies**, not even dev ones.
+  `specify extension add --dev` copies the directory verbatim, and a single
+  declared dependency is enough for Bun's isolated linker to create a
+  `node_modules/` here that then lands in someone else's repo or aborts their
+  install. `LICENSE` and `NOTICE` are committed rather than generated for the
+  same reason. Enforced by `test/packaging.test.ts`.
+- **Hooks can only reach commands that do not write.** `draft` is the only
+  writing command and is unreachable from any hook, by test.
+- `packages/core`, `packages/cli`, and `schema/` import nothing from
+  `packages/adapters/*`; CI enforces this, and the rule has been observed
+  failing against a deliberately introduced violation
+  ([ADR-0016](./docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).
 
 ## `adr queue`
 

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,27 +1,46 @@
-# adrkit — seed bundle manifest
+# adrkit — repository manifest
 
-Everything below is current as of packaging. Unpack at the repo root; the
-directory structure is the intended layout.
+A map of the tracked surfaces and the decision corpus that governs them. This
+file started as the seed-bundle manifest for the first commit; it is now the
+inventory, refreshed as the corpus and the package layout move.
 
 ```
 adrkit/
 ├── README.md                      positioning, quickstart, license carve-out
 ├── CONTRIBUTING.md                DCO + the two hard rules from ADR-0007
+├── CHANGELOG.md                   Keep a Changelog; SemVer per ADR-0002
 ├── CODEOWNERS                     governance surfaces gated
 ├── NOTICE                         Apache attribution + CC0 carve-out notice
 ├── plan.md                        orchestrator handoff: phases, exit criteria, tasks
 ├── MANIFEST.md                    this file
+├── DESIGN.md  PRODUCT.md          design and product framing
 ├── .gitignore  .editorconfig
 ├── bunfig.toml  .bun-version    linker = "isolated" is load-bearing (ADR-0010)
-├── .github/workflows/ci.yml       enforces ADR-0002 and ADR-0007 commitments
+├── .github/workflows/             CI enforces ADR-0002 and ADR-0007 commitments
 ├── schema/
-│   ├── adr.schema.ts              SOURCE OF TRUTH (Zod). v0.1.0
-│   ├── adr.schema.json            GENERATED. Do not hand-edit.
+│   ├── adr.schema.ts              re-export of the Zod source of truth
+│   ├── adr.schema.json            GENERATED. Do not hand-edit. $id at v0.1.0
 │   └── LICENSE                    CC0, schema only
+├── packages/
+│   ├── core/                      @adrkit/core — schema (SOURCE OF TRUTH:
+│   │                              src/schema/adr.schema.ts), resolver, queue kernel
+│   ├── cli/                       @adrkit/cli — the `adr` binary
+│   ├── evaluator/                 @adrkit/evaluator — deterministic Pass 0
+│   ├── mcp/                       @adrkit/mcp — read-only stdio MCP server
+│   ├── ci/                        private — the two GitHub Actions + bundled dist
+│   └── adapters/
+│       └── spec-kit/              @adrkit/spec-kit — independently versioned
+│                                  (ADR-0007); ships no dist, no dependencies
+├── scripts/                       release pack/publish, dep boundary + audit gates
+├── site/                          Astro Starlight docs site; hosts the schema at its $id
+├── specs/                         001–009, one spec-kit feature per phase/spike
 └── docs/
     ├── EVALUATOR_RUBRIC.md        4 passes, 8 dimensions, escalation triggers
+    ├── RELEASING.md               lockstep and adapter release procedures
+    ├── DISTRIBUTION.md            registry/directory playbook
+    ├── reference-verification-spec-kit-extension.md   ADR-0014 rung-2 evidence index
     └── adr/
-        ├── 0000-template.md
+        ├── 0000-template.md                              draft (template)
         ├── 0001  git-native markdown records            accepted
         ├── 0002  MADR-superset typed frontmatter        accepted
         ├── 0003  Spec Kit extension + standalone CLI    proposed
@@ -34,32 +53,30 @@ adrkit/
         ├── 0010  Bun toolchain, Node-targeted output      accepted
         ├── 0011  host schema at its $id (adrkit.dev)      accepted
         ├── 0012  explicit catalog owned-paths binding     accepted
-        └── 0013  reconcile 0007/0009 with offline gen     accepted
+        ├── 0013  reconcile 0007/0009 with offline gen     accepted
+        ├── 0014  three-rung phase-landing evidence ladder accepted
+        ├── 0015  validate descriptors before canonicalizing accepted
+        ├── 0016  observed-failing as the coverage bar      accepted
+        ├── 0017  explicit, release-scoped dependency audit accepted
+        ├── 0018  MCP SDK v2, dual-era protocol revisions   accepted
+        └── 0019  ship the Spec Kit extension (spike no-go) accepted
 ```
-
-## Not included — add at repo creation
-
-| File | Why not here |
-|---|---|
-| `LICENSE` (root, Apache-2.0) | Take GitHub's byte-exact copy from the license picker so detection works |
-| `CODE_OF_CONDUCT.md` | Standard template; GitHub's community-health prompt generates it |
-| `SECURITY.md` | Same |
-| `package.json`, lockfile, `packages/` | Phase 0, task seeds 1–7 in `plan.md` |
 
 ## Known-open, deliberately
 
-- CI references `bun run schema:emit`, `bun run check:deps`, `bun run adr lint` —
-  none exist yet. Phase 0 task seeds 2, 3, 6, 7. CI failing until they land is
-  the correct state for a repo whose first commit is its decisions.
-- Schema `$id` is `https://adrkit.dev/...`. Now recorded and hosted — see
-  ADR-0011: the docs site serves the schema byte-for-byte at its `$id` on the
-  apex domain via GitHub Pages, and the hostname is fixed for the life of the
-  major version. Not `mbeacom.github.io` — ADR-0006 publishes under a personal
-  namespace that may later transfer to an org, and a namespace-encoded `$id`
-  breaks every pinned reference on transfer. Remaining owner action: the apex
-  DNS records in Cloudflare (see `site/DEPLOYMENT.md`).
-- ADR-0006 action item 5 — outside-OSS participation obligations — is a gate on
-  going public, not on committing locally.
+- Schema `$id` is `https://adrkit.dev/...` — recorded and hosted per ADR-0011:
+  the docs site serves the schema byte-for-byte at its `$id` on the apex domain
+  via GitHub Pages, and the hostname is fixed for the life of the major version.
+  Not `mbeacom.github.io` — ADR-0006 publishes under a personal namespace that
+  may later transfer to an org, and a namespace-encoded `$id` breaks every
+  pinned reference on transfer.
+- Six records remain `proposed` (0003, 0005–0009). They are queued for review by
+  `adr queue`; being proposed does not stop the code they describe from having
+  shipped, and the queue reports that state rather than hiding it.
+- ADR-0014 rung-3 external/community validation is open for both the Phase 6 ARB
+  queue and the Spec Kit extension. Tracked honestly as absent, never as met.
+- Catalog binding (`packages/adapters/catalog-*`) is not built. The viability
+  spike `specs/009-catalog-binding-viability/` recorded `blocked`.
 - Three open questions at the foot of `plan.md`. Do not let an implementer
   resolve them silently.
 
@@ -72,7 +89,8 @@ independent of the GitHub namespace and unaffected either way.
 
 ## Verification
 
-13 records, ids 0001–0013, no gaps. All at schema 0.1.0. No dangling `relatesTo`.
-No one-way door on the auto tier. No accepted record without a decider or an
-import provenance. JSON Schema and Zod agree on property casing. No `@adr/`
-references remain — the scope is `@adrkit/*` throughout.
+20 files under `docs/adr/` — the template plus 19 records, ids 0001–0019, no
+gaps. All at schema 0.1.0: 13 accepted, 6 proposed, and the template at `draft`.
+No dangling `relatesTo`. No one-way door on the auto tier. No accepted record
+without a decider or an import provenance. JSON Schema and Zod agree on property
+casing. No `@adr/` references remain — the scope is `@adrkit/*` throughout.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -62,6 +62,7 @@ export default defineConfig({
 					items: [
 						{ label: 'Use in CI', slug: 'ci' },
 						{ label: 'MCP setup', slug: 'mcp' },
+						{ label: 'Spec Kit extension', slug: 'spec-kit' },
 					],
 				},
 				{

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -14,7 +14,7 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
 				</svg>
 				CLI works today
 			</span>
-			<span>v0.2.1 on npm · decision memory in git</span>
+			<span>v0.3.0 on npm · decision memory in git</span>
 		</div>
 
 		<h1 id="_top" data-page-title set:html={title} />

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -74,11 +74,12 @@ jobs:
 ```
 
 <Aside type="note" title="Pinning the queue Action">
-	`queue@v0` resolves as of the v0.2.1 release, which moved the `v0` tag to a
-	commit containing `packages/ci/queue/action.yml`. `@v0` is a moving tag; pin
-	the full commit SHA instead if you need a byte-immutable reference. Phase 6 is
-	landed and maintainer reference-verified; external validation
-	([ADR-0014](/adr/) rung 3) remains open.
+	`queue@v0` resolves because the `v0` tag points at a commit containing
+	`packages/ci/queue/action.yml` — first true of the v0.2.1 release, and the tag
+	has moved forward with each release since (currently the v0.3.0 commit). `@v0`
+	is a moving tag; pin the full commit SHA instead if you need a byte-immutable
+	reference. Phase 6 is landed and maintainer reference-verified; external
+	validation ([ADR-0014](/adr/) rung 3) remains open.
 </Aside>
 
 The managed issue's body is the same report you get locally:

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -21,16 +21,18 @@ hero:
 			<span class="adr-status adr-status--current">Published · v0.3.0</span>
 			<p>
 				<code>@adrkit/core</code>, <code>@adrkit/cli</code>,
-				<code>@adrkit/evaluator</code>, and <code>@adrkit/mcp</code> are on npm;
-				the CI Action ships at <code>mbeacom/adrkit/packages/ci@v0</code>.
+				<code>@adrkit/evaluator</code>, and <code>@adrkit/mcp</code> are on npm,
+				plus the independently versioned <code>@adrkit/spec-kit</code>
+				extension; the CI Action ships at
+				<code>mbeacom/adrkit/packages/ci@v0</code>.
 			</p>
 		</div>
 		<div class="adr-status-band__item">
 			<span class="adr-status adr-status--current">Works today</span>
 			<p>
 				Corpus validation, path explanation, graphing, migration, the ARB
-				queue, PR comments, the read-only MCP server, and the deterministic
-				Pass 0 evaluator.
+				queue, PR comments, the read-only MCP server, the Spec Kit
+				extension, and the deterministic Pass 0 evaluator.
 			</p>
 		</div>
 		<div class="adr-status-band__item">
@@ -155,9 +157,10 @@ hero:
 		<header class="adr-section-heading">
 			<h2 id="roadmap">Shipped, and honestly still ahead.</h2>
 			<p>
-				The surfaces once listed here as planned have shipped in v0.2.0. What
-				remains is stated plainly — no item claims more than the repository
-				proves.
+				The surfaces once listed here as planned have shipped — the CI
+				comment, agent retrieval, and Pass 0 in v0.2.0, and the Spec Kit
+				extension since, on its own version line. What remains is stated
+				plainly — no item claims more than the repository proves.
 			</p>
 		</header>
 
@@ -188,6 +191,15 @@ hero:
 				</p>
 			</li>
 			<li class="adr-roadmap__item">
+				<span class="adr-status adr-status--current">Works today</span>
+				<h3>Spec-driven planning</h3>
+				<p>
+					<code>@adrkit/spec-kit</code> adds three namespaced commands to a
+					<a href="https://github.com/github/spec-kit">Spec Kit</a> project, so
+					a plan is written against the decisions that govern it.
+				</p>
+			</li>
+			<li class="adr-roadmap__item">
 				<span class="adr-status adr-status--planned">Planned</span>
 				<h3>Evaluator Passes 1–3</h3>
 				<p>
@@ -207,8 +219,9 @@ hero:
 				<span class="adr-status adr-status--planned">Open</span>
 				<h3>External validation</h3>
 				<p>
-					The ARB queue is maintainer reference-verified; ADR-0014 rung-3
-					external/community validation is still open.
+					The ARB queue and the Spec Kit extension are maintainer
+					reference-verified; ADR-0014 rung-3 external/community validation is
+					still open for both.
 				</p>
 			</li>
 		</ul>

--- a/site/src/content/docs/spec-kit.mdx
+++ b/site/src/content/docs/spec-kit.mdx
@@ -1,0 +1,132 @@
+---
+title: Spec Kit extension
+description: Add adrkit's governing decisions to the Spec Kit plan loop — pull them into context before planning, check the produced plan against them, and draft an ADR from it.
+---
+
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+
+[Spec Kit](https://github.com/github/spec-kit) takes you from `specify` to
+`plan` to `tasks` to `implement`. What it does not do is check the plan it just
+produced against the decisions your organization already made, or record the new
+decisions that plan contains. Every feature starts from an empty context and
+re-litigates settled questions.
+
+`@adrkit/spec-kit` closes that loop, without leaving git.
+
+## What it adds
+
+| Command | What it does | Writes |
+|---|---|---|
+| `/speckit.adrkit.context` | Pulls the decisions governing the paths you're about to touch — **including superseded and rejected ones** — into context before you plan | no |
+| `/speckit.adrkit.check` | Checks a produced plan against the decisions that govern it, routing through the deterministic [Pass 0 evaluator](/commands/#adr-evaluate) when a snapshot bundle is configured | no |
+| `/speckit.adrkit.draft` | Scaffolds a draft ADR from the current plan artifact for you to fill in | one new record |
+
+Plus exactly one hook: `after_plan` **offers** to run
+`/speckit.adrkit.check`. It asks; it does not seize the plan loop.
+
+<Aside type="caution" title="Hooks never write">
+	`draft` is the only command that writes, and it is unreachable from any hook.
+	A plan-phase hook creating records unprompted would manufacture decision
+	memory rather than record it. The boundary is enforced by a test that fails if
+	a hook is ever pointed at a writing command.
+</Aside>
+
+## Requirements
+
+- **Spec Kit `>=0.13.0,<0.16.0`.** The upper bound is a verification boundary,
+  not a guess — the extension is installed and rendered against 0.13.0, 0.14.4,
+  and 0.15.1. Widening past 0.16 means re-verifying, not bumping a number
+  ([ADR-0007](/adr/0007-adapter-isolation-and-public-surface-build/)).
+- **The `adr` CLI** (`@adrkit/cli`), or `ADRKIT_CLI` pointing at its entry point.
+- **An ADR corpus.** Defaults to `docs/adr`.
+
+## Install
+
+<Tabs>
+<TabItem label="Spec Kit catalog">
+
+```sh
+specify extension add adrkit
+```
+
+</TabItem>
+<TabItem label="From a checkout">
+
+```sh
+specify extension add --dev path/to/packages/adapters/spec-kit
+```
+
+</TabItem>
+</Tabs>
+
+Then `/speckit.adrkit.context` is available in your agent, and `/speckit.plan`
+offers the `after_plan` hook.
+
+The package is also published on npm as
+[`@adrkit/spec-kit`](https://www.npmjs.com/package/@adrkit/spec-kit), versioned
+**independently** of the rest of the scope: an adapter's semver contract is with
+its upstream, not with `@adrkit/core`
+([ADR-0007](/adr/0007-adapter-isolation-and-public-surface-build/)). It does not
+move with the repository's release tag.
+
+## Configuration
+
+Every knob is an environment variable, because an extension that needs its own
+config file is an extension nobody installs.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `ADRKIT_DIR` | `docs/adr` | ADR corpus directory |
+| `ADRKIT_CLI` | resolved | Explicit path to the `adr` entry point |
+| `ADRKIT_FEATURE_DIR` | resolved | Override Spec Kit's own feature resolution |
+| `ADRKIT_SNAPSHOT` | unset | Snapshot bundle enabling the deterministic evaluator |
+| `ADRKIT_AS_OF` | today, UTC | Evaluation date |
+
+The CLI is resolved in a fixed order: `ADRKIT_CLI`, then
+`./node_modules/.bin/adr`, then `adr` on `PATH`. **No branch of that reaches the
+network** — a missing CLI is reported, never fetched.
+
+## What is guaranteed
+
+These are enforced by tests, and each was observed failing under a deliberately
+introduced defect before it was trusted
+([ADR-0016](/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage/)).
+
+- **The hook is never mandatory.** A mandatory hook fires without consent; this
+  one renders as an optional prompt.
+- **Failures name what is missing.** "0 decisions govern this" and "I could not
+  see the corpus" never render as the same string, so no command exits 0 having
+  found nothing because it was looking in the wrong place.
+- **`check` mutates nothing** — verified by byte-comparing the whole project
+  tree before and after.
+- **Nothing development-only reaches your repo.** `specify extension add --dev`
+  copies the directory verbatim, so `.extensionignore` keeps the test suite and
+  build config out of your `.specify/extensions/`. The package declares no
+  dependencies at all, so there is never a `node_modules/` to copy.
+
+## Status
+
+Authorized by
+[ADR-0019](/adr/0019-ship-the-spec-kit-extension-treating-the-spike-no-go-as-a-measurement-artifact/),
+which records the `no-go` verdict from the hook-viability spike as a measurement
+artifact of that spike's own verdict procedure — a byte-identical `git status`
+bar applied to `install` and `remove`, lifecycle actions whose entire purpose is
+to write files — rather than a finding against the mechanism, which the spike
+verified working in every respect.
+
+<Aside type="note" title="Landed and reference-verified — not externally validated">
+	Per [ADR-0014](/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder/)
+	this package sits on rungs 1–2. Rung 2 is a maintainer-owned isolated
+	reference repository that reinstalls the extension from a pinned adrkit commit
+	into a real Spec Kit project on every push and weekly, across all three
+	declared upstream versions — 41 self-verifying, fail-closed assertions each.
+	The gate was observed failing on a deliberate divergence before being trusted.
+
+	Rung 3 is **open**: nobody but the maintainer has run this in their own
+	repository yet.
+</Aside>
+
+Full detail lives in
+[`packages/adapters/spec-kit/README.md`](https://github.com/mbeacom/adrkit/blob/main/packages/adapters/spec-kit/README.md)
+and the
+[evidence index](https://github.com/mbeacom/adrkit/blob/main/docs/reference-verification-spec-kit-extension.md).


### PR DESCRIPTION
The `@adrkit/spec-kit` extension shipped, released three times (`spec-kit-v0.1.0` → `v0.1.2`), and existed **nowhere** on adrkit.dev — no page, no sidebar entry, and absent from the homepage's own list of published packages. Meanwhile the site still advertised v0.2.1 two releases after v0.3.0 shipped.

## Added

A **Spec Kit extension** guide at `/spec-kit/`, under **Guides** alongside "Use in CI" and "MCP setup". It covers the three namespaced commands, the optional `after_plan` hook and why `draft` is deliberately unreachable from it, the environment-variable configuration, the guarantees that are enforced by tests rather than convention, and the honest ADR-0014 rung-2 / rung-3-open status.

## Fixed — stale versions

| File | Was |
|---|---|
| `site/src/components/Hero.astro` | homepage hero: "v0.2.1 on npm" |
| `site/src/content/docs/index.mdx` | status band listed four packages, omitting `@adrkit/spec-kit`; roadmap said the planned surfaces "shipped in v0.2.0" |
| `site/src/content/docs/ci.mdx` | the `queue@v0` pinning note explained the tag as of the v0.2.1 release, though `v0` has since moved to the v0.3.0 commit |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | version placeholder `0.2.0`; the "Which surface?" dropdown offered no `@adrkit/spec-kit` to file against |

## Fixed — repository inventory

`MANIFEST.md` is an inventory again rather than a seed-bundle snapshot. It had not been touched since ADR-0013 and still claimed *"13 records, ids 0001–0013"* with statuses six records out of date, no `packages/` tree, and a "not included — add at repo creation" list of files that have existed for months. Now: the real layout including `packages/adapters/spec-kit`, records 0001–0019 with current statuses, and a verification paragraph that matches what `adr lint` actually reports.

`CLAUDE.md` documents `packages/adapters/spec-kit` — specifically the constraints that have each already been broken once: the two version fields (`package.json` + `extension.yml`) that must agree, the independent `spec-kit-v<semver>` release tag, and the no-dependencies / no-`dist` rule.

## Deliberately unchanged

`README.md`, `plan.md`, `docs/RELEASING.md`, `docs/DISTRIBUTION.md`, and `packages/mcp/server.json` were already current. `CHANGELOG.md` gained a `### Documentation` block under Unreleased; nothing in it was corrected.

No release is cut by this — docs and governance changes alone don't move a version.

## Verification

- `site: bun run build` — 29 pages, `/spec-kit/` renders, all four ADR deep links and `/commands/#adr-evaluate` resolve against generated pages
- `bun run adr lint` — checked 19 records, 0 errors, 0 warnings
- `bun test` — 857 pass, 0 fail
- `bun run typecheck`, `bun run check:deps` — clean (`core-has-no-adapter-deps: ok`)