### PR TITLE
fix(core,ci): sort corpus discovery by code unit, not localeCompare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,19 @@ Until `1.0.0`, minor releases may include breaking changes
   rather than `localeCompare` (#115): `CheckOutcome.changedFiles` (which also
   decides `changedRecords`), the shared `sortFindings` tuple that orders every
   findings array, the Action's `changedFiles` / `markerFiles` /
-  changed-dependency lists, and corpus discovery in
+  changed-dependency lists, corpus discovery in
   `packages/core/src/load/corpus.ts` (`discoverAdrFiles`,
-  `discoverSkippedMarkdownFiles`, `expandRecordInputs`). Identical inputs now
-  serialize to identical bytes regardless of the runtime's ICU locale for those
-  surfaces — but the contract is **not** fully closed. One tree still reaches
+  `discoverSkippedMarkdownFiles`, `expandRecordInputs`), and `lintCorpus`'s own
+  `scannedDirectories` and `records` sorts in
+  `packages/core/src/validate/index.ts`. Identical inputs now serialize to
+  identical bytes regardless of the runtime's ICU locale for those surfaces —
+  but the contract is **not** fully closed. One tree still reaches
   `CheckOutcome` through `localeCompare` and remains recorded on #115: the three
   sorts under `packages/core/src/affects/**`, pinned byte-identical by feature
   010's FR-004 guard until a separately-authorized unfreeze. The ordering guard
-  tests deliberately exclude that tree until it is addressed — see their header
-  for why.
+  now scans whole directories rather than a file allowlist, so a new module on
+  the scanned path is covered the day it lands; `affects/**` stays excluded, and
+  its header explains why.
 
   The `load/corpus.ts` half of this was live, not theoretical. Under a
   duplicate-id corpus, `discoverAdrFiles`'s locale-dependent discovery order
@@ -36,7 +39,28 @@ Until `1.0.0`, minor releases may include breaking changes
   duplicate-id case order-invariant and was observed failing against the
   `localeCompare` implementation (ADR-0016).
 
+  The `validate/index.ts` sorts are a narrower fix. For *distinct* ids
+  `records` order does not reach `CheckOutcome` — `resolveAffects` re-sorts its
+  matches totally by `recordId`, so the frozen `affects/**` sort, not this one,
+  decides `governedBy` order; and for *equal* ids the comparison is a no-op that
+  simply carries discovery order through. What changes is
+  `LintCorpusResult.records`, a public `@adrkit/core` surface a caller can
+  observe directly, which mixed-case ULID ids could previously order by locale.
+
+  Because `records` was already reordered downstream, note that a clean run of
+  the ordering guard means "no scanned module reaches for `localeCompare`" — not
+  "`check --json` is locale-independent end to end". That stronger statement
+  holds only once #115's `affects/**` remainder lands.
+
 ### Added
+
+- **One new `@adrkit/core` runtime export**, pinned by the package surface test:
+  `compareByDisplayPath(a, b, cwd)`, the code-unit comparison of two paths by
+  their normalized display form. It is the composition of the already-public
+  `compareCodeUnits` and `normalizeDisplayPath`, and it exists so the corpus
+  orderings settle their locale-independence in one place instead of repeating
+  the compound expression at each call site. Additive — nothing was removed or
+  renamed.
 
 - `adr check` and the governing-decisions Action now resolve inbound `@adr`
   markers from changed files. Reads are hoisted outside pure `checkChanges`, bounded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,23 +14,27 @@ Until `1.0.0`, minor releases may include breaking changes
 - Some of the `check --json` determinism-contract sorts now order by code unit
   rather than `localeCompare` (#115): `CheckOutcome.changedFiles` (which also
   decides `changedRecords`), the shared `sortFindings` tuple that orders every
-  findings array, and the Action's `changedFiles` / `markerFiles` /
-  changed-dependency lists. Identical inputs now serialize to identical bytes
-  regardless of the runtime's ICU locale for those surfaces — but the contract
-  is **not** fully closed. Two trees still reach `CheckOutcome` through
-  `localeCompare` and remain recorded on #115: the three sorts under
-  `packages/core/src/affects/**`, pinned byte-identical by feature 010's FR-004
-  guard until a separately-authorized unfreeze; and `packages/core/src/load/corpus.ts`
-  (`discoverAdrFiles`, `discoverSkippedMarkdownFiles`, `expandRecordInputs`),
-  out of scope for this sweep and left for a follow-up PR. The `load/corpus.ts`
-  gap is live, not theoretical — under a duplicate-id corpus, `discoverAdrFiles`'s
-  locale-dependent discovery order survives into `lintCorpus`'s `records` (the
-  `frontmatter.id` tiebreak is a no-op for equal ids), and `checkChanges` picks
-  whichever duplicate landed later as the id's canonical record. `ok` and
-  `findings` are unaffected, but `governing` / `activeProposals` / `governedBy`
-  can differ by runtime for byte-identical inputs. The new ordering guard tests
-  deliberately exclude both trees until each is addressed — see their headers
+  findings array, the Action's `changedFiles` / `markerFiles` /
+  changed-dependency lists, and corpus discovery in
+  `packages/core/src/load/corpus.ts` (`discoverAdrFiles`,
+  `discoverSkippedMarkdownFiles`, `expandRecordInputs`). Identical inputs now
+  serialize to identical bytes regardless of the runtime's ICU locale for those
+  surfaces — but the contract is **not** fully closed. One tree still reaches
+  `CheckOutcome` through `localeCompare` and remains recorded on #115: the three
+  sorts under `packages/core/src/affects/**`, pinned byte-identical by feature
+  010's FR-004 guard until a separately-authorized unfreeze. The ordering guard
+  tests deliberately exclude that tree until it is addressed — see their header
   for why.
