### PR TITLE
fix(docs): restore the v0.5.0 changelog section lost in #117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ Until `1.0.0`, minor releases may include breaking changes
   the compound expression at each call site. Additive — nothing was removed or
   renamed.
 
+## [0.5.0] - 2026-08-10
+
+### Added
+
 - `adr check` and the governing-decisions Action now resolve inbound `@adr`
   markers from changed files. Reads are hoisted outside pure `checkChanges`, bounded
   to 3,000 normalized paths — GitHub's own changed-file ceiling, so every diff the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ Until `1.0.0`, minor releases may include breaking changes
   `SourceMarkerScan` gains the same two optional fields. Recorded as
   [ADR-0024](docs/adr/0024-report-the-measured-scan-extent-not-the-window-constant.md).
 
+- **One new `@adrkit/core` runtime export**, pinned by the package surface test:
+  `compareByDisplayPath(a, b, cwd)`, the code-unit comparison of two paths by
+  their normalized display form. It is the composition of the already-public
+  `compareCodeUnits` and `normalizeDisplayPath`, and it exists so the corpus
+  orderings settle their locale-independence in one place instead of repeating
+  the compound expression at each call site. Additive — nothing was removed or
+  renamed.
+
 ### Changed
 
 - Human output no longer prints the header-window constant where it is not the
@@ -91,16 +99,6 @@ Until `1.0.0`, minor releases may include breaking changes
   the ordering guard means "no scanned module reaches for `localeCompare`" — not
   "`check --json` is locale-independent end to end". That stronger statement
   holds only once #115's `affects/**` remainder lands.
-
-### Added
-
-- **One new `@adrkit/core` runtime export**, pinned by the package surface test:
-  `compareByDisplayPath(a, b, cwd)`, the code-unit comparison of two paths by
-  their normalized display form. It is the composition of the already-public
-  `compareCodeUnits` and `normalizeDisplayPath`, and it exists so the corpus
-  orderings settle their locale-independence in one place instead of repeating
-  the compound expression at each call site. Additive — nothing was removed or
-  renamed.
 
 ## [0.5.0] - 2026-08-10
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint": "bun run --filter='*' lint",
     "schema:emit": "bun run --filter='@adrkit/core' schema:emit",
     "check:deps": "bun run scripts/check-deps.ts",
+    "check:changelog": "bun run scripts/check-changelog.ts",
     "check:freeze-hashes": "bun run scripts/check-freeze-hashes.ts",
     "audit:gate": "bun run scripts/audit-gate.ts",
     "adr": "bun packages/cli/src/index.ts",

