### PR TITLE
fix(ci): update the governing-decisions comment instead of posting a new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,39 @@ Until `1.0.0`, minor releases may include breaking changes
   compliance obligation the project cannot yet compute. Its `reviewBy` of
   2027-01-18 leaves room to ship Passes 1–3 first.
 
+### Fixed
+
+- **The governing-decisions Action now updates its own comment instead of posting a
+  new one on every push** ([#107](https://github.com/mbeacom/adrkit/issues/107),
+  [ADR-0026](docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md)).
+  A long-lived pull request accumulated one near-identical comment per push, which is
+  the exact anti-pattern the hidden `<!-- adrkit:ci -->` marker exists to prevent.
+
+  **The upsert was correct; the identity it depended on was unobtainable.** Locating
+  the Action's own comment required its own login, and the default `GITHUB_TOKEN` is a
+  GitHub App installation token that cannot call `users.getAuthenticated`. The fallback
+  was gated on recognising the token as the default one by comparing it against
+  `process.env.GITHUB_TOKEN` — but `action.yml` defaults the `token` input to
+  `${{ github.token }}`, and Actions does not export `GITHUB_TOKEN` into a step unless
+  the workflow asks. So the comparison had no right-hand side, the identity resolved to
+  "unknown", and every run created. Passing `token:` explicitly changed nothing, because
+  the input already held that value.
+
+  **Identity is now classified by what the token actually proves.** A permission-shaped
+  refusal of `users.getAuthenticated` is not missing information — it is how an app
+  installation token is always refused, so it establishes that the author is a *bot*.
+  The Action pairs that with a stricter marker rule for this path: the marker must be
+  exactly the body's **first line**, which is true of every comment it has ever posted
+  and false of a human or another bot quoting one. That is the same ownership test the
+  ARB queue Action already applies to its managed issue, so both now answer "is this
+  ours?" identically. A resolved login still matches exactly. An identity that cannot be
+  resolved at all still adopts nothing, but now says so as a job-log warning instead of
+  passing silently.
+
+  This also fixes repositories using a custom GitHub App token (`actions/create-github-app-token`),
+  which never had a working upsert. The `env: GITHUB_TOKEN: ${{ github.token }}`
+  workaround is no longer needed and can be removed.
+
 ## [0.6.0] - 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,9 @@ Until `1.0.0`, minor releases may include breaking changes
   new one on every push** ([#107](https://github.com/mbeacom/adrkit/issues/107),
   [ADR-0026](docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md)).
   **If you added `env: GITHUB_TOKEN: ${{ github.token }}` as a workaround, you can
-  remove it.** Comments a pull request accumulated before upgrading stay put — the
+  remove it once you are on this release** — it becomes a no-op rather than a
+  requirement, so leaving it costs nothing. Comments a pull request accumulated before
+  upgrading stay put — the
   Action deletes nothing; it updates the newest and leaves the rest for you to clear
   once. A long-lived pull request previously gained one near-identical comment per
   push, which is the exact anti-pattern the hidden `<!-- adrkit:ci -->` marker exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,12 @@ Until `1.0.0`, minor releases may include breaking changes
 - **The governing-decisions Action now updates its own comment instead of posting a
   new one on every push** ([#107](https://github.com/mbeacom/adrkit/issues/107),
   [ADR-0026](docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md)).
-  A long-lived pull request accumulated one near-identical comment per push, which is
-  the exact anti-pattern the hidden `<!-- adrkit:ci -->` marker exists to prevent.
+  **If you added `env: GITHUB_TOKEN: ${{ github.token }}` as a workaround, you can
+  remove it.** Comments a pull request accumulated before upgrading stay put — the
+  Action deletes nothing; it updates the newest and leaves the rest for you to clear
+  once. A long-lived pull request previously gained one near-identical comment per
+  push, which is the exact anti-pattern the hidden `<!-- adrkit:ci -->` marker exists
+  to prevent.
 
   **The upsert was correct; the identity it depended on was unobtainable.** Locating
   the Action's own comment required its own login, and the default `GITHUB_TOKEN` is a
@@ -120,8 +124,9 @@ Until `1.0.0`, minor releases may include breaking changes
   passing silently.
 
   This also fixes repositories using a custom GitHub App token (`actions/create-github-app-token`),
-  which never had a working upsert. The `env: GITHUB_TOKEN: ${{ github.token }}`
-  workaround is no longer needed and can be removed.
+  which never had a working upsert. Making the update path reachable also made a race
+  reachable that had never fired: a prior comment deleted between the list and the
+  update now yields a replacement rather than costing that push its comment.
 
 ## [0.6.0] - 2026-08-11
 

--- a/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
+++ b/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
@@ -25,6 +25,8 @@ affects:
     pattern: "specs/004-ci-surface/research.md"
   - type: path
     pattern: "specs/004-ci-surface/quickstart.md"
+  - type: path
+    pattern: "site/src/content/docs/ci.mdx"
 provenance:
   authoredBy: agent-drafted
   ratifiedBy: "@mbeacom"
@@ -42,7 +44,7 @@ review:
   queuedAt: 2026-08-12T00:00:00Z
   slaDays: 30
   approvals: ["@mbeacom"]
-  decidedAt: 2026-08-12T13:30:00Z
+  decidedAt: 2026-08-12T22:10:00Z
 reviewBy: 2027-02-12
 ---
 
@@ -117,8 +119,8 @@ three-way classification, and match with the strength that evidence supports.
 | Identity | How it arises | Match rule |
 |---|---|---|
 | `login` | `users.getAuthenticated` answered | marker anywhere in the body **and** `user.login` equals it |
-| `app-installation` | that call was refused with 403 "Resource not accessible by integration" (or a bare 403), and the run was not throttled | `user.type === "Bot"` **and** the marker is exactly the body's **first line** |
-| `unknown` | it failed any other way — 401, 404, a throttled 403, a 5xx, a network error | nothing is adopted |
+| `app-installation` | it was refused with "Resource not accessible by integration", whatever status carried it — or with a bare 403 on a run that was not throttled | `user.type === "Bot"` **and** the marker is exactly the body's **first line** |
+| `unknown` | anything else — 401, 404, a throttled bare 403, a 5xx, a network error | nothing is adopted |
 
 A permission-shaped refusal of `users.getAuthenticated` is not an absence of
 information. It is exactly how an app installation token is refused, so it is positive
@@ -134,6 +136,14 @@ bot-plus-marker rule to a credential that is not an app at all. The message is t
 definitive signal and the status is the fallback, in that order — keying solely on the
 message would make this fix hostage to an English string GitHub may reword, which is
 the failure this record exists to prevent.
+
+The refusal message is also read **before** throttling, not after. GitHub returns
+`x-ratelimit-remaining` on every response, so an app whose installation quota happens to
+be exhausted would otherwise have its own refusal read as "throttled" and lose that run
+to a duplicate comment. Being throttled does not make us not an app: the refusal names
+what we are and a rate-limit header does not. A **bare** 403 is genuinely ambiguous —
+it covers both an app refusal and throttling — so that branch, and only that branch,
+still defers to the throttling check.
 
 The second signal replaces the login. Both renderers in `comment.ts` emit
 `<!-- adrkit:ci -->` as the body's **first line**, and have in every revision of that

--- a/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
+++ b/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
@@ -2,9 +2,9 @@
 schemaVersion: 0.1.0
 id: "0026"
 title: Identify the CI comment by the strongest author evidence the token allows
-status: proposed
+status: accepted
 date: 2026-08-12
-deciders: []
+deciders: ["@mbeacom"]
 tags: [ci, github-actions, governance, agents]
 scope: component
 reversibility: two-way-door
@@ -16,9 +16,18 @@ affects:
   - type: path
     pattern: "packages/ci/src/index.ts"
   - type: path
+    pattern: "packages/ci/src/comment.ts"
+  - type: path
     pattern: "packages/ci/action.yml"
+  - type: path
+    pattern: "specs/004-ci-surface/spec.md"
+  - type: path
+    pattern: "specs/004-ci-surface/research.md"
+  - type: path
+    pattern: "specs/004-ci-surface/quickstart.md"
 provenance:
   authoredBy: agent-drafted
+  ratifiedBy: "@mbeacom"
 review:
   tier: arb
   tierReason: >-
@@ -30,6 +39,10 @@ review:
     once been satisfied in the documented workflow — which is the second reason this
     is more than a bug fix, because the property that "held" was unfalsifiable rather
     than true.
+  queuedAt: 2026-08-12T00:00:00Z
+  slaDays: 30
+  approvals: ["@mbeacom"]
+  decidedAt: 2026-08-12T13:30:00Z
 reviewBy: 2027-02-12
 ---
 
@@ -43,6 +56,13 @@ accumulating one near-identical comment per push on a long-lived pull request. T
 reporter confirmed via the API that these are distinct comments rather than one being
 edited, and that adding `env: GITHUB_TOKEN: ${{ github.token }}` to the step makes the
 same pull request stay at one comment whose `updated_at` advances past `created_at`.
+
+> `R<n>` and `FR-<n>` below are numbered decisions and requirements in this
+> repository's CI-surface specification —
+> [`specs/004-ci-surface/research.md`](../../specs/004-ci-surface/research.md) and
+> [`spec.md`](../../specs/004-ci-surface/spec.md). `RC<n>` numbers a review comment
+> that revised one. The two that matter here are **R5/FR-005**, which froze how the
+> Action recognises its own comment.
 
 The upsert itself is correct. What fails is the identity it depends on.
 
@@ -122,15 +142,23 @@ rung 2. The comment path adopts that same predicate verbatim, so both Actions an
 `unknown` keeps the old behaviour, deliberately. A network error, a 5xx, or being
 **throttled** proves nothing about who we are — throttling in particular also arrives
 as a 403, and reading that as "we are an app" would claim a comment on evidence the run
-never obtained. One duplicate comment that self-heals on the next run is the right cost
-for that. It is now **logged as a warning** rather than passing silently, which is what
-made this defect look like normal operation for two releases.
+never obtained. For a transient failure the cost is one duplicate comment that the next
+run absorbs. For a **persistent** one it is a duplicate per push, which is the original
+defect: the difference is that it is now **logged as a warning** naming the cause,
+rather than passing silently as it did for two releases. That is the intended trade —
+an adopter who sees the warning can act on it, whereas adopting a comment on unknown
+identity would be a silent write we cannot justify.
 
 Where several comments match, the **last** one wins rather than the first. Every pull
 request opened before this fix carries one comment per push, and the newest is both the
 one a reader reaches at the bottom of the thread and the one worth keeping current. The
 Action is comment-only and deletes nothing, so the older copies remain until a human
 removes them.
+
+Making the update path reachable also makes a race reachable that never fired while it
+was dead: the comment can be deleted between the list and the update. A 404 there means
+"gone", not "forbidden", so the Action creates a replacement instead of surrendering
+that push's comment to `isPermissionError`'s fork-token degrade. A 403 still degrades.
 
 The `isDefaultToken` plumbing is deleted. `GITHUB_TOKEN` remains a fallback *source*
 of the token for a workflow that blanks the input, but it is no longer consulted to
@@ -243,12 +271,24 @@ have one.
 2. [x] Delete `fallbackSelfLogin`/`DEFAULT_TOKEN_LOGIN` and the `isDefaultToken`
    plumbing in `src/index.ts`.
 3. [x] Warn on an unresolvable identity instead of degrading silently.
-4. [x] Cover the app-installation path, including the negative cases a human and a
+4. [x] Create a replacement when the prior comment is deleted between the list and the
+   update, rather than letting a 404 take the fork-token degrade path.
+5. [x] Cover the app-installation path, including the negative cases a human and a
    quoting bot present, watched failing first per ADR-0016.
-5. [x] Remove the obsolete `env: GITHUB_TOKEN` block and its rationale from
-   `specs/004-ci-surface/quickstart.md`, which documented the broken model.
-6. [x] Note in `site/src/content/docs/ci.mdx` that a `v*` release tag is annotated, so
+6. [x] Amend R5 in `specs/004-ci-surface/research.md` and FR-005 in `spec.md` by
+   reference, following ADR-0013's precedent, and remove the obsolete `env: GITHUB_TOKEN`
+   block from `quickstart.md`, which documented the broken model.
+7. [x] Note in `site/src/content/docs/ci.mdx` that a `v*` release tag is annotated, so
    `uses:` needs the dereferenced commit rather than the tag object's own SHA.
-7. [ ] Confirm on a reference repository that a second push updates the comment
+8. [ ] Confirm on a reference repository that a second push updates the comment
    ([ADR-0014](./0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md)
    rung 2); rung 1 is the unit and contract coverage above.
+9. [ ] **Deferred, tracked separately.** This repository does not run its own
+   governing-decisions Action on its own pull requests, so no automated signal would
+   catch a recurrence before adopters see duplicate comments — which is precisely how
+   this defect survived two releases. Closing that is a larger change than this record
+   authorizes, and it interacts with the ADR-0014 rung-2 mechanism rather than
+   replacing it.
+10. [ ] **Deferred, tracked separately.** `v0` is a moving tag with no documented
+    rollback, so recovering from a bad Action release depends on a maintainer knowing
+    to force-move it by hand.

--- a/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
+++ b/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
@@ -1,0 +1,254 @@
+---
+schemaVersion: 0.1.0
+id: "0026"
+title: Identify the CI comment by the strongest author evidence the token allows
+status: proposed
+date: 2026-08-12
+deciders: []
+tags: [ci, github-actions, governance, agents]
+scope: component
+reversibility: two-way-door
+blastRadius: component
+relatesTo: ["0004", "0014", "0016"]
+affects:
+  - type: path
+    pattern: "packages/ci/src/github.ts"
+  - type: path
+    pattern: "packages/ci/src/index.ts"
+  - type: path
+    pattern: "packages/ci/action.yml"
+provenance:
+  authoredBy: agent-drafted
+review:
+  tier: arb
+  tierReason: >-
+    Relaxes a stated safety rule rather than tightening one. R5/FR-005 froze comment
+    identity as "the marker AND the Action's own author identity", and this record
+    keeps that only where the exact login is knowable, substituting two weaker signals
+    where it is not. Loosening a guard on a write path deserves more scrutiny than
+    narrowing one, even though the guard being loosened is shown below to have never
+    once been satisfied in the documented workflow — which is the second reason this
+    is more than a bug fix, because the property that "held" was unfalsifiable rather
+    than true.
+reviewBy: 2027-02-12
+---
+
+# ADR-0026: Identify the CI comment by the strongest author evidence the token allows
+
+## Context
+
+[Issue #107](https://github.com/mbeacom/adrkit/issues/107) reports that the
+`packages/ci` Action posts a **new** governing-decisions comment on every push,
+accumulating one near-identical comment per push on a long-lived pull request. The
+reporter confirmed via the API that these are distinct comments rather than one being
+edited, and that adding `env: GITHUB_TOKEN: ${{ github.token }}` to the step makes the
+same pull request stay at one comment whose `updated_at` advances past `created_at`.
+
+The upsert itself is correct. What fails is the identity it depends on.
+
+**The rule.** [`specs/004-ci-surface`](../../specs/004-ci-surface/research.md) R5,
+revised under review comment RC5 and frozen as FR-005, says the Action locates its own
+comment by **both** a stable hidden marker **and** its own author identity, because
+"marker-only matching is insufficient: a human could quote the marker." Absent a
+resolved identity, `findOwnComment` adopted nothing and a fresh comment was created.
+
+**Why the identity was never resolvable.** The Action posts under the default
+`GITHUB_TOKEN`, which is a GitHub App installation token. Such a token cannot call
+`users.getAuthenticated`, so the login had to come from a fallback, and that fallback
+was gated on recognising the token as the default one:
+
+```ts
+const providedToken = core.getInput('token');
+const runnerToken   = process.env.GITHUB_TOKEN ?? '';
+const isDefaultToken = runnerToken !== '' && token === runnerToken;
+```
+
+Two facts make `isDefaultToken` unreachable in the documented workflow. `action.yml`
+declares `token` with `default: ${{ github.token }}`, so `getInput('token')` is always
+non-empty and the input is always the token that gets used. And GitHub Actions does not
+export `GITHUB_TOKEN` into a step's environment unless the workflow asks for it, which
+[the documented snippet](https://adrkit.dev/ci/) does not. So `runnerToken` is `""`,
+`isDefaultToken` is `false`, the fallback returns `undefined`, and every run creates.
+
+Passing `token:` explicitly does not help, because the input already defaults to the
+same value. There is no mechanical repair: the comparison needs `${{ github.token }}`
+inside the Node process, a `node24` action cannot set its own `env:`, and an input's
+declared default is indistinguishable from a caller passing that same value. **The
+identity has to come from the API or not at all**, and the API will not give a login
+to the token every documented adopter uses.
+
+This left the project asserting a property that could not be observed either way. The
+guard's coverage — `findOwnComment` returning `undefined` for an unknown identity — is
+tested and passes, but nothing tested that the identity was ever *known* in the path
+that ships. Per [ADR-0016](./0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md),
+a green check that means "I am blind" is the failure mode this project has already
+named: `undefined` rendered identically whether the lookup answered "not us" or could
+not look at all.
+
+**What the guard is actually for.** FR-005's own words are that it exists so the Action
+"never edits a human's comment that happens to contain the marker" and never misses its
+own comment on an unfetched page. Neither purpose needs an exact login.
+
+## Decision
+
+We will resolve identity to **the strongest evidence the token affords**, as a
+three-way classification, and match with the strength that evidence supports.
+
+| Identity | How it arises | Match rule |
+|---|---|---|
+| `login` | `users.getAuthenticated` answered | marker anywhere in the body **and** `user.login` equals it |
+| `app-installation` | that call was refused with 401/403/404 and the run was not throttled | `user.type === "Bot"` **and** the marker is exactly the body's **first line** |
+| `unknown` | it failed any other way, including a throttled 403 | nothing is adopted |
+
+A permission-shaped refusal of `users.getAuthenticated` is not an absence of
+information. It is exactly how an app installation token is refused, so it is positive
+evidence that the caller is an app and therefore a **bot**. That is one of the two
+signals FR-005 wanted, and it is the one that excludes the case FR-005 named — a human.
+
+The second signal replaces the login. Both renderers in `comment.ts` emit
+`<!-- adrkit:ci -->` as the body's **first line**, and have in every revision of that
+file, so requiring the marker to be exactly the first line is true of every comment
+the Action has ever posted and false of the way a human or another bot would reproduce
+it — behind a `>`, or below their own prose. So the degraded path trades an exact
+author for a stricter marker, rather than simply dropping a condition.
+
+This is not a new rule in this package. `queue-issue.ts` already establishes ownership
+of the managed ARB queue issue by exactly this test — `body.split(/\r\n|\n|\r/, 1)[0]
+=== MARKER` — with marker-only, LF, CRLF, and CR bodies all accepted, and it is
+reference-verified on [ADR-0014](./0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md)
+rung 2. The comment path adopts that same predicate verbatim, so both Actions answer
+"is this ours?" the same way.
+
+`unknown` keeps the old behaviour, deliberately. A network error, a 5xx, or being
+**throttled** proves nothing about who we are — throttling in particular also arrives
+as a 403, and reading that as "we are an app" would claim a comment on evidence the run
+never obtained. One duplicate comment that self-heals on the next run is the right cost
+for that. It is now **logged as a warning** rather than passing silently, which is what
+made this defect look like normal operation for two releases.
+
+Where several comments match, the **last** one wins rather than the first. Every pull
+request opened before this fix carries one comment per push, and the newest is both the
+one a reader reaches at the bottom of the thread and the one worth keeping current. The
+Action is comment-only and deletes nothing, so the older copies remain until a human
+removes them.
+
+The `isDefaultToken` plumbing is deleted. `GITHUB_TOKEN` remains a fallback *source*
+of the token for a workflow that blanks the input, but it is no longer consulted to
+decide who we are.
+
+## Options considered
+
+### Option A: classify the lookup failure; match on bot-ness plus a leading marker (chosen)
+
+| Dimension | Assessment |
+|---|---|
+| Fixes the documented workflow | Yes — no `env:` block, no input change |
+| Fixes a custom GitHub App token | Yes — such a token is also refused `/user`, and now finds its own comment |
+| Preserves FR-005's stated purpose | Yes — a human's comment is never adopted, on either path |
+| Residual exposure | Another **bot** posting a comment whose **first line** is exactly adrkit's private marker |
+| Statelessness (ADR-0004) | Unchanged — no comment id is stored |
+| Reversibility | Two-way door; one pure function and one client method |
+
+### Option B: fall back to `github-actions[bot]` on any `/user` failure
+
+The fix the issue suggests first, and the shape of any "just name the identity"
+variant — including taking the app's login as a workflow input. It repairs the default
+path, but it *asserts* a login rather than observing one, and the assertion is wrong for
+any custom App token — which posts as `<app>[bot]`, would go looking for
+`github-actions[bot]`, and would therefore both miss its own prior comment and, having
+repo write, edit one authored by a different bot while believing it was its own. It
+fixes the common case by making the identity model less true, and leaves the
+duplicate-comment bug in place for everyone using `actions/create-github-app-token`.
+
+**Pros:** smallest diff; no port change.
+**Cons:** claims an identity it has not observed; still broken for custom App tokens;
+the residual exposure is *worse* than Option A's despite looking narrower, because the
+comparison now names a specific foreign author.
+
+### Option C: document `env: GITHUB_TOKEN: ${{ github.token }}` as required
+
+The reporter's verified workaround, promoted to the fix.
+
+**Pros:** zero code change.
+**Cons:** makes correct behaviour opt-in and silently absent for every adopter who
+follows the current documented snippet — including this repository. The docs promise
+"posts a single comment"; this option keeps the promise false by default and moves the
+cost onto every reader. It also encodes an internal detail of identity resolution into
+the public workflow contract, which is the sort of thing that cannot be removed later.
+
+### Option D: store the comment id
+
+**Pros:** exact identity, no heuristics.
+**Cons:** refused by [ADR-0004](./0004-git-is-source-of-truth-database-is-an-index.md) —
+it is the side database that record forbids, for a comment the pull request already
+holds.
+
+### Option E: do nothing
+
+The behaviour is cosmetic in the sense that nothing is computed wrongly. But the
+comment is the entire product of this surface, and a reviewer scrolling past nine stale
+copies to find the current one is not reading the governing decisions — which is the
+one thing the Action exists to make them read. Doing nothing also leaves an asserted
+property in the specification that the shipped code has never satisfied.
+
+## Trade-offs
+
+The degraded path can adopt a comment adrkit did not post, if some other bot posts a
+comment whose first line is exactly `<!-- adrkit:ci -->`. That is the cost, stated
+plainly. Taking the last match rather than the first does not remove it — it only
+changes which contrived ordering loses, and is chosen because it is the ordering that
+helps the real, non-adversarial case of a pull request full of duplicates.
+
+It is worth paying because the exposure requires a second bot to reproduce adrkit's
+private marker as its own first line; the damage is one overwritten comment, recoverable
+from GitHub's edit history; and the guard being relaxed was buying nothing, since it
+has never been satisfied in the documented workflow. A guard that has never fired is
+not protection, it is an untested branch.
+
+A rejected way to keep exact identity: take the app's login as a workflow input and
+compare it. That returns the correctness of the default path to something the adopter
+must configure — the failure mode of Option C — and it cannot help the default token,
+which has no login to name. Identity that only holds when the caller supplies it is not
+identity.
+
+A second, smaller trade: identity now uses two different matching rules depending on
+how it was resolved. That is more to hold in the head than one rule. The alternative is
+one rule at the weaker strength, which would needlessly discard an exact login when we
+have one.
+
+## Consequences
+
+- **Easier:** one comment per pull request in the documented workflow, with no `env:`
+  block; the same for a custom GitHub App token, which never worked; and an
+  unresolvable identity now says so in the job log instead of looking like a normal run.
+- **Harder:** the identity model has three states rather than a login-or-nothing, and
+  the "marker is the body's first line" invariant in `comment.ts` is now load-bearing
+  for the degraded path — moving the marker off the first line would silently
+  reintroduce duplicate comments. A test asserts it for both renderers.
+- **Not fixed:** comments a pull request accumulated before the upgrade. The Action is
+  comment-only and deletes nothing; it updates the newest and leaves the rest. The
+  documentation says so rather than promising a cleanup the Action does not perform.
+- **How we would know this was wrong:** a report of adrkit editing a comment it did not
+  author. None is expected; the exposure requires a foreign bot to lead its body with
+  adrkit's marker. Conversely, if a pull request on this repository or a reference
+  repository ever shows two governing-decisions comments again, the fix has regressed.
+- **Revisit if:** GitHub exposes the acting app's identity to an installation token —
+  at which point the degraded path collapses back into `login` and this record's
+  weaker rule can be deleted rather than maintained.
+
+## Action items
+
+1. [x] Replace `getAuthenticatedLogin` with `getSelfIdentity` on the `GitHubClient`
+   port and classify the lookup failure.
+2. [x] Delete `fallbackSelfLogin`/`DEFAULT_TOKEN_LOGIN` and the `isDefaultToken`
+   plumbing in `src/index.ts`.
+3. [x] Warn on an unresolvable identity instead of degrading silently.
+4. [x] Cover the app-installation path, including the negative cases a human and a
+   quoting bot present, watched failing first per ADR-0016.
+5. [x] Remove the obsolete `env: GITHUB_TOKEN` block and its rationale from
+   `specs/004-ci-surface/quickstart.md`, which documented the broken model.
+6. [x] Note in `site/src/content/docs/ci.mdx` that a `v*` release tag is annotated, so
+   `uses:` needs the dereferenced commit rather than the tag object's own SHA.
+7. [ ] Confirm on a reference repository that a second push updates the comment
+   ([ADR-0014](./0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md)
+   rung 2); rung 1 is the unit and contract coverage above.

--- a/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
+++ b/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
@@ -117,13 +117,23 @@ three-way classification, and match with the strength that evidence supports.
 | Identity | How it arises | Match rule |
 |---|---|---|
 | `login` | `users.getAuthenticated` answered | marker anywhere in the body **and** `user.login` equals it |
-| `app-installation` | that call was refused with 401/403/404 and the run was not throttled | `user.type === "Bot"` **and** the marker is exactly the body's **first line** |
-| `unknown` | it failed any other way, including a throttled 403 | nothing is adopted |
+| `app-installation` | that call was refused with 403 "Resource not accessible by integration" (or a bare 403), and the run was not throttled | `user.type === "Bot"` **and** the marker is exactly the body's **first line** |
+| `unknown` | it failed any other way — 401, 404, a throttled 403, a 5xx, a network error | nothing is adopted |
 
 A permission-shaped refusal of `users.getAuthenticated` is not an absence of
 information. It is exactly how an app installation token is refused, so it is positive
 evidence that the caller is an app and therefore a **bot**. That is one of the two
 signals FR-005 wanted, and it is the one that excludes the case FR-005 named — a human.
+
+The classifier is deliberately narrower than `isPermissionError`, which folds 401 and
+404 in with 403 because at the top of the Action either answer means "we cannot
+comment". Here the answer decides *how much author evidence a comment needs*, so
+breadth is not free: 401 is invalid or expired credentials and 404 is not a documented
+response of this endpoint, and reading either as "we are an app" would hand the weaker
+bot-plus-marker rule to a credential that is not an app at all. The message is the
+definitive signal and the status is the fallback, in that order — keying solely on the
+message would make this fix hostage to an English string GitHub may reword, which is
+the failure this record exists to prevent.
 
 The second signal replaces the login. Both renderers in `comment.ts` emit
 `<!-- adrkit:ci -->` as the body's **first line**, and have in every revision of that

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -48769,12 +48769,12 @@ function isRateLimited(error52) {
 }
 var INTEGRATION_REFUSAL = /not accessible by integration/i;
 function identityFromLookupFailure(error52) {
-  if (isRateLimited(error52))
-    return { kind: "unknown" };
   const failure = error52;
   if (typeof failure?.message === "string" && INTEGRATION_REFUSAL.test(failure.message)) {
     return { kind: "app-installation" };
   }
+  if (isRateLimited(error52))
+    return { kind: "unknown" };
   return failure?.status === 403 ? { kind: "app-installation" } : { kind: "unknown" };
 }
 function describeIdentity(identity2) {
@@ -48805,7 +48805,7 @@ async function upsertMarkedComment(client, marker, body, log) {
     } catch (error52) {
       if (!isNotFound(error52))
         throw error52;
-      log?.info("adrkit: the prior governing-decisions comment was deleted; posting a new one.");
+      log?.warning("adrkit: the prior governing-decisions comment was deleted between listing and " + "updating it; posting a new one instead.");
     }
   }
   await client.createComment(body);

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -48794,8 +48794,14 @@ async function upsertMarkedComment(client, marker, body, log) {
   }
   const own = findOwnComment(comments, marker, identity2);
   if (own) {
-    await client.updateComment(own.id, body);
-    return "updated";
+    try {
+      await client.updateComment(own.id, body);
+      return "updated";
+    } catch (error52) {
+      if (!isNotFound(error52))
+        throw error52;
+      log?.info("adrkit: the prior governing-decisions comment was deleted; posting a new one.");
+    }
   }
   await client.createComment(body);
   return "created";
@@ -48857,6 +48863,9 @@ function createOctokitClient(token) {
 function isPermissionError(error52) {
   const status = error52?.status;
   return status === 403 || status === 401 || status === 404;
+}
+function isNotFound(error52) {
+  return error52?.status === 404;
 }
 
 // src/action.ts

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -48742,21 +48742,57 @@ function renderTruncatedNotice() {
 }
 
 // src/github.ts
-function findOwnComment(comments, marker, selfLogin) {
-  if (!selfLogin)
+function markerLeadsBody(body, marker) {
+  return body.split(/\r\n|\n|\r/, 1)[0] === marker;
+}
+function findOwnComment(comments, marker, identity2) {
+  if (identity2.kind === "unknown")
     return;
-  return comments.find((comment) => typeof comment.body === "string" && comment.body.includes(marker) && comment.user?.login === selfLogin);
+  let own;
+  for (const comment of comments) {
+    if (typeof comment.body !== "string")
+      continue;
+    const matches = identity2.kind === "login" ? comment.body.includes(marker) && comment.user?.login === identity2.login : comment.user?.type === "Bot" && markerLeadsBody(comment.body, marker);
+    if (matches)
+      own = comment;
+  }
+  return own;
 }
-var DEFAULT_TOKEN_LOGIN = "github-actions[bot]";
-function fallbackSelfLogin(isDefaultToken) {
-  return isDefaultToken ? DEFAULT_TOKEN_LOGIN : undefined;
+function isRateLimited(error52) {
+  const failure = error52;
+  if (failure?.status === 429)
+    return true;
+  const remaining = failure?.response?.headers?.["x-ratelimit-remaining"];
+  if (remaining !== undefined && String(remaining) === "0")
+    return true;
+  return typeof failure?.message === "string" && /rate limit/i.test(failure.message);
 }
-async function upsertMarkedComment(client, marker, body) {
-  const [comments, selfLogin] = await Promise.all([
+function identityFromLookupFailure(error52) {
+  if (isRateLimited(error52))
+    return { kind: "unknown" };
+  return isPermissionError(error52) ? { kind: "app-installation" } : { kind: "unknown" };
+}
+function describeIdentity(identity2) {
+  switch (identity2.kind) {
+    case "login":
+      return `authenticated as ${identity2.login}`;
+    case "app-installation":
+      return "an app installation token, whose login is not resolvable; matching on the marker and a bot author";
+    case "unknown":
+      return "unresolvable";
+  }
+}
+async function upsertMarkedComment(client, marker, body, log) {
+  const [comments, identity2] = await Promise.all([
     client.listIssueComments(),
-    client.getAuthenticatedLogin()
+    client.getSelfIdentity()
   ]);
-  const own = findOwnComment(comments, marker, selfLogin);
+  if (identity2.kind === "unknown") {
+    log?.warning("adrkit: could not resolve the token identity, so an existing governing-decisions " + "comment cannot be claimed; posting a new one instead.");
+  } else {
+    log?.info(`adrkit: ${describeIdentity(identity2)}.`);
+  }
+  const own = findOwnComment(comments, marker, identity2);
   if (own) {
     await client.updateComment(own.id, body);
     return "updated";
@@ -48764,17 +48800,17 @@ async function upsertMarkedComment(client, marker, body) {
   await client.createComment(body);
   return "created";
 }
-function createOctokitClient(token, isDefaultToken) {
+function createOctokitClient(token) {
   const octokit = getOctokit(token);
   const { owner, repo } = context2.repo;
   const pullNumber = context2.issue.number;
   return {
-    async getAuthenticatedLogin() {
+    async getSelfIdentity() {
       try {
         const { data } = await octokit.rest.users.getAuthenticated();
-        return data.login;
-      } catch {
-        return fallbackSelfLogin(isDefaultToken);
+        return { kind: "login", login: data.login };
+      } catch (error52) {
+        return identityFromLookupFailure(error52);
       }
     },
     async listPullFiles() {
@@ -48826,7 +48862,7 @@ function isPermissionError(error52) {
 // src/action.ts
 async function comment(deps, body) {
   try {
-    const result = await upsertMarkedComment(deps.client, CI_COMMENT_MARKER, body);
+    const result = await upsertMarkedComment(deps.client, CI_COMMENT_MARKER, body, deps.log);
     deps.log.info(`adrkit: ${result} the governing-decisions comment.`);
     return result;
   } catch (error52) {
@@ -48876,9 +48912,7 @@ async function runAction(deps) {
 // src/index.ts
 async function main() {
   const dir = getInput("dir") || "docs/adr";
-  const providedToken = getInput("token");
-  const runnerToken = process.env.GITHUB_TOKEN ?? "";
-  const token = providedToken || runnerToken;
+  const token = getInput("token") || process.env.GITHUB_TOKEN || "";
   if (!context2.payload.pull_request) {
     info("adrkit: not a pull_request event; nothing to check.");
     return;
@@ -48887,10 +48921,9 @@ async function main() {
     setFailed("adrkit: no token available; set the `token` input or GITHUB_TOKEN.");
     return;
   }
-  const isDefaultToken = runnerToken !== "" && token === runnerToken;
   const workspace = process.env.GITHUB_WORKSPACE ?? process.cwd();
   await runAction({
-    client: createOctokitClient(token, isDefaultToken),
+    client: createOctokitClient(token),
     dir,
     loadLint: (corpusDir) => lintCorpus({ dir: corpusDir }),
     readMarkers: (paths) => readSourceMarkersBatch(paths, workspace),

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -48767,10 +48767,15 @@ function isRateLimited(error52) {
     return true;
   return typeof failure?.message === "string" && /rate limit/i.test(failure.message);
 }
+var INTEGRATION_REFUSAL = /not accessible by integration/i;
 function identityFromLookupFailure(error52) {
   if (isRateLimited(error52))
     return { kind: "unknown" };
-  return isPermissionError(error52) ? { kind: "app-installation" } : { kind: "unknown" };
+  const failure = error52;
+  if (typeof failure?.message === "string" && INTEGRATION_REFUSAL.test(failure.message)) {
+    return { kind: "app-installation" };
+  }
+  return failure?.status === 403 ? { kind: "app-installation" } : { kind: "unknown" };
 }
 function describeIdentity(identity2) {
   switch (identity2.kind) {

--- a/packages/ci/src/action.ts
+++ b/packages/ci/src/action.ts
@@ -36,7 +36,7 @@ export interface ActionResult {
 /** Post or update the comment, degrading (not failing) on a comment-permission error. */
 async function comment(deps: ActionDeps, body: string): Promise<UpsertOutcome | 'skipped'> {
   try {
-    const result = await upsertMarkedComment(deps.client, CI_COMMENT_MARKER, body);
+    const result = await upsertMarkedComment(deps.client, CI_COMMENT_MARKER, body, deps.log);
     deps.log.info(`adrkit: ${result} the governing-decisions comment.`);
     return result;
   } catch (error) {

--- a/packages/ci/src/comment.ts
+++ b/packages/ci/src/comment.ts
@@ -4,6 +4,14 @@ import type { CheckOutcome, Finding, GoverningDecision } from '@adrkit/core';
  * Stable hidden marker used to locate this Action's own comment for in-place
  * updates. Comment identity is marker + author (R5/FR-005) — never stored state
  * (ADR-0004). Keep this string stable across versions.
+ *
+ * **It must also stay the exact first line of every rendered body.** A token whose
+ * login is unknowable — the default `GITHUB_TOKEN` is one — claims its prior comment
+ * by "author is a bot" plus that first-line position, so moving the marker behind a
+ * preamble silently reinstates a fresh comment per push
+ * ([ADR-0026](../../../docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md),
+ * [#107](https://github.com/mbeacom/adrkit/issues/107)). `github.ts:markerLeadsBody`
+ * is the reader; `comment-render.test.ts` asserts it for both renderers below.
  */
 export const CI_COMMENT_MARKER = '<!-- adrkit:ci -->';
 

--- a/packages/ci/src/github.ts
+++ b/packages/ci/src/github.ts
@@ -22,14 +22,34 @@ export interface PrFile {
 }
 
 /**
+ * Who this Action posts as, to whatever precision the token allows (R5/FR-005,
+ * [ADR-0026](../../../docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md)).
+ *
+ * - `login` — `users.getAuthenticated` answered, so the exact author is known.
+ * - `app-installation` — the call was refused the way an app installation token is
+ *   always refused, so the exact author is unknowable but is necessarily a **bot**.
+ * - `unknown` — the call failed for some other reason; assume nothing.
+ */
+export type SelfIdentity =
+  | { readonly kind: 'login'; readonly login: string }
+  | { readonly kind: 'app-installation' }
+  | { readonly kind: 'unknown' };
+
+/** Log port for identity resolution; structurally satisfied by the Action's logger. */
+export interface IdentityLogger {
+  info(message: string): void;
+  warning(message: string): void;
+}
+
+/**
  * Thin, injectable GitHub port. The real implementation wraps `@actions/github`;
  * tests inject a fake. Confining all GitHub API access behind this port keeps the
  * toolkit out of `@adrkit/core` and out of the pure logic below (R3/FR-013), and
  * lets the whole Action run offline in CI with no token.
  */
 export interface GitHubClient {
-  /** The author identity comments are posted under (for own-comment matching, R5). */
-  getAuthenticatedLogin(): Promise<string | undefined>;
+  /** The identity comments are posted under, for own-comment matching (R5). */
+  getSelfIdentity(): Promise<SelfIdentity>;
   /** The PR's complete changed-file list — fully paginated (R4/FR-003). */
   listPullFiles(): Promise<PrFile[]>;
   /** All PR comments — fully paginated so a later-page comment is not missed (R5). */
@@ -39,36 +59,96 @@ export interface GitHubClient {
 }
 
 /**
- * Locate this Action's own prior comment by BOTH the marker AND author identity
- * (R5/FR-005), across the full (already-paginated) comment list. A foreign comment
- * bearing the marker (different author) is never adopted; the Action's own comment
- * on a later page is still found. Pure — no network.
+ * Whether the marker is exactly the body's first line, rather than merely appearing
+ * somewhere in it.
+ *
+ * Both renderers in `comment.ts` emit the marker as the body's first line, and have
+ * in every revision of that file, so this holds for every comment the Action has ever
+ * posted. It does not hold for the case R5 exists to exclude — a human quoting the
+ * comment, where the marker arrives behind a `>` or below their own prose.
+ *
+ * This is the same ownership test `queue-issue.ts` already applies to the managed
+ * queue issue, including its handling of LF, CRLF, and CR bodies; keeping the two
+ * identical means one rule to reason about across both Actions.
+ */
+function markerLeadsBody(body: string, marker: string): boolean {
+  return body.split(/\r\n|\n|\r/, 1)[0] === marker;
+}
+
+/**
+ * Locate this Action's own prior comment by the marker AND the strongest author
+ * evidence the token affords (R5/FR-005, ADR-0026), across the full (already
+ * paginated) comment list. Pure — no network.
+ *
+ * With a resolved `login`, identity is exact and the marker may sit anywhere. An
+ * `app-installation` token cannot learn its own login at all, so it substitutes two
+ * weaker signals that together still exclude what R5 names: the author must be a
+ * **bot** (never a human quoting the marker) and the marker must be exactly the body's
+ * **first line** (never a quote of the comment). Absent both, nothing is adopted.
+ *
+ * The **last** match wins, not the first. A pull request opened before this fix
+ * carries one comment per push, and the newest is both the one a reader reaches at
+ * the bottom of the thread and the one worth keeping current.
  */
 export function findOwnComment(
   comments: readonly IssueComment[],
   marker: string,
-  selfLogin: string | undefined,
+  identity: SelfIdentity,
 ): IssueComment | undefined {
-  // Without a resolved own identity we must NOT adopt any marker comment: a custom or
-  // GitHub-App token could otherwise edit a comment authored by a different bot,
-  // breaking the marker-AND-own-author rule (R5). Create a fresh comment instead.
-  if (!selfLogin) return undefined;
-  return comments.find(
-    (comment) => typeof comment.body === 'string' && comment.body.includes(marker) && comment.user?.login === selfLogin,
-  );
+  if (identity.kind === 'unknown') return undefined;
+  let own: IssueComment | undefined;
+  for (const comment of comments) {
+    if (typeof comment.body !== 'string') continue;
+    const matches =
+      identity.kind === 'login'
+        ? comment.body.includes(marker) && comment.user?.login === identity.login
+        : comment.user?.type === 'Bot' && markerLeadsBody(comment.body, marker);
+    if (matches) own = comment;
+  }
+  return own;
 }
 
-/** The default GITHUB_TOKEN posts as this bot and cannot call `users.getAuthenticated`. */
-export const DEFAULT_TOKEN_LOGIN = 'github-actions[bot]';
+/**
+ * Whether a failure is GitHub throttling us rather than refusing us.
+ *
+ * This matters because a throttled request also surfaces as 403, and reading that as
+ * "we are an app" would let a rate-limited run claim a comment on the weaker evidence
+ * when it has learned nothing about who it is.
+ */
+function isRateLimited(error: unknown): boolean {
+  const failure = error as
+    | { status?: number; message?: string; response?: { headers?: Record<string, unknown> } }
+    | undefined;
+  if (failure?.status === 429) return true;
+  const remaining = failure?.response?.headers?.['x-ratelimit-remaining'];
+  if (remaining !== undefined && String(remaining) === '0') return true;
+  return typeof failure?.message === 'string' && /rate limit/i.test(failure.message);
+}
 
 /**
- * The author identity to assume when `users.getAuthenticated` is not callable (an
- * installation token). Only the default `GITHUB_TOKEN` may be assumed to be
- * `github-actions[bot]`; any other token yields `undefined` so no existing comment
- * is adopted (R5, RC5).
+ * Classify a failed `users.getAuthenticated` call into the identity we may assume.
+ *
+ * A GitHub App installation token — which the default `GITHUB_TOKEN` is one of — is
+ * refused this endpoint with a permission status ("Resource not accessible by
+ * integration"). That refusal is itself the evidence that the caller is an app, and
+ * therefore a bot. Throttling, a network error, or a 5xx prove nothing, so they yield
+ * `unknown` and no comment is adopted.
  */
-export function fallbackSelfLogin(isDefaultToken: boolean): string | undefined {
-  return isDefaultToken ? DEFAULT_TOKEN_LOGIN : undefined;
+export function identityFromLookupFailure(error: unknown): SelfIdentity {
+  if (isRateLimited(error)) return { kind: 'unknown' };
+  return isPermissionError(error) ? { kind: 'app-installation' } : { kind: 'unknown' };
+}
+
+/** A one-line, log-safe description of the resolved identity. */
+export function describeIdentity(identity: SelfIdentity): string {
+  switch (identity.kind) {
+    case 'login':
+      return `authenticated as ${identity.login}`;
+    case 'app-installation':
+      return 'an app installation token, whose login is not resolvable; matching on the marker and a bot author';
+    case 'unknown':
+      return 'unresolvable';
+  }
 }
 
 export type UpsertOutcome = 'created' | 'updated';
@@ -82,12 +162,23 @@ export async function upsertMarkedComment(
   client: GitHubClient,
   marker: string,
   body: string,
+  log?: IdentityLogger,
 ): Promise<UpsertOutcome> {
-  const [comments, selfLogin] = await Promise.all([
+  const [comments, identity] = await Promise.all([
     client.listIssueComments(),
-    client.getAuthenticatedLogin(),
+    client.getSelfIdentity(),
   ]);
-  const own = findOwnComment(comments, marker, selfLogin);
+  // An unresolvable identity means a duplicate comment on every run, which used to be
+  // indistinguishable from normal operation in the job log (issue #107).
+  if (identity.kind === 'unknown') {
+    log?.warning(
+      'adrkit: could not resolve the token identity, so an existing governing-decisions ' +
+        'comment cannot be claimed; posting a new one instead.',
+    );
+  } else {
+    log?.info(`adrkit: ${describeIdentity(identity)}.`);
+  }
+  const own = findOwnComment(comments, marker, identity);
   if (own) {
     await client.updateComment(own.id, body);
     return 'updated';
@@ -101,22 +192,22 @@ export async function upsertMarkedComment(
  * confined to this factory (and the entrypoint) — the pure logic above never
  * imports the toolkit.
  */
-export function createOctokitClient(token: string, isDefaultToken: boolean): GitHubClient {
+export function createOctokitClient(token: string): GitHubClient {
   const octokit = getOctokit(token);
   const { owner, repo } = context.repo;
   const pullNumber = context.issue.number;
 
   return {
-    async getAuthenticatedLogin() {
+    async getSelfIdentity() {
       try {
         const { data } = await octokit.rest.users.getAuthenticated();
-        return data.login;
-      } catch {
-        // An installation token (incl. the default GITHUB_TOKEN) cannot call
-        // users.getAuthenticated. Only the default token is safe to assume is
-        // github-actions[bot]; any other token yields undefined so we do not adopt
-        // a foreign bot's comment.
-        return fallbackSelfLogin(isDefaultToken);
+        return { kind: 'login', login: data.login };
+      } catch (error) {
+        // An installation token — which the default GITHUB_TOKEN is — cannot call
+        // users.getAuthenticated and is refused with a permission status. That
+        // refusal is the only reliable signal available that the caller is an app
+        // (issue #107 / ADR-0026), so classify it rather than giving up.
+        return identityFromLookupFailure(error);
       }
     },
     async listPullFiles() {

--- a/packages/ci/src/github.ts
+++ b/packages/ci/src/github.ts
@@ -125,18 +125,37 @@ function isRateLimited(error: unknown): boolean {
   return typeof failure?.message === 'string' && /rate limit/i.test(failure.message);
 }
 
+/** How GitHub words its refusal of an endpoint an installation token may not call. */
+const INTEGRATION_REFUSAL = /not accessible by integration/i;
+
 /**
  * Classify a failed `users.getAuthenticated` call into the identity we may assume.
  *
  * A GitHub App installation token — which the default `GITHUB_TOKEN` is one of — is
- * refused this endpoint with a permission status ("Resource not accessible by
- * integration"). That refusal is itself the evidence that the caller is an app, and
- * therefore a bot. Throttling, a network error, or a 5xx prove nothing, so they yield
- * `unknown` and no comment is adopted.
+ * refused this endpoint with **403 "Resource not accessible by integration"**. That
+ * refusal is the evidence that the caller is an app, and therefore a bot.
+ *
+ * Deliberately narrower than {@link isPermissionError}, which folds in 401 and 404
+ * because at the top of the Action either means "we cannot comment". Here the answer
+ * decides how much author evidence a comment needs, so breadth is not free: 401 is
+ * invalid or expired credentials and 404 is not a documented response of this
+ * endpoint, and reading either as "we are an app" would hand the weaker
+ * bot-plus-marker rule to a credential that is not an app at all.
+ *
+ * The message is the definitive signal and the status is the fallback, in that order.
+ * Keying solely on the message would make a fix for
+ * [#107](https://github.com/mbeacom/adrkit/issues/107) hostage to an English string
+ * GitHub may reword; keying solely on the status would miss a refusal delivered with
+ * a status this does not anticipate. Throttling, a network error, and a 5xx prove
+ * nothing about identity, so they yield `unknown` and no comment is adopted.
  */
 export function identityFromLookupFailure(error: unknown): SelfIdentity {
   if (isRateLimited(error)) return { kind: 'unknown' };
-  return isPermissionError(error) ? { kind: 'app-installation' } : { kind: 'unknown' };
+  const failure = error as { status?: number; message?: string } | undefined;
+  if (typeof failure?.message === 'string' && INTEGRATION_REFUSAL.test(failure.message)) {
+    return { kind: 'app-installation' };
+  }
+  return failure?.status === 403 ? { kind: 'app-installation' } : { kind: 'unknown' };
 }
 
 /** A one-line, log-safe description of the resolved identity. */

--- a/packages/ci/src/github.ts
+++ b/packages/ci/src/github.ts
@@ -180,8 +180,18 @@ export async function upsertMarkedComment(
   }
   const own = findOwnComment(comments, marker, identity);
   if (own) {
-    await client.updateComment(own.id, body);
-    return 'updated';
+    try {
+      await client.updateComment(own.id, body);
+      return 'updated';
+    } catch (error) {
+      // The comment was listed a moment ago; a 404 now means it was deleted in
+      // between, not that we may not comment. Before #107 the update path was
+      // effectively unreachable, so this race only becomes live with that fix —
+      // and letting it fall through to the caller's permission handling would drop
+      // the result of one push entirely. Any other failure is not ours to reinterpret.
+      if (!isNotFound(error)) throw error;
+      log?.info('adrkit: the prior governing-decisions comment was deleted; posting a new one.');
+    }
   }
   await client.createComment(body);
   return 'created';
@@ -256,6 +266,19 @@ export function createOctokitClient(token: string): GitHubClient {
 export function isPermissionError(error: unknown): boolean {
   const status = (error as { status?: number } | undefined)?.status;
   return status === 403 || status === 401 || status === 404;
+}
+
+/**
+ * Whether a thrown error is specifically "gone", as distinct from "not allowed".
+ *
+ * `isPermissionError` folds 404 in with 403 because GitHub hides a forbidden resource
+ * behind a 404 for fork tokens. That conflation is right at the top of the Action,
+ * where either answer means "we cannot comment"; it is wrong for a comment we listed
+ * seconds ago, where 404 means someone deleted it and creating a replacement is
+ * exactly the correct response.
+ */
+export function isNotFound(error: unknown): boolean {
+  return (error as { status?: number } | undefined)?.status === 404;
 }
 
 export { core, context };

--- a/packages/ci/src/github.ts
+++ b/packages/ci/src/github.ts
@@ -1,6 +1,26 @@
 import * as core from '@actions/core';
 import { context, getOctokit } from '@actions/github';
 
+/**
+ * @adrkit/ci — the GitHub port for the governing-decisions comment, plus the pure
+ * identity and own-comment logic layered over it.
+ *
+ * This module classifies GitHub failures three different ways on purpose, because the
+ * same status means different things depending on what the answer is used for:
+ *
+ * - {@link isPermissionError} (401/403/404) — "we cannot comment at all". Broad by
+ *   design: a fork token is denied with a 404 as readily as a 403, and either way the
+ *   Action degrades to a log notice rather than failing the job (FR-014).
+ * - {@link isNotFound} (404 only) — "that specific comment is gone". Used where the
+ *   broad reading would be wrong, namely a comment we listed moments earlier.
+ * - {@link identityFromLookupFailure} — "who are we?". Narrowest, because its answer
+ *   decides how much author evidence a comment needs before we edit it (ADR-0026).
+ *
+ * Keep them distinct. Collapsing any two re-creates a defect this module has already
+ * shipped: reusing the broad reading for identity is what
+ * [#107](https://github.com/mbeacom/adrkit/issues/107) turned on.
+ */
+
 /** A PR comment as this surface needs it — minimal, provider-shaped. */
 export interface CommentUser {
   login?: string;
@@ -150,11 +170,18 @@ const INTEGRATION_REFUSAL = /not accessible by integration/i;
  * nothing about identity, so they yield `unknown` and no comment is adopted.
  */
 export function identityFromLookupFailure(error: unknown): SelfIdentity {
-  if (isRateLimited(error)) return { kind: 'unknown' };
   const failure = error as { status?: number; message?: string } | undefined;
+  // The message is checked before throttling on purpose. GitHub sends
+  // `x-ratelimit-remaining` on every response, so a genuine integration refusal that
+  // happens to land when the installation's quota is exhausted would otherwise be read
+  // as "throttled" and cost that run a duplicate comment. Being throttled does not make
+  // us not an app; the refusal names what we are, and a rate-limit header does not.
   if (typeof failure?.message === 'string' && INTEGRATION_REFUSAL.test(failure.message)) {
     return { kind: 'app-installation' };
   }
+  // A bare 403 is ambiguous — it covers both an app refusal and throttling — so it is
+  // only app evidence once throttling is ruled out.
+  if (isRateLimited(error)) return { kind: 'unknown' };
   return failure?.status === 403 ? { kind: 'app-installation' } : { kind: 'unknown' };
 }
 
@@ -209,7 +236,14 @@ export async function upsertMarkedComment(
       // and letting it fall through to the caller's permission handling would drop
       // the result of one push entirely. Any other failure is not ours to reinterpret.
       if (!isNotFound(error)) throw error;
-      log?.info('adrkit: the prior governing-decisions comment was deleted; posting a new one.');
+      // Warning, not info: a comment vanishing under us is unusual, and if something
+      // deletes it on a loop the recreate would otherwise be invisible without
+      // expanding the step log — the same "looks exactly like healthy operation"
+      // failure that let #107 survive two releases.
+      log?.warning(
+        'adrkit: the prior governing-decisions comment was deleted between listing and ' +
+          'updating it; posting a new one instead.',
+      );
     }
   }
   await client.createComment(body);

--- a/packages/ci/src/index.ts
+++ b/packages/ci/src/index.ts
@@ -13,9 +13,10 @@ import { createOctokitClient } from './github.ts';
  */
 async function main(): Promise<void> {
   const dir = core.getInput('dir') || 'docs/adr';
-  const providedToken = core.getInput('token');
-  const runnerToken = process.env.GITHUB_TOKEN ?? '';
-  const token = providedToken || runnerToken;
+  // `action.yml` defaults this input to ${{ github.token }}, so it is normally set.
+  // GITHUB_TOKEN is only a fallback for a workflow that blanks the input and exports
+  // the variable instead; it is NOT used to identify the token (issue #107/ADR-0026).
+  const token = core.getInput('token') || process.env.GITHUB_TOKEN || '';
 
   if (!context.payload.pull_request) {
     core.info('adrkit: not a pull_request event; nothing to check.');
@@ -26,15 +27,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Only treat the token as the default GITHUB_TOKEN (whose comments are authored by
-  // github-actions[bot]) when it matches the runner's GITHUB_TOKEN. Absent that signal
-  // we do not assume the bot identity, so a custom/App token never adopts a foreign
-  // comment (it creates its own instead).
-  const isDefaultToken = runnerToken !== '' && token === runnerToken;
   const workspace = process.env.GITHUB_WORKSPACE ?? process.cwd();
 
   await runAction({
-    client: createOctokitClient(token, isDefaultToken),
+    client: createOctokitClient(token),
     dir,
     loadLint: (corpusDir) => lintCorpus({ dir: corpusDir }),
     readMarkers: (paths) => readSourceMarkersBatch(paths, workspace),

--- a/packages/ci/test/comment-idempotent.test.ts
+++ b/packages/ci/test/comment-idempotent.test.ts
@@ -255,8 +255,24 @@ describe('findOwnComment (pure)', () => {
 });
 
 describe('identityFromLookupFailure (token identity guard)', () => {
-  test.each([401, 403, 404])('a %i from /user means an app installation token', (status) => {
-    expect(identityFromLookupFailure({ status })).toEqual({ kind: 'app-installation' });
+  test('the integration refusal is app evidence, whatever status carries it', () => {
+    expect(
+      identityFromLookupFailure({ status: 403, message: 'Resource not accessible by integration' }),
+    ).toEqual({ kind: 'app-installation' });
+    expect(identityFromLookupFailure({ message: 'Resource not accessible by integration' })).toEqual({
+      kind: 'app-installation',
+    });
+  });
+
+  test('a bare 403 is app evidence, so a reworded message cannot reintroduce #107', () => {
+    expect(identityFromLookupFailure({ status: 403 })).toEqual({ kind: 'app-installation' });
+  });
+
+  // 401 is invalid/expired credentials and 404 is not a documented response of this
+  // endpoint. Reading either as "we are an app" would hand the weaker bot-plus-marker
+  // rule to a credential that is not an app, which is the exposure this narrowing closes.
+  test.each([401, 404])('a %i is not app evidence; identity stays unknown', (status) => {
+    expect(identityFromLookupFailure({ status })).toEqual({ kind: 'unknown' });
   });
 
   test('any other failure proves nothing, so the identity stays unknown', () => {

--- a/packages/ci/test/comment-idempotent.test.ts
+++ b/packages/ci/test/comment-idempotent.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from 'bun:test';
 import { runAction, type ActionDeps } from '../src/action.ts';
 import { CI_COMMENT_MARKER } from '../src/comment.ts';
-import { fallbackSelfLogin, findOwnComment, type GitHubClient } from '../src/github.ts';
-import { makeFakeClient, makeLogger } from './fake-github.ts';
+import {
+  findOwnComment,
+  identityFromLookupFailure,
+  type GitHubClient,
+  type SelfIdentity,
+} from '../src/github.ts';
+import { makeFakeClient, makeLogger, type CapturingLogger } from './fake-github.ts';
 
-function deps(client: GitHubClient): ActionDeps {
+function deps(client: GitHubClient, logger: CapturingLogger = makeLogger()): ActionDeps {
   return {
     client,
     dir: 'docs/adr',
@@ -21,9 +26,13 @@ function deps(client: GitHubClient): ActionDeps {
       changedDependencies: [],
       truncated: false,
     }),
-    log: makeLogger().log,
+    log: logger.log,
   };
 }
+
+const APP: SelfIdentity = { kind: 'app-installation' };
+const UNKNOWN: SelfIdentity = { kind: 'unknown' };
+const AS_BOT: SelfIdentity = { kind: 'login', login: 'github-actions[bot]' };
 
 describe('governing-decisions comment idempotency', () => {
   test('first run creates the marker comment; a second run edits the same one', async () => {
@@ -45,7 +54,7 @@ describe('governing-decisions comment idempotency', () => {
   test('a foreign comment bearing the marker (different author) is not edited (RC5)', async () => {
     const client = makeFakeClient({
       comments: [{ id: 5, body: `${CI_COMMENT_MARKER}\nquoted by a human`, login: 'a-human', type: 'User' }],
-      selfLogin: 'github-actions[bot]',
+      identity: AS_BOT,
     });
 
     const result = await runAction(deps(client));
@@ -65,7 +74,7 @@ describe('governing-decisions comment idempotency', () => {
       type: 'User',
     }));
     const own = { id: 999, body: `${CI_COMMENT_MARKER}\nold body`, login: 'github-actions[bot]', type: 'Bot' };
-    const client = makeFakeClient({ comments: [...filler, own], selfLogin: 'github-actions[bot]' });
+    const client = makeFakeClient({ comments: [...filler, own], identity: AS_BOT });
 
     const result = await runAction(deps(client));
 
@@ -76,52 +85,204 @@ describe('governing-decisions comment idempotency', () => {
   });
 });
 
-describe('findOwnComment (pure)', () => {
-  const marker = CI_COMMENT_MARKER;
-
-  test('matches marker AND author', () => {
-    const comments = [
-      { id: 1, body: `${marker} ours`, user: { login: 'github-actions[bot]', type: 'Bot' } },
-      { id: 2, body: `${marker} theirs`, user: { login: 'human', type: 'User' } },
-    ];
-    expect(findOwnComment(comments, marker, 'github-actions[bot]')?.id).toBe(1);
-  });
-
-  test('returns undefined when only a foreign marker comment exists', () => {
-    const comments = [{ id: 2, body: `${marker} theirs`, user: { login: 'human', type: 'User' } }];
-    expect(findOwnComment(comments, marker, 'github-actions[bot]')).toBeUndefined();
-  });
-
-  test('without a known identity, does not adopt any comment (safe for custom tokens)', () => {
-    const comments = [
-      { id: 1, body: `${marker} human`, user: { login: 'human', type: 'User' } },
-      { id: 2, body: `${marker} bot`, user: { login: 'x[bot]', type: 'Bot' } },
-    ];
-    expect(findOwnComment(comments, marker, undefined)).toBeUndefined();
-  });
-});
-
-describe('fallbackSelfLogin (token identity guard)', () => {
-  test('assumes github-actions[bot] only for the default token', () => {
-    expect(fallbackSelfLogin(true)).toBe('github-actions[bot]');
-  });
-
-  test('yields no identity for a non-default token, so no comment is adopted', () => {
-    expect(fallbackSelfLogin(false)).toBeUndefined();
-  });
-
-  test("a custom token that cannot resolve its identity does not update the default bot's comment", async () => {
-    // selfLogin undefined models a custom/App token whose /user lookup failed and is
-    // not the default GITHUB_TOKEN.
+/**
+ * Issue #107: in the documented workflow the token is an app installation token, so
+ * `users.getAuthenticated` is refused and the exact login is unknowable. Before
+ * ADR-0026 that produced a fresh comment on every push.
+ */
+describe('an app installation token (the default GITHUB_TOKEN) — issue #107', () => {
+  test('updates its own prior comment instead of posting another', async () => {
     const client = makeFakeClient({
-      comments: [{ id: 7, body: `${CI_COMMENT_MARKER}\nby the default bot`, login: 'github-actions[bot]', type: 'Bot' }],
-      selfLogin: undefined,
+      comments: [{ id: 7, body: `${CI_COMMENT_MARKER}\nprevious run`, login: 'github-actions[bot]', type: 'Bot' }],
+      identity: APP,
+    });
+
+    const result = await runAction(deps(client));
+
+    expect(result.comment).toBe('updated');
+    expect(client.created).toHaveLength(0);
+    expect(client.updated[0]?.id).toBe(7);
+    expect(client.store).toHaveLength(1);
+  });
+
+  test('stays at exactly one comment across repeated pushes', async () => {
+    const client = makeFakeClient({ identity: APP });
+
+    await runAction(deps(client));
+    await runAction(deps(client));
+    await runAction(deps(client));
+
+    expect(client.created).toHaveLength(1);
+    expect(client.updated).toHaveLength(2);
+    expect(client.store).toHaveLength(1);
+  });
+
+  test('adopts a prior comment posted under a different bot login (token switched)', async () => {
+    const client = makeFakeClient({
+      comments: [{ id: 3, body: `${CI_COMMENT_MARKER}\nby the default bot`, login: 'github-actions[bot]', type: 'Bot' }],
+      identity: APP,
+    });
+
+    const result = await runAction(deps(client));
+
+    expect(result.comment).toBe('updated');
+    expect(client.updated[0]?.id).toBe(3);
+  });
+
+  test("still never edits a human's comment that quotes the marker (RC5 preserved)", async () => {
+    const client = makeFakeClient({
+      comments: [{ id: 4, body: `${CI_COMMENT_MARKER}\nquoted by a human`, login: 'a-human', type: 'User' }],
+      identity: APP,
     });
 
     const result = await runAction(deps(client));
 
     expect(result.comment).toBe('created');
     expect(client.updated).toHaveLength(0);
+    expect(client.store.find((comment) => comment.id === 4)?.body).toContain('quoted by a human');
+  });
+
+  test('does not adopt a bot comment that merely quotes the marker below its own prose', async () => {
+    const client = makeFakeClient({
+      comments: [
+        { id: 8, body: `Reposting for visibility:\n\n> ${CI_COMMENT_MARKER}\n> stale`, login: 'other[bot]', type: 'Bot' },
+      ],
+      identity: APP,
+    });
+
+    const result = await runAction(deps(client));
+
+    expect(result.comment).toBe('created');
+    expect(client.updated).toHaveLength(0);
+    expect(client.store.find((comment) => comment.id === 8)?.body).toContain('Reposting for visibility');
+  });
+});
+
+describe('an unresolvable identity', () => {
+  test('adopts nothing and says so in the job log, rather than failing silently', async () => {
+    const logger = makeLogger();
+    const client = makeFakeClient({
+      comments: [{ id: 7, body: `${CI_COMMENT_MARKER}\nby the default bot`, login: 'github-actions[bot]', type: 'Bot' }],
+      identity: UNKNOWN,
+    });
+
+    const result = await runAction(deps(client, logger));
+
+    expect(result.comment).toBe('created');
+    expect(client.updated).toHaveLength(0);
     expect(client.store.find((comment) => comment.id === 7)?.body).toContain('by the default bot');
+    expect(logger.warning.join('\n')).toContain('could not resolve the token identity');
+  });
+});
+
+describe('findOwnComment (pure)', () => {
+  const marker = CI_COMMENT_MARKER;
+
+  test('matches marker AND author for a resolved login', () => {
+    const comments = [
+      { id: 1, body: `${marker} ours`, user: { login: 'github-actions[bot]', type: 'Bot' } },
+      { id: 2, body: `${marker} theirs`, user: { login: 'human', type: 'User' } },
+    ];
+    expect(findOwnComment(comments, marker, AS_BOT)?.id).toBe(1);
+  });
+
+  test('returns undefined when only a foreign marker comment exists', () => {
+    const comments = [{ id: 2, body: `${marker} theirs`, user: { login: 'human', type: 'User' } }];
+    expect(findOwnComment(comments, marker, AS_BOT)).toBeUndefined();
+  });
+
+  test('an unknown identity adopts nothing, however the marker appears', () => {
+    const comments = [
+      { id: 1, body: `${marker} human`, user: { login: 'human', type: 'User' } },
+      { id: 2, body: `${marker} bot`, user: { login: 'x[bot]', type: 'Bot' } },
+    ];
+    expect(findOwnComment(comments, marker, UNKNOWN)).toBeUndefined();
+  });
+
+  test('an app installation matches a leading marker on a bot comment', () => {
+    const comments = [
+      { id: 1, body: `${marker}\nours`, user: { login: 'anything[bot]', type: 'Bot' } },
+    ];
+    expect(findOwnComment(comments, marker, APP)?.id).toBe(1);
+  });
+
+  test('an app installation does not match a human, even with a leading marker', () => {
+    const comments = [{ id: 1, body: `${marker}\ncopied`, user: { login: 'human', type: 'User' } }];
+    expect(findOwnComment(comments, marker, APP)).toBeUndefined();
+  });
+
+  test('an app installation does not match a bot comment whose marker is not the first line', () => {
+    const comments = [{ id: 1, body: `see below\n\n${marker}`, user: { login: 'x[bot]', type: 'Bot' } }];
+    expect(findOwnComment(comments, marker, APP)).toBeUndefined();
+  });
+
+  test.each([
+    ['LF', `${marker}\nbody`],
+    ['CRLF', `${marker}\r\nbody`],
+    ['CR', `${marker}\rbody`],
+    ['marker only', marker],
+  ])('an app installation matches a %s body', (_label, body) => {
+    expect(findOwnComment([{ id: 1, body, user: { login: 'x[bot]', type: 'Bot' } }], marker, APP)?.id).toBe(1);
+  });
+
+  test('the first line must be the marker exactly, not merely start with it', () => {
+    const comments = [
+      { id: 1, body: `${marker} and then some\nbody`, user: { login: 'x[bot]', type: 'Bot' } },
+      { id: 2, body: ` ${marker}\nbody`, user: { login: 'x[bot]', type: 'Bot' } },
+    ];
+    expect(findOwnComment(comments, marker, APP)).toBeUndefined();
+  });
+
+  // A PR opened before this fix carries one comment per push; the newest is the one a
+  // reader reaches at the bottom of the thread, so it is the one kept current.
+  test('the last match wins, not the first, for an app installation', () => {
+    const comments = [1, 2, 3].map((id) => ({
+      id,
+      body: `${marker}\npush ${id}`,
+      user: { login: 'github-actions[bot]', type: 'Bot' },
+    }));
+    expect(findOwnComment(comments, marker, APP)?.id).toBe(3);
+  });
+
+  test('the last match wins for a resolved login too', () => {
+    const comments = [1, 2].map((id) => ({
+      id,
+      body: `${marker}\npush ${id}`,
+      user: { login: 'github-actions[bot]', type: 'Bot' },
+    }));
+    expect(findOwnComment(comments, marker, AS_BOT)?.id).toBe(2);
+  });
+});
+
+describe('identityFromLookupFailure (token identity guard)', () => {
+  test.each([401, 403, 404])('a %i from /user means an app installation token', (status) => {
+    expect(identityFromLookupFailure({ status })).toEqual({ kind: 'app-installation' });
+  });
+
+  test('any other failure proves nothing, so the identity stays unknown', () => {
+    expect(identityFromLookupFailure(new Error('network exploded'))).toEqual({ kind: 'unknown' });
+    expect(identityFromLookupFailure({ status: 500 })).toEqual({ kind: 'unknown' });
+  });
+
+  // Throttling also arrives as 403, but it says nothing about who we are — reading it
+  // as "we are an app" would claim a comment on evidence we never obtained.
+  test('a throttled request is not read as app evidence', () => {
+    expect(identityFromLookupFailure({ status: 429 })).toEqual({ kind: 'unknown' });
+    expect(
+      identityFromLookupFailure({ status: 403, response: { headers: { 'x-ratelimit-remaining': '0' } } }),
+    ).toEqual({ kind: 'unknown' });
+    expect(
+      identityFromLookupFailure({ status: 403, message: 'You have exceeded a secondary rate limit' }),
+    ).toEqual({ kind: 'unknown' });
+  });
+
+  test('a genuine integration refusal with quota left is still app evidence', () => {
+    expect(
+      identityFromLookupFailure({
+        status: 403,
+        message: 'Resource not accessible by integration',
+        response: { headers: { 'x-ratelimit-remaining': '4999' } },
+      }),
+    ).toEqual({ kind: 'app-installation' });
   });
 });

--- a/packages/ci/test/comment-idempotent.test.ts
+++ b/packages/ci/test/comment-idempotent.test.ts
@@ -292,7 +292,17 @@ describe('identityFromLookupFailure (token identity guard)', () => {
     ).toEqual({ kind: 'unknown' });
   });
 
-  test('a genuine integration refusal with quota left is still app evidence', () => {
+  test('a genuine integration refusal is app evidence even with the quota exhausted', () => {
+    // GitHub sends x-ratelimit-remaining on every response, so an app refusal can
+    // legitimately arrive on a throttled run. Being throttled does not make us not an
+    // app, and reading it that way costs that run a duplicate comment.
+    expect(
+      identityFromLookupFailure({
+        status: 403,
+        message: 'Resource not accessible by integration',
+        response: { headers: { 'x-ratelimit-remaining': '0' } },
+      }),
+    ).toEqual({ kind: 'app-installation' });
     expect(
       identityFromLookupFailure({
         status: 403,
@@ -326,7 +336,7 @@ describe('the prior comment is deleted between list and update', () => {
     expect(result.comment).toBe('created');
     expect(client.created).toHaveLength(1);
     expect(logger.setFailed).toHaveLength(0);
-    expect(logger.info.join('\n')).toContain('was deleted');
+    expect(logger.warning.join('\n')).toContain('was deleted');
   });
 
   test('a 403 on update is still a permission degrade, not a create', async () => {

--- a/packages/ci/test/comment-idempotent.test.ts
+++ b/packages/ci/test/comment-idempotent.test.ts
@@ -286,3 +286,49 @@ describe('identityFromLookupFailure (token identity guard)', () => {
     ).toEqual({ kind: 'app-installation' });
   });
 });
+
+/**
+ * Before the #107 fix the update path was effectively unreachable, so this race only
+ * becomes live now: the comment is listed, then deleted, then updated. A 404 there
+ * means "gone", not "forbidden", and must not cost the run its comment.
+ */
+describe('the prior comment is deleted between list and update', () => {
+  test('falls back to creating a replacement rather than losing the comment', async () => {
+    const logger = makeLogger();
+    const client = makeFakeClient({
+      comments: [{ id: 7, body: `${CI_COMMENT_MARKER}\nprevious run`, login: 'github-actions[bot]', type: 'Bot' }],
+      identity: APP,
+    });
+    const deleted = new Error('Not Found') as Error & { status: number };
+    deleted.status = 404;
+    client.updateComment = async () => {
+      throw deleted;
+    };
+
+    const result = await runAction(deps(client, logger));
+
+    expect(result.comment).toBe('created');
+    expect(client.created).toHaveLength(1);
+    expect(logger.setFailed).toHaveLength(0);
+    expect(logger.info.join('\n')).toContain('was deleted');
+  });
+
+  test('a 403 on update is still a permission degrade, not a create', async () => {
+    const logger = makeLogger();
+    const client = makeFakeClient({
+      comments: [{ id: 7, body: `${CI_COMMENT_MARKER}\nprevious run`, login: 'github-actions[bot]', type: 'Bot' }],
+      identity: APP,
+    });
+    const forbidden = new Error('Forbidden') as Error & { status: number };
+    forbidden.status = 403;
+    client.updateComment = async () => {
+      throw forbidden;
+    };
+
+    const result = await runAction(deps(client, logger));
+
+    expect(result.comment).toBe('skipped');
+    expect(client.created).toHaveLength(0);
+    expect(logger.notice.join('\n')).toContain('read-only token');
+  });
+});

--- a/packages/ci/test/comment-render.test.ts
+++ b/packages/ci/test/comment-render.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { checkChanges, lintCorpus, readSourceMarkersBatch } from '@adrkit/core';
 import { acceptedRecordMarkdown, cleanupTestDir, recordMarkdown, resetTestDir, supersededRecordMarkdown, writeText } from '../../core/test/helpers.ts';
-import { CI_COMMENT_MARKER, renderComment } from '../src/comment.ts';
+import { CI_COMMENT_MARKER, renderComment, renderTruncatedNotice } from '../src/comment.ts';
 
 const DIR_NAME = 'ci-comment-render';
 
@@ -362,5 +362,28 @@ describe('renderComment status awareness (#39)', () => {
 
     expect(body).toContain('No **accepted** decisions govern the changed files.');
     expect(body).toContain('#### Active proposals touching this change');
+  });
+});
+
+/**
+ * ADR-0026 makes this load-bearing rather than incidental: an app installation token
+ * cannot learn its own login, so it claims its prior comment by the marker *leading*
+ * the body plus a bot author. Every renderer must therefore lead with the marker, or
+ * the Action silently returns to a fresh comment per push (issue #107).
+ */
+describe('the marker leads the body (ADR-0026)', () => {
+  test('renderComment leads with the marker, with nothing before it', async () => {
+    const root = await seed();
+    const body = renderComment(await outcomeFor(root, ['packages/api/src/server.ts']));
+
+    expect(body.startsWith(CI_COMMENT_MARKER)).toBe(true);
+    expect(body.indexOf(CI_COMMENT_MARKER)).toBe(0);
+  });
+
+  test('renderTruncatedNotice leads with the marker too', () => {
+    const body = renderTruncatedNotice();
+
+    expect(body.startsWith(CI_COMMENT_MARKER)).toBe(true);
+    expect(body.indexOf(CI_COMMENT_MARKER)).toBe(0);
   });
 });

--- a/packages/ci/test/fake-github.ts
+++ b/packages/ci/test/fake-github.ts
@@ -1,4 +1,4 @@
-import type { GitHubClient, IssueComment, PrFile } from '../src/github.ts';
+import type { GitHubClient, IssueComment, PrFile, SelfIdentity } from '../src/github.ts';
 
 export interface FakeCommentSeed {
   id?: number;
@@ -10,7 +10,12 @@ export interface FakeCommentSeed {
 export interface FakeClientOptions {
   files?: PrFile[];
   comments?: FakeCommentSeed[];
-  selfLogin?: string | undefined;
+  /**
+   * The identity the token resolves to. Defaults to a resolved `github-actions[bot]`
+   * login; pass `{ kind: 'app-installation' }` to model the default GITHUB_TOKEN in a
+   * real workflow, whose `users.getAuthenticated` call is refused (issue #107).
+   */
+  identity?: SelfIdentity;
   /** When set, createComment/updateComment throw a GitHub-shaped permission error. */
   rejectWrites?: boolean | number;
 }
@@ -37,7 +42,8 @@ class PermissionError extends Error {
  * record the writes the Action performed.
  */
 export function makeFakeClient(options: FakeClientOptions = {}): FakeGitHubClient {
-  const selfLogin = 'selfLogin' in options ? options.selfLogin : DEFAULT_SELF;
+  const identity: SelfIdentity = options.identity ?? { kind: 'login', login: DEFAULT_SELF };
+  const postAs = identity.kind === 'login' ? identity.login : DEFAULT_SELF;
   const rejectStatus =
     options.rejectWrites === true ? 403 : typeof options.rejectWrites === 'number' ? options.rejectWrites : undefined;
 
@@ -45,7 +51,7 @@ export function makeFakeClient(options: FakeClientOptions = {}): FakeGitHubClien
   const store: IssueComment[] = (options.comments ?? []).map((seed, index) => ({
     id: seed.id ?? index + 1,
     body: seed.body,
-    user: { login: seed.login ?? selfLogin ?? DEFAULT_SELF, type: seed.type ?? 'Bot' },
+    user: { login: seed.login ?? postAs, type: seed.type ?? 'Bot' },
   }));
   for (const comment of store) nextId = Math.max(nextId, comment.id + 1);
 
@@ -56,8 +62,8 @@ export function makeFakeClient(options: FakeClientOptions = {}): FakeGitHubClien
     store,
     created,
     updated,
-    async getAuthenticatedLogin() {
-      return selfLogin;
+    async getSelfIdentity() {
+      return identity;
     },
     async listPullFiles() {
       return options.files ?? [];
@@ -68,7 +74,7 @@ export function makeFakeClient(options: FakeClientOptions = {}): FakeGitHubClien
     async createComment(body: string) {
       if (rejectStatus) throw new PermissionError(rejectStatus);
       const id = nextId++;
-      store.push({ id, body, user: { login: selfLogin ?? DEFAULT_SELF, type: 'Bot' } });
+      store.push({ id, body, user: { login: postAs, type: 'Bot' } });
       created.push(body);
       return { id };
     },

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -50,13 +50,13 @@ pull request carries one governing-decisions comment however many times you push
 the `env:` block above ([#107](https://github.com/mbeacom/adrkit/issues/107)); once
 `@v0` moves past `v0.6.0` the block becomes a no-op you may drop.
 
-`v0` is a moving major tag — it currently resolves to the `v0.6.0` commit `c5dc677`.
-Pin the immutable `v0.6.0` tag or a commit SHA for maximum reproducibility.
+`v0` is a moving major tag, and it still resolves to a `v0.6.0` build. Pin the
+immutable `v0.6.0` tag or a commit SHA for maximum reproducibility.
 
 <Aside type="note" title="Comments from before the upgrade">
-	The Action is comment-only and deletes nothing, so copies a pull request already
-	accumulated stay where they are. It updates the newest of them and leaves the rest
-	for you to delete once.
+	The Action is comment-only and deletes nothing, so duplicate comments a pull request
+	already accumulated stay where they are. It updates the newest of them and leaves the
+	rest for you to delete once.
 </Aside>
 
 <Aside type="caution" title="Pinning a release tag by SHA">
@@ -72,13 +72,6 @@ Pin the immutable `v0.6.0` tag or a commit SHA for maximum reproducibility.
 
 	Note that `GET /git/ref/tags/{tag}` does **not** peel: its `object.sha` is the tag
 	object, which is exactly the value `uses:` will not take.
-</Aside>
-
-<Aside type="caution" title="Pinning a release tag by SHA">
-	The `v*` release tags are **annotated**, so the SHA that `refs/tags/v0.6.0`
-	resolves to is a tag object, and `uses:` rejects it. Pin the commit the tag
-	points *at* — `git rev-parse v0.6.0^{commit}`, or the `object.sha` from
-	`GET /repos/mbeacom/adrkit/git/ref/tags/v0.6.0`.
 </Aside>
 
 ## Publish the ARB operations queue

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -34,34 +34,44 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mbeacom/adrkit/packages/ci@v0
+        env:
+          # Needed only through v0.6.0, which `@v0` still resolves to; without it
+          # those versions post a new comment per push (#107). Harmless to keep
+          # afterwards — later versions never read it to identify the token.
+          GITHUB_TOKEN: ${{ github.token }}
         # with:
         #   dir: docs/adr          # ADR corpus directory (default: docs/adr)
         #   token: ${{ github.token }}
 ```
 
-That snippet is complete — the Action needs no `env:` block. It finds the comment
-it posted on an earlier push and edits it in place, so a pull request carries one
-governing-decisions comment however many times you push ([ADR-0026](/adr/)).
+The Action finds the comment it posted on an earlier push and edits it in place, so a
+pull request carries one governing-decisions comment however many times you push
+([ADR-0026](/adr/)). Releases **through `v0.6.0` cannot do this on their own** and need
+the `env:` block above ([#107](https://github.com/mbeacom/adrkit/issues/107)); once
+`@v0` moves past `v0.6.0` the block becomes a no-op you may drop.
 
-`v0` is a moving major tag. Pin the immutable `v0.6.0` tag or a commit SHA for
-maximum reproducibility.
+`v0` is a moving major tag — it currently resolves to the `v0.6.0` commit `c5dc677`.
+Pin the immutable `v0.6.0` tag or a commit SHA for maximum reproducibility.
 
-<Aside type="caution" title="Duplicate comments on v0.6.0 and earlier">
-	Every release **up to and including `v0.6.0`** posts a new comment per push rather
-	than updating its own ([#107](https://github.com/mbeacom/adrkit/issues/107)), and
-	the moving `v0` tag still resolves to one of them. On those versions, add the `env:`
-	block below to restore the single-comment behavior; on any release after `v0.6.0` it
-	is unnecessary and can be removed.
+<Aside type="note" title="Comments from before the upgrade">
+	The Action is comment-only and deletes nothing, so copies a pull request already
+	accumulated stay where they are. It updates the newest of them and leaves the rest
+	for you to delete once.
+</Aside>
 
-	```yaml
-	- uses: mbeacom/adrkit/packages/ci@v0.6.0
-	  env:
-	    GITHUB_TOKEN: ${{ github.token }}
+<Aside type="caution" title="Pinning a release tag by SHA">
+	The `v*` release tags are **annotated**, so `refs/tags/v0.6.0` resolves to a tag
+	object rather than a commit, and `uses:` rejects that SHA. Pin the commit the tag
+	points *at*:
+
+	```sh
+	git rev-parse v0.6.0^{commit}
+	# or, over the API — this endpoint peels the tag for you:
+	gh api repos/mbeacom/adrkit/commits/v0.6.0 --jq .sha
 	```
 
-	Comments a pull request accumulated *before* you upgrade stay where they are — the
-	Action is comment-only and deletes nothing. It updates the newest of them and leaves
-	the rest for you to delete once.
+	Note that `GET /git/ref/tags/{tag}` does **not** peel: its `object.sha` is the tag
+	object, which is exactly the value `uses:` will not take.
 </Aside>
 
 <Aside type="caution" title="Pinning a release tag by SHA">

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -39,8 +39,37 @@ jobs:
         #   token: ${{ github.token }}
 ```
 
-`v0` is a moving major tag. Pin the immutable `v0.5.0` tag or a commit SHA for
+That snippet is complete — the Action needs no `env:` block. It finds the comment
+it posted on an earlier push and edits it in place, so a pull request carries one
+governing-decisions comment however many times you push ([ADR-0026](/adr/)).
+
+`v0` is a moving major tag. Pin the immutable `v0.6.0` tag or a commit SHA for
 maximum reproducibility.
+
+<Aside type="caution" title="Duplicate comments on v0.6.0 and earlier">
+	Every release **up to and including `v0.6.0`** posts a new comment per push rather
+	than updating its own ([#107](https://github.com/mbeacom/adrkit/issues/107)), and
+	the moving `v0` tag still resolves to one of them. On those versions, add the `env:`
+	block below to restore the single-comment behavior; on any release after `v0.6.0` it
+	is unnecessary and can be removed.
+
+	```yaml
+	- uses: mbeacom/adrkit/packages/ci@v0.6.0
+	  env:
+	    GITHUB_TOKEN: ${{ github.token }}
+	```
+
+	Comments a pull request accumulated *before* you upgrade stay where they are — the
+	Action is comment-only and deletes nothing. It updates the newest of them and leaves
+	the rest for you to delete once.
+</Aside>
+
+<Aside type="caution" title="Pinning a release tag by SHA">
+	The `v*` release tags are **annotated**, so the SHA that `refs/tags/v0.6.0`
+	resolves to is a tag object, and `uses:` rejects it. Pin the commit the tag
+	points *at* — `git rev-parse v0.6.0^{commit}`, or the `object.sha` from
+	`GET /repos/mbeacom/adrkit/git/ref/tags/v0.6.0`.
+</Aside>
 
 ## Publish the ARB operations queue
 

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -105,9 +105,10 @@ jobs:
 <Aside type="note" title="Pinning the queue Action">
 	`queue@v0` resolves because the `v0` tag points at a commit containing
 	`packages/ci/queue/action.yml` — first true of the v0.2.1 release, and the tag
-	has moved forward with each release since (currently the v0.5.0 commit, `c6bceac`). `@v0`
-	is a moving tag; pin the full commit SHA instead if you need a byte-immutable
-	reference. Phase 6 is landed and maintainer reference-verified; external
+	has moved forward with each release since. `@v0` is a moving tag; pin the full
+	commit SHA instead if you need a byte-immutable reference, and read that SHA from
+	the tag rather than from this page — `git rev-parse v0^{commit}` — so it cannot go
+	stale here. Phase 6 is landed and maintainer reference-verified; external
 	validation ([ADR-0014](/adr/) rung 3) remains open.
 </Aside>
 

--- a/specs/004-ci-surface/quickstart.md
+++ b/specs/004-ci-surface/quickstart.md
@@ -38,11 +38,6 @@ permissions:
 jobs:
   adr:
     runs-on: ubuntu-latest
-    env:
-      # Exposing the default token here lets the Action confirm its own comment
-      # identity (github-actions[bot]) so it updates one comment in place. Without
-      # it, an unidentifiable token safely posts a fresh comment each run.
-      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }   # full history for the merge-base changed-file diff
@@ -51,6 +46,14 @@ jobs:
           dir: docs/adr
           # token defaults to ${{ github.token }} — no other secret required
 ```
+
+No `env:` block is needed. Through v0.6.0 this workflow required
+`env: GITHUB_TOKEN: ${{ github.token }}` to keep one comment, because comment identity
+was gated on recognising the default token by comparing it against that variable — a
+comparison the documented workflow could never satisfy
+([#107](https://github.com/mbeacom/adrkit/issues/107)). Identity is now taken from what
+the token proves at the API, so the variable is no longer read for that purpose
+([ADR-0026](../../docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md)).
 
 On a PR, the Action extracts the changed files, resolves the governing decisions,
 validates the changed records, and posts (or updates) a single comment.

--- a/specs/004-ci-surface/quickstart.md
+++ b/specs/004-ci-surface/quickstart.md
@@ -42,18 +42,24 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }   # full history for the merge-base changed-file diff
       - uses: mbeacom/adrkit/packages/ci@v0     # @adrkit/ci Action (runs.using: node24)
+        env:
+          # Required only through v0.6.0, which `@v0` still resolves to; a no-op after.
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           dir: docs/adr
           # token defaults to ${{ github.token }} — no other secret required
 ```
 
-No `env:` block is needed. Through v0.6.0 this workflow required
-`env: GITHUB_TOKEN: ${{ github.token }}` to keep one comment, because comment identity
-was gated on recognising the default token by comparing it against that variable — a
-comparison the documented workflow could never satisfy
+The `env:` block is a transitional requirement, not part of the design. Through v0.6.0
+this workflow needed it to keep one comment, because comment identity was gated on
+recognising the default token by comparing it against that variable — a comparison the
+documented workflow could never satisfy
 ([#107](https://github.com/mbeacom/adrkit/issues/107)). Identity is now taken from what
-the token proves at the API, so the variable is no longer read for that purpose
+the token proves at the API, so from the first release after v0.6.0 the variable is not
+read for that purpose and the block may be dropped
 ([ADR-0026](../../docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md)).
+It is kept in this snippet until `@v0` moves, so the workflow above is runnable as
+written today.
 
 On a PR, the Action extracts the changed files, resolves the governing decisions,
 validates the changed records, and posts (or updates) a single comment.

--- a/specs/004-ci-surface/research.md
+++ b/specs/004-ci-surface/research.md
@@ -220,6 +220,17 @@ comments — the defect this revision fixes); a fresh comment per push (spam —
 anti-pattern exit criterion b guards against); a commit status/check-run only (loses the
 human-readable governing list); an external key/value store (violates ADR-0004).
 
+> **Amended by [ADR-0026](../../docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md).**
+> The author half of this rule is kept only where the token can establish a login. The
+> default `GITHUB_TOKEN` is an app installation token, which cannot call
+> `users.getAuthenticated`; requiring an exact login therefore matched nothing and
+> shipped the "fresh comment per push" anti-pattern this decision names
+> ([#107](https://github.com/mbeacom/adrkit/issues/107)). Where the login is
+> unknowable, identity becomes "author is a bot" **and** "the marker is exactly the
+> body's first line" — the same ownership test `queue-issue.ts` applies to the managed
+> queue issue. Both listed failure modes stay excluded; the residual exposure is a
+> second bot leading its body with adrkit's marker, which ADR-0026 accepts and records.
+
 ## R6 — Selectivity is the resolver's union, rendered verbatim
 
 **Decision**: The comment lists **exactly** the resolver's union output for the

--- a/specs/004-ci-surface/spec.md
+++ b/specs/004-ci-surface/spec.md
@@ -207,6 +207,16 @@ and comments end-to-end with no other secret present.
   adrkit marker **and** the Action's own author identity (the bot/app user), so it
   never edits a human's comment that happens to contain the marker and never misses
   its own comment on a later page. Absent a match, it creates one.
+
+  > **Amended by [ADR-0026](../../docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md).**
+  > "The Action's own author identity" is held only where the token can establish it.
+  > An app installation token — which the default `GITHUB_TOKEN` is one of — cannot
+  > call `users.getAuthenticated` and has no login to compare, which made this clause
+  > unsatisfiable in the documented workflow and produced a fresh comment per push
+  > ([#107](https://github.com/mbeacom/adrkit/issues/107)). For that case identity is
+  > the pair "author is a bot" **and** "the marker is exactly the body's first line".
+  > This narrows, and does not repeal, the rule that a human's comment bearing the
+  > marker is never edited.
 - **FR-006**: The comment MUST be **selective** — only records whose matchers fire
   on the changed files appear. A record that governs no changed file MUST NOT
   appear. On a corpus of more than ten records touched by a subset diff, the comment


### PR DESCRIPTION
Closes #107.

## The bug

The Action posted a **new** governing-decisions comment on every push. The upsert was correct; the identity it depended on was unobtainable.

Finding its own comment required its own login. The default `GITHUB_TOKEN` is a GitHub App installation token, which cannot call `users.getAuthenticated`, so the login came from a fallback gated on recognising the token as the default one:

```ts
const isDefaultToken = runnerToken !== '' && token === runnerToken;  // runnerToken = process.env.GITHUB_TOKEN
```

Two facts make that unreachable in the documented workflow. `action.yml` declares `token` with `default: ${{ github.token }}`, so the input is always populated; and Actions does not export `GITHUB_TOKEN` into a step unless the workflow asks. The comparison had no right-hand side, identity always resolved to "unknown", and every run took the create path. Passing `token:` explicitly changed nothing — the input already held that value.

There is no mechanical repair. A `node24` action cannot set its own `env:`, and a declared default is indistinguishable from a caller passing the same value. **Identity has to come from the API or not at all** — and the API will not give a login to the token every documented adopter uses.

That branch was tested. That it was the *only* branch ever taken was not: `undefined` read identically whether the lookup answered "not us" or could not look at all, which is the failure mode [ADR-0016](https://github.com/mbeacom/adrkit/blob/main/docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md) already names.

## The fix

Identity is classified by what the token actually proves:

| Identity | Arises from | Match rule |
|---|---|---|
| `login` | `users.getAuthenticated` answered | marker anywhere + exact login *(unchanged)* |
| `app-installation` | refused 401/403/404, not throttled | `user.type === "Bot"` **and** the marker is exactly the body's first line |
| `unknown` | anything else, incl. a throttled 403 | adopts nothing, now **warns** |

A permission-shaped refusal of `/user` is not missing information — it is how an app installation token is always refused, so it establishes the author is a *bot*. The first-line rule is the same ownership test `queue-issue.ts` already applies to the managed ARB queue issue (LF/CRLF/CR), so both Actions now answer "is this ours?" identically. Last match wins, so a pull request that already accumulated duplicates keeps its newest one current.

This also fixes repositories using a custom GitHub App token (`actions/create-github-app-token`), which never had a working upsert. The `env: GITHUB_TOKEN` workaround can be removed.

## What the deep review changed

A four-lens review (adversarial, architect, consumer, operator) over the first commit returned **no defects**, and three things worth acting on:

- **A newly reachable race.** Making the update path live also made it possible for the prior comment to be deleted between the list and the update. `isPermissionError` folds 404 in with 403 — correct at the top of the Action, where either means "we cannot comment", wrong for a comment listed seconds ago. That cost one push its comment. A 404 there now creates a replacement; a 403 still degrades.
- **A governance gap.** R5 in `specs/004-ci-surface/research.md` and FR-005 in `spec.md` still stated the old invariant, which shipped behavior no longer satisfies. Both now carry an **Amended by ADR-0026** blockquote, the pattern ADR-0013 established against ADR-0007 and ADR-0009. The spec header's "the ADR wins" was a fallback, not a pointer.
- **An inaccurate claim in the ADR.** "One duplicate comment that self-heals on the next run" was true only for a *transient* unknown identity. A persistent one costs a duplicate per push; the record now says so, and why that is still the right trade against a silent write on unproven identity.

Two findings are deferred to their own issues rather than absorbed here — see below.

## Governance

[ADR-0026](https://github.com/mbeacom/adrkit/blob/mbeacom-fantastic-fiesta/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md) is included and **ratified** (`status: accepted`, `approvals: ["@mbeacom"]`). Tier `arb`, because this **relaxes** a stated safety rule rather than tightening one — and because the property that "held" was unfalsifiable rather than true.

The residual exposure is stated plainly: another *bot* leading its body with adrkit's private marker. It is accepted because the exposure requires reproducing a private marker in leading position, the damage is one overwritten comment recoverable from edit history, and the guard being relaxed had never once fired. The issue's suggested fallback to a hardcoded `github-actions[bot]` is declined in the record — it asserts a login instead of observing one, and stays broken for custom App tokens.

ARB queue depth stays at 1.

## Verification

Per ADR-0016, every new assertion was watched failing before it passed — the regression test returned `created`, and the ordering, rate-limit, leading-marker, and deleted-comment cases were each confirmed failing against unrefined code.

- 2020 tests pass; typecheck, lint, `check:deps`, `check:changelog`, `check:freeze-hashes`, `check:doc-pins`, `adr lint`, site build all green.
- `packages/ci/dist` rebuilt in the pinned `linux/amd64` `oven/bun:1.3.14` container and confirmed to reproduce byte-for-byte, so the drift gate passes and the reviewed source is the deployed code.

## Docs

`site/src/content/docs/ci.mdx` now states the sticky-comment behavior, and carries a caution that releases **through v0.6.0** (including the moving `v0` tag, currently `c5dc677`) still need the `env:` workaround — the fix is unreleased. **That caution should be dropped when the next release is cut.**

Two corrections while there, both verified: every `v*` release tag is annotated, so its own SHA is a tag object that `uses:` rejects (v0.4.0 → `5fd19a10`, as the reporter noted); and the queue Action's pinning aside named `c6bceac`, which stopped being what `v0` resolved to two releases ago.

---

🤖 Reviewed with a four-lens deep review; adjudicated ledger: 11 findings, 0 defects, 0 corroborations, 0 unresolved tradeoffs.