+
+  The `load/corpus.ts` half of this was live, not theoretical. Under a
+  duplicate-id corpus, `discoverAdrFiles`'s locale-dependent discovery order
+  survived into `lintCorpus`'s `records` (the `frontmatter.id` tiebreak is a
+  no-op for equal ids over a stable sort), and `checkChanges` picked whichever
+  duplicate landed later as the id's canonical record — so `governing` /
+  `activeProposals` / `governedBy` could differ by runtime for byte-identical
+  inputs while `ok` and `findings` stayed the same. A regression test pins the
+  duplicate-id case order-invariant and was observed failing against the
+  `localeCompare` implementation (ADR-0016).
 
 ### Added
 

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -47499,6 +47499,13 @@ function parseFrontmatter(source) {
 // ../core/src/load/corpus.ts
 import { readdir as readdir2, readFile, stat as stat2 } from "node:fs/promises";
 import { basename, isAbsolute, join, relative, resolve, sep as sep2 } from "node:path";
+
+// ../core/src/ordering/index.ts
+function compareCodeUnits(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+// ../core/src/load/corpus.ts
 var RECORD_FILE_PATTERN = /^[0-9]{4,}-.+\.md$/;
 var TEMPLATE_FILE_NAME = "0000-template.md";
 var NON_RECORD_FILE_NAMES = new Set(["readme.md", "index.md", "contributing.md", "template.md"]);
@@ -47519,7 +47526,7 @@ function toAbsolutePath(path, cwd = process.cwd()) {
 async function discoverAdrFiles(dir = "docs/adr", cwd = process.cwd()) {
   const absoluteDir = toAbsolutePath(dir, cwd);
   const entries = await readdir2(absoluteDir, { withFileTypes: true });
-  return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+  return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)));
 }
 var MAX_SKIP_SCAN_DEPTH = 8;
 async function collectSkippedMarkdown(absoluteDir, depth, found) {
@@ -47545,7 +47552,7 @@ async function collectSkippedMarkdown(absoluteDir, depth, found) {
 async function discoverSkippedMarkdownFiles(dir = "docs/adr", cwd = process.cwd()) {
   const found = [];
   await collectSkippedMarkdown(toAbsolutePath(dir, cwd), 0, found);
-  return found.sort((a, b) => normalizeDisplayPath(a.path, cwd).localeCompare(normalizeDisplayPath(b.path, cwd)));
+  return found.sort((a, b) => compareCodeUnits(normalizeDisplayPath(a.path, cwd), normalizeDisplayPath(b.path, cwd)));
 }
 async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) {
   if (!paths || paths.length === 0) {
@@ -47565,7 +47572,7 @@ async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) 
       expanded.push(absolutePath);
     }
   }
-  return Array.from(new Set(expanded)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+  return Array.from(new Set(expanded)).sort((a, b) => compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)));
 }
 async function parseAdrFile(path, cwd = process.cwd()) {
   const absolutePath = toAbsolutePath(path, cwd);
@@ -47585,11 +47592,6 @@ function decisionBucketFor(status) {
     return "activeProposals";
   return "history";
 }
-// ../core/src/ordering/index.ts
-function compareCodeUnits(a, b) {
-  return a < b ? -1 : a > b ? 1 : 0;
-}
-
 // ../core/src/validate/findings.ts
 function compareOptional(a, b) {
   return compareCodeUnits(a ?? "", b ?? "");

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -47523,10 +47523,13 @@ function normalizeDisplayPath(path, cwd = process.cwd()) {
 function toAbsolutePath(path, cwd = process.cwd()) {
   return isAbsolute(path) ? path : resolve(cwd, path);
 }
+function compareByDisplayPath(a, b, cwd = process.cwd()) {
+  return compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd));
+}
 async function discoverAdrFiles(dir = "docs/adr", cwd = process.cwd()) {
   const absoluteDir = toAbsolutePath(dir, cwd);
   const entries = await readdir2(absoluteDir, { withFileTypes: true });
-  return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)));
+  return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => compareByDisplayPath(a, b, cwd));
 }
 var MAX_SKIP_SCAN_DEPTH = 8;
 async function collectSkippedMarkdown(absoluteDir, depth, found) {
@@ -47552,7 +47555,7 @@ async function collectSkippedMarkdown(absoluteDir, depth, found) {
 async function discoverSkippedMarkdownFiles(dir = "docs/adr", cwd = process.cwd()) {
   const found = [];
   await collectSkippedMarkdown(toAbsolutePath(dir, cwd), 0, found);
-  return found.sort((a, b) => compareCodeUnits(normalizeDisplayPath(a.path, cwd), normalizeDisplayPath(b.path, cwd)));
+  return found.sort((a, b) => compareByDisplayPath(a.path, b.path, cwd));
 }
 async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) {
   if (!paths || paths.length === 0) {
@@ -47572,7 +47575,7 @@ async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) 
       expanded.push(absolutePath);
     }
   }
