### PR TITLE
chore(release): v0.4.0 — ratify ADR-0021 and cut the inbound-marker release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,81 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-08
+
+### Added
+
+- **Inbound `@adr <id>` source markers, resolved without a schema change.** A file
+  can now declare the decision it lives under by writing `@adr 0012` on a dedicated
+  comment line in its first 8192 bytes, and `adr explain <path>` reports that record
+  as governing the file alongside the `affects` patterns that already matched it.
+  Until now a decision reached a file in exactly one direction — the record declared
+  `affects` patterns and `resolveAffects` matched repo-relative paths against them,
+  with no way for a file to point back
+  ([ADR-0021](docs/adr/0021-resolve-inbound-source-annotations-without-changing-the-schema.md)).
+  `AdrFrontmatter`, `AffectsType`, and `schema/adr.schema.json` are unchanged, and
+  no runtime dependency is added.
+
+  Contributed by [@aballiet](https://github.com/aballiet) in
+  [#97](https://github.com/mbeacom/adrkit/pull/97), from
+  [#95](https://github.com/mbeacom/adrkit/issues/95) — the first community feature
+  this project has shipped.
+
+  **The asymmetry is deliberate: markers reach `adr explain` and nothing else.**
+  `adr check`, `checkChanges`, the CI Action, and the Spec Kit context script do not
+  scan them, so no CI semantics move and `packages/ci/dist` is byte-identical to
+  v0.3.0. `declaredBy` lands on an explain-only `ExplainedDecision` rather than the
+  shared `GoverningDecision`, so `adr check --json` output is unchanged. Extending
+  enforcement to those surfaces is a separate decision, because it changes CI
+  semantics and moves the filesystem boundary.
+
+  A marker is a *claim*, so both ways it could lie are closed and tested. The
+  scanner requires a **dedicated comment line** — an introducer begins the physical
+  line and `@adr` is the comment's first content — because prose that merely
+  discusses a decision, a string literal containing one, and a trailing
+  `} // @adr 0012` must not make an accepted record binding; across this repository
+  that rule finds 4 marker-looking lines where a looser first draft found 51.
+  **Truncation uses the byte count the read observed** rather than re-deriving it
+  from decoded text: `TextDecoder` may drop a BOM or expand invalid bytes, so a
+  re-derived window can sever a reference mid-token, report a record the file never
+  named, and still claim `truncated: false`. The read is confined to one regular
+  file beneath the working tree, checked lexically before any I/O and again on the
+  real path.
+
+  **Landed** on [ADR-0014](docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md)
+  rung 1 — unit, contract, and purity coverage, plus maintainer verification against
+  the branch. No reference-repository run yet (rung 2 open); not externally
+  validated (rung 3 open).
+
+- The release pipeline now supports **independently versioned, dist-less
+  packages**. `scripts/release-pack.ts` previously asserted that every release
+  package shared one version and shipped a `dist` — both true of a single
+  lockstep Node surface, neither true of an adapter, and forcing them would have
+  contradicted ADR-0007's "adapters ... are versioned independently. Their
+  semver contract is with their upstream, not with our core." Definitions now
+  declare `versioning: 'lockstep' | 'independent'` and `shipsNodeArtifact`, and a
+  package that ships no Node artifact is *rejected* for publishing `dist`.
+  Workspace dependencies also now resolve against the dependency's own version
+  rather than the depender's.
+
+- **Adapter releases.** Independently versioned packages now release on their own
+  tag (`spec-kit-v0.1.0`) rather than riding a lockstep release. Without this,
+  shipping an adapter fix would mean republishing core, evaluator, CLI, and MCP
+  under a new version despite no change to any of them — which would make
+  ADR-0007's "versioned independently" true of the number and false of everything
+  that matters. `release-pack` gains `--only`, the release manifest carries its
+  own `tag`, and the workflow derives scope from the tag: installed-tarball
+  smoke and the `packages/ci/queue@v0` Action tag are lockstep-only. An adapter
+  release also attaches a catalog `.zip` asset, derived from the packed tarball
+  so the npm and catalog artifacts cannot disagree.
+
+### Changed
+
+- ADR-0007's `core-has-no-adapter-deps` assertion is no longer vacuous. It had
+  nothing to guard while `packages/adapters/` was empty; with the first adapter
+  present it has been observed failing against a deliberately introduced
+  `@adrkit/core → @adrkit/spec-kit` dependency.
+
 ### Security
 
 - `BOOTSTRAP_PACKAGES` is empty again. `@adrkit/spec-kit` needed a credential for
@@ -17,6 +92,34 @@ Until `1.0.0`, minor releases may include breaking changes
   on, it publishes over OIDC and the `NPM_BOOTSTRAP_TOKEN` secret can be deleted.
   A test asserts no package receives the credential, and was observed failing
   against a name left in the set.
+
+### Documentation
+
+- **adrkit.dev documents the Spec Kit extension.** It had shipped, been released
+  three times, and existed nowhere on the site — no page, no sidebar entry, and
+  absent from the homepage's own list of published packages. A new
+  [Spec Kit extension](https://adrkit.dev/spec-kit/) guide joins "Use in CI" and
+  "MCP setup", covering the three commands, the optional hook and why `draft` is
+  unreachable from it, the environment-variable configuration, the tested
+  guarantees, and the honest ADR-0014 rung-2 status.
+
+- Stale versions swept out of the docs. The homepage hero still advertised
+  v0.2.1 two releases after v0.3.0 shipped; the roadmap still said "shipped in
+  v0.2.0"; the `queue@v0` pinning note explained the tag as of the v0.2.1
+  release though it has since moved to the v0.3.0 commit; and the bug-report
+  template suggested `0.2.0` as the version to report and offered no
+  `@adrkit/spec-kit` surface to file against.
+
+- `MANIFEST.md` is an inventory again rather than a seed-bundle snapshot. It had
+  not been touched since ADR-0013 and still claimed "13 records, ids 0001–0013"
+  with statuses six records out of date, no `packages/` tree, and a "not
+  included — add at repo creation" list of files that have existed for months.
+
+- `CLAUDE.md` documents `packages/adapters/spec-kit`, including the constraints
+  that have already been broken once each: the two version fields that must
+  agree, the independent release tag, and the no-dependencies/no-`dist` rule.
+
+## [spec-kit-0.1.2] - 2026-08-03
 
 ### Fixed
 
@@ -27,6 +130,10 @@ Until `1.0.0`, minor releases may include breaking changes
   them in sync. A test now asserts they match, and was observed failing against
   the exact 0.1.1 state.
 
+## [spec-kit-0.1.1] - 2026-08-03
+
+### Fixed
+
 - `@adrkit/spec-kit` **0.1.1** ships `LICENSE` and `NOTICE`. 0.1.0 did not: every
   sibling package copies them into `dist` at build time, and this package has no
   build, so nothing carried them. The files are committed rather than generated
@@ -34,6 +141,8 @@ Until `1.0.0`, minor releases may include breaking changes
   `specify extension add --dev` from a checkout — and a generated file would be
   absent from the last one. A test asserts they stay byte-identical to the root
   copies, and that `.extensionignore` never excludes them.
+
+## [spec-kit-0.1.0] - 2026-08-03
 
 ### Added
 
@@ -77,35 +186,6 @@ Until `1.0.0`, minor releases may include breaking changes
   in every respect. Spike 008's verdict, evidence bundle, and audit history are
   unmodified.
 
-- The release pipeline now supports **independently versioned, dist-less
-  packages**. `scripts/release-pack.ts` previously asserted that every release
-  package shared one version and shipped a `dist` — both true of a single
-  lockstep Node surface, neither true of an adapter, and forcing them would have
-  contradicted ADR-0007's "adapters ... are versioned independently. Their
-  semver contract is with their upstream, not with our core." Definitions now
-  declare `versioning: 'lockstep' | 'independent'` and `shipsNodeArtifact`, and a
-  package that ships no Node artifact is *rejected* for publishing `dist`.
-  Workspace dependencies also now resolve against the dependency's own version
-  rather than the depender's.
-
-- **Adapter releases.** Independently versioned packages now release on their own
-  tag (`spec-kit-v0.1.0`) rather than riding a lockstep release. Without this,
-  shipping an adapter fix would mean republishing core, evaluator, CLI, and MCP
-  under a new version despite no change to any of them — which would make
-  ADR-0007's "versioned independently" true of the number and false of everything
-  that matters. `release-pack` gains `--only`, the release manifest carries its
-  own `tag`, and the workflow derives scope from the tag: installed-tarball
-  smoke and the `packages/ci/queue@v0` Action tag are lockstep-only. An adapter
-  release also attaches a catalog `.zip` asset, derived from the packed tarball
-  so the npm and catalog artifacts cannot disagree.
-
-### Changed
-
-- ADR-0007's `core-has-no-adapter-deps` assertion is no longer vacuous. It had
-  nothing to guard while `packages/adapters/` was empty; with the first adapter
-  present it has been observed failing against a deliberately introduced
-  `@adrkit/core → @adrkit/spec-kit` dependency.
-
 ### Fixed
 
 Two packaging defects that only surfaced by installing the extension for real,
@@ -120,32 +200,6 @@ against live Spec Kit, rather than reasoning about it:
 - The install was depositing the extension's own test suite and `tsconfig.json`
   into the consuming project's `.specify/extensions/adrkit/`. Now excluded via
   `.extensionignore`, which upstream supports across the whole pinned range.
-
-### Documentation
-
-- **adrkit.dev documents the Spec Kit extension.** It had shipped, been released
-  three times, and existed nowhere on the site — no page, no sidebar entry, and
-  absent from the homepage's own list of published packages. A new
-  [Spec Kit extension](https://adrkit.dev/spec-kit/) guide joins "Use in CI" and
-  "MCP setup", covering the three commands, the optional hook and why `draft` is
-  unreachable from it, the environment-variable configuration, the tested
-  guarantees, and the honest ADR-0014 rung-2 status.
-
-- Stale versions swept out of the docs. The homepage hero still advertised
-  v0.2.1 two releases after v0.3.0 shipped; the roadmap still said "shipped in
-  v0.2.0"; the `queue@v0` pinning note explained the tag as of the v0.2.1
-  release though it has since moved to the v0.3.0 commit; and the bug-report
-  template suggested `0.2.0` as the version to report and offered no
-  `@adrkit/spec-kit` surface to file against.
-
-- `MANIFEST.md` is an inventory again rather than a seed-bundle snapshot. It had
-  not been touched since ADR-0013 and still claimed "13 records, ids 0001–0013"
-  with statuses six records out of date, no `packages/` tree, and a "not
-  included — add at repo creation" list of files that have existed for months.
-
-- `CLAUDE.md` documents `packages/adapters/spec-kit`, including the constraints
-  that have already been broken once each: the two version fields that must
-  agree, the independent release tag, and the no-dependencies/no-`dist` rule.
 
 ## [0.3.0] - 2026-07-31
 
@@ -314,7 +368,11 @@ against live Spec Kit, rather than reasoning about it:
 - Node-targeted published distribution of all packages, smoke-tested under Node
   22 and 24.
 
-[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/mbeacom/adrkit/compare/v0.3.0...v0.4.0
+[spec-kit-0.1.2]: https://github.com/mbeacom/adrkit/compare/spec-kit-v0.1.1...spec-kit-v0.1.2
+[spec-kit-0.1.1]: https://github.com/mbeacom/adrkit/compare/spec-kit-v0.1.0...spec-kit-v0.1.1
+[spec-kit-0.1.0]: https://github.com/mbeacom/adrkit/releases/tag/spec-kit-v0.1.0
 [0.3.0]: https://github.com/mbeacom/adrkit/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/mbeacom/adrkit/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mbeacom/adrkit/compare/v0.1.0...v0.2.0

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "bin": {
         "adr": "./dist/index.js",
       },
@@ -65,7 +65,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -80,7 +80,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -91,7 +91,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/docs/adr/0021-resolve-inbound-source-annotations-without-changing-the-schema.md
+++ b/docs/adr/0021-resolve-inbound-source-annotations-without-changing-the-schema.md
@@ -2,9 +2,9 @@
 schemaVersion: 0.1.0
 id: "0021"
 title: Resolve inbound source annotations without changing the schema
-status: proposed
+status: accepted
 date: 2026-08-05
-deciders: []
+deciders: ["@mbeacom"]
 tags: [core, cli, matching, governance, agents]
 scope: component
 reversibility: two-way-door
@@ -17,6 +17,16 @@ affects:
     pattern: "packages/cli/src/index.ts"
 provenance:
   authoredBy: agent-drafted
+  ratifiedBy: "@mbeacom"
+review:
+  tier: async
+  tierReason: >-
+    Adds an inbound edge to resolution without touching the schema, and reaches
+    exactly one surface: `adr explain`. `checkChanges`, the Action, and the
+    published `GoverningDecision` shape are unchanged, so no CI semantics and no
+    consumer contract move. What is new is that `@adrkit/core` opens a file
+    during resolution at all, which is why the read boundary and its residual
+    disclosures are stated in this record rather than left to the code.
 reviewBy: 2027-02-05
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Decision memory for human and agent-authored plans — machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ import { isMainModule } from './main-module.ts';
  * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
  * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
  */
-export const CLI_VERSION = '0.3.0';
+export const CLI_VERSION = '0.4.0';
 
 function writeStdout(text: string): void {
   process.stdout.write(text);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adrkit/mcp",
   "mcpName": "dev.adrkit/mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetDecisionContext } from './tools/get-decision-context.ts';
 import { registerListSuperseded } from './tools/list-superseded.ts';
 import type { ToolConfig } from './tools/shared.ts';
 
-export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.3.0' } as const;
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.4.0' } as const;
 
 /**
  * The MCP protocol revision this server serves through `serveStdio`'s modern era.


### PR DESCRIPTION
Cuts **v0.4.0**, the release that ships #97.

The only change to a published package since `v0.3.0` is the inbound `@adr` marker feature. Everything else on `main` since then is the unpublished catalog adapter (`@adrkit/catalog-backstage` is at `0.0.0` and is not in `release-pack.ts`'s package list), specs, docs, or dependency bumps. Minor rather than patch: `@adrkit/core` gains exports and `adr explain` gains output, nothing is removed.

## What's in it

**Version bump to 0.4.0** across the four lockstep manifests, the root manifest, `packages/mcp/server.json` (both the registry `version` and `packages[0].version` that the MCP registry validates as a pair), and the two hardcoded constants `CLI_VERSION` and `SERVER_INFO`. Each constant is guarded by its own test, so both were caught by `bun test` rather than by reading.

**ADR-0021 moves from `proposed` to `accepted`.** It shipped in #97 while still proposed, which meant the tool reported this about the code that record authorizes:

```
$ adr explain packages/core/src/markers/scan.ts
No accepted decision governs packages/core/src/markers/scan.ts.
Active proposals (not yet binding):
  0021  [proposed] Resolve inbound source annotations without changing the schema
```

A decision-memory tool should not publish a feature its own corpus reports as ungoverned. It now reads `0021 [accepted] ... via path: packages/core/src/markers/**`. The record also gains the `review:` block every other non-template ADR carries; `tier: async` follows ADR-0018, the only other component-scoped record. `adr lint` is clean at 21 records, 0 errors, 0 warnings.

**The changelog gets adapter sections.** `@adrkit/spec-kit` 0.1.0, 0.1.1 and 0.1.2 shipped on their own `spec-kit-v*` tags per ADR-0007, so rolling them into `[0.4.0]` would file already-released adapter work under a lockstep version that never carried it. Their entries move verbatim into `[spec-kit-0.1.0]`, `[spec-kit-0.1.1]` and `[spec-kit-0.1.2]`, dated from the tags. The release-pipeline and documentation work that shipped with the lockstep surface stays in `[0.4.0]`, alongside the new markers entry.

**`bun.lock` carries four workspace `version` fields and nothing else.** `release-pack` validates that a packed dependency resolves to the dependency's own version, and it caught the stale lockfile: `@adrkit/evaluator must resolve @adrkit/core to 0.4.0, got 0.3.0`. Neither `bun install` nor `bun install --force` refreshes those fields. Regenerating the lockfile does, but it also pulls transitive drift (`jose` 6.2.3 → 6.2.8, `undici` 6.27.0 → 6.28.0, `@octokit/types` 16 → 17, `@types/node` 26.1.1 → 26.1.2) into a release commit that has no business carrying it, so the four lines are edited directly and `bun install --frozen-lockfile` confirms the result is self-consistent.

## Verification

| Step | Result |
|---|---|
| `bun test` | 1840 pass, 0 fail |
| `bun run typecheck` / `lint` / `build` | clean |
| `bun run check:deps` | `core-has-no-adapter-deps: ok` |
| `bun run schema:emit` | no diff |
| `bun run release:pack -- --tag v0.4.0` | prepared 5 packages |
| `node .release/smoke/smoke.mjs` | passes on **22.22.2** and **24.16.0** |
| `packages/ci/dist` vs `v0.3.0` | byte-identical |

`packages/ci/dist` being byte-identical means `mbeacom/adrkit/packages/ci@v0` needs no move for content; the workflow's force-update of the major tag is a no-op relocation to the release commit.

## One thing the simulation gets wrong, and it is not this release

`bun run release:publish -- --dry-run` passes all four lockstep packages at 0.4.0 and then fails:

```
npm error You cannot publish over the previously published versions: 0.1.2.
error: Publishing @adrkit/spec-kit@0.1.2 failed with exit 1
```

The registry idempotency check that skips an already-published artifact lives inside `if (!dryRun)` in `release-publish.ts:135`, so the dry run never consults the registry and asks npm to republish a version that exists. The real path does check, and the packed tarball is byte-identical to what is published:

```
packed now:  sha512-63jDIb5zYogVOb9Z4nDU+jgyL28UBUs0GPvHhz1Ec1eCvGClXhxSAz2La6hzBprccnHISeHRqbVFR9N+yH0LVA==
registry:    sha512-63jDIb5zYogVOb9Z4nDU+jgyL28UBUs0GPvHhz1Ec1eCvGClXhxSAz2La6hzBprccnHISeHRqbVFR9N+yH0LVA==
```

So the real run logs `already matches; skipping`. This is the first lockstep release since an independently versioned adapter existed, which is why nobody has hit it before, and it will now fail the documented local simulation on every lockstep release. Filed separately rather than fixed here, because changing `release-publish.ts` needs a test observed failing (ADR-0016) and that does not belong in a release cut.

## Follow-ups, deliberately not in this PR

- **The dry-run gap above** (#104).
- **Post-release docs sync.** `README.md`, `CLAUDE.md`, and `docs/DISTRIBUTION.md` still say v0.3.0. They are left alone on purpose: the v0.3.0 cutover synced docs in #81, which is a descendant of the `v0.3.0` tag. Claiming "v0.4.0 on npm" before it is published would be briefly false.
- **`@adrkit/mcp` registry re-publication at 0.4.0**, as was done for 0.3.0.
