### PR TITLE
chore(release): v0.6.0 — ratify ADR-0024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,7 +568,8 @@ against live Spec Kit, rather than reasoning about it:
 - Node-targeted published distribution of all packages, smoke-tested under Node
   22 and 24.
 
-[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/mbeacom/adrkit/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mbeacom/adrkit/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/mbeacom/adrkit/compare/v0.3.0...v0.4.0
 [spec-kit-0.1.2]: https://github.com/mbeacom/adrkit/compare/spec-kit-v0.1.1...spec-kit-v0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-11
+
 ### Added
 
 - `adr explain --json` reports `markers.scannedBytes` and `markers.fileBytes`

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "adr": "./dist/index.js",
       },
@@ -65,7 +65,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -80,7 +80,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -91,7 +91,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Decision memory for human and agent-authored plans — machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,7 +37,7 @@ import { isMainModule } from './main-module.ts';
  * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
  * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
  */
-export const CLI_VERSION = '0.5.0';
+export const CLI_VERSION = '0.6.0';
 
 function writeStdout(text: string): void {
   process.stdout.write(text);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adrkit/mcp",
   "mcpName": "dev.adrkit/mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetDecisionContext } from './tools/get-decision-context.ts';
 import { registerListSuperseded } from './tools/list-superseded.ts';
 import type { ToolConfig } from './tools/shared.ts';
 
-export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.5.0' } as const;
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.6.0' } as const;
 
 /**
  * The MCP protocol revision this server serves through `serveStdio`'s modern era.

--- a/scripts/check-changelog.test.ts
+++ b/scripts/check-changelog.test.ts
@@ -31,6 +31,10 @@ const HEALTHY = `# Changelog
 ### Added
 
 - An older shipped feature.
+
+[Unreleased]: https://example.invalid/compare/v0.5.0...HEAD
+[0.5.0]: https://example.invalid/compare/v0.4.0...v0.5.0
+[0.4.0]: https://example.invalid/compare/v0.3.0...v0.4.0
 `;
 
 afterEach(async () => {
@@ -61,8 +65,15 @@ describe('check-changelog', () => {
     const result = checkChangelogContent(absorbed, '0.5.0');
 
     expect(result.ok).toBe(false);
-    expect(result.violations.map((violation) => violation.rule)).toEqual(['missing-release-section']);
-    expect(result.violations[0]?.message).toContain('0.5.0');
+    // Two faults, both real: the heading is gone, and `[Unreleased]` is left
+    // comparing from a version that no longer has a section. `[0.5.0]`'s own
+    // definition survives #117's edit, so no link goes missing — only the
+    // heading it pointed at.
+    expect(result.violations.map((violation) => violation.rule)).toEqual([
+      'stale-unreleased-link',
+      'missing-release-section',
+    ]);
+    expect(result.violations.some((violation) => violation.message.includes('0.5.0'))).toBe(true);
     // The healthy fixture it was derived from does pass, so the failure is caused by
     // the absorbed heading and not by something else in the fixture.
     expect(checkChangelogContent(HEALTHY, '0.5.0').ok).toBe(true);
@@ -107,6 +118,9 @@ describe('check-changelog', () => {
     const WITH_ADAPTER = HEALTHY.replace(
       '## [0.4.0] - 2026-08-08',
       '## [spec-kit-0.1.2] - 2026-08-03\n\n### Fixed\n\n- An adapter fix.\n\n## [0.4.0] - 2026-08-08',
+    ).replace(
+      '[0.4.0]: https://example.invalid/compare/v0.3.0...v0.4.0',
+      '[spec-kit-0.1.2]: https://example.invalid/compare/spec-kit-v0.1.1...spec-kit-v0.1.2\n[0.4.0]: https://example.invalid/compare/v0.3.0...v0.4.0',
     );
 
     test('an adapter section is recognized but never satisfies the root version', () => {
@@ -144,6 +158,39 @@ ${WITH_ADAPTER.slice(WITH_ADAPTER.indexOf('## [Unreleased]'))}`;
     const result = await checkChangelog();
     expect(result.releaseLabels.length).toBeGreaterThan(result.releasedVersions.length);
     expect(result.releaseLabels.some((label) => label.startsWith('spec-kit-'))).toBe(true);
+  });
+
+  describe('compare-link definitions', () => {
+    // The omission this caught in the v0.6.0 release PR: the heading was cut
+    // correctly but neither link definition was updated, so `[0.6.0]` resolved to
+    // nothing and `[Unreleased]` still compared from the previous tag.
+    test('a release heading with no link definition is caught', () => {
+      const orphaned = HEALTHY.replace('[0.5.0]: https://example.invalid/compare/v0.4.0...v0.5.0\n', '');
+      const result = checkChangelogContent(orphaned, '0.5.0');
+      expect(result.violations.map((violation) => violation.rule)).toEqual(['missing-compare-link']);
+      expect(result.violations[0]?.message).toContain('0.5.0');
+    });
+
+    test('an [Unreleased] link left comparing from the previous tag is caught', () => {
+      const stale = HEALTHY.replace('compare/v0.5.0...HEAD', 'compare/v0.4.0...HEAD');
+      const result = checkChangelogContent(stale, '0.5.0');
+      expect(result.violations.map((violation) => violation.rule)).toEqual(['stale-unreleased-link']);
+    });
+
+    test('an adapter release needs a definition too', () => {
+      const undefinedAdapter = HEALTHY.replace(
+        '## [0.4.0] - 2026-08-08',
+        '## [spec-kit-0.1.2] - 2026-08-03\n\n### Fixed\n\n- An adapter fix.\n\n## [0.4.0] - 2026-08-08',
+      );
+      expect(checkChangelogContent(undefinedAdapter, '0.5.0').violations.map((v) => v.rule)).toEqual([
+        'missing-compare-link',
+      ]);
+    });
+
+    test('a changelog with no link definitions at all is not badgered into the convention', () => {
+      const none = HEALTHY.split('\n[Unreleased]:')[0] as string;
+      expect(checkChangelogContent(none, '0.5.0').ok).toBe(true);
+    });
   });
 
   test('reads the real package.json and CHANGELOG.md from the given root', async () => {

--- a/scripts/check-changelog.ts
+++ b/scripts/check-changelog.ts
@@ -30,8 +30,21 @@ import { fileURLToPath } from 'node:url';
 const RELEASE_HEADING = /^## \[(?:([a-z0-9][a-z0-9-]*)-)?(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})\s*$/;
 const UNRELEASED_HEADING = /^## \[Unreleased\]\s*$/;
 
+/**
+ * Every release heading is a link reference (`## [0.6.0] - …`), resolved by a
+ * definition at the foot of the file. A heading with no definition renders as literal
+ * brackets, and an `[Unreleased]` definition left comparing from the previous tag
+ * silently reports the just-released changes as still unreleased.
+ */
+const LINK_DEFINITION = /^\[([^\]]+)\]:\s*(\S+)\s*$/;
+
 export interface ChangelogViolation {
-  rule: 'missing-release-section' | 'missing-unreleased' | 'unreleased-not-first';
+  rule:
+    | 'missing-release-section'
+    | 'missing-unreleased'
+    | 'unreleased-not-first'
+    | 'missing-compare-link'
+    | 'stale-unreleased-link';
   message: string;
 }
 