-  return Array.from(new Set(expanded)).sort((a, b) => compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)));
+  return Array.from(new Set(expanded)).sort((a, b) => compareByDisplayPath(a, b, cwd));
 }
 async function parseAdrFile(path, cwd = process.cwd()) {
   const absolutePath = toAbsolutePath(path, cwd);
@@ -47815,7 +47818,7 @@ async function scannedDirectories(paths, dir, cwd) {
     if (await isDirectory2(absolutePath))
       directories.add(absolutePath);
   }
-  return [...directories].sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+  return [...directories].sort((a, b) => compareByDisplayPath(a, b, cwd));
 }
 async function lintCorpus(options = {}) {
   const cwd = options.cwd ?? process.cwd();
@@ -47848,7 +47851,7 @@ async function lintCorpus(options = {}) {
   return {
     checked: files.length,
     findings: sortFindings(findings),
-    records: [...records].sort((a, b) => a.frontmatter.id.localeCompare(b.frontmatter.id))
+    records: [...records].sort((a, b) => compareCodeUnits(a.frontmatter.id, b.frontmatter.id))
   };
 }
 // ../core/src/affects/inert.ts

--- a/packages/ci/dist/queue-action.js
+++ b/packages/ci/dist/queue-action.js
@@ -45853,10 +45853,13 @@ function normalizeDisplayPath(path, cwd = process.cwd()) {
 function toAbsolutePath(path, cwd = process.cwd()) {
   return isAbsolute(path) ? path : resolve(cwd, path);
 }
+function compareByDisplayPath(a, b, cwd = process.cwd()) {
+  return compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd));
+}
 async function discoverAdrFiles(dir = "docs/adr", cwd = process.cwd()) {
   const absoluteDir = toAbsolutePath(dir, cwd);
   const entries = await readdir2(absoluteDir, { withFileTypes: true });
-  return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)));
+  return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => compareByDisplayPath(a, b, cwd));
 }
 var MAX_SKIP_SCAN_DEPTH = 8;
 async function collectSkippedMarkdown(absoluteDir, depth, found) {
@@ -45882,7 +45885,7 @@ async function collectSkippedMarkdown(absoluteDir, depth, found) {
 async function discoverSkippedMarkdownFiles(dir = "docs/adr", cwd = process.cwd()) {
   const found = [];
   await collectSkippedMarkdown(toAbsolutePath(dir, cwd), 0, found);
-  return found.sort((a, b) => compareCodeUnits(normalizeDisplayPath(a.path, cwd), normalizeDisplayPath(b.path, cwd)));
+  return found.sort((a, b) => compareByDisplayPath(a.path, b.path, cwd));
 }
 async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) {
   if (!paths || paths.length === 0) {
@@ -45902,7 +45905,7 @@ async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) 
       expanded.push(absolutePath);
     }
   }
-  return Array.from(new Set(expanded)).sort((a, b) => compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)));
+  return Array.from(new Set(expanded)).sort((a, b) => compareByDisplayPath(a, b, cwd));
 }
 async function parseAdrFile(path, cwd = process.cwd()) {
   const absolutePath = toAbsolutePath(path, cwd);
@@ -46137,7 +46140,7 @@ async function scannedDirectories(paths, dir, cwd) {
     if (await isDirectory2(absolutePath))
       directories.add(absolutePath);
   }
-  return [...directories].sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+  return [...directories].sort((a, b) => compareByDisplayPath(a, b, cwd));
 }
 async function lintCorpus(options = {}) {
   const cwd = options.cwd ?? process.cwd();
@@ -46170,7 +46173,7 @@ async function lintCorpus(options = {}) {
   return {
     checked: files.length,
     findings: sortFindings(findings),
-    records: [...records].sort((a, b) => a.frontmatter.id.localeCompare(b.frontmatter.id))
+    records: [...records].sort((a, b) => compareCodeUnits(a.frontmatter.id, b.frontmatter.id))
   };
 }
 // ../core/src/affects/matchers/package.ts

--- a/packages/ci/dist/queue-action.js
+++ b/packages/ci/dist/queue-action.js
@@ -45823,6 +45823,19 @@ function parseFrontmatter(source) {
 // ../core/src/load/corpus.ts
 import { readdir as readdir2, readFile, stat as stat2 } from "node:fs/promises";
 import { basename, isAbsolute, join, relative, resolve, sep as sep2 } from "node:path";
+
+// ../core/src/ordering/index.ts
+function compareCodeUnits(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+function compareFindings(a, b) {
+  return compareCodeUnits(a.rule, b.rule) || compareCodeUnits(a.id ?? "", b.id ?? "") || compareCodeUnits(a.pattern ?? "", b.pattern ?? "") || compareCodeUnits(a.path ?? "", b.path ?? "") || compareCodeUnits(a.field ?? "", b.field ?? "") || compareCodeUnits(a.message, b.message);
+}
+function sortFindingsCanonical(findings) {
+  return [...findings].sort(compareFindings);
+}
+
+// ../core/src/load/corpus.ts
 var RECORD_FILE_PATTERN = /^[0-9]{4,}-.+\.md$/;
 var TEMPLATE_FILE_NAME = "0000-template.md";
 var NON_RECORD_FILE_NAMES = new Set(["readme.md", "index.md", "contributing.md", "template.md"]);
@@ -45843,7 +45856,7 @@ function toAbsolutePath(path, cwd = process.cwd()) {
 async function discoverAdrFiles(dir = "docs/adr", cwd = process.cwd()) {
   const absoluteDir = toAbsolutePath(dir, cwd);
   const entries = await readdir2(absoluteDir, { withFileTypes: true });
-  return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+  return entries.filter((entry) => entry.isFile() && isRecordFileName(entry.name)).map((entry) => join(absoluteDir, entry.name)).sort((a, b) => compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)));
 }
 var MAX_SKIP_SCAN_DEPTH = 8;
 async function collectSkippedMarkdown(absoluteDir, depth, found) {
@@ -45869,7 +45882,7 @@ async function collectSkippedMarkdown(absoluteDir, depth, found) {
 async function discoverSkippedMarkdownFiles(dir = "docs/adr", cwd = process.cwd()) {
   const found = [];
   await collectSkippedMarkdown(toAbsolutePath(dir, cwd), 0, found);
-  return found.sort((a, b) => normalizeDisplayPath(a.path, cwd).localeCompare(normalizeDisplayPath(b.path, cwd)));
+  return found.sort((a, b) => compareCodeUnits(normalizeDisplayPath(a.path, cwd), normalizeDisplayPath(b.path, cwd)));
 }
 async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) {
   if (!paths || paths.length === 0) {
@@ -45889,7 +45902,7 @@ async function expandRecordInputs(paths, dir = "docs/adr", cwd = process.cwd()) 
       expanded.push(absolutePath);
     }
   }
-  return Array.from(new Set(expanded)).sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+  return Array.from(new Set(expanded)).sort((a, b) => compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)));
 }
 async function parseAdrFile(path, cwd = process.cwd()) {
   const absolutePath = toAbsolutePath(path, cwd);
@@ -45901,17 +45914,6 @@ async function parseAdrFile(path, cwd = process.cwd()) {
     path: normalizeDisplayPath(absolutePath, cwd)
   };
 }
