### PR TITLE
chore(release): v0.5.0 — ratify ADR-0022 and ADR-0023, retire ADR-0021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-10
+
 ### Added
 
 - `adr check` and the governing-decisions Action now resolve inbound `@adr`
@@ -20,8 +22,15 @@ Until `1.0.0`, minor releases may include breaking changes
 
   This answers the separate decision ADR-0021 left open rather than revising it.
   [ADR-0022](docs/adr/0022-scan-inbound-markers-in-check-and-ci-without-giving-them-exit-code-authority.md)
-  supersedes ADR-0021, which stands unedited as the record of the explain-only
-  scope shipped in v0.4.0.
+  supersedes ADR-0021, whose argument stands unedited as the record of the
+  explain-only scope shipped in v0.4.0; only its `status` and `supersededBy`
+  moved when ADR-0022 was ratified.
+
+- **Three new `@adrkit/core` runtime exports**, pinned by the package surface
+  test: `readSourceMarkersBatch`, the impure batch boundary callers use to
+  pre-scan before the pure `checkChanges`; and `MARKER_SCAN_FILE_CAP` /
+  `MARKER_SCAN_CONCURRENCY`, the bounds it enforces. Additive — nothing was
+  removed or renamed.
 
 - **`{/*` is accepted as a comment introducer.** MDX rejects `<!-- -->`, so the
   markdown introducer rule under *Fixed* below would otherwise leave that dialect
@@ -46,6 +55,15 @@ Until `1.0.0`, minor releases may include breaking changes
   both sides of a rename for `affects` matching. Previous rename paths can no longer
   consume the 3,000-file scan budget and cause a current file's marker-only
   governance to be skipped.
