### PR TITLE
ci(codeql): replace default setup with an advanced workflow so required checks report

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,80 @@
+# CodeQL advanced setup.
+#
+# This replaces GitHub's CodeQL *default* setup, which cannot satisfy this
+# repository's ruleset. The `main` ruleset requires the status checks
+# `Analyze (actions)` and `Analyze (javascript-typescript)`, but default setup
+# does not run "on a pull request based against the repository's default branch
+# ... excluding pull requests from forks", so fork PRs (and, observed here,
+# Dependabot PRs) never produce those check runs. A required check that is never
+# reported stays "Expected - Waiting for status to be reported" forever, which
+# blocks the PR with no way to clear it. The same gap is what makes the results
+# check report "N configurations present on refs/heads/main were not found":
+# `main` has a baseline for both languages and the PR has none.
+#
+# Advanced setup fixes both because the workflow is an ordinary `pull_request`
+# workflow: it runs for forks and for Dependabot, and code scanning permits
+# SARIF upload from `pull_request`-triggered runs even under a read-only token.
+#
+# Two things here are load-bearing and easy to break:
+#
+#   - The job name must render exactly `Analyze (actions)` and
+#     `Analyze (javascript-typescript)`. Those strings are the required status
+#     check contexts in the `main` ruleset. Renaming the job, or renaming a
+#     matrix language, silently reintroduces the permanently-pending check.
+#   - `category` must stay `/language:<language>` so analyses keep the same
+#     category keys the default-setup baseline on `main` used, so PR-vs-base
+#     alert comparison keeps working across the switch.
+#
+# Default setup must stay disabled. Re-enabling it disables this workflow and
+# blocks its uploads.
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Keep a baseline on `main` fresh even in quiet weeks, so PR comparison has
+    # something to diff against. Default setup ran weekly; match that.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload SARIF results.
+      security-events: write
+      # Read the workflow run context on private repos / for fork PRs.
+      actions: read
+      contents: read
+    strategy:
+      # One language failing should not mask the other language's findings.
+      fail-fast: false
+      matrix:
+        # `actions` scans .github/workflows and packages/ci/*/action.yml;
+        # `javascript-typescript` covers the TypeScript sources and the
+        # committed Action bundles under packages/ci/dist.
+        language: [actions, javascript-typescript]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        with:
+          languages: ${{ matrix.language }}
+          # Both languages are interpreted, so there is nothing to compile.
+          # This repo builds with Bun, which CodeQL does not drive; scanning
+          # sources directly is what default setup did too.
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

Two symptoms, one root cause.

**1. Required checks never report.** The `main` ruleset requires the status checks `Analyze (actions)` and `Analyze (javascript-typescript)`. Those check runs came from CodeQL **default setup**, which GitHub documents as running on pull requests against the default branch *"excluding pull requests from forks."* When default setup doesn't run, the check runs are never created, and a required check that is never reported sits at `Expected — Waiting for status to be reported` forever. There is no way to clear it, so the PR is permanently blocked.

Observed on the current corpus — neither head SHA has a CodeQL workflow run of any kind:

| PR | Author | CodeQL run on head SHA |
| --- | --- | --- |
| #97 | fork (`aballiet`) | none |
| #99 | Dependabot | none |
| #98 | same-repo branch | ran |

**2. `2 configurations not found`.** The same fault seen from the other side. `main` has a baseline analysis for `/language:actions` and `/language:javascript-typescript`; the PR has neither, so code scanning cannot diff them and reports that it *"cannot determine the alerts introduced by this pull request."*

Requiring the `CodeQL` results check instead would not have helped — on the fork PR that check is absent too. Default setup fundamentally cannot back a required check on a repository that takes fork PRs.

## Fix

Replace default setup with advanced setup: a committed `.github/workflows/codeql.yml`. Because it is an ordinary `pull_request` workflow it runs for forks and for Dependabot, and code scanning permits SARIF upload from `pull_request`-triggered runs even under a read-only token.

Two details are load-bearing:

- The job name renders **exactly** `Analyze (actions)` and `Analyze (javascript-typescript)`, so the existing ruleset contexts keep resolving. **No ruleset edit is required.** Renaming the job or a matrix language silently reintroduces the permanently-pending check.
- `category` stays `/language:<language>`, matching the category keys the default-setup baseline used, so PR-vs-base alert comparison survives the switch.

Both languages are interpreted, so `build-mode: none`. Actions are SHA-pinned with a trailing version comment to match `ci.yml` and to stay in Dependabot's `github-actions` group. A weekly cron preserves the baseline cadence default setup had.

## Repository setting changed

Default setup and advanced setup are mutually exclusive — default setup *"disables any existing CodeQL workflows, and blocks any CodeQL analysis API uploads."* It has been set to `not-configured` via `PATCH /repos/mbeacom/adrkit/code-scanning/default-setup`.

⚠️ **Re-enabling default setup will disable this workflow and block its uploads.**

## Verification

Rung 1 of the [ADR-0014](../blob/main/docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md) ladder is this PR itself: the two required checks must move off `Expected` and report a real conclusion. That is the behavior that was broken, observed directly.

Note that until this lands on `main`, the results check may still warn about stale default-setup configurations, which have a different `analysis_key` (`dynamic/github-code-scanning/codeql:analyze`) than this workflow's. That clears once `main` has a baseline from this workflow; any leftover stale configurations get deleted afterwards.