-// ../core/src/ordering/index.ts
-function compareCodeUnits(a, b) {
-  return a < b ? -1 : a > b ? 1 : 0;
-}
-function compareFindings(a, b) {
-  return compareCodeUnits(a.rule, b.rule) || compareCodeUnits(a.id ?? "", b.id ?? "") || compareCodeUnits(a.pattern ?? "", b.pattern ?? "") || compareCodeUnits(a.path ?? "", b.path ?? "") || compareCodeUnits(a.field ?? "", b.field ?? "") || compareCodeUnits(a.message, b.message);
-}
-function sortFindingsCanonical(findings) {
-  return [...findings].sort(compareFindings);
-}
-
 // ../core/src/validate/findings.ts
 function compareOptional(a, b) {
   return compareCodeUnits(a ?? "", b ?? "");

--- a/packages/core/src/load/corpus.ts
+++ b/packages/core/src/load/corpus.ts
@@ -46,6 +46,18 @@ function toAbsolutePath(path: string, cwd = process.cwd()): string {
 }
 
 /**
+ * Compare two paths by their normalized display form, by code unit.
+ *
+ * Every corpus ordering goes through here rather than repeating the compound
+ * `compareCodeUnits(normalizeDisplayPath(…), normalizeDisplayPath(…))` per call site,
+ * so a future sort cannot quietly normalize one side and not the other, and so the
+ * locale-independence of the whole family is settled in one place (#115).
+ */
+export function compareByDisplayPath(a: string, b: string, cwd = process.cwd()): number {
+  return compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd));
+}
+
+/**
  * Discovery order is a determinism contract, not display polish: it survives into
  * `lintCorpus`'s `records` whenever two records share an id (the `frontmatter.id`
  * tiebreak is then a no-op over a stable sort), and `checkChanges` reads whichever
@@ -59,7 +71,7 @@ export async function discoverAdrFiles(dir = 'docs/adr', cwd = process.cwd()): P
   return entries
     .filter((entry) => entry.isFile() && isRecordFileName(entry.name))
     .map((entry) => join(absoluteDir, entry.name))
-    .sort((a, b) => compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)));
+    .sort((a, b) => compareByDisplayPath(a, b, cwd));
 }
 
 /**
@@ -116,9 +128,7 @@ export async function discoverSkippedMarkdownFiles(
 ): Promise<SkippedMarkdownFile[]> {
   const found: SkippedMarkdownFile[] = [];
   await collectSkippedMarkdown(toAbsolutePath(dir, cwd), 0, found);
-  return found.sort((a, b) =>
-    compareCodeUnits(normalizeDisplayPath(a.path, cwd), normalizeDisplayPath(b.path, cwd)),
-  );
+  return found.sort((a, b) => compareByDisplayPath(a.path, b.path, cwd));
 }
 
 export async function expandRecordInputs(
@@ -145,9 +155,7 @@ export async function expandRecordInputs(
     }
   }
 
-  return Array.from(new Set(expanded)).sort((a, b) =>
-    compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)),
-  );
+  return Array.from(new Set(expanded)).sort((a, b) => compareByDisplayPath(a, b, cwd));
 }
 
 export async function parseAdrFile(path: string, cwd = process.cwd()): Promise<ParsedAdrFile> {

--- a/packages/core/src/load/corpus.ts
+++ b/packages/core/src/load/corpus.ts
@@ -1,6 +1,7 @@
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { AdrFrontmatter, type Adr } from '../schema/adr.schema.ts';
+import { compareCodeUnits } from '../ordering/index.ts';
 import { parseFrontmatter } from '../parse/frontmatter.ts';
 
 export const RECORD_FILE_PATTERN = /^[0-9]{4,}-.+\.md$/;
@@ -44,13 +45,21 @@ function toAbsolutePath(path: string, cwd = process.cwd()): string {
   return isAbsolute(path) ? path : resolve(cwd, path);
 }
 
+/**
+ * Discovery order is a determinism contract, not display polish: it survives into
+ * `lintCorpus`'s `records` whenever two records share an id (the `frontmatter.id`
+ * tiebreak is then a no-op over a stable sort), and `checkChanges` reads whichever
+ * duplicate landed later as that id's canonical record. Ordering by `compareCodeUnits`
+ * rather than the runtime's ICU locale is what keeps `governing` / `activeProposals` /
+ * `governedBy` identical for byte-identical corpus files (#115).
+ */
 export async function discoverAdrFiles(dir = 'docs/adr', cwd = process.cwd()): Promise<string[]> {
   const absoluteDir = toAbsolutePath(dir, cwd);
   const entries = await readdir(absoluteDir, { withFileTypes: true });
   return entries
     .filter((entry) => entry.isFile() && isRecordFileName(entry.name))
     .map((entry) => join(absoluteDir, entry.name))
-    .sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+    .sort((a, b) => compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)));
 }
 
 /**
@@ -107,7 +116,9 @@ export async function discoverSkippedMarkdownFiles(
 ): Promise<SkippedMarkdownFile[]> {
   const found: SkippedMarkdownFile[] = [];
   await collectSkippedMarkdown(toAbsolutePath(dir, cwd), 0, found);
-  return found.sort((a, b) => normalizeDisplayPath(a.path, cwd).localeCompare(normalizeDisplayPath(b.path, cwd)));
+  return found.sort((a, b) =>
+    compareCodeUnits(normalizeDisplayPath(a.path, cwd), normalizeDisplayPath(b.path, cwd)),
+  );
 }
 
 export async function expandRecordInputs(
@@ -135,7 +146,7 @@ export async function expandRecordInputs(
   }
 
   return Array.from(new Set(expanded)).sort((a, b) =>
-    normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)),
+    compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd)),
   );
 }
 

--- a/packages/core/src/validate/index.ts
+++ b/packages/core/src/validate/index.ts
@@ -3,12 +3,14 @@ import { isAbsolute, resolve } from 'node:path';
 import {
   parseAdrFile,
   expandRecordInputs,
+  compareByDisplayPath,
   discoverSkippedMarkdownFiles,
   normalizeDisplayPath,
   type SkippedMarkdownFile,
 } from '../load/corpus.ts';
 import type { Adr } from '../schema/adr.schema.ts';
 import { FrontmatterError } from '../parse/frontmatter.ts';
+import { compareCodeUnits } from '../ordering/index.ts';
 import { validateParsedAdr } from './contract.ts';
 import { validateCorpusInvariants } from './corpus-invariants.ts';
 import { validateImportIncomplete } from './import-incomplete.ts';
@@ -90,7 +92,7 @@ async function scannedDirectories(
     const absolutePath = isAbsolute(path) ? path : resolve(cwd, path);
     if (await isDirectory(absolutePath)) directories.add(absolutePath);
   }
-  return [...directories].sort((a, b) => normalizeDisplayPath(a, cwd).localeCompare(normalizeDisplayPath(b, cwd)));
+  return [...directories].sort((a, b) => compareByDisplayPath(a, b, cwd));
 }
 
 export async function lintCorpus(options: LintCorpusOptions = {}): Promise<LintCorpusResult> {
@@ -129,6 +131,10 @@ export async function lintCorpus(options: LintCorpusOptions = {}): Promise<LintC
   return {
     checked: files.length,
     findings: sortFindings(findings),
-    records: [...records].sort((a, b) => a.frontmatter.id.localeCompare(b.frontmatter.id)),
+    // `records` is a public surface of `LintCorpusResult` and the input `checkChanges`
+    // reads, so its order is locale-independent too. For equal ids this comparison is a
+    // no-op and the stable sort preserves `discoverAdrFiles`' order, which is what makes
+    // the duplicate-id decision in `toGoverningDecisions` deterministic (#115).
+    records: [...records].sort((a, b) => compareCodeUnits(a.frontmatter.id, b.frontmatter.id)),
   };
 }

--- a/packages/core/test/ordering-contract.test.ts
+++ b/packages/core/test/ordering-contract.test.ts
@@ -19,27 +19,21 @@
  * any change there a violation and routes legitimate changes to
  * separately-authorized later work. Those sites stay recorded on #115 until the
  * freeze lifts; scanning them here would only force one guard to break another.
- *
- * `packages/core/src/load/corpus.ts` also still contains three `localeCompare`
- * sorts (`discoverAdrFiles`, `discoverSkippedMarkdownFiles`,
- * `expandRecordInputs`) and also reaches `CheckOutcome`, via `lintCorpus`'s
- * `records`. Not merely display order: `discoverAdrFiles`'s discovery order
- * survives into `lint.records` whenever two records share an id, because the
- * `frontmatter.id` tiebreak `lintCorpus` sorts by is then a no-op and the sort
- * is stable — and `checkChanges` (`toGoverningDecisions`'s `byId` map) picks
- * whichever duplicate landed later as that id's canonical record, changing
- * `governing` / `activeProposals` / `governedBy` by runtime for byte-identical
- * inputs. This file was scoped to #115's `check`/`markers`/`ordering`/`validate`
- * sweep; `load/corpus.ts` is left for a follow-up PR and stays recorded on
- * #115 and unscanned here until that lands.
  */
 
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { checkChanges, type CheckLintResult } from '../src/check/index.ts';
+import {
+  discoverAdrFiles,
+  discoverSkippedMarkdownFiles,
+  expandRecordInputs,
+} from '../src/load/corpus.ts';
 import { compareCodeUnits } from '../src/ordering/index.ts';
