### PR TITLE
feat(core,cli): report the measured marker scan extent, not the window constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+### Added
+
+- `adr explain --json` reports `markers.scannedBytes` and `markers.fileBytes`
+  alongside the existing `windowBytes` and `truncated` (#108). `truncated` says
+  bytes were left unscanned but not how many, and the window constant does not
+  answer that either: the scan stops at the last complete line inside the window,
+  so `min(fileBytes, windowBytes)` is not the extent. Measured over all 144
+  tracked `.ts` files under `packages/<pkg>/src/**` and
+  `packages/adapters/<pkg>/src/**` at canonical LF content, 29 exceed the
+  window and their extents land 1–77 bytes short of it — and arbitrarily further
+  when one line spans the boundary, down to `0` for a window with no terminator at
+  all. `fileBytes - scannedBytes` is now the size of the unscanned remainder,
+  which is the number a per-file policy is written against:
+  `packages/cli/src/evaluate.ts` and `packages/cli/src/evaluate-snapshot.ts` both
+  report `truncated: true`, but the first left 141 bytes unread and the second
+  18825. This does **not** distinguish "a marker may lie past the window" from
+  "every marker is in the header" — nothing can, short of reading further — and
+  `truncated: false` licensed `declared: []` as a complete search before this
+  change and still does. Both new fields are omitted for a state that never opened
+  the file (`absent`, `unreadable`, `out-of-tree`), because `0` is itself a real
+  extent and cannot also mean "not measured" — the "found none" vs "could not
+  look" distinction ADR-0021 and ADR-0022 built the scan states for. Purely
+  additive and no existing field changed meaning, though the two keys are inserted
+  between `windowBytes` and `truncated`, so a consumer golden-diffing the
+  `markers` block sees a positional change rather than an append; `check --json` is
+  untouched and stays byte-identical. `@adrkit/core`'s exported
+  `SourceMarkerScan` gains the same two optional fields. Recorded as
+  [ADR-0024](docs/adr/0024-report-the-measured-scan-extent-not-the-window-constant.md).
+
+### Changed
+
+- Human output no longer prints the header-window constant where it is not the
+  number it describes (#108). `adr explain`'s note reads "only the first \<extent>
+  of \<size> bytes of \<path> were scanned" instead of restating 8192, and
+  `adr check`'s per-path warning reads "marker scan truncated **within the
+  first** 8192 bytes" instead of "truncated after 8192 bytes" — a bound stated as
+  a bound, since not one of this repository's 29 over-window source files stops
+  there. `adr explain --help` is corrected the same way. `check --json` is
+  unchanged.
+
 ### Fixed
 
 - Some of the `check --json` determinism-contract sorts now order by code unit

--- a/docs/adr/0024-report-the-measured-scan-extent-not-the-window-constant.md
+++ b/docs/adr/0024-report-the-measured-scan-extent-not-the-window-constant.md
@@ -1,0 +1,236 @@
+---
+schemaVersion: 0.1.0
+id: "0024"
+title: Report the measured scan extent, not the window constant
+status: proposed
+date: 2026-08-11
+deciders: []
+tags: [core, cli, matching, governance, agents]
+scope: component
+reversibility: two-way-door
+blastRadius: component
+relatesTo: ["0016", "0021", "0022", "0023"]
+affects:
+  - type: path
+    pattern: "packages/core/src/markers/**"
+  - type: path
+    pattern: "packages/cli/src/index.ts"
+provenance:
+  authoredBy: agent-drafted
+review:
+  tier: async
+  tierReason: >-
+    Two additive, optional report fields; no existing field changes meaning and
+    `check --json` stays byte-identical. What makes it more than a bug fix is that
+    the reporter asked for the intended semantics rather than a patch, and that
+    answering means declining two named alternatives — one of which knocks on the
+    door ADR-0021 left for a configurable window. It also corrects a place where
+    the window constant was being printed as though it were the extent.
+reviewBy: 2027-02-11
+---
+
+# ADR-0024: Report the measured scan extent, not the window constant
+
+## Context
+
+[Issue #108](https://github.com/mbeacom/adrkit/issues/108) reports that
+`adr explain --json` says a marker scan was bounded without saying where it stopped.
+`markers.truncated: true` means "bytes were left unscanned"; the only other number in
+the block is `windowBytes`, the constant. So a consumer that hits a truncated file
+learns that its result is partial and nothing about by how much.
+
+**What the report could not say.** The window is a bound on the extent, not the
+extent: the scan is cut back to the last complete line inside it, because half of
+`@adr 00123` is `@adr 0012` — a different and perfectly valid reference. So
+`min(fileBytes, windowBytes)` is not the answer either. Measured over all 144 tracked
+`.ts` files under a package source tree — `packages/<pkg>/src/**` plus
+`packages/adapters/<pkg>/src/**`, 113 and 31 files — at their canonical (LF) content
+(a literal `packages/**/src/**/*.ts` pathspec is *not* that set; git resolves it to
+115 files, which is why the corpus is spelled out here), 29 exceed the window
+(20.1%; median file 3962.5 bytes), and for those 29 the extent lands **1 to 77 bytes**
+short of it — small, but not derivable, and unbounded in the general case: one line
+spanning the boundary puts the extent arbitrarily far below the window, down to `0`
+when the window holds no terminator at all.
+
+| file | extent | size | unscanned |
+| --- | --- | --- | --- |
+| `packages/cli/src/evaluate-snapshot.ts` | 8167 | 26992 | 18825 |
+| `packages/adapters/catalog-backstage/src/pipeline.ts` | 8191 | 21530 | 13339 |
+| `packages/mcp/src/tools/shared.ts` | 8178 | 20370 | 12192 |
+| `packages/evaluator/src/assertions/rego.ts` | 8115 | 11225 | 3110 |
+| `packages/cli/src/evaluate.ts` | 8148 | 8289 | 141 |
+| `packages/core/src/markers/types.ts` | 1582 | 1582 | 0 |
+
+(Rows are files this change does not touch, so the numbers stay checkable after it
+lands. `pipeline.ts` stops 1 byte short of the window and `rego.ts` 77 — the spread
+that makes the extent worth reporting rather than deriving.)
+
+`evaluate.ts` and `evaluate-snapshot.ts` are the point. Both report
+`state: "scanned"`, `truncated: true` — identical, before this change, in everything a
+consumer could see. One of them was 141 bytes from being read whole; the other left
+18825 unread. That is the difference between "re-read this one if you care" and "this
+answer is mostly guesswork", and it was not reportable.
+
+**What this does not fix, and cannot.** #108's title frames the gap as
+distinguishing "the window was hit and markers may lie past it" from "the window was
+hit and every marker is in the header". Those two remain indistinguishable, and no
+report can separate them without reading further — the second is a claim about bytes
+nobody looked at. `truncated: false` already licensed `declared: []` as complete, and
+still does; that is not what changes here. What changes is that a truncated result
+carries its magnitude, which is what the reporter asked for and accepted as
+sufficient: *"with `scannedBytes` and `fileBytes` we can decide our own policy rather
+than inheriting one."*
+
+## Decision
+
+**`readSourceMarkers` and `adr explain --json` will report the measured extent of the
+read — `scannedBytes` and `fileBytes` — as optional fields present only for a
+`scanned` state. Human output will state the measurement where it has one and the
+bound where it does not.**
+
+Four properties are why this is a rule and not just two fields:
+
+1. **The extent is measured, never derived.** Not `min(fileBytes, windowBytes)`, for
+   the reason above. `fileBytes - scannedBytes` is the unscanned remainder, and it is
+   the number a per-file policy is written against.
+2. **The extent is measured on the bytes, not on the decoded text.** `TextDecoder`
+   may drop a BOM or expand one invalid byte into U+FFFD, so a re-encoded length is
+   not the length that was read. The cut is found by scanning the raw window backwards
+   for `0x0A` / `0x0D`, which is *equivalent* to the existing string search rather than
+   an approximation of it: both terminators are single-byte code points, every UTF-8
+   continuation byte is `>= 0x80` so neither can hide inside a multi-byte sequence, and
+   the decoder flushes any pending invalid sequence before processing a terminator. The
+   reported number and the text handed to the scanner come from that one computation,
+   so they cannot drift.
+3. **A state that never opened the file carries no extent.** `absent`, `unreadable`,
+   and `out-of-tree` omit both fields rather than reporting `0`. This matters because
+   `0` is itself a real answer here — a window holding no line terminator scanned
+   nothing — so it cannot double as "not measured" without collapsing the distinction
+   ADR-0021 and ADR-0022 built the scan states to protect. One edge is worth recording: an I/O error raised after a
+   partial read also reports `unreadable`, and so reports no extent although bytes were
+   read.
+4. **No surface prints the constant as if it were the measurement.** `explain`'s note
+   now reads "only the first &lt;extent&gt; of &lt;size&gt; bytes" — the two numbers
+   it measured, whatever they are for that file on that checkout. `check`'s per-path warning said
+   "truncated after 8192 bytes" — a specific number that is wrong for every one of the
+   29 source files above, none of which stops there — and now says "truncated **within
+   the first** 8192 bytes", which is what a bound claims. (Two tracked non-source files,
+   `packages/mcp/README.md` and one spec fixture, do happen to have a terminator at byte
+   8191 and so stop at exactly 8192. A bound is right for them too.)
+
+### Relationship to ADR-0021 and ADR-0022
+
+This record does not contradict either. ADR-0021 introduced the bounded read and
+`truncated` as its disclosure; ADR-0022 carried that into `check` and CI and recorded
+that scan states keep "no markers" apart from "could not look". Both hold. This record
+narrows one thing only: that `truncated` is a *sufficient* disclosure of a bounded
+read. It answers whether, not how much, and the human surfaces were filling the gap
+with the constant.
+
+It is filed as an amendment rather than as a superseding record because there is
+nothing to retire — ADR-0022's decision stands in full, and this adds two fields to a
+report it does not otherwise touch. Note that ADR-0023's *mechanical* reason for
+amending does not apply here: ADR-0022 has an empty `supersededBy`, so superseding it
+would be well-formed and lints clean. The reason is substantive, not schema-shaped. If
+the maintainer would rather this supersede ADR-0022, that is a one-field change at
+ratification.
+
+## Options considered
+
+### Option A: Report the measured extent, additively, `scanned` only — chosen
+
+| Dimension | Assessment |
+| --- | --- |
+| Answers #108 | In the reporter's own preferred form (direction 1): they own the policy instead of inheriting one |
+| Compatibility | Purely additive; no existing field changes meaning, `check --json` and the Action comment stay byte-identical |
+| Cost | No new syscall — the size comes from the `fstat` already performed for the `isFile` check on the open handle |
+| Honesty | A path that was never opened reports no extent rather than `0` |
+| Reversibility | Two-way door: the fields stop being set and every existing consumer is unaffected |
+
+### Option B: A `windowState: "complete" | "truncated"` enum (#108 direction 2)
+
+**Pros:** names the consumer's question in one field.
+
+**Cons:** it reports a judgement where the complaint was a missing measurement — it
+would say "partial" without saying "by 141 bytes" or "by 21 KB", which is the
+distinction #108 needs. It is also a third name for something already named twice:
+`truncated` is `scannedBytes < fileBytes` absent a concurrent write (kept for
+compatibility, so this record inherits that redundancy rather than defending it), and
+`windowState` would add a second alias to it.
+
+### Option C: Make the window configurable, `--marker-window-bytes` (#108 direction 3)
+
+**Pros:** lets a consumer trade cost for completeness on a corpus it understands, and
+ADR-0021's "revisit if" clause explicitly anticipates this door.
+
+**Cons:** it makes the scan cost caller-controlled on a surface CI runs, which is its
+own decision with its own threat model — the shape ADR-0022 was written for. It also
+does not answer #108 on its own: at any window, a consumer still cannot size what was
+missed without the extent. Better reconsidered *after* this record, using the
+measurements it makes possible — 20.1% of this repo's sources are over the current
+bound, and the 21 KB row is the kind of evidence that argument needs.
+
+### Option D: Do nothing; document that `truncated` means what it says
+
+**Pros:** no surface change at all.
+
+**Cons:** leaves a consumer with a boolean where they asked for a magnitude, and
+leaves `check` printing 8192 as the place a scan stopped when it is not that for any
+file in this repository. #108 is a consumer report from a real corpus, not a
+hypothetical.
+
+## Trade-offs
+
+- **`explain --json` grows two fields.** Additive and optional, but a consumer
+  asserting an exact key set will see them. That is the intended signal, which is why
+  the tests assert exact key *sequences* — the block is a byte contract.
+- **`fileBytes` and `scannedBytes` are two observations, not one.** The size is taken
+  by `fstat` before the read loop, so a file appended to in between can report
+  `scannedBytes > fileBytes`, and one truncated in between can make a fully read file
+  look partial. This is *not* the check/open race ADR-0021 records — that one is path
+  substitution before `open` — but content mutation behind an already-open handle, and
+  it is newly visible because these are the first numbers to expose it. Left
+  unreconciled rather than clamped: agreeing them would hide a file that changed
+  underneath the scan.
+- **`check` reports the bound while `explain` reports the measurement.** Not forced by
+  the JSON contract — `runCheck` holds the batch scan and could thread per-path extents
+  into the human warning without touching `MarkerScanReport`. It is a scope choice: the
+  warning is a capped summary of up to ten paths, the fix for the false number was to
+  state the bound as a bound, and carrying extents there is a separate change with its
+  own `check --json` question. Left as an action item rather than assumed.
+- **The 8192-byte window is unchanged.** This record does not reopen it. It does turn
+  ADR-0022's open action item — "reassess the window against real corpora once markers
+  are in use" — from rhetorical into measurable, and the numbers above are the first
+  data against it.
+
+## Consequences
+
+- **Easier:** a consumer can size the unscanned remainder per file and act on it, and
+  the window's real cost across a corpus is now observable rather than argued from a
+  constant.
+- **Harder:** two fields whose relationship is a contract, so any future change to the
+  cut must keep the reported number and the scanned text one computation. The tests pin
+  the boundary in both directions — a terminator at the window's last byte, and one at
+  the probe byte past it — and assert exact extents rather than `< fileBytes` bounds,
+  which are satisfied by any wrong smaller number.
+- **How we would know this was wrong:** a consumer reports that the magnitude is not
+  what they needed and they wanted the window widened instead (Option C); or the
+  `scanned`-only omission forces enough `undefined` handling that a discriminated union
+  on `state` is worth the breaking type change; or the two-observation skew above shows
+  up in practice rather than in theory. Review by 2027-02-11.
+- **Revisit if:** the header window becomes configurable, or `check` acquires per-path
+  extents and the asymmetry closes.
+
+## Action items
+
+1. [ ] Ratify or reject; if ratified, decide whether this stays an amendment alongside
+       ADR-0023 or supersedes ADR-0022 (see above — either is well-formed here).
+2. [x] Measure the extent against a real corpus, so ADR-0022's action item 1 has data:
+       all 144 tracked `.ts` files under `packages/<pkg>/src/**` and
+       `packages/adapters/<pkg>/src/**` at canonical LF content, 29 over
+       the window, extents 1–77 bytes short of it. Note this is adrkit's own sources,
+       most of which carry no marker; a corpus that uses markers heavily may look
+       different, which is what that action item ultimately wants.
+3. [ ] Decide whether `check`'s truncation warning should carry per-path extents, and
+       whether that belongs in `MarkerScanReport` (changing `check --json`) or only in
+       the human renderer.

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -48144,6 +48144,14 @@ function completeLinePrefix(source) {
 `), source.lastIndexOf("\r"));
   return lastNewline === -1 ? "" : source.slice(0, lastNewline + 1);
 }
+function completeLineByteExtent(bytes, limit) {
+  for (let index = Math.min(limit, bytes.length) - 1;index >= 0; index -= 1) {
+    const byte = bytes[index];
+    if (byte === 10 || byte === 13)
+      return index + 1;
+  }
+  return 0;
+}
 function dedicatedMarkerIndex(line, introducers) {
   let commentStart = 0;
   while (commentStart < line.length && isSpace(line[commentStart] ?? ""))
@@ -48300,7 +48308,8 @@ async function readWithPreparedRoot(path, prepared) {
     if (!isInsideRoot(prepared.realRoot, target))
       return refuse("out-of-tree");
     handle = await open(candidate, readFlags());
-    if (!(await handle.stat()).isFile())
+    const opened = await handle.stat();
+    if (!opened.isFile())
       return refuse("unreadable");
     const buffer = new Uint8Array(MARKER_HEADER_WINDOW_BYTES + 1);
     let bytesRead = 0;
@@ -48311,9 +48320,17 @@ async function readWithPreparedRoot(path, prepared) {
       bytesRead += chunk.bytesRead;
     }
     const truncated = bytesRead > MARKER_HEADER_WINDOW_BYTES;
-    const source = new TextDecoder().decode(buffer.subarray(0, Math.min(bytesRead, MARKER_HEADER_WINDOW_BYTES)));
+    const scannedBytes = truncated ? completeLineByteExtent(buffer, MARKER_HEADER_WINDOW_BYTES) : bytesRead;
+    const source = new TextDecoder().decode(buffer.subarray(0, scannedBytes));
     const scan = scanBoundedSourceMarkerWindow(source, normalizedPath, truncated);
-    return { path: normalizedPath, state: "scanned", markers: scan.markers, truncated: scan.truncated };
+    return {
+      path: normalizedPath,
+      state: "scanned",
+      markers: scan.markers,
+      truncated: scan.truncated,
+      scannedBytes,
+      fileBytes: opened.size
+    };
   } catch (error52) {
     return refuse(scanStateForError(error52));
   } finally {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -45,8 +45,9 @@ Decisions governing src/services/sync/retry.ts:
 ```
 
 This lets `affects` stay narrow — the *defining* files — while the surrounding
-neighbourhood opts in one line at a time. Only the first 8192 bytes of a file
-are scanned, in any language, and the marker must be the first content on a
+neighbourhood opts in one line at a time. At most the first 8192 bytes of a file
+are scanned, in any language — the scan stops at the last complete line inside that
+bound — and the marker must be the first content on a
 dedicated comment line that is not inside a ` ``` ` or `~~~` fence — so
 documenting the syntax, as this file does above, is not declaring it. In a
 markdown file (`.md`, `.mdx`, `.markdown`) the comment is `<!--` or `{/*`; `#`
@@ -55,8 +56,11 @@ back to the record. In
 `--json`, pattern matches carry `firedMatchers` and file declarations carry
 `declaredBy`. `explain --json` carries a single-file `markers` block, while
 `check --json` carries a `markerScan` report with scan-state counts and exact
-unavailable, truncated, and skipped paths. Human output also names truncated
-paths and the 8192-byte window that stopped the scan. Multi-file scans are capped
+unavailable, truncated, and skipped paths. The `explain` block also reports
+`scannedBytes` / `fileBytes`, so `fileBytes - scannedBytes` sizes the unscanned
+remainder of a truncated file instead of leaving it to be guessed from the window
+constant; its human note discloses that measured extent, while `check` reports the
+window as the bound it is. Multi-file scans are capped
 at 3,000 normalized paths and 16 concurrent reads; skipped paths warn but never
 fail. The cap matches GitHub's changed-file ceiling, so only a local invocation
 can reach it.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -167,9 +167,10 @@ Report which decisions govern one repo-relative path, and why.
 
 A decision reaches a path in two directions. The record declares an "affects" pattern
 that matches it ("via path: src/**"), or the file itself declares the record in a
-comment ("declared by src/sync.ts:3 (@adr 0012)"). If <path> exists, its first 8192
-bytes are scanned for dedicated "@adr <id>" comment lines; a marker naming a record
-the corpus does not have is reported as a dangling-marker warning.
+comment ("declared by src/sync.ts:3 (@adr 0012)"). If <path> exists, at most its first
+8192 bytes are scanned for dedicated "@adr <id>" comment lines -- the scan stops at the
+last complete line inside that bound, and --json reports the extent it reached. A marker
+naming a record the corpus does not have is reported as a dangling-marker warning.
 
 Options:
   --dir <path>    ADR corpus directory (default: docs/adr)
@@ -592,16 +593,28 @@ function renderDecisionGroup(heading: string, decisions: readonly ExplainedDecis
   return output;
 }
 
-/** The `markers` block of `adr explain --json`: what was scanned, and what was found. */
+/**
+ * The `markers` block of `adr explain --json`: what was scanned, and what was found.
+ *
+ * `truncated` says bytes were left unscanned, but not how many — and the window constant
+ * does not answer that either, because the scan stops at the last complete line inside it.
+ * `scannedBytes` / `fileBytes` report the measurement, so a consumer can size the
+ * unscanned remainder and set its own policy instead of inheriting one (#108). Both are
+ * omitted for a state that never opened the file, rather than reported as `0`.
+ */
 function markerScanJson(scan: SourceMarkerScan): {
   state: SourceMarkerScan['state'];
   windowBytes: number;
+  scannedBytes?: number;
+  fileBytes?: number;
   truncated: boolean;
   declared: Array<{ ref: string; line: number }>;
 } {
   return {
     state: scan.state,
     windowBytes: MARKER_HEADER_WINDOW_BYTES,
+    ...(scan.scannedBytes === undefined ? {} : { scannedBytes: scan.scannedBytes }),
+    ...(scan.fileBytes === undefined ? {} : { fileBytes: scan.fileBytes }),
     truncated: scan.truncated,
     declared: scan.markers.map((marker) => ({ ref: marker.ref, line: marker.line })),
   };
@@ -622,8 +635,13 @@ function renderMarkerScanNote(scan: SourceMarkerScan): string {
   if (scan.state === 'out-of-tree') {
     return `Note: ${scan.path} is not a repo-relative path inside this working tree; no @adr markers were scanned.\n`;
   }
-  if (scan.truncated) {
-    return `Note: only the first ${MARKER_HEADER_WINDOW_BYTES} bytes of ${scan.path} were scanned for @adr markers.\n`;
+  // The measured extent, not the window constant: the scan stops at the last complete
+  // line inside the window, so the two differ for almost every real file. Only a scanned
+  // state can be truncated, so the extent is present whenever this branch is — the
+  // conjunction is how the types say that, not a fallback, which is why there is no
+  // window-constant default to reprint if it were ever absent.
+  if (scan.truncated && scan.scannedBytes !== undefined && scan.fileBytes !== undefined) {
+    return `Note: only the first ${scan.scannedBytes} of ${scan.fileBytes} bytes of ${scan.path} were scanned for @adr markers.\n`;
   }
   return '';
 }
@@ -674,7 +692,12 @@ function renderHumanCheck(outcome: ReturnType<typeof checkChanges>): string {
     if (outcome.markerScan.truncatedPaths.length > 0) {
       const shown = outcome.markerScan.truncatedPaths.slice(0, 10);
       const remaining = outcome.markerScan.truncatedPaths.length - shown.length;
-      output += `marker scan truncated after ${MARKER_HEADER_WINDOW_BYTES} bytes for: ${shown.join(', ')}`;
+      // "within the first N" rather than "after N": the scan stops at the last complete
+      // line inside the window, so the window is a bound on the extent, not the extent.
+      // `check` reports the bound because per-path extents would have to travel through
+      // `MarkerScanReport`, which is `check --json`'s contract; `explain` reports the
+      // measurement (ADR-0024).
+      output += `marker scan truncated within the first ${MARKER_HEADER_WINDOW_BYTES} bytes for: ${shown.join(', ')}`;
       if (remaining > 0) output += `, and ${remaining} more (see --json for the complete list)`;
       output += '\n';
     }

--- a/packages/cli/test/check.test.ts
+++ b/packages/cli/test/check.test.ts
@@ -180,9 +180,14 @@ describe('adr check CLI', () => {
     expect(result.stdout).toContain(
       'marker scan: 1 scanned, 0 absent, 0 unreadable, 0 out-of-tree, 1 truncated, 0 skipped',
     );
+    // "within the first", not "after": this file's scan stopped at its last complete
+    // line — byte 13 — so naming 8192 as where it stopped states a specific wrong
+    // number. `check` reports the window as the bound it is; `explain` reports the
+    // measurement (ADR-0024).
     expect(result.stdout).toContain(
-      'marker scan truncated after 8192 bytes for: src/large.ts',
+      'marker scan truncated within the first 8192 bytes for: src/large.ts',
     );
+    expect(result.stdout).not.toContain('truncated after 8192 bytes');
   });
 
   // Only a local invocation can reach the cap: the Action refuses to evaluate a diff

--- a/packages/cli/test/explain-markers.test.ts
+++ b/packages/cli/test/explain-markers.test.ts
@@ -70,7 +70,9 @@ describe('adr explain — inbound @adr markers', () => {
   test('--json separates firedMatchers from declaredBy and is byte-stable', async () => {
     const root = await resetTestDir(DIR_NAME);
     await corpus(root);
-    await writeText(join(root, 'src/sync/protocol.ts'), '// @adr 0002\nexport const protocol = 1;\n');
+    const source = '// @adr 0002\nexport const protocol = 1;\n';
+    await writeText(join(root, 'src/sync/protocol.ts'), source);
+    const bytes = new TextEncoder().encode(source).length;
 
     const first = await runAdr(['explain', 'src/sync/protocol.ts', '--dir', 'docs/adr', '--json'], root);
     const second = await runAdr(['explain', 'src/sync/protocol.ts', '--dir', 'docs/adr', '--json'], root);
@@ -97,6 +99,8 @@ describe('adr explain — inbound @adr markers', () => {
     expect(parsed.markers).toEqual({
       state: 'scanned',
       windowBytes: 8192,
+      scannedBytes: bytes,
+      fileBytes: bytes,
       truncated: false,
       declared: [{ ref: '0002', line: 1 }],
     });
@@ -174,16 +178,90 @@ describe('adr explain — inbound @adr markers', () => {
     });
   });
 
-  test('discloses that only the header window of a large file was scanned', async () => {
+  test('discloses how much of a large file was scanned, and of what total', async () => {
     const root = await resetTestDir(DIR_NAME);
     await corpus(root);
-    await writeText(join(root, 'src/sync/big.ts'), `// @adr 0002\n${'#'.repeat(9000)}\n`);
+    const source = `// @adr 0002\n${'#'.repeat(9000)}\n`;
+    await writeText(join(root, 'src/sync/big.ts'), source);
+    const bytes = new TextEncoder().encode(source).length;
 
     const result = await runAdr(['explain', 'src/sync/big.ts', '--dir', 'docs/adr'], root);
 
     expect(result.stdout).toContain('declared by src/sync/big.ts:1 (@adr 0002)');
+    // The single 9000-byte line cannot be cut anywhere inside the window, so the header
+    // line is the whole scanned extent — 13 bytes, not the 8192 the window suggests.
     expect(result.stdout).toContain(
-      'Note: only the first 8192 bytes of src/sync/big.ts were scanned for @adr markers.',
+      `Note: only the first 13 of ${bytes} bytes of src/sync/big.ts were scanned for @adr markers.`,
     );
+  });
+
+  /**
+   * Issue #108: `truncated: true` alone cannot say whether `declared` is complete, so a
+   * consumer had to treat every file over the window as indeterminate. The extent makes
+   * the coverage question answerable without knowing the window constant.
+   */
+  test('--json reports the scanned extent, so a hit window is not automatically unknown', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await corpus(root);
+    // Markers in the header, exactly where the docs recommend, in a file over the window.
+    const header = '// @adr 0002\n';
+    const body = `${'x'.repeat(200)}\n`.repeat(60);
+    await writeText(join(root, 'src/sync/large.ts'), `${header}${body}`);
+
+    const result = await runAdr(['explain', 'src/sync/large.ts', '--dir', 'docs/adr', '--json'], root);
+    const markers = JSON.parse(result.stdout).markers;
+
+    expect(markers.state).toBe('scanned');
+    expect(markers.declared).toEqual([{ ref: '0002', line: 1 }]);
+    expect(markers.truncated).toBe(true);
+    // The consumer's own policy is now expressible: bytes remain unscanned, and it can
+    // see how many rather than inheriting "indeterminate".
+    expect(markers.fileBytes).toBe(new TextEncoder().encode(`${header}${body}`).length);
+    // The exact extent, not a range: 13 header bytes plus as many whole 201-byte body
+    // lines as fit under 8192. A bound like `scannedBytes < fileBytes` is satisfied by
+    // any wrong smaller number, including the 13 a first-terminator cut would report.
+    expect(markers.scannedBytes).toBe(header.length + 201 * 40);
+    expect(markers.scannedBytes).toBeLessThan(markers.fileBytes);
+  });
+
+  test('--json omits the extent only for a path it never read', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await corpus(root);
+    await writeText(join(root, 'src/sync/present.ts'), '// @adr 0002\n');
+
+    const absent = await runAdr(['explain', 'src/sync/missing.ts', '--dir', 'docs/adr', '--json'], root);
+    const scanned = await runAdr(['explain', 'src/sync/present.ts', '--dir', 'docs/adr', '--json'], root);
+
+    // Asserted as exact key sequences, so this fails if the fields stop being reported,
+    // if they appear for a path nothing was read from, or if the block's key ORDER
+    // changes — `--json` is a byte contract, and a consumer may golden-diff it. Reporting
+    // `0` for an unread path would read as a measurement of an empty file.
+    expect(Object.keys(JSON.parse(absent.stdout).markers)).toEqual([
+      'state',
+      'windowBytes',
+      'truncated',
+      'declared',
+    ]);
+    expect(Object.keys(JSON.parse(scanned.stdout).markers)).toEqual([
+      'state',
+      'windowBytes',
+      'scannedBytes',
+      'fileBytes',
+      'truncated',
+      'declared',
+    ]);
+  });
+
+  test('the scan note is silent when the whole file was read', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await corpus(root);
+    await writeText(join(root, 'src/sync/small.ts'), '// @adr 0002\nexport const small = 1;\n');
+
+    const result = await runAdr(['explain', 'src/sync/small.ts', '--dir', 'docs/adr'], root);
+
+    // The note exists to disclose an incomplete read. On the common case — the whole file
+    // scanned — it would state a limit that did not apply, so its absence is the contract.
+    expect(result.stdout).toContain('declared by src/sync/small.ts:1 (@adr 0002)');
+    expect(result.stdout).not.toContain('were scanned for @adr markers');
   });
 });

--- a/packages/cli/test/help-version.test.ts
+++ b/packages/cli/test/help-version.test.ts
@@ -68,6 +68,17 @@ describe('adr help (#42)', () => {
     expect(result.stdout).toContain('--rename');
   });
 
+  test('adr help explain states the scan bound as a bound, not as the extent', async () => {
+    const result = await runAdr(['help', 'explain']);
+
+    expect(result.exitCode).toBe(0);
+    // The window bounds the scan; the scan stops at the last complete line inside it, so
+    // "its first 8192 bytes are scanned" would promise an extent the tool does not reach
+    // (ADR-0024). Pinned because help text is otherwise only compared against itself.
+    expect(result.stdout).toContain('at most its first');
+    expect(result.stdout).not.toContain('its first 8192\nbytes are scanned');
+  });
+
   test('adr <command> --help matches adr help <command>', async () => {
     for (const command of ['lint', 'migrate', 'new', 'graph', 'explain', 'check', 'evaluate', 'queue']) {
       const [viaFlag, viaHelp] = await Promise.all([runAdr([command, '--help']), runAdr(['help', command])]);

--- a/packages/cli/test/lint.test.ts
+++ b/packages/cli/test/lint.test.ts
@@ -23,7 +23,7 @@ describe('adr lint CLI', () => {
   test('passes on this repository corpus', async () => {
     const result = await runAdr(['lint']);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('checked 23 records, 0 errors');
+    expect(result.stdout).toContain('checked 24 records, 0 errors');
     expect(result.stderr).toBe('');
   });
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -61,7 +61,11 @@ therefore scan differently.
 `readSourceMarkers` wraps the scanner with a bounded read and reports `state` as
 `scanned`, `absent`,
 `unreadable`, or `out-of-tree`, so "found no markers" is never confused with
-"could not look."
+"could not look." A `scanned` result also carries `scannedBytes` and `fileBytes`, the
+measured extent of the read: `fileBytes - scannedBytes` is how much of a truncated
+file went unscanned, which `truncated` alone does not say. `scannedBytes` is the cut
+actually taken, not `min(fileBytes, 8192)`, because the window is cut back to its last
+complete line. Both are omitted for a state that never opened the file.
 
 Its `path` argument is repo-relative to `cwd`. Absolute paths and paths that climb
 out of the tree are `out-of-tree`. Every symlink is refused as `unreadable`

--- a/packages/core/src/markers/read.ts
+++ b/packages/core/src/markers/read.ts
@@ -15,7 +15,11 @@
 import { constants, lstat, open, realpath } from 'node:fs/promises';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
 import { compareCodeUnits } from '../ordering/index.ts';
-import { MARKER_HEADER_WINDOW_BYTES, scanBoundedSourceMarkerWindow } from './scan.ts';
+import {
+  MARKER_HEADER_WINDOW_BYTES,
+  completeLineByteExtent,
+  scanBoundedSourceMarkerWindow,
+} from './scan.ts';
 import { mapConcurrent } from './pool.ts';
 import type { SourceMarker } from './types.ts';
 
@@ -41,6 +45,33 @@ export interface SourceMarkerScan {
   markers: SourceMarker[];
   /** Whether the header window stopped short of the end of the file. */
   truncated: boolean;
+  /**
+   * Bytes decoded and handed to the scanner.
+   *
+   * Not `min(fileBytes, MARKER_HEADER_WINDOW_BYTES)`: a truncated window is cut back to
+   * its last complete line, so the extent depends on where that line ends and cannot be
+   * derived from the constants alone. Absent unless `state` is `scanned` — a file that was
+   * never opened has no extent, and `0` would report a measurement rather than its absence
+   * (`0` is itself a real answer: a window holding no line terminator scanned nothing).
+   *
+   * Note the `unreadable` edge: an I/O error raised *after* some bytes were read also
+   * reports `unreadable`, and therefore no extent, even though bytes were read (#108).
+   */
+  scannedBytes?: number;
+  /**
+   * The file's size in bytes, so the size of the unscanned remainder is
+   * `fileBytes - scannedBytes` without the caller knowing the window constant. Absent
+   * unless `state` is `scanned`.
+   *
+   * Taken by `fstat` on the open handle *before* the read loop, so the two numbers are two
+   * observations of a file that can change between them: an append can yield
+   * `scannedBytes > fileBytes`, and a truncation can make a fully read file look partial.
+   * This is not the check/open race ADR-0021 records — that one is path substitution before
+   * `open`, which cannot produce this — but a content mutation behind an already-open
+   * handle. Left unreconciled rather than clamped, because agreeing the two numbers would
+   * hide a file that changed underneath the scan.
+   */
+  fileBytes?: number;
 }
 
 /**
@@ -202,7 +233,8 @@ async function readWithPreparedRoot(path: string, prepared: PreparedRoot): Promi
     // Check the opened handle rather than a path before `open`, so the file-type check
     // applies to the object we read. This does not close the `lstat` -> `open` race:
     // a concurrent process can still replace the approved path before it is opened.
-    if (!(await handle.stat()).isFile()) return refuse('unreadable');
+    const opened = await handle.stat();
+    if (!opened.isFile()) return refuse('unreadable');
 
     const buffer = new Uint8Array(MARKER_HEADER_WINDOW_BYTES + 1);
     let bytesRead = 0;
@@ -213,11 +245,22 @@ async function readWithPreparedRoot(path: string, prepared: PreparedRoot): Promi
     }
 
     const truncated = bytesRead > MARKER_HEADER_WINDOW_BYTES;
-    const source = new TextDecoder().decode(
-      buffer.subarray(0, Math.min(bytesRead, MARKER_HEADER_WINDOW_BYTES)),
-    );
+    // The scanner discards a severed line, so the extent it actually read is the cut
+    // itself, not the window. Cutting here rather than only inside the scanner keeps the
+    // reported number and the scanned text the same computation, so they cannot drift.
+    const scannedBytes = truncated
+      ? completeLineByteExtent(buffer, MARKER_HEADER_WINDOW_BYTES)
+      : bytesRead;
+    const source = new TextDecoder().decode(buffer.subarray(0, scannedBytes));
     const scan = scanBoundedSourceMarkerWindow(source, normalizedPath, truncated);
-    return { path: normalizedPath, state: 'scanned', markers: scan.markers, truncated: scan.truncated };
+    return {
+      path: normalizedPath,
+      state: 'scanned',
+      markers: scan.markers,
+      truncated: scan.truncated,
+      scannedBytes,
+      fileBytes: opened.size,
+    };
   } catch (error) {
     return refuse(scanStateForError(error));
   } finally {

--- a/packages/core/src/markers/scan.ts
+++ b/packages/core/src/markers/scan.ts
@@ -131,6 +131,29 @@ function completeLinePrefix(source: string): string {
   return lastNewline === -1 ? '' : source.slice(0, lastNewline + 1);
 }
 
+/**
+ * {@link completeLinePrefix}'s cut, measured on the raw bytes: the extent of the
+ * complete lines within `bytes[0, limit)`, or `0` when the window holds no line
+ * terminator at all.
+ *
+ * The byte search is equivalent to the string search rather than an approximation of
+ * it. `\n` (0x0A) and `\r` (0x0D) are single-byte code points, and every UTF-8
+ * continuation byte is >= 0x80, so neither terminator can occur inside a multi-byte
+ * sequence.
+ *
+ * Measured here rather than by re-encoding the decoded prefix, for the same reason the
+ * truncation flag is observed rather than inferred (see
+ * {@link scanBoundedSourceMarkerWindow}): `TextDecoder` may drop a BOM or expand one
+ * invalid byte into U+FFFD, so a re-encoded length is not the length that was read.
+ */
+export function completeLineByteExtent(bytes: Uint8Array, limit: number): number {
+  for (let index = Math.min(limit, bytes.length) - 1; index >= 0; index -= 1) {
+    const byte = bytes[index];
+    if (byte === 0x0a || byte === 0x0d) return index + 1;
+  }
+  return 0;
+}
+
 export function headerWindow(source: string): HeaderWindow {
   const bytes = new Uint8Array(MARKER_HEADER_WINDOW_BYTES);
   const encoded = new TextEncoder().encodeInto(source, bytes);

--- a/packages/core/test/markers-scan.test.ts
+++ b/packages/core/test/markers-scan.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdir, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, symlink, writeFile } from 'node:fs/promises';
 import { join, sep } from 'node:path';
 import {
   MARKER_HEADER_WINDOW_BYTES,
@@ -293,13 +293,17 @@ describe('scanSourceMarkers — the header window', () => {
 describe('readSourceMarkers', () => {
   test('reports a scanned file, its markers, and an untruncated window', async () => {
     const root = await resetTestDir(DIR_NAME);
-    await writeText(join(root, 'src/sync.ts'), '// @adr 0012\nexport const sync = true;\n');
+    const source = '// @adr 0012\nexport const sync = true;\n';
+    await writeText(join(root, 'src/sync.ts'), source);
+    const bytes = new TextEncoder().encode(source).length;
 
     expect(await readSourceMarkers('src/sync.ts', root)).toEqual({
       path: 'src/sync.ts',
       state: 'scanned',
       truncated: false,
       markers: [{ path: 'src/sync.ts', ref: '0012', id: '0012', line: 1 }],
+      scannedBytes: bytes,
+      fileBytes: bytes,
     });
   });
 
@@ -384,6 +388,252 @@ describe('readSourceMarkers', () => {
 
     expect(scan.truncated).toBe(true);
     expect(scan.markers).toEqual([]);
+  });
+});
+
+/**
+ * Issue #108: `truncated` says bytes were left unscanned but not how many, and the window
+ * constant does not answer that either — the scan stops at the last complete line inside
+ * it, so `min(fileBytes, windowBytes)` is not the extent. `scannedBytes` / `fileBytes`
+ * report the measurement, making `fileBytes - scannedBytes` the size of the unscanned
+ * remainder. They do NOT say whether a marker sits past the window; nothing can, short of
+ * reading further (ADR-0024).
+ *
+ * These cases pin the boundary from both sides and assert exact extents rather than
+ * `< fileBytes` bounds, which any wrong smaller number satisfies.
+ */
+describe('readSourceMarkers — the scanned extent', () => {
+  /** Reads what the scanner reports it read, so the claim is checked against the file. */
+  async function scannedPrefix(root: string, path: string, scannedBytes: number): Promise<Uint8Array> {
+    return (await readFile(join(root, path))).subarray(0, scannedBytes);
+  }
+
+  test('a fully scanned file reports equal extents, so an empty result is complete', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const source = 'export const sync = true;\n';
+    await writeText(join(root, 'src/sync.ts'), source);
+
+    const scan = await readSourceMarkers('src/sync.ts', root);
+
+    expect(scan.markers).toEqual([]);
+    expect(scan.truncated).toBe(false);
+    expect(scan.scannedBytes).toBe(new TextEncoder().encode(source).length);
+    expect(scan.scannedBytes).toBe(scan.fileBytes);
+  });
+
+  test('the #108 shape: markers in the header of a large file, reported as found and bounded', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const header = `${MARKER_LINE}\n`;
+    const body = `${'#'.repeat(MARKER_HEADER_WINDOW_BYTES * 2)}\n`;
+    await writeText(join(root, 'src/big.ts'), `${header}${body}`);
+
+    const scan = await readSourceMarkers('src/big.ts', root);
+
+    // Every marker in the file was found, and the extent says the search was partial —
+    // which is exactly the pair `truncated` alone could not express.
+    expect(scan.markers.map((marker) => marker.ref)).toEqual(['0012']);
+    expect(scan.truncated).toBe(true);
+    // The exact extent: the body is one unbroken run, so the header's terminator is the
+    // last one inside the window. A `< fileBytes` bound would accept any wrong smaller
+    // number, which is the assertion this pair replaces.
+    expect(scan.scannedBytes).toBe(header.length);
+    expect(scan.fileBytes).toBe(header.length + body.length);
+  });
+
+  test('the extent is the cut-back line, not the window constant', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    // One enormous line after the header, so the last complete line inside the window
+    // ends far short of it: `min(fileBytes, windowBytes)` would be wrong by 8 KB.
+    const header = `${MARKER_LINE}\n`;
+    await writeText(join(root, 'src/oneline.ts'), `${header}${'#'.repeat(MARKER_HEADER_WINDOW_BYTES * 3)}\n`);
+
+    const scan = await readSourceMarkers('src/oneline.ts', root);
+
+    expect(scan.truncated).toBe(true);
+    expect(scan.scannedBytes).toBe(header.length);
+    expect(scan.scannedBytes).toBeLessThan(MARKER_HEADER_WINDOW_BYTES);
+    expect(scan.markers.map((marker) => marker.ref)).toEqual(['0012']);
+  });
+
+  test('the extent is the LAST complete line in the window, not the first', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    // 100-byte lines, so 81 of them (8100 bytes) fit under the window and the 82nd does
+    // not. The marker sits on line 81 — the last complete line inside the window — so a
+    // cut at any earlier terminator both misreports the extent and loses the marker.
+    const LINE_BYTES = 100;
+    const filler = `${'x'.repeat(LINE_BYTES - 1)}\n`.repeat(80);
+    const markerLine = `${MARKER_LINE}${' '.repeat(LINE_BYTES - MARKER_LINE.length - 1)}\n`;
+    expect(markerLine.length).toBe(LINE_BYTES);
+    await writeText(join(root, 'src/lines.ts'), `${filler}${markerLine}${filler}`);
+
+    const scan = await readSourceMarkers('src/lines.ts', root);
+
+    expect(scan.truncated).toBe(true);
+    expect(scan.scannedBytes).toBe(LINE_BYTES * 81);
+    expect(scan.markers.map((marker) => marker.ref)).toEqual(['0012']);
+    expect(scan.markers.map((marker) => marker.line)).toEqual([81]);
+  });
+
+  test('a window holding no line terminator reports nothing scanned rather than 8192', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'src/blob.ts'), '#'.repeat(MARKER_HEADER_WINDOW_BYTES + 500));
+
+    const scan = await readSourceMarkers('src/blob.ts', root);
+
+    // The scanner was handed no complete line, so it examined nothing. Reporting the
+    // window here would claim 8192 bytes were searched when none were.
+    expect(scan.scannedBytes).toBe(0);
+    expect(scan.truncated).toBe(true);
+    expect(scan.markers).toEqual([]);
+  });
+
+  test('a line completed only by the probe byte is outside the window, in both the extent and the scan', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    // The reader probes one byte past the window to observe truncation. Here that probe
+    // byte is the terminator of a MARKER line whose content fills the window exactly, so
+    // the fixture pins both halves of the coupling at once:
+    //   - measuring the cut over what was READ rather than over the window would report
+    //     8193, more than the window it is meant to bound;
+    //   - decoding what was READ rather than the measured extent would complete this line
+    //     and turn it into a declaration, while the reported extent still said 0.
+    // The reported number and the scanned text have to be the same computation.
+    const overWindow = `${MARKER_LINE}${' '.repeat(MARKER_HEADER_WINDOW_BYTES - MARKER_LINE.length)}\n`;
+    expect(overWindow.length).toBe(MARKER_HEADER_WINDOW_BYTES + 1);
+    await writeText(join(root, 'src/probe.ts'), `${overWindow}export const tail = 1;\n`);
+
+    const scan = await readSourceMarkers('src/probe.ts', root);
+
+    expect(scan.truncated).toBe(true);
+    expect(scan.scannedBytes).toBe(0);
+    expect(scan.scannedBytes).toBeLessThanOrEqual(MARKER_HEADER_WINDOW_BYTES);
+    expect(scan.markers).toEqual([]);
+  });
+
+  test('a line ending exactly at the window boundary is inside it', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    // Last byte of the window is this line's terminator, so the whole window is complete
+    // lines: the extent is the window exactly. A cut that stopped a byte short would
+    // fall back to the header's terminator and lose 8179 bytes of scanned text.
+    const header = `${MARKER_LINE}\n`;
+    const filler = `${'#'.repeat(MARKER_HEADER_WINDOW_BYTES - header.length - 1)}\n`;
+    expect(header.length + filler.length).toBe(MARKER_HEADER_WINDOW_BYTES);
+    await writeText(join(root, 'src/edge.ts'), `${header}${filler}tail\n`);
+
+    const scan = await readSourceMarkers('src/edge.ts', root);
+
+    expect(scan.truncated).toBe(true);
+    expect(scan.scannedBytes).toBe(MARKER_HEADER_WINDOW_BYTES);
+    expect(scan.markers.map((marker) => marker.ref)).toEqual(['0012']);
+  });
+
+  test('a file of exactly the window size is complete, not truncated', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const header = `${MARKER_LINE}\n`;
+    const source = `${header}${'#'.repeat(MARKER_HEADER_WINDOW_BYTES - header.length - 1)}\n`;
+    expect(source.length).toBe(MARKER_HEADER_WINDOW_BYTES);
+    await writeText(join(root, 'src/exact.ts'), source);
+
+    const scan = await readSourceMarkers('src/exact.ts', root);
+
+    // Nothing was left unread, so reporting `truncated` here would call a provably
+    // complete scan partial — and would pair it with equal extents, which is incoherent.
+    expect(scan.truncated).toBe(false);
+    expect([scan.scannedBytes, scan.fileBytes]).toEqual([
+      MARKER_HEADER_WINDOW_BYTES,
+      MARKER_HEADER_WINDOW_BYTES,
+    ]);
+  });
+
+  test('a file with no trailing terminator is still measured whole', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    // Untruncated, so the extent is what was read, not a cut: cutting an untruncated
+    // window back to its last terminator would drop the final line from both the
+    // measurement and the scan, and here that line is the whole body.
+    const source = `${MARKER_LINE}\nexport const x = 1;`;
+    await writeText(join(root, 'src/notrail.ts'), source);
+
+    const scan = await readSourceMarkers('src/notrail.ts', root);
+
+    expect(scan.truncated).toBe(false);
+    expect([scan.scannedBytes, scan.fileBytes]).toEqual([source.length, source.length]);
+    expect(scan.markers.map((marker) => marker.ref)).toEqual(['0012']);
+  });
+
+  test('a CR-only file is measured and scanned like any other', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    // `\r` alone is a line terminator to this scanner (`completeLinePrefix` cuts on it
+    // and `scanWindow` splits on it), so the byte-level cut has to honour 0x0D as well
+    // as 0x0A. Recognising only 0x0A would report nothing scanned for this file and lose
+    // a header marker the pre-measurement decode found.
+    const header = `${MARKER_LINE}\r`;
+    const body = `${'x'.repeat(99)}\r`.repeat(200);
+    await writeText(join(root, 'src/mac.ts'), `${header}${body}`);
+
+    const scan = await readSourceMarkers('src/mac.ts', root);
+
+    expect(scan.truncated).toBe(true);
+    expect(scan.scannedBytes).toBe(header.length + 100 * 81);
+    expect(scan.markers.map((marker) => marker.ref)).toEqual(['0012']);
+  });
+
+  test('a terminator at the very first byte is inside the window', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'src/leading.ts'), `\n${'#'.repeat(MARKER_HEADER_WINDOW_BYTES + 100)}`);
+
+    const scan = await readSourceMarkers('src/leading.ts', root);
+
+    // One complete line — an empty one — was scanned. Byte 0 is a byte like any other.
+    expect(scan.truncated).toBe(true);
+    expect(scan.scannedBytes).toBe(1);
+  });
+
+  test('the extent lands on a code-point boundary when the window splits one', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const head = new TextEncoder().encode(`${MARKER_LINE}\n`);
+    // Fill to one byte short of the window, then straddle it with a 2-byte code point.
+    const filler = new TextEncoder().encode('#'.repeat(MARKER_HEADER_WINDOW_BYTES - head.length - 1));
+    const straddle = new TextEncoder().encode('é\ntail\n');
+    const bytes = new Uint8Array(head.length + filler.length + straddle.length);
+    bytes.set(head);
+    bytes.set(filler, head.length);
+    bytes.set(straddle, head.length + filler.length);
+    await mkdir(join(root, 'src'), { recursive: true });
+    await writeFile(join(root, 'src/straddle.ts'), bytes);
+
+    const scan = await readSourceMarkers('src/straddle.ts', root);
+
+    expect(scan.truncated).toBe(true);
+    // The only complete line inside the window is the header, so the extent stops there
+    // and the split code point is never part of what was scanned. Decoding the reported
+    // prefix in fatal mode proves the boundary claim rather than assuming it.
+    expect(scan.scannedBytes).toBe(head.length);
+    const prefix = await scannedPrefix(root, 'src/straddle.ts', scan.scannedBytes as number);
+    expect(() => new TextDecoder('utf-8', { fatal: true }).decode(prefix)).not.toThrow();
+    expect(scan.markers.map((marker) => marker.ref)).toEqual(['0012']);
+  });
+
+  test('a state that read nothing carries no extent, and a scanned one always does', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'src/sync.ts'), '// @adr 0012\n');
+    const outside = await resetTestDir(OUTSIDE_DIR_NAME);
+    await writeText(join(outside, 'claim.ts'), '// @adr 0012\n');
+
+    const refused = [
+      await readSourceMarkers('src/missing.ts', root),
+      await readSourceMarkers('src', root),
+      await readSourceMarkers(`..${sep}${OUTSIDE_DIR_NAME}/claim.ts`, root),
+    ];
+    const scanned = await readSourceMarkers('src/sync.ts', root);
+
+    expect(refused.map((scan) => scan.state)).toEqual(['absent', 'unreadable', 'out-of-tree']);
+    // The scanned control is what makes the absences meaningful: without it this test
+    // would pass just as well if the extent were never reported at all.
+    expect([scanned.scannedBytes, scanned.fileBytes]).toEqual([13, 13]);
+    // `0` would be a measurement, and nothing was measured. Absent is the honest report.
+    for (const scan of refused) {
+      expect(scan.scannedBytes).toBeUndefined();
+      expect(scan.fileBytes).toBeUndefined();
+    }
   });
 });
 