--- a/scripts/check-changelog.test.ts
+++ b/scripts/check-changelog.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The negative cases here are the point. A guard that only ever runs against a healthy
+ * tree proves nothing (ADR-0016), so each rule is exercised against a changelog that
+ * violates it — including a verbatim reconstruction of the PR #117 regression this
+ * check exists to catch.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import { checkChangelog, checkChangelogContent } from './check-changelog.ts';
+import { cleanupTestDir, resetTestDir, writeText } from '../packages/core/test/helpers.ts';
+
+const DIR_NAME = 'check-changelog';
+
+const HEALTHY = `# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- Something not yet released.
+
+## [0.5.0] - 2026-08-10
+
+### Added
+
+- A shipped feature.
+
+## [0.4.0] - 2026-08-08
+
+### Added
+
+- An older shipped feature.
+`;
+
+afterEach(async () => {
+  await cleanupTestDir(DIR_NAME);
+});
+
+describe('check-changelog', () => {
+  test('passes on this repository, and reports what it examined', async () => {
+    const result = await checkChangelog();
+    expect(result.violations).toEqual([]);
+    expect(result.ok).toBe(true);
+    // Not vacuous: the scan must have actually found released sections, and the
+    // version under test must be among them.
+    expect(result.releasedVersions.length).toBeGreaterThanOrEqual(2);
+    expect(result.releasedVersions).toContain(result.version);
+  });
+
+  test('accepts a well-formed changelog', () => {
+    const result = checkChangelogContent(HEALTHY, '0.5.0');
+    expect(result.ok).toBe(true);
+    expect(result.releasedVersions).toEqual(['0.5.0', '0.4.0']);
+  });
+
+  test('catches the PR #117 regression: a released heading absorbed into [Unreleased]', () => {
+    // Exactly what happened — the `## [0.5.0] - 2026-08-10` line was replaced by the
+    // incoming `### Fixed` block, so every shipped entry fell under [Unreleased].
+    const absorbed = HEALTHY.replace('## [0.5.0] - 2026-08-10', '### Fixed\n\n- A newly merged fix.');
+    const result = checkChangelogContent(absorbed, '0.5.0');
+
+    expect(result.ok).toBe(false);
+    expect(result.violations.map((violation) => violation.rule)).toEqual(['missing-release-section']);
+    expect(result.violations[0]?.message).toContain('0.5.0');
+    // The healthy fixture it was derived from does pass, so the failure is caused by
+    // the absorbed heading and not by something else in the fixture.
+    expect(checkChangelogContent(HEALTHY, '0.5.0').ok).toBe(true);
+  });
+
+  test('catches a version bump whose section was never written', () => {
+    const result = checkChangelogContent(HEALTHY, '0.6.0');
+    expect(result.violations.map((violation) => violation.rule)).toEqual(['missing-release-section']);
+  });
+
+  test('catches a missing [Unreleased] heading', () => {
+    const result = checkChangelogContent(HEALTHY.replace('## [Unreleased]\n\n', ''), '0.5.0');
+    expect(result.violations.map((violation) => violation.rule)).toEqual(['missing-unreleased']);
+  });
+
+  test('catches [Unreleased] sorted below a released section', () => {
+    const inverted = `# Changelog
+
+## [0.5.0] - 2026-08-10
+
+### Added
+
+- A shipped feature.
+
+## [Unreleased]
+`;
+    const result = checkChangelogContent(inverted, '0.5.0');
+    expect(result.violations.map((violation) => violation.rule)).toEqual(['unreleased-not-first']);
+  });
+
+  test('a heading without a date is not counted as a release section', () => {
+    // Keep a Changelog dates every release; an undated heading is a draft, and
+    // treating it as released would let a version ship with no date.
+    const undated = HEALTHY.replace('## [0.5.0] - 2026-08-10', '## [0.5.0]');
+    expect(checkChangelogContent(undated, '0.5.0').ok).toBe(false);
+  });
+
+  test('reads the real package.json and CHANGELOG.md from the given root', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, 'package.json'), JSON.stringify({ version: '9.9.9' }));
+    await writeText(join(root, 'CHANGELOG.md'), HEALTHY);
+
+    const result = await checkChangelog(root);
+    expect(result.version).toBe('9.9.9');
+    expect(result.violations.map((violation) => violation.rule)).toEqual(['missing-release-section']);
+  });
+});

--- a/scripts/check-changelog.test.ts
+++ b/scripts/check-changelog.test.ts
@@ -100,6 +100,52 @@ describe('check-changelog', () => {
     expect(checkChangelogContent(undated, '0.5.0').ok).toBe(false);
   });
 