+- The Action no longer hands deleted files to the marker scanner. A `removed` path
+  is guaranteed absent in the checkout, so it consumed a scan slot only to report
+  `absent` — the one signal that would otherwise tell an operator the checkout does
+  not match the pull request head.
+- Marker path selection and every `markerScan` path list now sort by code unit
+  rather than `localeCompare`, whose order depends on the runtime's ICU locale.
+  The sort decides which paths survive the 3,000-file cap and which ten appear in
+  the `marker-scan-capped` warning, so two environments could disagree on both
+  while `CheckOutcome` promises identical inputs produce identical output.
 
 - **A fenced documentation example no longer declares the decision it
   illustrates.** `@adr` markers are now skipped inside ` ``` ` and `~~~` fenced
@@ -446,7 +464,8 @@ against live Spec Kit, rather than reasoning about it:
 - Node-targeted published distribution of all packages, smoke-tested under Node
   22 and 24.
 
-[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/mbeacom/adrkit/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/mbeacom/adrkit/compare/v0.3.0...v0.4.0
 [spec-kit-0.1.2]: https://github.com/mbeacom/adrkit/compare/spec-kit-v0.1.1...spec-kit-v0.1.2
 [spec-kit-0.1.1]: https://github.com/mbeacom/adrkit/compare/spec-kit-v0.1.0...spec-kit-v0.1.1

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "bin": {
         "adr": "./dist/index.js",
       },
@@ -65,7 +65,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -80,7 +80,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -91,7 +91,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/docs/adr/0021-resolve-inbound-source-annotations-without-changing-the-schema.md
+++ b/docs/adr/0021-resolve-inbound-source-annotations-without-changing-the-schema.md
@@ -2,13 +2,14 @@
 schemaVersion: 0.1.0
 id: "0021"
 title: Resolve inbound source annotations without changing the schema
-status: accepted
+status: superseded
 date: 2026-08-05
 deciders: ["@mbeacom"]
 tags: [core, cli, matching, governance, agents]
 scope: component
 reversibility: two-way-door
 blastRadius: component
+supersededBy: "0022"
 relatesTo: ["0009", "0012", "0014", "0016"]
 affects:
   - type: path

--- a/docs/adr/0022-scan-inbound-markers-in-check-and-ci-without-giving-them-exit-code-authority.md
+++ b/docs/adr/0022-scan-inbound-markers-in-check-and-ci-without-giving-them-exit-code-authority.md
@@ -2,9 +2,9 @@
 schemaVersion: 0.1.0
 id: "0022"
 title: Scan inbound markers in check and CI without giving them exit-code authority
-status: proposed
+status: accepted
 date: 2026-08-08
-deciders: []
+deciders: ["@mbeacom"]
 tags: [core, cli, ci, matching, governance, agents]
 scope: component
 reversibility: two-way-door
@@ -22,6 +22,22 @@ affects:
     pattern: "packages/ci/src/**"
 provenance:
   authoredBy: agent-drafted
+  ratifiedBy: "@mbeacom"
+review:
+  tier: arb
+  tierReason: >-
+    ADR-0021 reached `adr explain`, a command a developer runs against a file
+    they already own, and took the `async` tier on that basis. This record points
+    the same reader at content a fork pull request authored, inside CI, and
+    renders strings derived from it into a comment signed by
+    github-actions[bot]. That is a change of kind rather than of degree — the
+    first time `@adrkit/core` opens untrusted input in an automated context — and
+    it is why this record carries a cross-team blast radius where its predecessor
+    carried component. The failure modes are all quiet ones: an existence oracle
+    handed to a fork, a live link inside a trusted comment, a 422 turning
+    authored content into a failed check. Two of those three were closed by
+    review rather than by design, which is the argument for the higher tier
+    rather than against it.
 reviewBy: 2027-02-08
 ---
 

--- a/docs/adr/0023-read-a-marker-only-where-the-format-hides-it-fences-and-markdown-prose.md
+++ b/docs/adr/0023-read-a-marker-only-where-the-format-hides-it-fences-and-markdown-prose.md
@@ -2,9 +2,9 @@
 schemaVersion: 0.1.0
 id: "0023"
 title: "Read a marker only where the format hides it: fences and markdown prose"
-status: proposed
+status: accepted
 date: 2026-08-10
-deciders: []
+deciders: ["@mbeacom"]
 tags: [core, matching, governance, agents, docs]
 scope: component
 reversibility: two-way-door
@@ -15,6 +15,7 @@ affects:
     pattern: "packages/core/src/markers/**"
 provenance:
   authoredBy: agent-drafted
+  ratifiedBy: "@mbeacom"
 review:
   tier: async
   tierReason: >-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Decision memory for human and agent-authored plans — machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,7 @@ import { isMainModule } from './main-module.ts';
  * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
  * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
  */
-export const CLI_VERSION = '0.4.0';
+export const CLI_VERSION = '0.5.0';
 
 function writeStdout(text: string): void {
   process.stdout.write(text);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adrkit/mcp",
   "mcpName": "dev.adrkit/mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetDecisionContext } from './tools/get-decision-context.ts';
 import { registerListSuperseded } from './tools/list-superseded.ts';
 import type { ToolConfig } from './tools/shared.ts';
 
-export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.4.0' } as const;
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.5.0' } as const;
 
 /**
  * The MCP protocol revision this server serves through `serveStdio`'s modern era.


### PR DESCRIPTION
# What and why

Cuts **v0.5.0** and ratifies the three records behind it.

This is the release where inbound `@adr` markers stop being a single local
command and start appearing in pull-request comments. ADR-0023 rides along
deliberately: the window in which the loose marker grammar is visible *in CI* is
exactly the window between two releases, so shipping #106 and #109 together means
no adopter ever sees `* @adr 0012` in a `NOTES.md` produce a governing decision
and then watch it disappear on upgrade.

## Governance

| Record | Before | After |
|---|---|---|
| [ADR-0021](docs/adr/0021-resolve-inbound-source-annotations-without-changing-the-schema.md) | `accepted` | `superseded`, `supersededBy: "0022"` |
| [ADR-0022](docs/adr/0022-scan-inbound-markers-in-check-and-ci-without-giving-them-exit-code-authority.md) | `proposed` | `accepted`, `deciders: ["@mbeacom"]`, `provenance.ratifiedBy`, `review.tier: arb` |
| [ADR-0023](docs/adr/0023-read-a-marker-only-where-the-format-hides-it-fences-and-markdown-prose.md) | `proposed` | `accepted`, `deciders: ["@mbeacom"]`, `provenance.ratifiedBy` |

ADR-0021's argument is untouched — only `status` and `supersededBy` moved, so the
record of the explain-only scope shipped in v0.4.0 still reads as written.

Nothing mechanical enforces the retirement: `corpus-invariants.ts` only checks
reference resolvability, and the schema only couples `status: superseded` with
`supersededBy` in both directions. Verified functionally rather than assumed —
`adr check packages/core/src/markers/read.ts` now reports:

```
Decisions governing this change:
  0022  [accepted] Scan inbound markers in check and CI without giving them exit-code authority
  0023  [accepted] Read a marker only where the format hides it: fences and markdown prose
Historical records that once covered this change (not binding):
  0021  [superseded] Resolve inbound source annotations without changing the schema (superseded by 0022)