@@ -547,13 +797,22 @@ describe('readSourceMarkersBatch', () => {
       // Two distinct POSIX files. Rewriting the backslash would scan the second and
       // report its marker under the first's name — a wrong answer that reads as
       // `scanned`, not `absent`.
-      await writeText(join(root, 'src/we\\ird.ts'), 'export const plain = true;\n');
+      const plain = 'export const plain = true;\n';
+      await writeText(join(root, 'src/we\\ird.ts'), plain);
       await writeText(join(root, 'src/we/ird.ts'), '// @adr 0012\n');
+      const bytes = new TextEncoder().encode(plain).length;
 
       const batch = await readSourceMarkersBatch(['src/we\\ird.ts'], root);
 
       expect(batch.scans).toEqual([
-        { path: 'src/we\\ird.ts', state: 'scanned', markers: [], truncated: false },
+        {
+          path: 'src/we\\ird.ts',
+          state: 'scanned',
+          markers: [],
+          truncated: false,
+          scannedBytes: bytes,
+          fileBytes: bytes,
+        },
       ]);
     },
   );

--- a/site/src/content/docs/commands.mdx
+++ b/site/src/content/docs/commands.mdx
@@ -140,9 +140,10 @@ export function syncOnce() { … }
   render, so they are content rather than comments, and `# @adr 0012` does not
   declare the file. Every other introducer above belongs to a source language and
   is ignored there.