@@ -62,7 +75,35 @@ export function checkChangelogContent(changelog: string, version: string): Chang
     if (firstReleaseAt === -1) firstReleaseAt = index;
   });
 
+  const links = new Map<string, string>();
+  for (const line of lines) {
+    const definition = LINK_DEFINITION.exec(line);
+    if (definition) links.set(definition[1] as string, definition[2] as string);
+  }
+
   const violations: ChangelogViolation[] = [];
+
+  // Only enforced once the file uses link definitions at all, so a changelog that
+  // does not adopt the convention is not badgered into it.
+  if (links.size > 0) {
+    for (const label of releaseLabels) {
+      if (!links.has(label)) {
+        violations.push({
+          rule: 'missing-compare-link',
+          message: `"## [${label}]" has no "[${label}]: <url>" definition, so the heading renders as literal brackets.`,
+        });
+      }
+    }
+
+    const unreleasedLink = links.get('Unreleased');
+    const newest = releasedVersions[0];
+    if (unreleasedLink && newest && !unreleasedLink.endsWith(`v${newest}...HEAD`)) {
+      violations.push({
+        rule: 'stale-unreleased-link',
+        message: `[Unreleased] compares from "${unreleasedLink}" but the newest release is ${newest}; it must end with "v${newest}...HEAD" or it reports released changes as unreleased.`,
+      });
+    }
+  }
 
   if (!releasedVersions.includes(version)) {
     violations.push({


### PR DESCRIPTION
Version bump only — **not tagged**. Steps 3–5 of `docs/RELEASING.md` §"Subsequent releases" (annotated tag, protected `npm` environment approval, confirming the `v0` move) stay with you.

Per the runbook this should be the **last change merged before tagging**; if anything lands ahead of it, the changelog needs refreshing and the simulation re-running.

> **Rebased onto #123.** That PR also ratified ADR-0024, so this one no longer touches the record at all — see "Overlap with #123" below.

## Why minor, not patch

v0.6.0 adds a runtime export. `docs/RELEASING.md` §"SemVer and export-surface policy" says adding one is not breaking but "intentionally expands the API: update the matching surface test and mention the addition in the release notes" — both done (`compareByDisplayPath` is pinned in the surface test and called out under `### Added`).

## Contents

| | |
| --- | --- |
| #117, #119 | the #115 determinism sweep — `check --json` surfaces, corpus discovery, `lintCorpus` |
| #120 | measured marker scan extent (ADR-0024) |
| #121 | restored the v0.5.0 changelog boundary, added `check:changelog` |
| #123 | ADR-0024 ratified + `check`'s human warning reports the measured extent |

## Overlap with #123

Both PRs originally ratified ADR-0024. **#123's version is the better one** — it ratifies *and* widens the Decision text with a ratification note, rather than shipping the asymmetry the record itself flagged as an open question. So #123 merged first and this PR was rebased on top, at which point my identical frontmatter edit became a no-op and git dropped it:

```
$ git diff origin/main -- docs/adr/0024-*.md
(empty)
```

Two things I checked rather than assumed, because #123 branched from `261e38b` — *before* #121 restored the `## [0.5.0]` heading, so a two-dot diff makes it look like it deletes that heading again:

1. **A three-way merge of #123 into main is clean** and preserves the restored boundary. Simulated it before merging: `## [0.5.0]` intact, `compareByDisplayPath` entry intact, `check:changelog` ok, 1970 tests pass. The apparent deletion was a diff artifact — #123 never touched that line, because it did not exist at its base.
2. **After rebasing, the 0.6.0 section is byte-equal to main's `[Unreleased]` body**, `[Unreleased]` is empty, and the 0.5.0 section is untouched. The only content line in main not present here is the old `[Unreleased]` compare link, which is intentionally replaced.

## ADR-0024 ratification (landed in #123)

Worth recording since it surprised me: ratifying needed `provenance.ratifiedBy`, not just `deciders`. The record is `agent-drafted`, and adrkit's own rule refused it:

```
error agent-accepted-requires-ratifier 0024 provenance.ratifiedBy:
  a machine-originated record cannot reach "accepted" without a named human ratifier
```

Caught on its own corpus by `adr lint` and the CLI's "passes on this repository corpus" test. The governance rule did the thing it was written for.

## The lockfile, and a deliberate omission

Version moves across nine sites plus the four workspace entries in `bun.lock`.

I edited the lockfile **surgically rather than regenerating it**. A full `bun install` regeneration produced 22 insertions / 14 deletions, pulling in unrelated upgrades:

- `@octokit/core` 7.0.6 → 7.0.7 (and `@octokit/types` 16 → 17, `openapi-types` 27 → 28, endpoint, graphql, request, request-error)
- `undici` 6.27.0 → 6.28.0, `jose` 6.2.3 → 6.2.8, `@types/node` 26.1.1 → 26.2.0

That is precisely the transitive drift `docs/RELEASING.md` warns "can pull … into the committed `packages/ci/dist` bundles" — and `@actions/github` bundles Octokit into the shipped Action. **Worth taking, but deliberately and in its own PR**, where the dist diff can be reviewed as a dependency change rather than buried in a release. Happy to open that next.

The diff here is the same four version lines the v0.5.0 release commit changed, and `bun install --frozen-lockfile` is satisfied.

## Local release simulation (re-run after the rebase)

- `bun run release:pack -- --tag v0.6.0` — prepared 5 packages. `git status` clean afterwards; **no lockfile or `packages/ci/dist` drift** (the runbook's step-2 check).
- `bun run release:publish -- --dry-run` — all four lockstep packages dry-ran cleanly at 0.6.0, then failed on `@adrkit/spec-kit@0.1.2`: the known dry-run-only #104 behaviour.

  Verified rather than trusted, as the v0.5.0 cutover note asks:

  ```
  packed by dry run : a2dca70f95667f8552fece58f57b750445cbc00c
  registry shasum   : a2dca70f95667f8552fece58f57b750445cbc00c
  ```

  `dist.integrity` matches too, so the real run will skip the adapter rather than attempt a republish.

## Compare links (review feedback)

The first push cut the heading but not the link definitions, so `[0.6.0]` resolved to nothing and `[Unreleased]` still compared from `v0.5.0`. Fixed — and more usefully, the `check:changelog` guard from #121 *didn't catch it*, which is the same overstated-coverage failure it exists to prevent. Two rules added: `missing-compare-link` and `stale-unreleased-link`, both observed failing against this PR's own previous state.

## Verification

- `bun test` — 1974 pass, 0 fail, 168 files
- `bun run typecheck`, `bun run lint` — clean
- `check:deps`, `check:freeze-hashes`, `check:changelog`, `adr lint` (24 records, 0 errors) — all ok
- `bun packages/cli/src/index.ts --version` → `0.6.0`