```

## Why ADR-0022 takes the `arb` tier

0022 shipped without a `review` block at all, which made it the only ratified
record in the corpus carrying no routing tier. Filling that in turned out to need
an actual judgment rather than a copied value, because the corpus's two signals
disagree here.

Surveying all 24 records: `arb` tracks `scope: org` (17 records), `async` tracks
the narrower ones (0016, 0017, 0018, 0021, 0023). **0022 is the only record in
the corpus with `blastRadius: cross-team` at `scope: component`** — by scope it
looks like `async`, by blast radius it looks like `arb`.

Resolved toward `arb`, and the reason is now in the record: ADR-0021 reached
`adr explain`, a command run against a file the caller owns. 0022 points the same
reader at content a fork pull request authored, inside CI, and renders strings
derived from it into a comment signed by `github-actions[bot]`. That is a change
of kind — the first time `@adrkit/core` opens untrusted input in an automated
context — and it is precisely why 0022's blast radius is cross-team where its
predecessor's was component. Its failure modes are all quiet: an existence oracle
handed to a fork, a live link in a trusted comment, a `422` turning authored
content into a failed check. Two of those three were closed by review rather than
by design, which argues for the higher tier rather than against it.

Held to the corpus's actual convention on shape: `tier` + `tierReason` only,
matching 0016/0017/0018/0021/0023. `queuedAt`/`slaDays` appear only on the six
records from the original 2026-07-28 queueing batch, and `approvals`,
`decidedAt`, `quorum`, and `objections` are used nowhere in the corpus — so none
were invented here.

If you read the scope axis as decisive instead, this is a one-word change to
`async`; the tierReason explains the call either way.

## Why minor, not patch

Two things exceed the patch rule in `docs/RELEASING.md`:

- **Three additive runtime exports** on `@adrkit/core` — `readSourceMarkersBatch`,
  `MARKER_SCAN_FILE_CAP`, `MARKER_SCAN_CONCURRENCY` — all pinned by
  `packages/core/test/surface.test.ts`. Nothing removed or renamed.
- **`scanSourceMarkers(source, path)` now varies with `path`.** Same signature,
  different semantics: the extension selects the introducer set, so two files with
  identical bytes scan differently. TypeScript will not catch this for an existing
  caller, which is why it is called out here and in the changelog. It is fail-safe
  — it only ever removes a declaration, plus the one addition of `{/*`.

## Version surfaces touched

The four lockstep manifests, plus the three places a version is duplicated
outside them: `CLI_VERSION`, `SERVER_INFO`, and both fields in
`packages/mcp/server.json`. Also the four `bun.lock` workspace `version` lines —
edited by hand per `docs/RELEASING.md`, because neither `bun install` nor
`bun install --force` refreshes them, and regenerating the lockfile pulls
transitive `@octokit/*` drift into the release commit (confirmed: it did, and was
reverted).

## Changelog

`[Unreleased]` promoted to `[0.5.0]`, link refs added. Three corrections while
promoting:

- The entry claimed ADR-0021 "stands unedited" — true of its argument, false of
  its frontmatter once ratified here. Reworded rather than left to imply the
  record was untouched.
- The deleted-file marker-slot fix from #106's revisions was not recorded.
- The `localeCompare` → code-unit sort from #106's revisions was not recorded,
  including that it decides which paths survive the cap and which ten appear in
  the `marker-scan-capped` warning.

## Verification

Run on this branch:

| Gate | Result |
|---|---|
| `bun test` | **1895 pass, 0 fail** |
| `bun run typecheck` | clean |
| `bun run lint` | clean |
| `bun run adr lint` | **23 records, 0 errors, 0 warnings** |
| `bun run build` → `git status packages/ci/dist` | no drift |
| `bun run schema:emit` | no diff |
| `bun run check:deps` | ok |
| `bun run check:freeze-hashes` | ok (2 artifacts) |
| `bun run audit:gate` | PASSED — 0 high, 0 critical (3 moderate) |
| `bun run release:pack -- --tag v0.5.0` | 5 packages prepared; `git status` clean afterwards |
| `bun install --frozen-lockfile` | clean after the hand-edited lock |
| `adr queue` | 0022/0023 correctly absent — the queue projects `proposed` only |

`.release/npm/` contains `adrkit-{core,evaluator,cli,mcp}-0.5.0.tgz` plus
`adrkit-spec-kit-0.1.2.tgz` riding along unchanged.

## Not done here — needs you

- **Node 22 and Node 24 installed-tarball smoke.** Requires switching Node
  versions in one shell; not something to fake.
- **`bun run release:publish -- --dry-run`.** Expected to fail on the adapter
  (#104) — the idempotency skip is gated behind `!dryRun`, so it tries to
  republish `@adrkit/spec-kit` at its current version. The four lockstep packages
  dry-run cleanly first.
- **Tag `v0.5.0` and move `v0`** (`bun run release:action-tag`) after npm succeeds.

## Follow-ups, not blockers

Post-release docs sync (matching #105): `README.md:228,234`,
`site/src/components/Hero.astro:17`, `ci.mdx:42,79`, `index.mdx:21`,
`quickstart.mdx:13`, and `docs/RELEASING.md:12,17`. Plus the four open items from
the #106 review — marker-per-scan cap, scan health in the rendered comment,
`toForwardSlash` divergence, and the remaining `uniqueSorted` `localeCompare`.

One structural note worth its own issue: `adr queue` emits `item.tier-absent`
only when a `review` block exists but omits `tier`. A record with no `review`
block at all — which is what 0022 was — produces no finding, so it can be
ratified carrying no routing tier without anything noticing. That is the gap that
let this one through.