+  describe('independently versioned adapter releases', () => {
+    // `docs/RELEASING.md` §"Adapter releases": `@adrkit/spec-kit` ships on its own
+    // `spec-kit-v<semver>` tag and does not move with the root version. Its sections
+    // are still dated release boundaries, so they participate in the ordering rule.
+    const WITH_ADAPTER = HEALTHY.replace(
+      '## [0.4.0] - 2026-08-08',
+      '## [spec-kit-0.1.2] - 2026-08-03\n\n### Fixed\n\n- An adapter fix.\n\n## [0.4.0] - 2026-08-08',
+    );
+
+    test('an adapter section is recognized but never satisfies the root version', () => {
+      const result = checkChangelogContent(WITH_ADAPTER, '0.5.0');
+      expect(result.ok).toBe(true);
+      expect(result.releaseLabels).toEqual(['0.5.0', 'spec-kit-0.1.2', '0.4.0']);
+      // The adapter label must not leak into the lockstep list, or `0.1.2` could
+      // satisfy a root version bump to 0.1.2 that was never actually cut.
+      expect(result.releasedVersions).toEqual(['0.5.0', '0.4.0']);
+    });
+
+    test('an adapter release above [Unreleased] is caught by the ordering rule', () => {
+      // The gap this closes: with an unprefixed-only pattern, an adapter section
+      // hoisted above [Unreleased] was invisible and the check passed.
+      const hoisted = `# Changelog
+
+## [spec-kit-0.1.2] - 2026-08-03
+
+### Fixed
+
+- An adapter fix.
+
+${WITH_ADAPTER.slice(WITH_ADAPTER.indexOf('## [Unreleased]'))}`;
+      const result = checkChangelogContent(hoisted, '0.5.0');
+      expect(result.violations.map((violation) => violation.rule)).toEqual(['unreleased-not-first']);
+    });
+
+    test('a root version bump still fails when only an adapter section exists', () => {
+      const result = checkChangelogContent(WITH_ADAPTER, '0.1.2');
+      expect(result.violations.map((violation) => violation.rule)).toEqual(['missing-release-section']);
+    });
+  });
+
+  test('this repository has both lockstep and adapter sections, so the split is exercised', async () => {
+    const result = await checkChangelog();
+    expect(result.releaseLabels.length).toBeGreaterThan(result.releasedVersions.length);
+    expect(result.releaseLabels.some((label) => label.startsWith('spec-kit-'))).toBe(true);
+  });
+
   test('reads the real package.json and CHANGELOG.md from the given root', async () => {
     const root = await resetTestDir(DIR_NAME);
     await writeText(join(root, 'package.json'), JSON.stringify({ version: '9.9.9' }));

--- a/scripts/check-changelog.ts
+++ b/scripts/check-changelog.ts
@@ -20,8 +20,14 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-/** `## [1.2.3] - 2026-08-10`, the Keep a Changelog release heading this repo uses. */
-const RELEASE_HEADING = /^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})\s*$/;
+/**
+ * `## [1.2.3] - 2026-08-10` for the lockstep packages, and `## [spec-kit-0.1.2] -
+ * 2026-08-03` for an independently versioned adapter (`docs/RELEASING.md` §"Adapter
+ * releases"). Both are dated release boundaries and both must sit below
+ * `[Unreleased]`, so the ordering rule matches either; only the unprefixed form is a
+ * candidate for the root `package.json` version, because adapters do not move with it.
+ */
+const RELEASE_HEADING = /^## \[(?:([a-z0-9][a-z0-9-]*)-)?(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})\s*$/;
 const UNRELEASED_HEADING = /^## \[Unreleased\]\s*$/;
 
 export interface ChangelogViolation {
@@ -32,13 +38,17 @@ export interface ChangelogViolation {
 export interface ChangelogCheckResult {
   ok: boolean;
   version: string;
+  /** Lockstep (unprefixed) versions only — the ones the root version can match. */
   releasedVersions: string[];
+  /** Every dated release label, adapters included, in file order. */
+  releaseLabels: string[];
   violations: ChangelogViolation[];
 }
 
 export function checkChangelogContent(changelog: string, version: string): ChangelogCheckResult {
   const lines = changelog.split('\n');
   const releasedVersions: string[] = [];
+  const releaseLabels: string[] = [];
   let unreleasedAt = -1;
   let firstReleaseAt = -1;
 
@@ -46,7 +56,9 @@ export function checkChangelogContent(changelog: string, version: string): Chang
     if (UNRELEASED_HEADING.test(line) && unreleasedAt === -1) unreleasedAt = index;
     const release = RELEASE_HEADING.exec(line);
     if (!release) return;
-    releasedVersions.push(release[1] as string);
+    const [, adapter, released] = release;
+    releaseLabels.push(adapter ? `${adapter}-${released}` : (released as string));
+    if (!adapter) releasedVersions.push(released as string);
     if (firstReleaseAt === -1) firstReleaseAt = index;
   });
 
@@ -71,7 +83,7 @@ export function checkChangelogContent(changelog: string, version: string): Chang
     });
   }
 
-  return { ok: violations.length === 0, version, releasedVersions, violations };
+  return { ok: violations.length === 0, version, releasedVersions, releaseLabels, violations };
 }
 
 export async function checkChangelog(root = process.cwd()): Promise<ChangelogCheckResult> {
@@ -83,6 +95,7 @@ export async function checkChangelog(root = process.cwd()): Promise<ChangelogChe
       ok: false,
       version: '(missing)',
       releasedVersions: [],
+      releaseLabels: [],
       violations: [{ rule: 'missing-release-section', message: 'package.json declares no version.' }],
     };
   }
