### PR TITLE
feat(cli,core): ratify ADR-0024 and report the measured extent in check too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,13 @@ Until `1.0.0`, minor releases may include breaking changes
   between `windowBytes` and `truncated`, so a consumer golden-diffing the
   `markers` block sees a positional change rather than an append; `check --json` is
   untouched and stays byte-identical. `@adrkit/core`'s exported
-  `SourceMarkerScan` gains the same two optional fields. Recorded as
+  `SourceMarkerScan` gains the same two optional fields. Note when differencing
+  them: `scannedBytes` is the prefix handed to the scanner, not the bytes pulled
+  from the handle (which include a truncation probe byte and a discarded partial
+  line), and `fileBytes` comes from an `fstat` taken before the read loop — so a
+  file written concurrently can make `fileBytes - scannedBytes` negative. The two
+  are left unreconciled deliberately, because agreeing them would hide a file that
+  changed underneath the scan; clamp the difference at `0`. Recorded as
   [ADR-0024](docs/adr/0024-report-the-measured-scan-extent-not-the-window-constant.md).
 
 ### Changed
@@ -43,11 +49,16 @@ Until `1.0.0`, minor releases may include breaking changes
 - Human output no longer prints the header-window constant where it is not the
   number it describes (#108). `adr explain`'s note reads "only the first \<extent>
   of \<size> bytes of \<path> were scanned" instead of restating 8192, and
-  `adr check`'s per-path warning reads "marker scan truncated **within the
-  first** 8192 bytes" instead of "truncated after 8192 bytes" — a bound stated as
-  a bound, since not one of this repository's 29 over-window source files stops
-  there. `adr explain --help` is corrected the same way. `check --json` is
-  unchanged.
+  `adr check`'s per-path warning now reads "marker scan truncated (bytes scanned
+  of total): \<path> \<extent>/\<size>" instead of "truncated after 8192 bytes".
+  Not one of this repository's 29 over-window source files stops at 8192, and the
+  gap is not cosmetic: a file whose header is one 12-byte marker line followed by
+  8192 bytes of content was reported as stopping at 8192 when it stopped at 13.
+  `adr explain --help` is corrected the same way. `check --json` is unchanged and
+  stays byte-identical — `runCheck` already holds the batch scan, so the human
+  renderer could report the measurement without `MarkerScanReport` carrying it
+  (ADR-0024 action item 3). `adr check`'s human stdout is not a stability
+  contract; consumers that need the truncated-path list should read `--json`.
 
 ### Fixed
 

--- a/docs/adr/0024-report-the-measured-scan-extent-not-the-window-constant.md
+++ b/docs/adr/0024-report-the-measured-scan-extent-not-the-window-constant.md
@@ -2,9 +2,9 @@
 schemaVersion: 0.1.0
 id: "0024"
 title: Report the measured scan extent, not the window constant
-status: proposed
+status: accepted
 date: 2026-08-11
-deciders: []
+deciders: ["@mbeacom"]
 tags: [core, cli, matching, governance, agents]
 scope: component
 reversibility: two-way-door
@@ -17,6 +17,7 @@ affects:
     pattern: "packages/cli/src/index.ts"
 provenance:
   authoredBy: agent-drafted
+  ratifiedBy: "@mbeacom"
 review:
   tier: async
   tierReason: >-
@@ -85,8 +86,15 @@ than inheriting one."*
 
 **`readSourceMarkers` and `adr explain --json` will report the measured extent of the
 read — `scannedBytes` and `fileBytes` — as optional fields present only for a
-`scanned` state. Human output will state the measurement where it has one and the
-bound where it does not.**
+`scanned` state. Every human surface that names where a scan stopped will state the
+measurement rather than the window constant.**
+
+*Ratification note (2026-08-11): as proposed, this record's second sentence read
+"Human output will state the measurement where it has one and the bound where it
+does not", because `check`'s warning was thought to need a `MarkerScanReport` change
+to carry extents. It does not — see action item 3 — so the decision was widened at
+ratification rather than shipping an asymmetry the record itself called an open
+question. `check --json` is unchanged either way.*
 
 Four properties are why this is a rule and not just two fields:
 
@@ -101,7 +109,11 @@ Four properties are why this is a rule and not just two fields:
    continuation byte is `>= 0x80` so neither can hide inside a multi-byte sequence, and
    the decoder flushes any pending invalid sequence before processing a terminator. The
    reported number and the text handed to the scanner come from that one computation,
