### PR TITLE
docs(readme): add the corpus-size and ARB queue badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ without leaving git.
 
 [![npm version](https://img.shields.io/npm/v/@adrkit/cli?logo=npm&label=%40adrkit%2Fcli)](https://www.npmjs.com/package/@adrkit/cli)
 [![CI](https://github.com/mbeacom/adrkit/actions/workflows/ci.yml/badge.svg)](https://github.com/mbeacom/adrkit/actions/workflows/ci.yml)
+[![ADRs](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fadrkit.dev%2Flint.json&query=%24.checked&label=ADRs&color=cb492d)](./docs/adr)
+[![ARB queue](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fadrkit.dev%2Fqueue.json&query=%24.totalItems&label=ARB%20queue&suffix=%20pending&color=cb492d)](./docs/adr)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 
 Most ADR tooling is a markdown template and a static site generator. That

--- a/docs/adr/0025-ship-badges-as-recipes-over-existing-output.md
+++ b/docs/adr/0025-ship-badges-as-recipes-over-existing-output.md
@@ -350,11 +350,12 @@ an artifact claim more than it can support — but readers will over-read it.
 
 ## Action items
 
-1. [ ] Add the queue badge to `README.md` once `https://adrkit.dev/queue.json`
-       is live, verifying the render end to end at that point — the shields mechanism and both failure
-       renders were observed, and the first-run/no-change/changed paths of the
-       adopter recipe were executed, but the deployed path cannot be exercised
-       until this merges and the site publishes (ADR-0016).
+1. [x] Add the badges to `README.md` once the reports are live, verifying the
+       render end to end at that point. Done: `https://adrkit.dev/lint.json` and
+       `/queue.json` both return HTTP 200 from the first post-merge deploy, and
+       shields renders `ADRs: 25` and `ARB queue: 6` against them. This closes
+       the last claim in this record that had been reasoned rather than observed
+       (ADR-0016).
 2. [x] Fix the badge's brand color against the site palette — resolved to
        `#cb492d` / `#1d1311`, converted from `site/src/styles/custom.css`.
 3. [x] Publish `lint.json` alongside `queue.json` from the site build, and


### PR DESCRIPTION
Closes [ADR-0025](https://github.com/mbeacom/adrkit/blob/main/docs/adr/0025-ship-badges-as-recipes-over-existing-output.md) action item 1 — the last claim in that record that had been reasoned rather than observed.

## What this adds

Two badges to the README, both reading JSON the site now publishes:

| Badge | Source | Renders |
|---|---|---|
| `ADRs` | `$.checked` from `adrkit.dev/lint.json` | **25** |
| `ARB queue` | `$.totalItems` from `adrkit.dev/queue.json` | **6 pending** |

## Why this is a separate PR

The URLs did not exist until #127 merged and the site deployed. Shipping the badges in that PR would have put two error tiles on this project's front page — the exact failure ADR-0025 exists to avoid — so the record tracked it as an open action item instead.

## Verified end to end, not reasoned

```
GET https://adrkit.dev/lint.json   → 200  {"checked": 25, "findings": []}
GET https://adrkit.dev/queue.json  → 200  totalItems = 6, asOf = 2026-08-12
shields dynamic/json               → "ADRs: 25"  ·  "ARB queue: 6"
```

Both were rendered through shields against the live URLs before this was written.

## One deliberate choice worth surfacing

`ARB queue: 6 pending` is not a flattering number — those six records (0003, 0005–0009) have been awaiting review since July. It is shown anyway. A queue badge that only ever reads zero is decoration; the number earns its place precisely when it is uncomfortable, and a tool whose thesis is that decision records must not lie should not hide its own backlog.

If you'd rather ship only `ADRs: 25` and keep the badge row at four, say so and I'll drop the queue badge — but I'd argue for keeping it.

## Notes

- No source changes; README and the ADR's action item only.
- The badge row is now five. If that feels crowded, the `License` badge is the most redundant of the five (the LICENSE file is one click away and GitHub surfaces it in the sidebar).