@@ -94,7 +107,7 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   if (result.ok) {
     // Report what was examined, not only what was concluded (ADR-0016 clause 3).
     console.log(
-      `check-changelog: ok (${result.version} has a section; ${result.releasedVersions.length} released sections found)`,
+      `check-changelog: ok (${result.version} has a section; ${result.releaseLabels.length} dated release sections found, ${result.releaseLabels.length - result.releasedVersions.length} of them adapter releases)`,
     );
   } else {
     for (const violation of result.violations) console.error(`${violation.rule}: ${violation.message}`);

--- a/scripts/check-changelog.ts
+++ b/scripts/check-changelog.ts
@@ -1,0 +1,103 @@
+/**
+ * The released-section guard.
+ *
+ * `package.json`'s version is bumped by the release commit, so once a version is cut
+ * the changelog must carry a `## [<version>] - <date>` heading for it. Nothing checked
+ * that, and the failure it allows is silent in both directions: PR #117 replaced the
+ * `## [0.5.0] - 2026-08-10` line with its own `### Fixed` block, which folded every
+ * shipped v0.5.0 entry back under `[Unreleased]`. The changelog still parsed, still
+ * rendered, and still read plausibly — it simply described a released version as
+ * unreleased, and the next release cut from it would have re-announced v0.5.0's
+ * features as new.
+ *
+ * The check is deliberately narrow. It does not police wording, ordering, or whether
+ * an entry belongs where it sits; it asserts only the two structural facts that make a
+ * changelog's release boundaries trustworthy: the current version has a section, and
+ * `[Unreleased]` still exists above it to receive the next change.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** `## [1.2.3] - 2026-08-10`, the Keep a Changelog release heading this repo uses. */
+const RELEASE_HEADING = /^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})\s*$/;
+const UNRELEASED_HEADING = /^## \[Unreleased\]\s*$/;
+
+export interface ChangelogViolation {
+  rule: 'missing-release-section' | 'missing-unreleased' | 'unreleased-not-first';
+  message: string;
+}
+
+export interface ChangelogCheckResult {
+  ok: boolean;
+  version: string;
+  releasedVersions: string[];
+  violations: ChangelogViolation[];
+}
+
+export function checkChangelogContent(changelog: string, version: string): ChangelogCheckResult {
+  const lines = changelog.split('\n');
+  const releasedVersions: string[] = [];
+  let unreleasedAt = -1;
+  let firstReleaseAt = -1;
+
+  lines.forEach((line, index) => {
+    if (UNRELEASED_HEADING.test(line) && unreleasedAt === -1) unreleasedAt = index;
+    const release = RELEASE_HEADING.exec(line);
+    if (!release) return;
+    releasedVersions.push(release[1] as string);
+    if (firstReleaseAt === -1) firstReleaseAt = index;
+  });
+
+  const violations: ChangelogViolation[] = [];
+
+  if (!releasedVersions.includes(version)) {
+    violations.push({
+      rule: 'missing-release-section',
+      message: `package.json is at ${version}, but CHANGELOG.md has no "## [${version}] - <date>" heading. A released version whose section is missing means its entries are either lost or sitting under [Unreleased], where the next release would re-announce them.`,
+    });
+  }
+
+  if (unreleasedAt === -1) {
+    violations.push({
+      rule: 'missing-unreleased',
+      message: 'CHANGELOG.md has no "## [Unreleased]" heading, so the next change has nowhere to land.',
+    });
+  } else if (firstReleaseAt !== -1 && unreleasedAt > firstReleaseAt) {
+    violations.push({
+      rule: 'unreleased-not-first',
+      message: `"## [Unreleased]" appears at line ${unreleasedAt + 1}, below the first release heading at line ${firstReleaseAt + 1}; entries are ordered newest-first, so it must come before every released section.`,
+    });
+  }
+
+  return { ok: violations.length === 0, version, releasedVersions, violations };
+}
+
+export async function checkChangelog(root = process.cwd()): Promise<ChangelogCheckResult> {
+  const { version } = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as {
+    version?: string;
+  };
+  if (!version) {
+    return {
+      ok: false,
+      version: '(missing)',
+      releasedVersions: [],
+      violations: [{ rule: 'missing-release-section', message: 'package.json declares no version.' }],
+    };
+  }
+  return checkChangelogContent(await readFile(join(root, 'CHANGELOG.md'), 'utf8'), version);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const result = await checkChangelog();
+  if (result.ok) {
+    // Report what was examined, not only what was concluded (ADR-0016 clause 3).
+    console.log(
+      `check-changelog: ok (${result.version} has a section; ${result.releasedVersions.length} released sections found)`,
+    );
+  } else {
+    for (const violation of result.violations) console.error(`${violation.rule}: ${violation.message}`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## The bug

`v0.5.0` was tagged on 2026-08-10 with a proper `## [0.5.0] - 2026-08-10` section. It is not on `main`:

```
$ git show v0.5.0:CHANGELOG.md | grep -n '^## \['     $ grep -n '^## \[' CHANGELOG.md   # main
10:## [Unreleased]                                     10:## [Unreleased]
12:## [0.5.0] - 2026-08-10                             157:## [0.4.0] - 2026-08-08
108:## [0.4.0] - 2026-08-08
```

`git log -S'## [0.5.0]' -- CHANGELOG.md` names the commit: **#117** replaced the `## [0.5.0] - 2026-08-10` *line* with its own `### Fixed` block. The heading was consumed, so every shipped v0.5.0 entry — the marker work, ADR-0022/0023, the Security notes — fell under `[Unreleased]`.

Nothing broke visibly. The file still parsed, still rendered, still read plausibly. It just described a released version as unreleased — and the next release cut from it would have re-announced v0.5.0's features as new. My own #119 inherited the state and didn't notice either.

## The fix

Restore the boundary. Two properties I verified rather than assumed:

- The recovered section is **byte-identical** to the one at tag `v0.5.0` (6008 bytes, compared programmatically against `git show v0.5.0:CHANGELOG.md`).
- The diff is a **pure four-line insertion**. No existing content line is removed or reworded — checked by asserting every non-blank line of the old file still appears in the new one.

The two entries authored *after* the release — the #115 determinism sweep and the `compareByDisplayPath` export — stay in `[Unreleased]`.

Worth noting: I hit the same trap twice while writing this. My first two reconstruction attempts silently dropped the `compareByDisplayPath` entry, because v0.5.0's `### Added` heading is the very one my #119 entry was filed under, so splitting on the heading put my bullet on the wrong side. The "no content lines lost" assertion is what caught it both times. That is the same failure mode as #117, which is the argument for the guard below rather than for being more careful.

## The guard

`check:changelog` asserts only the two structural facts that make release boundaries trustworthy:

1. the version in `package.json` has a dated `## [x.y.z] - <date>` section;
2. `## [Unreleased]` sits above every released section.

It deliberately does not police wording, ordering within a section, or whether an entry belongs where it sits.

**No workflow change is needed** — CI's existing `bun test` step already runs `scripts/*.test.ts`, and the suite includes a case asserting this repository passes. (I'd initially added an explicit CI step; the push was rejected for lack of `workflow` scope, and on inspection it was redundant. Happy to add it separately if you'd like it named explicitly in the job log.)

### Observed failing before it counted (ADR-0016)

Against `main`'s actual CHANGELOG at `6582e58`:

```
$ git show 6582e58:CHANGELOG.md > CHANGELOG.md && bun run check:changelog
missing-release-section: package.json is at 0.5.0, but CHANGELOG.md has no
"## [0.5.0] - <date>" heading. …
exit=1
```

and the repository case in the test suite fails. The unit tests reconstruct the #117 edit verbatim from a fixture that otherwise passes, so the failure is attributable to the absorbed heading rather than to the fixture. Each of the other rules has its own negative case.

## Verification

- `bun test` — 1935 pass, 0 fail, 168 files
- `bun run typecheck` — clean
- `check:deps`, `check:freeze-hashes`, `check:changelog`, `adr lint` — all ok

## Note on releasing

This should land **before** any v0.5.1/v0.6.0 cut. `[Unreleased]` currently holds the #115 determinism fixes (#117 + #119) and one additive export (`compareByDisplayPath`) — a minor bump by the repo's export-surface policy. Cutting a release from `main` as it stands today would have re-announced all of v0.5.0.