-   so they cannot drift.
+   so they cannot drift *for a given implementation* — but the rule now exists in two
+   representations, and nothing in the type system holds them together. That equivalence
+   is therefore pinned by test ("the byte cut and the text cut cannot drift apart"),
+   which asserts the boundary property and the no-op-second-cut property over named
+   edge cases and a seeded fuzz corpus rather than re-implementing the search.
 3. **A state that never opened the file carries no extent.** `absent`, `unreadable`,
    and `out-of-tree` omit both fields rather than reporting `0`. This matters because
    `0` is itself a real answer here — a window holding no line terminator scanned
@@ -111,12 +123,13 @@ Four properties are why this is a rule and not just two fields:
    read.
 4. **No surface prints the constant as if it were the measurement.** `explain`'s note
    now reads "only the first &lt;extent&gt; of &lt;size&gt; bytes" — the two numbers
-   it measured, whatever they are for that file on that checkout. `check`'s per-path warning said
-   "truncated after 8192 bytes" — a specific number that is wrong for every one of the
-   29 source files above, none of which stops there — and now says "truncated **within
-   the first** 8192 bytes", which is what a bound claims. (Two tracked non-source files,
-   `packages/mcp/README.md` and one spec fixture, do happen to have a terminator at byte
-   8191 and so stop at exactly 8192. A bound is right for them too.)
+   it measured, whatever they are for that file on that checkout. `check`'s per-path
+   warning said "truncated after 8192 bytes" — a specific number that is wrong for
+   every one of the 29 source files above, none of which stops there — and now reads
+   "marker scan truncated (bytes scanned of total): &lt;path&gt; &lt;extent&gt;/&lt;size&gt;".
+   The distance this closes is not cosmetic: a file whose header is a 12-byte marker
+   line followed by 8192 bytes of unbroken content stops at byte 13, and was reported
+   as stopping at 8192.
 
 ### Relationship to ADR-0021 and ADR-0022
 
@@ -192,12 +205,15 @@ hypothetical.
   it is newly visible because these are the first numbers to expose it. Left
   unreconciled rather than clamped: agreeing them would hide a file that changed
   underneath the scan.
-- **`check` reports the bound while `explain` reports the measurement.** Not forced by
-  the JSON contract — `runCheck` holds the batch scan and could thread per-path extents
-  into the human warning without touching `MarkerScanReport`. It is a scope choice: the
-  warning is a capped summary of up to ten paths, the fix for the false number was to
-  state the bound as a bound, and carrying extents there is a separate change with its
-  own `check --json` question. Left as an action item rather than assumed.
+- **`check` reports the bound while `explain` reports the measurement.** *Closed at
+  ratification (action item 3): it does not.* This was recorded as an open scope choice
+  on the argument that per-path extents would have to travel through
+  `MarkerScanReport`, `check --json`'s contract. That turned out to be the wrong
+  constraint — `runCheck` holds the batch scan and hands the renderer a path→extent map
+  directly, so the human warning states the measurement and the JSON report is
+  unchanged. What survives is the narrower asymmetry that `check --json` carries no
+  extent while `explain --json` does, which is a deliberate contract decision rather
+  than an unresolved one.
 - **The 8192-byte window is unchanged.** This record does not reopen it. It does turn
   ADR-0022's open action item — "reassess the window against real corpora once markers
   are in use" — from rhetorical into measurable, and the numbers above are the first
@@ -212,25 +228,44 @@ hypothetical.
   cut must keep the reported number and the scanned text one computation. The tests pin
   the boundary in both directions — a terminator at the window's last byte, and one at
   the probe byte past it — and assert exact extents rather than `< fileBytes` bounds,