+import { lintCorpus } from '../src/validate/index.ts';
 import { sortFindings, type Finding } from '../src/validate/findings.ts';
+import { cleanupTestDir, recordMarkdown, resetTestDir, writeText } from './helpers.ts';
 
 const emptyLint = (findings: Finding[] = []): CheckLintResult => ({ records: [], findings, checked: 0 });
 
@@ -93,10 +87,9 @@ describe('sortFindings orders every tuple field by code unit', () => {
 describe('the check --json path never reaches for localeCompare', () => {
   // The same source-scan shape as the adapter's
   // `test/glob-order.test.ts` guard, widened to every core module that feeds
-  // `CheckOutcome`: `check/`, `markers/`, `ordering/`, and the shared finding
-  // sort. See the header for why `affects/` and `load/corpus.ts` are excluded
-  // for now.
-  const SCANNED_DIRS = ['src/check', 'src/markers', 'src/ordering'];
+  // `CheckOutcome`: `check/`, `load/`, `markers/`, `ordering/`, and the shared
+  // finding sort. See the header for why `affects/` is excluded for now.
+  const SCANNED_DIRS = ['src/check', 'src/load', 'src/markers', 'src/ordering'];
   const SCANNED_FILES = ['src/validate/findings.ts'];
 
   function tsFilesUnder(relativeDir: string): string[] {
@@ -120,6 +113,7 @@ describe('the check --json path never reaches for localeCompare', () => {
     // an empty walk would make the per-file assertions below vacuous.
     expect(scanned.length).toBeGreaterThanOrEqual(8);
     expect(scanned).toContain('src/check/index.ts');
+    expect(scanned).toContain('src/load/corpus.ts');
     expect(scanned).toContain('src/markers/resolve.ts');
     expect(scanned).toContain('src/validate/findings.ts');
   });
@@ -131,4 +125,122 @@ describe('the check --json path never reaches for localeCompare', () => {
       expect(code).not.toContain('localeCompare');
     });
   }
+});
+
+/**
+ * `load/corpus.ts`'s discovery order is not display polish. It survives into
+ * `lintCorpus`'s `records` whenever two records share an id — the `frontmatter.id`
+ * tiebreak is a no-op for equal ids over a stable sort — and `checkChanges` reads
+ * whichever duplicate landed *later* as that id's canonical record
+ * (`toGoverningDecisions`'s `byId` map is last-write-wins). Under `localeCompare`
+ * that made `governing` / `activeProposals` / `governedBy` a function of the
+ * runtime's ICU locale for byte-identical corpus files.
+ */
+describe('corpus discovery orders by code unit, not by locale', () => {
+  const DIR_NAME = 'ordering-contract-corpus';
+  const CORPUS = 'docs/adr';
+  const MATCHER = ['affects:', '  - type: path', '    pattern: "src/**"'].join('\n');
+
+  /**
+   * The pair that separates the comparators without depending on filesystem case
+   * sensitivity: 'Z' (0x5A) sorts before 'a' (0x61) by code unit, while a locale-aware
+   * comparison puts 'alpha' first. A case-only pair (`0001-A…` / `0001-a…`) cannot be
+   * used — macOS's default case-insensitive filesystem collapses it to one file.
+   */
+  const FIRST = '0001-Zeta-duplicate.md';
+  const LAST = '0001-alpha-duplicate.md';
+
+  afterEach(async () => {
+    await cleanupTestDir(DIR_NAME);
+  });
+
+  /**
+   * Two schema-valid records that share id `0001` and the same matcher, differing
+   * only in filename and status. Whichever one discovery yields last decides
+   * the bucket every match lands in.
+   */
+  async function seedDuplicateIds(): Promise<string> {
+    const root = await resetTestDir(DIR_NAME);
+    const withMatcher = (markdown: string): string => markdown.replace('affects: []', MATCHER);
+    await writeText(
+      join(root, CORPUS, FIRST),
+      withMatcher(recordMarkdown('0001', 'Zeta duplicate'))
+        .replace('status: draft', 'status: accepted')
+        .replace('deciders: []', 'deciders: ["@tester"]'),
+    );
+    await writeText(join(root, CORPUS, LAST), withMatcher(recordMarkdown('0001', 'Alpha duplicate')));
+    return root;
+  }
+
+  test('the case that separates the two comparators, at the filename level', () => {
+    expect(FIRST.localeCompare(LAST)).toBeGreaterThan(0);
+    expect(compareCodeUnits(FIRST, LAST)).toBeLessThan(0);
+  });
+
+  test('discovery yields code-unit order regardless of readdir order', async () => {
+    const root = await seedDuplicateIds();
+    const files = await discoverAdrFiles(CORPUS, root);
+    expect(files.map((file) => file.slice(root.length + 1))).toEqual([
+      `${CORPUS}/${FIRST}`,
+      `${CORPUS}/${LAST}`,
+    ]);
+  });
+
+  test('expandRecordInputs is order-invariant and code-unit ordered', async () => {
+    const root = await seedDuplicateIds();
+    const forward = await expandRecordInputs([join(root, CORPUS, FIRST), join(root, CORPUS, LAST)], CORPUS, root);
+    const reversed = await expandRecordInputs([join(root, CORPUS, LAST), join(root, CORPUS, FIRST)], CORPUS, root);
+    expect(forward).toEqual(reversed);
+    expect(forward.map((file) => file.slice(root.length + 1))).toEqual([
+      `${CORPUS}/${FIRST}`,
+      `${CORPUS}/${LAST}`,
+    ]);
+  });
+
+  test('skipped-markdown reporting is code-unit ordered too', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    // Misnamed, so discovery skips them — the `corpus-file-skipped` warning list.
+    for (const name of ['a_b.md', 'a-b.md', 'ab.md', 'Z.md', 'a.md']) {
+      await writeText(join(root, CORPUS, name), '# not a record\n');
+    }
+    const skipped = await discoverSkippedMarkdownFiles(CORPUS, root);
+    const names = skipped.map((file) => file.path.slice(join(root, CORPUS).length + 1));
+    // localeCompare yields `a_b.md a-b.md a.md ab.md Z.md` for the same set.
+    expect(names).toEqual(['Z.md', 'a-b.md', 'a.md', 'a_b.md', 'ab.md']);
+    expect(names).toEqual([...names].sort(compareCodeUnits));
+  });
+
+  test('a duplicate id resolves to the same governing decision in either input order', async () => {
+    const root = await seedDuplicateIds();
+    const first = join(root, CORPUS, FIRST);
+    const last = join(root, CORPUS, LAST);
+
+    const forward = await lintCorpus({ dir: CORPUS, cwd: root, paths: [first, last] });
+    const reversed = await lintCorpus({ dir: CORPUS, cwd: root, paths: [last, first] });
+    const discovered = await lintCorpus({ dir: CORPUS, cwd: root });
+
+    // Both files are schema-valid, so both survive into `records` (with a
+    // `unique-id` error alongside) and the id tiebreak cannot separate them.
+    for (const lint of [forward, reversed, discovered]) {
+      expect(lint.records.map((record) => record.path)).toEqual([
+        `${CORPUS}/${FIRST}`,
+        `${CORPUS}/${LAST}`,
+      ]);
+    }
+
+    const outcomes = [forward, reversed, discovered].map((lint) =>
+      checkChanges({ lint, changedFiles: ['src/app.ts'], dir: CORPUS }),
+    );
+    for (const outcome of outcomes) expect(outcome).toEqual(outcomes[0] as never);
+
+    // `0001-alpha-duplicate.md` is discovered last, so it is the canonical `0001` — a
+    // draft, which never governs. Under `localeCompare` the accepted record landed
+    // last instead and `governing` was non-empty, flipping on collation alone.
+    const [outcome] = outcomes as [ReturnType<typeof checkChanges>];
+    expect(outcome.governing).toEqual([]);
+    expect(outcome.activeProposals.map((decision) => decision.title)).toEqual([
+      'Alpha duplicate',
+      'Alpha duplicate',
+    ]);
+  });
 });

--- a/packages/core/test/ordering-contract.test.ts
+++ b/packages/core/test/ordering-contract.test.ts
@@ -19,6 +19,14 @@
  * any change there a violation and routes legitimate changes to
  * separately-authorized later work. Those sites stay recorded on #115 until the
  * freeze lifts; scanning them here would only force one guard to break another.
+ *
+ * That exclusion is load-bearing for how this suite's name should be read:
+ * `affects/index.ts`'s `matches.sort((a, b) => a.recordId.localeCompare(...))`
+ * is a *total* re-sort of the resolver's output, so for distinct record ids it
+ * is the frozen sort — not any scanned module — that fixes `governedBy` order.
+ * A clean run of this file therefore means "no scanned module reaches for
+ * `localeCompare`", not "`check --json` is locale-independent end to end".
+ * The second claim is only true once #115's `affects/**` remainder lands.
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';
@@ -84,13 +92,16 @@ describe('sortFindings orders every tuple field by code unit', () => {
   });
 });
 