-- **Only the first 8192 bytes** of a file are scanned. A marker is a claim that
-  the file lives under a decision; a mention far down the file is prose about
-  that decision.
+- **At most the first 8192 bytes** of a file are scanned, and the scan stops at the
+  last complete line inside that bound — `--json` reports the extent it reached. A
+  marker is a claim that the file lives under a decision; a mention far down the
+  file is prose about that decision.
 - **Nothing enters the record.** The edge is discovered when you run `explain` or `check`.
   There is no schema change and no new `affects` matcher type
   ([ADR-0021](https://github.com/mbeacom/adrkit/blob/main/docs/adr/0021-resolve-inbound-source-annotations-without-changing-the-schema.md)).
@@ -158,6 +159,8 @@ has to be guessed at:
 "markers": {
   "state": "scanned",
   "windowBytes": 8192,
+  "scannedBytes": 1582,
+  "fileBytes": 1582,
   "truncated": false,
   "declared": [{ "ref": "0012", "line": 3 }]
 }
@@ -165,8 +168,21 @@ has to be guessed at:
 
 `state` is `scanned`, `absent` (no such file), `unreadable` (not a regular file,
 or permission denied), or `out-of-tree`. `truncated` is `true` when the file is
-longer than the header window, so a marker below it was never seen. In
-`governedBy`, a pattern match carries `firedMatchers` and a file declaration
+longer than the header window, so a marker below it was never seen — and
+`truncated: false` is what makes `declared: []` mean "nothing declares this path"
+rather than "we stopped reading first".
+
+`scannedBytes` and `fileBytes` say **how much** was read, which `truncated` does
+not: `fileBytes - scannedBytes` is the size of the unscanned remainder, so a policy
+for a truncated file is yours to set rather than inherited. They cannot tell you
+whether a marker sits past the window — nothing can, short of reading further — but
+they do tell you how much further that would be. `scannedBytes` is also not
+`min(fileBytes, windowBytes)`: the scan stops at the last complete line inside the
+window, which across this repository's own sources lands 1–77 bytes short of it, and
+much further short when one long line spans the boundary. Both fields are omitted
+for a state that never opened the file.
+
+In `governedBy`, a pattern match carries `firedMatchers` and a file declaration
 carries `declaredBy`; `declaredBy` is omitted entirely when nothing declared the
 record.
 


### PR DESCRIPTION
## What and why

Closes #108. `adr explain --json` said a marker scan had been bounded without saying where it stopped: `truncated: true` means "bytes were left unscanned", and the only other number in the block was the `windowBytes` constant. A consumer hitting a truncated file learned that its result was partial and nothing about by how much.

The window is a bound on the extent, not the extent — the scan is cut back to the last complete line inside it, so `min(fileBytes, windowBytes)` is not the answer either. `scannedBytes` / `fileBytes` report the measurement, present only for a `scanned` state, so `fileBytes - scannedBytes` sizes the unscanned remainder. `packages/cli/src/evaluate.ts` and `packages/cli/src/evaluate-snapshot.ts` both report `truncated: true`; the first left 141 bytes unread and the second 18825. Nothing a consumer could see told them apart.

I took direction 1 alone, as you suggested was sufficient. Directions 2 and 3 are declined in ADR-0024 with reasons — 3 in particular knocks on ADR-0021's "revisit if the header-window bound has to become configurable" door, and I did not want to open that inside a reporting fix.

**What this deliberately does not do.** It does not distinguish "a marker may lie past the window" from "every marker is in the header" — nothing can, short of reading further — and `truncated: false` already licensed `declared: []` as a complete search, before and after. An earlier draft of this PR claimed otherwise; the claim was false (`truncated === false` is equivalent to `scannedBytes === fileBytes` absent a concurrent write) and the record, changelog, docs and commit message were rewritten around the magnitude instead. Flagging it because the framing is the part worth disagreeing with, if you do.

Also corrected three places where the constant was printed as though it were the extent: `check`'s per-path warning said "truncated **after** 8192 bytes" — a specific number wrong for every one of this repository's 29 over-window source files — and now says "within the first"; `explain`'s note names its two measured numbers; `explain --help` said "its first 8192 bytes are scanned". `check --json` is untouched and byte-identical, verified by running base and HEAD over a fixture corpus spanning every scan state.

## Checklist

- [x] Commits are **DCO signed off** (`git commit -s`). No CLA is required.
- [x] If this changes a recorded decision in `docs/adr/`, an ADR is **added or supersedes** the affected record — with the argument, not just a status flip.
- [x] If the schema changed, I edited the Zod source … — n/a, no schema change (`bun run schema:emit` produces no diff).
- [ ] If `packages/ci/src` **or** `@adrkit/core` changed, I regenerated `packages/ci/dist` under **linux/amd64 bun 1.3.14** and committed it — **see Notes; built on Windows, bun 1.3.14.**
- [x] New or changed behavior is covered by tests, and each test was **observed failing before it passed**.
- [x] `bun run typecheck && bun run build && bun test && bun run lint` pass … — see Notes for the Windows caveat on `bun test`.

## Notes for reviewers

**The bundle box is unticked deliberately.** I have no linux/amd64 environment here, so `packages/ci/dist/index.js` was regenerated on Windows with bun 1.3.14. Two things that argue it is nonetheless the right bytes: the same build reproduces the committed `dist/queue-action.js` byte-for-byte (unchanged, and it still contains no marker fragments — `bundle-scope` passes), and the `index.js` diff is exactly the four places source changed, with no codegen reshuffling. `bun run build && git diff --exit-code packages/ci/dist` passes locally. Your CI runs that same gate on `ubuntu-latest`, so it is the arbiter — if it disagrees, say so and I will find a Linux box rather than guess.

**Test evidence.** Each new assertion was observed failing before passing, by mutation rather than by assertion: dropping `0x0D` from the cut, searching forward instead of backward, `return index` off by one, limiting to `bytesRead` or to `window - 1`, `truncated` as `>=`, reporting `min(fileBytes, window)`, decoding `bytesRead` instead of the measured extent, dropping the `truncated` guard on the note, reordering the JSON keys, and reverting each of the three human strings — every one of those is now killed by a named test. Two are worth calling out because they were holes I had to close after finding them: the `0x0D` branch (a truncated CR-only file lost its header marker and reported extent `0`), and decoding `bytesRead` rather than `scannedBytes`, which let a marker line completed only by the truncation probe byte become a declaration while the extent still said `0`. The probe-byte fixture pins both halves of that coupling.

**Windows caveat on `bun test`.** 1844 pass / 98 fail on my box, and the same 98 test *names* fail on `upstream/main` — path separators, byte-identity pins, `uv_spawn` limits, symlink fixtures. Zero new failures by name diff; I did not judge by counts. I cannot claim a green suite from this machine, only an unchanged one.

**Measurements.** Every number in ADR-0024 is canonical (LF / git-blob) content, and the table rows are all files this commit does not touch so they stay checkable after it lands. Note the corpus is spelled out rather than given as a glob: a literal `packages/**/src/**/*.ts` pathspec resolves to 115 files in git, not the 144 I measured, so the glob would have been a trap for anyone re-running it.

**Two things I would rather you decide than assume.**

1. The optional-fields shape. `scannedBytes?` / `fileBytes?` are absent for a state that never opened the file, because `0` is itself a real extent (a window with no line terminator scanned nothing) and cannot also mean "not measured". `refuse()` pins `truncated: false`, so `truncated` implies `scanned` implies both fields present — but a type cannot prove that, so `renderMarkerScanNote` guards with a conjunction rather than falling back to reprinting the window. A discriminated union on `state` would delete the guard and is recorded in the ADR as the escape hatch, but it is a breaking type change for anyone constructing `SourceMarkerScan` literals, so I did not take it unilaterally.
2. `check` reports the bound while `explain` reports the measurement. Not forced by the JSON contract — `runCheck` holds the batch scan and could thread per-path extents into the human warning without touching `MarkerScanReport`. It is a scope choice, and ADR-0024 action item 3 leaves it as a question for you rather than assuming an answer.

ADR-0024 is `proposed` with `deciders: []`, as ADR-0023 was. It is filed as an amendment rather than a superseding record because ADR-0022's decision stands in full and there is nothing to retire — and note that ADR-0023's *mechanical* reason for amending does not apply here: ADR-0022 has an empty `supersededBy`, so superseding it would be well-formed and lints clean. If you would rather re-point the chain, that is a one-field change at ratification.