-  which are satisfied by any wrong smaller number.
+  which are satisfied by any wrong smaller number. The cut itself now exists in two
+  representations (`completeLinePrefix` on text, `completeLineByteExtent` on bytes), a
+  duplication the type system cannot police, so their equivalence is pinned by a
+  dedicated property and fuzz suite; each of dropping `0x0D`, searching forward, an
+  off-by-one, and reaching into the probe byte was observed failing it before it passed
+  ([ADR-0016](0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).
 - **How we would know this was wrong:** a consumer reports that the magnitude is not
   what they needed and they wanted the window widened instead (Option C); or the
   `scanned`-only omission forces enough `undefined` handling that a discriminated union
   on `state` is worth the breaking type change; or the two-observation skew above shows
   up in practice rather than in theory. Review by 2027-02-11.
-- **Revisit if:** the header window becomes configurable, or `check` acquires per-path
-  extents and the asymmetry closes.
+- **Revisit if:** the header window becomes configurable, or a consumer asks for extents
+  in `check --json` and can say what shape they need.
 
 ## Action items
 
-1. [ ] Ratify or reject; if ratified, decide whether this stays an amendment alongside
+1. [x] Ratify or reject; if ratified, decide whether this stays an amendment alongside
        ADR-0023 or supersedes ADR-0022 (see above — either is well-formed here).
+       **Ratified 2026-08-11 as an amendment.** ADR-0022's decision stands in full and
+       there is nothing to retire: this adds two fields to a report ADR-0022 does not
+       otherwise touch, and narrows only the claim that `truncated` is a *sufficient*
+       disclosure of a bounded read. `supersededBy` on ADR-0022 stays empty.
 2. [x] Measure the extent against a real corpus, so ADR-0022's action item 1 has data:
        all 144 tracked `.ts` files under `packages/<pkg>/src/**` and
        `packages/adapters/<pkg>/src/**` at canonical LF content, 29 over
        the window, extents 1–77 bytes short of it. Note this is adrkit's own sources,
        most of which carry no marker; a corpus that uses markers heavily may look
        different, which is what that action item ultimately wants.
-3. [ ] Decide whether `check`'s truncation warning should carry per-path extents, and
+3. [x] Decide whether `check`'s truncation warning should carry per-path extents, and
        whether that belongs in `MarkerScanReport` (changing `check --json`) or only in
-       the human renderer.
+       the human renderer. **Decided 2026-08-11: the human renderer only.** `runCheck`
+       already holds the batch scan, so the warning now reads
+       `marker scan truncated (bytes scanned of total): <path> <extent>/<size>` while
+       `MarkerScanReport` and `check --json` stay byte-identical. Extending the report
+       was considered and declined: `truncatedPaths` is one of five flat code-unit-sorted
+       `string[]`s, so extents would need either a breaking shape change, a parallel
+       array duplicating the paths (the redundancy Option B was rejected for), or a
+       path-keyed map that reopens the ordering surface #117 and #119 just hardened —
+       and `check --json` is a contract that cannot be withdrawn once shipped, unlike a
+       human string. No consumer has asked for it; the door stays open for one that does,
+       at which point the shape would be a requirement rather than a guess.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -57,10 +57,14 @@ back to the record. In
 `declaredBy`. `explain --json` carries a single-file `markers` block, while
 `check --json` carries a `markerScan` report with scan-state counts and exact
 unavailable, truncated, and skipped paths. The `explain` block also reports
-`scannedBytes` / `fileBytes`, so `fileBytes - scannedBytes` sizes the unscanned
-remainder of a truncated file instead of leaving it to be guessed from the window
-constant; its human note discloses that measured extent, while `check` reports the
-window as the bound it is. Multi-file scans are capped
+`scannedBytes` / `fileBytes` — the prefix handed to the scanner and the file's size —
+so `fileBytes - scannedBytes` sizes the unscanned remainder of a truncated file
+instead of leaving it to be guessed from the window constant. The two are separate
+observations taken either side of the read, so clamp the difference at `0`: a file
+appended to mid-scan can report more scanned than total. Both `explain`'s human note
+and `check`'s truncation warning disclose that measured extent per path; `check --json`
+deliberately does not carry it, so its report shape is unchanged. Multi-file scans are
+capped
 at 3,000 normalized paths and 16 concurrent reads; skipped paths warn but never
 fail. The cap matches GitHub's changed-file ceiling, so only a local invocation
 can reach it.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,6 +25,7 @@ import {
   toGoverningDecisions,
   type ExplainedDecision,
   type Finding,
+  type SourceMarkerBatchScan,
   type SourceMarkerScan,
 } from '@adrkit/core';
 import { evaluate } from './evaluate.ts';
@@ -646,7 +647,29 @@ function renderMarkerScanNote(scan: SourceMarkerScan): string {
   return '';
 }
 
-function renderHumanCheck(outcome: ReturnType<typeof checkChanges>): string {
+/**
+ * Per-path measured extents for `check`'s human warning, keyed by the same normalized
+ * path `MarkerScanReport` sorts on.
+ *
+ * Built from the batch scan the caller already holds rather than from `MarkerScanReport`,
+ * which carries paths only. That is the whole reason the asymmetry closes without a
+ * contract change: `check --json` stays byte-identical while the human surface stops
+ * printing a bound where it can print the measurement (ADR-0024 action item 3).
+ */
+function markerScanExtents(batch: SourceMarkerBatchScan): Map<string, string> {
+  const extents = new Map<string, string>();
+  for (const scan of batch.scans) {
+    if (!scan.truncated) continue;
+    if (scan.scannedBytes === undefined || scan.fileBytes === undefined) continue;
+    extents.set(scan.path, `${scan.scannedBytes}/${scan.fileBytes}`);
+  }
+  return extents;
+}
+
+function renderHumanCheck(
+  outcome: ReturnType<typeof checkChanges>,
+  extents: Map<string, string> = new Map(),
+): string {
   let output = '';
   if (outcome.governedBy.length === 0) {
     output += 'No decisions govern the changed files.\n';
@@ -692,12 +715,18 @@ function renderHumanCheck(outcome: ReturnType<typeof checkChanges>): string {
     if (outcome.markerScan.truncatedPaths.length > 0) {
       const shown = outcome.markerScan.truncatedPaths.slice(0, 10);
       const remaining = outcome.markerScan.truncatedPaths.length - shown.length;
-      // "within the first N" rather than "after N": the scan stops at the last complete
-      // line inside the window, so the window is a bound on the extent, not the extent.
-      // `check` reports the bound because per-path extents would have to travel through
-      // `MarkerScanReport`, which is `check --json`'s contract; `explain` reports the
-      // measurement (ADR-0024).
-      output += `marker scan truncated within the first ${MARKER_HEADER_WINDOW_BYTES} bytes for: ${shown.join(', ')}`;
+      // The measured extent per path, not the window constant: the scan stops at the last
+      // complete line inside the window, so the window is a bound on the extent and was
+      // wrong for every over-window file in this repository. `check` can report the
+      // measurement without touching `MarkerScanReport` because `runCheck` already holds
+      // the batch scan, so `check --json` stays byte-identical (ADR-0024 action item 3).
+      // A path whose extent is missing degrades to the bare path rather than to the
+      // constant — reprinting the bound is the error this replaced.
+      const labelled = shown.map((path) => {
+        const extent = extents.get(path);
+        return extent === undefined ? path : `${path} ${extent}`;
+      });
+      output += `marker scan truncated (bytes scanned of total): ${labelled.join(', ')}`;
       if (remaining > 0) output += `, and ${remaining} more (see --json for the complete list)`;
       output += '\n';
     }
@@ -741,7 +770,7 @@ async function runCheck(args: string[]): Promise<number> {
   if (parsed.values.json) {
     writeStdout(`${JSON.stringify(outcome, null, 2)}\n`);
   } else {
-    writeStdout(renderHumanCheck(outcome));
+    writeStdout(renderHumanCheck(outcome, markerScanExtents(markerScans)));
   }
 
   return outcome.ok ? 0 : 1;

--- a/packages/cli/test/check.test.ts
+++ b/packages/cli/test/check.test.ts
@@ -170,7 +170,7 @@ describe('adr check CLI', () => {
     expect(result.stdout).not.toContain('marker scan');
   });
 
-  test('reports truncated scans in human output with the affected path', async () => {
+  test('reports truncated scans in human output with the measured per-path extent', async () => {
     const root = await seedCorpus();
     await writeText(join(root, 'src/large.ts'), `// @adr 0001\n${'x'.repeat(8192)}`);
 
@@ -180,14 +180,37 @@ describe('adr check CLI', () => {
     expect(result.stdout).toContain(
       'marker scan: 1 scanned, 0 absent, 0 unreadable, 0 out-of-tree, 1 truncated, 0 skipped',
     );
-    // "within the first", not "after": this file's scan stopped at its last complete
-    // line — byte 13 — so naming 8192 as where it stopped states a specific wrong
-    // number. `check` reports the window as the bound it is; `explain` reports the
-    // measurement (ADR-0024).
+    // The measured extent, not the window. This file stops at its last complete line —
+    // byte 13 — so the old "within the first 8192 bytes" was off by 8179 for this very
+    // fixture, and "after 8192 bytes" before it named a byte nothing stopped at.
+    // `check` can say 13/8205 because `runCheck` already holds the batch scan, so
+    // `check --json` never had to change (ADR-0024 action item 3).
     expect(result.stdout).toContain(
-      'marker scan truncated within the first 8192 bytes for: src/large.ts',
+      'marker scan truncated (bytes scanned of total): src/large.ts 13/8205',
     );
+    // Order is scanned-of-total, not total-of-scanned: the reversal is still two true
+    // numbers, so only pinning the sequence catches it.
+    expect(result.stdout).not.toContain('8205/13');
+    // Neither the old bound phrasing nor the constant may return.
     expect(result.stdout).not.toContain('truncated after 8192 bytes');
+    expect(result.stdout).not.toContain('within the first 8192 bytes');
+    expect(result.stdout).not.toContain('8192');
+  });
+
+  test('check --json carries no extent fields, so its contract is unchanged', async () => {
+    const root = await seedCorpus();
+    await writeText(join(root, 'src/large.ts'), `// @adr 0001\n${'x'.repeat(8192)}`);
+
+    const result = await runAdr(['check', 'src/large.ts', '--dir', 'docs/adr', '--json'], root);
+
+    expect(result.exitCode).toBe(0);
+    const outcome = JSON.parse(result.stdout);
+    // The human surface gained the measurement; `MarkerScanReport` deliberately did not.
+    // `truncatedPaths` stays a plain sorted string list, and no extent leaks into the
+    // Action's contract — that is what made closing the asymmetry a non-breaking change.
+    expect(outcome.markerScan.truncatedPaths).toEqual(['src/large.ts']);
+    expect(result.stdout).not.toContain('scannedBytes');
+    expect(result.stdout).not.toContain('fileBytes');
   });
 
   // Only a local invocation can reach the cap: the Action refuses to evaluate a diff

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -61,11 +61,21 @@ therefore scan differently.
 `readSourceMarkers` wraps the scanner with a bounded read and reports `state` as
 `scanned`, `absent`,
 `unreadable`, or `out-of-tree`, so "found no markers" is never confused with
-"could not look." A `scanned` result also carries `scannedBytes` and `fileBytes`, the
-measured extent of the read: `fileBytes - scannedBytes` is how much of a truncated
-file went unscanned, which `truncated` alone does not say. `scannedBytes` is the cut
-actually taken, not `min(fileBytes, 8192)`, because the window is cut back to its last
-complete line. Both are omitted for a state that never opened the file.
+"could not look." A `scanned` result also carries `scannedBytes` and `fileBytes`.
+`scannedBytes` is the prefix handed to the scanner — not the number of bytes pulled
+from the handle, which also includes a truncation probe byte and any partial trailing
+line the cut then discards — and it is the cut actually taken rather than
+`min(fileBytes, 8192)`, because the window is cut back to its last complete line.
+`fileBytes - scannedBytes` is how much of a truncated file went unscanned, which
+`truncated` alone does not say. Both are omitted for a state that never opened the
+file, so a `0` extent means a window with no line terminator, never "not measured."
+
+The two are separate observations, not one: `fileBytes` comes from an `fstat` taken
+before the read loop, so a file written concurrently can report `scannedBytes >
+fileBytes` (appended) or look partial when it was read whole (truncated). They are
+left unreconciled deliberately — agreeing them would hide a file that changed
+underneath the scan — so a consumer differencing them should clamp at `0` rather than
+assume the remainder is non-negative.
 
 Its `path` argument is repo-relative to `cwd`. Absolute paths and paths that climb
 out of the tree are `out-of-tree`. Every symlink is refused as `unreadable`

--- a/packages/core/src/markers/scan.ts
+++ b/packages/core/src/markers/scan.ts
@@ -136,10 +136,16 @@ function completeLinePrefix(source: string): string {
  * complete lines within `bytes[0, limit)`, or `0` when the window holds no line
  * terminator at all.
  *
+ * Internal to `@adrkit/core`: `markers/index.ts` does not re-export it, and it is not
+ * public API. It exists so the filesystem reader can report the number it cut at
+ * without decoding twice.
+ *
  * The byte search is equivalent to the string search rather than an approximation of
  * it. `\n` (0x0A) and `\r` (0x0D) are single-byte code points, and every UTF-8
  * continuation byte is >= 0x80, so neither terminator can occur inside a multi-byte
- * sequence.
+ * sequence. That equivalence is a rule spanning two representations and nothing in the
+ * type system holds it, so it is pinned by test ("the byte cut and the text cut cannot
+ * drift apart") rather than left to this comment.
  *
  * Measured here rather than by re-encoding the decoded prefix, for the same reason the
  * truncation flag is observed rather than inferred (see

--- a/packages/core/test/markers-scan.test.ts
+++ b/packages/core/test/markers-scan.test.ts
@@ -8,6 +8,10 @@ import {
   readSourceMarkersBatch,
   scanSourceMarkers,
 } from '../src/markers/index.ts';
+// Reached through the module rather than the barrel: both are internal to `@adrkit/core`
+// and deliberately unexported from `markers/index.ts`. Importing them here pins their
+// behaviour without widening the package's public surface.
+import { completeLineByteExtent, scanBoundedSourceMarkerWindow } from '../src/markers/scan.ts';
 import { cleanupTestDir, resetTestDir, writeText } from './helpers.ts';
 
 const DIR_NAME = 'core-markers-scan';
@@ -830,5 +834,122 @@ describe('readSourceMarkersBatch', () => {
     expect(batch.scans.map((scan) => scan.path)).toEqual(selectedNames);
     expect(batch.skippedPaths).toEqual(['src/z-last.ts', 'src/ä-last.ts']);
     expect(batch.totalCandidates).toBe(MARKER_SCAN_FILE_CAP + 2);
+  });
+});
+
+/**
+ * ADR-0024 leaves one invariant unguarded by the type system: the cut back to the last
+ * complete line is now implemented twice — `completeLineByteExtent` on raw bytes, which
+ * produces the reported `scannedBytes`, and `completeLinePrefix` on decoded text, which
+ * produces the string the scanner actually reads. The record states the requirement as
+ * "any future change to the cut must keep the reported number and the scanned text one
+ * computation", and nothing enforces it: a change to either alone compiles, and the
+ * damage is a `scannedBytes` that claims bytes the scanner discarded.
+ *
+ * These tests are the enforcement. They assert the property rather than re-implementing
+ * the search, so they cannot drift with it in the way a copied algorithm would.
+ */
+describe('the byte cut and the text cut cannot drift apart', () => {
+  const PROBE_PATH = 'src/probe.ts';
+
+  function assertCutsAgree(bytes: Uint8Array, limit: number): void {
+    const extent = completeLineByteExtent(bytes, limit);
+    const capped = Math.min(limit, bytes.length);
+    const isTerminator = (byte: number | undefined): boolean => byte === 0x0a || byte === 0x0d;
+
+    expect(extent).toBeGreaterThanOrEqual(0);
+    expect(extent).toBeLessThanOrEqual(capped);
+
+    // Stated as a boundary property, independent of how the boundary is found: the
+    // extent ends just past a terminator, and no terminator is left unclaimed behind it.
+    // A forward search, an off-by-one, or dropping `0x0D` each breaks one of these.
+    if (extent === 0) {
+      for (let index = 0; index < capped; index += 1) {
+        expect(isTerminator(bytes[index])).toBe(false);
+      }
+    } else {
+      expect(isTerminator(bytes[extent - 1])).toBe(true);
+      for (let index = extent; index < capped; index += 1) {
+        expect(isTerminator(bytes[index])).toBe(false);
+      }
+    }
+
+    // The behavioural half. `scanBoundedSourceMarkerWindow` applies the *text* cut only
+    // when told the read was truncated, so identical markers under both flags means the
+    // text cut removed nothing from what the byte cut produced — i.e. the two agree.
+    const source = new TextDecoder().decode(bytes.subarray(0, extent));
+    expect(scanBoundedSourceMarkerWindow(source, PROBE_PATH, true).markers).toEqual(
+      scanBoundedSourceMarkerWindow(source, PROBE_PATH, false).markers,
+    );
+  }
+
+  test.each([
+    ['no terminator anywhere', '// @adr 0012 with no newline at all'],
+    ['lone CR only', '// @adr 0012\r'],
+    ['lone LF only', '// @adr 0012\n'],
+    ['CRLF', '// @adr 0012\r\n'],
+    ['trailing partial line', '// @adr 0012\n// @adr 001'],
+    ['terminator as the very first byte', '\n// @adr 0012'],
+    ['blank lines after the marker', '// @adr 0012\n\n\n'],
+    ['BOM then a marker', '\ufeff// @adr 0012\nrest'],
+    ['multi-byte content around the marker', '// @adr 0012\n// caf\u00e9 \u00e9\u00e9\u00e9 \ud83d\ude80\nx'],
+    ['CR inside a longer body', 'a\rb\rc'],
+  ])('agrees for %s', (_name, source) => {
+    const bytes = new TextEncoder().encode(source);
+    for (const limit of [0, 1, 2, bytes.length - 1, bytes.length, bytes.length + 5]) {
+      if (limit >= 0) assertCutsAgree(bytes, limit);
+    }
+  });
+
+  test('agrees on invalid UTF-8, which the decoder rewrites but the byte search must not', () => {
+    // A truncated multi-byte sequence and a stray continuation byte. `TextDecoder`
+    // expands each into U+FFFD, so a re-encoded length would not be the length that was
+    // read — the reason the extent is measured on bytes in the first place.
+    const bytes = new Uint8Array([0x2f, 0x2f, 0x20, 0xe2, 0x82, 0x0a, 0x80, 0xff, 0x0a, 0x78]);
+    for (let limit = 0; limit <= bytes.length + 2; limit += 1) assertCutsAgree(bytes, limit);
+  });
+
+  test('agrees across a deterministic fuzz corpus spanning the window boundary', () => {
+    // Seeded so a failure is reproducible; the repository treats determinism as a
+    // property worth pinning rather than a coincidence.
+    let seed = 0x9e3779b9;
+    const next = (): number => {
+      seed = (seed + 0x6d2b79f5) >>> 0;
+      let t = seed;
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+    // Terminators and marker-ish bytes are over-weighted so the interesting cases are
+    // actually hit; the tail covers multi-byte and invalid sequences.
+    const alphabet = [0x0a, 0x0d, 0x20, 0x2f, 0x40, 0x61, 0x30, 0xc3, 0xa9, 0xe2, 0x82, 0xac, 0xff];
+
+    for (let trial = 0; trial < 400; trial += 1) {
+      const length = Math.floor(next() * 40) + 1;
+      const bytes = new Uint8Array(length);
+      for (let index = 0; index < length; index += 1) {
+        bytes[index] = alphabet[Math.floor(next() * alphabet.length)]!;
+      }
+      assertCutsAgree(bytes, Math.floor(next() * (length + 3)));
+    }
+  });
+
+  test('agrees at the real window boundary, where the probe byte sits just past the limit', () => {
+    // The shape `read.ts` actually produces: a full window plus one truncation probe
+    // byte. The extent must never reach into the probe, whatever the probe happens to be.
+    for (const probe of [0x0a, 0x0d, 0x78]) {
+      for (const lastWindowByte of [0x0a, 0x0d, 0x78]) {
+        const bytes = new Uint8Array(MARKER_HEADER_WINDOW_BYTES + 1);
+        bytes.fill(0x78);
+        bytes[0] = 0x0a;
+        bytes[MARKER_HEADER_WINDOW_BYTES - 1] = lastWindowByte;
+        bytes[MARKER_HEADER_WINDOW_BYTES] = probe;
+
+        const extent = completeLineByteExtent(bytes, MARKER_HEADER_WINDOW_BYTES);
+        expect(extent).toBeLessThanOrEqual(MARKER_HEADER_WINDOW_BYTES);
+        expect(extent).toBe(lastWindowByte === 0x78 ? 1 : MARKER_HEADER_WINDOW_BYTES);
+        assertCutsAgree(bytes, MARKER_HEADER_WINDOW_BYTES);
+      }
+    }
   });
 });

--- a/site/src/content/docs/commands.mdx
+++ b/site/src/content/docs/commands.mdx
@@ -182,6 +182,15 @@ window, which across this repository's own sources lands 1–77 bytes short of i
 much further short when one long line spans the boundary. Both fields are omitted
 for a state that never opened the file.
 
+Two details matter if you difference them. `scannedBytes` is the prefix handed to the
+scanner, not the byte count pulled from the handle — the reader also fetches a
+truncation probe byte, and discards any partial trailing line. And the two numbers are
+separate observations: `fileBytes` is taken by `fstat` before the read loop, so a file
+appended to mid-scan can report `scannedBytes` greater than `fileBytes`, and one
+truncated mid-scan can look partial when it was read whole. They are left unreconciled
+on purpose, because agreeing them would hide a file that changed underneath the scan —
+so clamp `fileBytes - scannedBytes` at `0` rather than assuming it is non-negative.
+
 In `governedBy`, a pattern match carries `firedMatchers` and a file declaration
 carries `declaredBy`; `declaredBy` is omitted entirely when nothing declared the
 record.


### PR DESCRIPTION
Closes ADR-0024's two open action items and the review findings against #120. Taken together because action item 1 is the ratification and action item 3 is a decision the ratified text had to state.

## Action item 3 — decided: the human renderer only

ADR-0024 left open whether `check`'s truncation warning should carry per-path extents, on the premise that they'd have to travel through `MarkerScanReport` and change `check --json`. **That premise was wrong.** `runCheck` already holds the batch scan, so it hands `renderHumanCheck` a path→extent map:

```
marker scan truncated (bytes scanned of total): src/big.ts 13/8205
```

`check --json` stays byte-identical — verified by running base and HEAD over the same corpus and diffing SHA256, not by assertion:

```
8748874a56e8ff30dacd15c45f7a664fa1685ac6a1de8541f0a9b2d4008b6a32  main
8748874a56e8ff30dacd15c45f7a664fa1685ac6a1de8541f0a9b2d4008b6a32  HEAD
```

The distance this closes isn't cosmetic. The repository's own fixture is a 12-byte marker line followed by 8192 bytes of unbroken content — it stops at **byte 13**, and both prior phrasings named 8192.

**Extending `MarkerScanReport` was considered and declined**, recorded in the ADR. `truncatedPaths` is one of five flat code-unit-sorted `string[]`s, so extents would need a breaking shape change, a parallel array duplicating the paths (the redundancy Option B was rejected for), or a path-keyed map that reopens the ordering surface #117 and #119 just hardened. A shipped `check --json` field can't be withdrawn; a human string can. No consumer has asked, so the door stays open for one that can say what shape it needs.

## Action item 1 — ratified as an amendment

`status: accepted`, `deciders: ["@mbeacom"]`, `provenance.ratifiedBy`. ADR-0022 stands in full and its `supersededBy` stays empty.

The Decision text is **widened at ratification** rather than shipping the asymmetry the record itself called an open question. A ratification note records that the proposed text differed — the record shouldn't silently claim it always said this.

## Review findings closed

**The cut now exists in two representations** (`completeLinePrefix` on text, `completeLineByteExtent` on bytes) and nothing in the type system holds them together — which the record names as load-bearing. Pinned by a property + seeded-fuzz suite that asserts the *property* (extent lands at a terminator; the text cut is a no-op on the byte-cut text) rather than re-implementing the search, so it can't drift along with the code.

Each mutant was observed failing before it passed ([ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)):

| Mutant | Failures |
| --- | --- |
| drop `0x0D` from the cut | 6 |
| `return index` off-by-one | 19 |
| forward search instead of backward | 10 |
| reach into the probe byte (`limit + 1`) | 10 |

Plus two on the `check` renderer: swapped `scanned`/`total` order, and dropping the extent to a bare path.

**Every published surface presented `fileBytes - scannedBytes` as unconditionally non-negative.** The caveat that a concurrent append can invert it lived only in `read.ts` JSDoc and the ADR — not where a `--json` consumer reads. Now stated in `commands.mdx`, both READMEs, and the CHANGELOG, along with the distinction that `scannedBytes` is the prefix *handed to the scanner*, not the bytes pulled from the handle.

**`completeLineByteExtent`** gains the "Internal to `@adrkit/core`" note its sibling carries, so its exclusion from the barrel is documented at the definition rather than only enforced at it.

## Note on the CHANGELOG

The #120 entry is **amended, not corrected in a new bullet** — it's still unreleased and described a `check` phrasing that will never ship. Layering a correction onto an unreleased entry would leave the changelog narrating an intermediate state no user can observe.

## Checklist

- [x] Commits are **DCO signed off** (`git commit -s`).
- [x] Changes a recorded decision — ADR-0024 is ratified, with the Decision text and action items updated to what was actually decided.
- [x] No schema change (`bun run schema:emit` produces no diff).
- [x] New behavior covered by tests, each **observed failing before it passed** (table above).
- [x] `bun run typecheck && bun run build && bun test && bun run lint` pass — **1958 pass / 0 fail**, up from 1944.
- [x] `packages/ci/dist` rebuilds with **no diff** (the core change is JSDoc; the CLI isn't in that bundle). Also clean: `adr lint` (24 records, 0 errors), `check:deps`, `check:freeze-hashes`.

## Notes for reviewers

`adr check`'s human stdout is not a stability contract — `--json` is — but this is the second wording change in two PRs, so anything scraping it should move to `--json`. Called out in the CHANGELOG.

Everything here was validated on macOS/bun 1.3.14; CI on `ubuntu-latest` is the arbiter as usual.