-describe('the check --json path never reaches for localeCompare', () => {
+describe('no scanned module on the check --json path reaches for localeCompare', () => {
   // The same source-scan shape as the adapter's
   // `test/glob-order.test.ts` guard, widened to every core module that feeds
-  // `CheckOutcome`: `check/`, `load/`, `markers/`, `ordering/`, and the shared
-  // finding sort. See the header for why `affects/` is excluded for now.
-  const SCANNED_DIRS = ['src/check', 'src/load', 'src/markers', 'src/ordering'];
-  const SCANNED_FILES = ['src/validate/findings.ts'];
+  // `CheckOutcome`: `check/`, `load/`, `markers/`, `ordering/`, and `validate/`.
+  // These are scanned as whole directories rather than as a file allowlist, so a
+  // new module added to any of them is covered the day it lands — an allowlist
+  // silently exempts new files, which is how `validate/index.ts` stayed unscanned
+  // while `validate/findings.ts` was named individually. See the header for why
+  // `affects/` is excluded.
+  const SCANNED_DIRS = ['src/check', 'src/load', 'src/markers', 'src/ordering', 'src/validate'];
 
   function tsFilesUnder(relativeDir: string): string[] {
     const root = join(import.meta.dir, '..', relativeDir);
@@ -106,7 +117,7 @@ describe('the check --json path never reaches for localeCompare', () => {
     return found;
   }
 
-  const scanned = [...SCANNED_DIRS.flatMap(tsFilesUnder), ...SCANNED_FILES];
+  const scanned = SCANNED_DIRS.flatMap(tsFilesUnder);
 
   test('the scan examined a non-trivial module list', () => {
     // Report what was examined, not only what was concluded (ADR-0016 clause 3):
@@ -116,6 +127,9 @@ describe('the check --json path never reaches for localeCompare', () => {
     expect(scanned).toContain('src/load/corpus.ts');
     expect(scanned).toContain('src/markers/resolve.ts');
     expect(scanned).toContain('src/validate/findings.ts');
+    // `lintCorpus` lives here and produces the `records` `checkChanges` reads, so
+    // its absence from the scan was the gap the directory walk closes.
+    expect(scanned).toContain('src/validate/index.ts');
   });
 
   for (const file of scanned) {
@@ -208,6 +222,28 @@ describe('corpus discovery orders by code unit, not by locale', () => {
     // localeCompare yields `a_b.md a-b.md a.md ab.md Z.md` for the same set.
     expect(names).toEqual(['Z.md', 'a-b.md', 'a.md', 'a_b.md', 'ab.md']);
     expect(names).toEqual([...names].sort(compareCodeUnits));
+  });
+
+  /**
+   * `lintCorpus`'s own `records` sort, distinct from discovery order. Ids may be
+   * mixed-case ULIDs (`^([0-9]{4,}|[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26})$`), so this
+   * comparison separates the comparators for *distinct* ids — the case the
+   * duplicate-id test above cannot reach, because there the comparison returns 0.
+   */
+  test('lintCorpus orders distinct record ids by code unit', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const upper = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+    const lower = '01arz3ndektsv4rrffq69g5fav';
+    expect(upper.localeCompare(lower)).toBeGreaterThan(0);
+    expect(compareCodeUnits(upper, lower)).toBeLessThan(0);
+
+    // Filenames are numeric so discovery order cannot supply the answer; only the
+    // id sort can decide which record comes first.
+    await writeText(join(root, CORPUS, `0001-${upper}.md`), recordMarkdown(upper, 'Upper ULID record'));
+    await writeText(join(root, CORPUS, `0002-${lower}.md`), recordMarkdown(lower, 'Lower ULID record'));
+
+    const lint = await lintCorpus({ dir: CORPUS, cwd: root });
+    expect(lint.records.map((record) => record.frontmatter.id)).toEqual([upper, lower]);
   });
 
   test('a duplicate id resolves to the same governing decision in either input order', async () => {

--- a/packages/core/test/surface.test.ts
+++ b/packages/core/test/surface.test.ts
@@ -38,6 +38,7 @@ const PUBLIC_RUNTIME_EXPORTS = [
   'canonicalStringify',
   'checkChanges',
   'classifyReimport',
+  'compareByDisplayPath',
   'compareByIdThenPath',
   'compareCodeUnits',
   'compareFindings',


### PR DESCRIPTION
Follow-up to #115 / #117. That PR swept `check --json`'s determinism-contract sorts onto `compareCodeUnits` but scoped itself to `check/`, `markers/`, `ordering/`, and `validate/findings.ts`, leaving `packages/core/src/load/corpus.ts`'s three `localeCompare` sorts behind. This closes that gap, and — after review — the `validate/index.ts` gap next to it.

## Why the corpus change isn't cosmetic

`discoverAdrFiles`'s discovery order reaches `CheckOutcome` via `lintCorpus`. `lintCorpus`'s `records` sort is a no-op tiebreak when two records share an id, so the stable sort preserves whatever order discovery produced. `checkChanges` (`toGoverningDecisions`'s `byId` map, last-write-wins) then picks whichever duplicate landed later as that id's canonical record. `governing` / `activeProposals` / `governedBy` could therefore differ by the runtime's ICU locale for byte-identical corpus files, while `ok` and `findings` stayed the same.

## Changes

- **`packages/core/src/load/corpus.ts`** — `discoverAdrFiles`, `discoverSkippedMarkdownFiles`, and `expandRecordInputs` now sort by code unit. A doc comment on `discoverAdrFiles` records *why* its order is a contract rather than display polish.
- **`packages/core/src/validate/index.ts`** — `scannedDirectories` and `lintCorpus`'s `records` sort migrated too (see below).
- **`compareByDisplayPath`** — extracted rather than writing a fourth copy of `compareCodeUnits(normalizeDisplayPath(a, cwd), normalizeDisplayPath(b, cwd))`. Additive public API (the composition of two already-public functions), pinned in the package surface test.
- **`packages/core/test/ordering-contract.test.ts`** — `SCANNED_FILES` deleted, `src/validate` scanned as a directory; header corrected; suite renamed. Six new tests.
- **`CHANGELOG.md`**, **`packages/ci/dist/*`** — updated and rebuilt.

## Review round: the `validate/` gap

A four-lens deep review (adversarial / architect / consumer / operator, run independently) and both bot comments converged on the same finding, so I closed it rather than documenting it — `validate/index.ts` is not frozen and was freely changeable.

The root cause is more general than the one file. The guard mixed two mechanisms: `SCANNED_DIRS` for directories, `SCANNED_FILES` for one named file. **An allowlist exempts new files by default** — naming `src/validate/findings.ts` individually is exactly what hid `src/validate/index.ts`, a file that defines `lintCorpus`. `SCANNED_FILES` is gone; `src/validate` is now scanned as a directory. The scan went from 11 files to 15.

### Scoping the claim honestly

`records` order does **not** reach `CheckOutcome` for *distinct* ids. `resolveAffects` re-sorts its matches *totally* by `recordId`, so the frozen `affects/index.ts:237` sort decides `governedBy` order and any upstream `records` order is discarded. I verified this instead of reasoning about it: feeding both possible `records` orders for a mixed-case ULID pair through `checkChanges` produced identical `governedBy` — and the output order was itself the *locale* order, which is the frozen leak, still open on #115.

So `validate/index.ts:132` protects `LintCorpusResult.records`, a public `@adrkit/core` surface a caller observes directly. The suite is renamed accordingly — `no scanned module on the check --json path reaches for localeCompare`, not "never reaches" — because the stronger claim stays false until `affects/**` lands.

## The fixture, and why it isn't a case-only pair

The obvious repro (`0001-Alpha-…md` / `0001-alpha-…md`) does not survive macOS's default case-insensitive filesystem — the two files collapse into one and the test passes vacuously. It did, on the first run. The fixture uses `0001-Zeta-duplicate.md` (accepted) and `0001-alpha-duplicate.md` (draft): `'Z'` (0x5A) sorts before `'a'` (0x61) by code unit while a locale-aware comparison puts `alpha` first, so the canonical record — and therefore the bucket — flips on collation alone with no case collision.

## Verification

Per [ADR-0016](https://github.com/mbeacom/adrkit/blob/main/docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md), **every** new check was observed failing against its pre-fix source: the four corpus behavioural tests plus the widened source-scan guard (5 failures), and in the second round the `src/validate/index.ts` guard plus the new `lintCorpus orders distinct record ids by code unit` test (2 failures) — the latter covering the mixed-case ULID case the duplicate-id test structurally cannot reach, since there the id comparison returns 0.

- `bun test` — 1927 pass, 0 fail, 167 files
- `bun run typecheck`, `bun run lint` — clean
- `bun run check:deps`, `bun run check:freeze-hashes` — ok (the `affects/**` freeze is untouched)
- `bun run adr check` / `adr queue` against this repo's own corpus — clean
- Two consecutive `bun run build` runs in `packages/ci` are byte-identical. `queue-action.js` now bundles **zero** `localeCompare`; the three left in `index.js` are exactly the frozen `affects/**` sorts.

## Scope

`packages/core/src/affects/**` is untouched — pinned byte-identical by feature 010's FR-004 guard.

**#115 stays open**, now scoped to just that `affects/**` remainder, so the freeze and the issue lift together.

One out-of-scope finding from the operator lens, reported rather than fixed: `docs/RELEASING.md` documents the forward release flow but has no rollback procedure for the force-pushed `v0` Action tag, and the prior target SHA isn't recorded anywhere. Pre-existing and unrelated to this diff — worth its own issue.

Refs #115. Follow-up to #117.