### PR TITLE
chore(release): v0.7.0 — ship the ADR-0026 comment fix on the moving v0 tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: adrkit version
       description: Output of `adr --version` (or the package version you installed).
-      placeholder: '0.4.0'
+      placeholder: '0.7.0'
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-12
+
 ### Added
 
 - **DCO sign-off is enforced, not just documented** ([ADR-0006](docs/adr/0006-license-apache-2-and-single-monorepo.md)
@@ -727,7 +729,8 @@ against live Spec Kit, rather than reasoning about it:
 - Node-targeted published distribution of all packages, smoke-tested under Node
   22 and 24.
 
-[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/mbeacom/adrkit/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mbeacom/adrkit/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mbeacom/adrkit/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/mbeacom/adrkit/compare/v0.3.0...v0.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Decision memory for human- and agent-authored plans — machine-readable ADRs
 that are enforceable in CI and legible to agents, without leaving git.
-Status: early — phases 0–6 landed and v0.5.0 is public. `@adrkit/core`,
+Status: early — phases 0–6 landed and v0.7.0 is public. `@adrkit/core`,
 `@adrkit/evaluator`, `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
 `check`, `queue`, `migrate --from madr`, `evaluate`) are published on npm, as is
 the independently versioned `@adrkit/spec-kit` Spec Kit extension (0.1.2); the

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -65,7 +65,8 @@ adrkit/
         ├── 0022  scan markers in check and CI, no authority accepted
         ├── 0023  read a marker only where the format hides it accepted
         ├── 0024  report the measured scan extent            accepted
-        └── 0025  badges as recipes over existing output     accepted
+        ├── 0025  badges as recipes over existing output     accepted
+        └── 0026  identify the CI comment by token evidence  accepted
 ```
 
 ## Known-open, deliberately
@@ -100,8 +101,8 @@ independent of the GitHub namespace and unaffected either way.
 
 ## Verification
 
-26 files under `docs/adr/` — the template plus 25 records, ids 0001–0025, no
-gaps. All at schema 0.1.0: 23 accepted, 1 proposed, 1 superseded, and the
+27 files under `docs/adr/` — the template plus 26 records, ids 0001–0026, no
+gaps. All at schema 0.1.0: 24 accepted, 1 proposed, 1 superseded, and the
 template at `draft`.
 No dangling `relatesTo`. No one-way door on the auto tier. No accepted record
 without a decider or an import provenance. JSON Schema and Zod agree on property

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ different artifact from a heading convention. That is the whole thesis.
 
 Early, under active development, and deliberately honest about what is proven.
 
-- **Published — v0.5.0 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
+- **Published — v0.7.0 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
   the deterministic Pass 0 `@adrkit/evaluator`, and the read-only `@adrkit/mcp`
   server are all implemented and released. The MCP server speaks both protocol
   eras and passed real-session dogfood against the published artifact on each,

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "bin": {
         "adr": "./dist/index.js",
       },
@@ -65,7 +65,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -80,7 +80,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -91,7 +91,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -5,9 +5,11 @@ the `@adrkit/*` CLI presence in the MCP and ADR-tooling ecosystems. It contains
 ready-to-paste content and exact procedures.
 
 > **Submission status.** The official MCP registry entry (§A) **has been published**
-> — `dev.adrkit/mcp` at `0.5.0`, status `active` (first published 2026-07-28 at
-> `0.2.1`; re-published 2026-07-31 for v0.3.0, 2026-08-08 for v0.4.0, and
-> 2026-08-10 for v0.5.0). Every other
+> — `dev.adrkit/mcp` at `0.6.0`, status `active` (first published 2026-07-28 at
+> `0.2.1`; re-published 2026-07-31 for v0.3.0, 2026-08-08 for v0.4.0,
+> 2026-08-10 for v0.5.0, and 2026-08-11 for v0.6.0). Re-publication is a **manual
+> per-release step** (§A) and is not automated by the release workflow, so after a
+> release the registry lags npm until a human runs `mcp-publisher publish`. Every other
 > venue below remains prepared but **not submitted**. Every outbound action —
 > publishing to a registry, opening a PR, filling a form, creating a git tag, or
 > posting anywhere — is performed by a human, never by tooling or an agent.
@@ -32,14 +34,16 @@ GitHub repo, so a small number of prerequisites unblock several venues at once.
 
 ### P1 — npm packages are published ✅
 
-**Satisfied.** `@adrkit/mcp`, `@adrkit/cli`, `@adrkit/core`, and `@adrkit/evaluator`
-are published at `0.5.0` — the exact version `server.json` names. The MCP registry
-hosts *metadata only*; the npm package must already exist at the version named in
-`server.json`. Verified with `npm view @adrkit/mcp@0.5.0 version` → `0.5.0`.
+**Satisfied for every version published so far.** `@adrkit/mcp`, `@adrkit/cli`,
+`@adrkit/core`, and `@adrkit/evaluator` publish in lockstep, and the registry hosts
+*metadata only*: the npm package must already exist at the version `server.json`
+names. That ordering has to be re-established each release — verified at v0.6.0 with
+`npm view @adrkit/mcp@0.6.0 version` → `0.6.0`. When `server.json` has been bumped for
+a release that has not published yet, this precondition is pending, not satisfied.
 
 ### P2 — `mcpName` in the **published** `@adrkit/mcp` ✅
 
-**Satisfied.** `npm view @adrkit/mcp@0.5.0 mcpName` returns `dev.adrkit/mcp`,
+**Satisfied.** `npm view @adrkit/mcp mcpName` returns `dev.adrkit/mcp`,
 matching `server.json` `name` exactly.
 
 The requirement, and why the ordering mattered: the official registry verifies npm
@@ -105,10 +109,12 @@ confusion in every listing:
 ## A. Official MCP registry (`registry.modelcontextprotocol.io`) — **PUBLISHED**
 
 **Status: published.** First published 2026-07-28 via the DNS namespace path;
-re-published 2026-07-31 for v0.3.0, 2026-08-08 for v0.4.0, and 2026-08-10 for
-v0.5.0. `dev.adrkit/mcp` is listed at `0.5.0` with
+re-published 2026-07-31 for v0.3.0, 2026-08-08 for v0.4.0, 2026-08-10 for
+v0.5.0, and 2026-08-11 for v0.6.0. `dev.adrkit/mcp` is listed at `0.6.0` with
 status `active` and `isLatest: true`; see §A4 for the verified response. The
-subsections below are retained as the procedure to repeat on each release.
+subsections below are retained as the procedure to repeat on each release — it is
+manual, so a release that bumps `@adrkit/mcp` leaves this entry behind until it is
+run again.
 
 This is the highest-leverage venue: **PulseMCP, mcp.so, Glama, and Smithery all
 ingest or can ingest from it.** The registry is in public preview.
@@ -264,7 +270,7 @@ after the npm publish lands.
 **Listing criteria met?** Yes — schema-valid, npm package exists at the manifest
 version, stdio transport, public repo. Both original blockers (the human namespace
 proof and an npm publication carrying `mcpName`) were cleared for v0.2.1 and remain
-satisfied at v0.5.0.
+satisfied at v0.6.0.
 
 ---
 
@@ -546,8 +552,8 @@ ARB-queue Action from its moving major tag like any other:
 uses: mbeacom/adrkit/packages/ci/queue@v0
 ```
 
-`v0` moves with every release, so it now peels to the v0.5.0 release commit
-(`c6bceac`) rather than to `31bed03`. That is the point of a moving major tag; the
+`v0` moves with every release, so it now peels to the v0.6.0 release commit
+(`c5dc677`) rather than to `31bed03`. That is the point of a moving major tag; the
 commit named below is the historical one that first made `@v0` resolve.
 
 The rest of this section is the historical record of why a full-commit pin was
@@ -635,7 +641,7 @@ itself, not a pin.
 
 No distribution-blocking source edits are currently delegated to another
 workstream. `packages/mcp/package.json` declares `"mcpName": "dev.adrkit/mcp"`
-(matching `server.json` `name`), v0.5.0 has been cut, and the registry entry is
+(matching `server.json` `name`), v0.6.0 has been cut, and the registry entry is
 **published** at that version (§A4). Nothing in this repository blocks any remaining venue; what is
 left is per-venue human submission, tracked in the readiness table above.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -263,7 +263,12 @@ bootstrap described below.
    Leave *historical* statements alone ("expanded in v0.5.0" records when something
    happened and stays true). This drifts silently: v0.6.0 shipped with all three
    site surfaces still advertising v0.5.0, so the hosted docs were a release behind
-   for anyone reading them.
+   for anyone reading them. Check `MANIFEST.md`'s inventory and its Verification
+   counts against the corpus in the same pass — it is hand-maintained
+   ([#131](https://github.com/mbeacom/adrkit/issues/131)) and drifts the same way; it
+   was missing ADR-0026 and understating the record and accepted counts by one when
+   v0.7.0 was cut. `ls docs/adr/*.md | wc -l` and
+   `grep -h '^status:' docs/adr/*.md | sort | uniq -c` give the numbers to compare.
 5. Merge the version change only after CI passes.
 6. Create and push the matching annotated tag, such as `v0.3.0`.
 7. Approve the protected `npm` environment deployment.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,12 +9,12 @@ Action:
 | `@adrkit/evaluator` | npm |
 | `@adrkit/cli` (`adr`) | npm |
 | `@adrkit/mcp` (`adrkit-mcp`) | npm |
-| `packages/ci/action.yml` | Git tag (latest immutable release `v0.5.0`, moving `v0`) |
+| `packages/ci/action.yml` | Git tag (latest immutable release `v0.7.0`, moving `v0`) |
 
 `@adrkit/ci` stays private because GitHub executes the committed Action bundle
 directly from the referenced repository ref.
 
-The coordinated lockstep surface is published; the current release is `v0.5.0`. `@adrkit/core`,
+The coordinated lockstep surface is published; the current release is `v0.7.0`. `@adrkit/core`,
 `@adrkit/evaluator`, and `@adrkit/cli` use GitHub Actions Trusted Publishing.
 `@adrkit/mcp` was created with the isolated one-time bootstrap path below; its
 Trusted Publisher and token-restriction cleanup must be completed before the

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -233,24 +233,54 @@ bootstrap described below.
 
 ## Subsequent releases
 
-1. Update the version in all four public package manifests. Update any
-   inter-package expectations and run `bun install` with stable Bun 1.3.14 when
-   the lockfile changes.
-2. Bump the pinned `@adrkit/cli@<version>` in the published badges recipe
+1. Update the version in all four public package manifests, and the three places
+   the version is restated outside them: `CLI_VERSION` in
+   `packages/cli/src/index.ts`, `SERVER_INFO` in `packages/mcp/src/server.ts`, and
+   both `version` fields in `packages/mcp/server.json`.
+2. Update `bun.lock`'s four `packages/*` `version` fields to match. **`bun install`
+   will not do this for you.** The dependency graph is unchanged — `workspace:*`
+   still resolves to the same paths — so the install is a no-op, and
+   `bun install --frozen-lockfile` reports no drift even though the file is stale.
+   Nothing catches it until `release:pack` fails with
+   `@adrkit/evaluator must resolve @adrkit/core to <version>, got <previous>`,
+   because it validates packed manifests through the lockfile rather than the
+   manifests. Deleting `bun.lock` does regenerate those fields, but it re-resolves
+   the entire tree and silently upgrades transitive dependencies — edit the four
+   fields directly instead, then confirm with `bun install --frozen-lockfile`. The
+   diff should be exactly four lines, as in v0.6.0 (`c5dc677`) and v0.7.0.
+3. Bump the pinned `@adrkit/cli@<version>` in the published badges recipe
    (`site/src/content/docs/badges.mdx`). It is pinned deliberately — the snippet
    runs inside a job holding `contents: write` (ADR-0025) — so it cannot float
    with the release. `bun run check:doc-pins` fails when the pin and the root
    `package.json` version disagree, and it runs in `clean-clone-builds`, a
    required check, so a missed bump blocks the merge rather than reaching
    adopters as an old CLI.
-3. Merge the version change only after CI passes.
-4. Create and push the matching annotated tag, such as `v0.3.0`.
-5. Approve the protected `npm` environment deployment.
-6. Confirm the workflow published all packages, created the immutable GitHub
+4. Sweep the version *narrative* — the claims prose makes about what is current,
+   which no check enforces. `git grep -nE 'v?0\.[0-9]+\.0'` and update anything
+   asserting the current release: `site/src/components/Hero.astro`,
+   `site/src/content/docs/index.mdx`, `site/src/content/docs/quickstart.mdx`,
+   README's "Project status", this file's artifact table and lede, and `CLAUDE.md`.
+   Leave *historical* statements alone ("expanded in v0.5.0" records when something
+   happened and stays true). This drifts silently: v0.6.0 shipped with all three
+   site surfaces still advertising v0.5.0, so the hosted docs were a release behind
+   for anyone reading them.
+5. Merge the version change only after CI passes.
+6. Create and push the matching annotated tag, such as `v0.3.0`.
+7. Approve the protected `npm` environment deployment.
+8. Confirm the workflow published all packages, created the immutable GitHub
    release, and moved `v0` to the released commit.
+9. Re-publish the MCP registry entry — `cd packages/mcp && mcp-publisher publish`
+   (`docs/DISTRIBUTION.md` §A). **No workflow does this**, so `dev.adrkit/mcp` stays
+   at the previous version until a human runs it, and `docs/DISTRIBUTION.md` should
+   not claim the new version before then.
 
 Never move an immutable `vX.Y.Z` tag. The release workflow may force-update only
 the moving major Action tag (`v0`, later `v1`, and so on).
+
+Note that steps 1–4 land on `main` before step 6 creates the tag, so between the
+merge and the tag the site is deployed claiming a release that does not exist yet.
+The window is short and self-correcting; it is called out here so it is not
+mistaken for a mistake.
 
 ## v0.3.0 cutover runbook — **COMPLETE**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Decision memory for human and agent-authored plans — machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,7 +37,7 @@ import { isMainModule } from './main-module.ts';
  * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
  * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
  */
-export const CLI_VERSION = '0.6.0';
+export const CLI_VERSION = '0.7.0';
 
 function writeStdout(text: string): void {
   process.stdout.write(text);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adrkit/mcp",
   "mcpName": "dev.adrkit/mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetDecisionContext } from './tools/get-decision-context.ts';
 import { registerListSuperseded } from './tools/list-superseded.ts';
 import type { ToolConfig } from './tools/shared.ts';
 
-export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.6.0' } as const;
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.7.0' } as const;
 
 /**
  * The MCP protocol revision this server serves through `serveStdio`'s modern era.

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -14,7 +14,7 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
 				</svg>
 				CLI works today
 			</span>
-			<span>v0.5.0 on npm · decision memory in git</span>
+			<span>v0.7.0 on npm · decision memory in git</span>
 		</div>
 
 		<h1 id="_top" data-page-title set:html={title} />

--- a/site/src/content/docs/badges.mdx
+++ b/site/src/content/docs/badges.mdx
@@ -92,8 +92,8 @@ jobs:
       # current release.
       - run: |
           mkdir -p .adrkit
-          npx @adrkit/cli@0.6.0 queue --format json > .adrkit/queue.json.tmp
-          npx @adrkit/cli@0.6.0 lint --json  > .adrkit/lint.json.tmp
+          npx @adrkit/cli@0.7.0 queue --format json > .adrkit/queue.json.tmp
+          npx @adrkit/cli@0.7.0 lint --json  > .adrkit/lint.json.tmp
 
       # A truncated or malformed write renders as `no result` on the badge, which
       # reads as a bug in your tooling. Fail here instead of committing it.

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -34,11 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mbeacom/adrkit/packages/ci@v0
-        env:
-          # Needed only through v0.6.0, which `@v0` still resolves to; without it
-          # those versions post a new comment per push (#107). Harmless to keep
-          # afterwards — later versions never read it to identify the token.
-          GITHUB_TOKEN: ${{ github.token }}
         # with:
         #   dir: docs/adr          # ADR corpus directory (default: docs/adr)
         #   token: ${{ github.token }}
@@ -46,12 +41,14 @@ jobs:
 
 The Action finds the comment it posted on an earlier push and edits it in place, so a
 pull request carries one governing-decisions comment however many times you push
-([ADR-0026](/adr/)). Releases **through `v0.6.0` cannot do this on their own** and need
-the `env:` block above ([#107](https://github.com/mbeacom/adrkit/issues/107)); once
-`@v0` moves past `v0.6.0` the block becomes a no-op you may drop.
+([ADR-0026](/adr/)). Releases **through `v0.6.0` could not do this on their own** and
+needed an `env: GITHUB_TOKEN: ${{ github.token }}` block
+([#107](https://github.com/mbeacom/adrkit/issues/107)). `@v0` now resolves to `v0.7.0`,
+so that block is no longer required — and costs nothing if you still have it, because
+the Action never reads the variable to identify its token.
 
-`v0` is a moving major tag, and it still resolves to a `v0.6.0` build. Pin the
-immutable `v0.6.0` tag or a commit SHA for maximum reproducibility.
+`v0` is a moving major tag, and it now resolves to a `v0.7.0` build. Pin the
+immutable `v0.7.0` tag or a commit SHA for maximum reproducibility.
 
 <Aside type="note" title="Comments from before the upgrade">
 	The Action is comment-only and deletes nothing, so duplicate comments a pull request
@@ -60,14 +57,14 @@ immutable `v0.6.0` tag or a commit SHA for maximum reproducibility.
 </Aside>
 
 <Aside type="caution" title="Pinning a release tag by SHA">
-	The `v*` release tags are **annotated**, so `refs/tags/v0.6.0` resolves to a tag
+	The `v*` release tags are **annotated**, so `refs/tags/v0.7.0` resolves to a tag
 	object rather than a commit, and `uses:` rejects that SHA. Pin the commit the tag
 	points *at*:
 
 	```sh
-	git rev-parse v0.6.0^{commit}
+	git rev-parse v0.7.0^{commit}
 	# or, over the API — this endpoint peels the tag for you:
-	gh api repos/mbeacom/adrkit/commits/v0.6.0 --jq .sha
+	gh api repos/mbeacom/adrkit/commits/v0.7.0 --jq .sha
 	```
 
 	Note that `GET /git/ref/tags/{tag}` does **not** peel: its `object.sha` is the tag

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
 <div class="adr-home">
 	<section class="adr-status-band" aria-label="Project status">
 		<div class="adr-status-band__item">
-			<span class="adr-status adr-status--current">Published · v0.5.0</span>
+			<span class="adr-status adr-status--current">Published · v0.7.0</span>
 			<p>
 				<code>@adrkit/core</code>, <code>@adrkit/cli</code>,
 				<code>@adrkit/evaluator</code>, and <code>@adrkit/mcp</code> are on npm,

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -10,7 +10,7 @@ decisions govern a file, renders the decision graph, migrates an existing MADR
 corpus in place, emits the ARB operations queue, and runs the deterministic
 evaluator.
 
-<Aside type="tip" title="Published on npm (v0.5.0)">
+<Aside type="tip" title="Published on npm (v0.7.0)">
 	`@adrkit/cli` is live. Consumers install it with your Node package manager and
 	run the `adr` binary — no clone required. Published artifacts are Node-targeted
 	([ADR-0010](/adr/0010-bun-toolchain/)); Bun is used for developing adrkit

--- a/specs/004-ci-surface/quickstart.md
+++ b/specs/004-ci-surface/quickstart.md
@@ -42,24 +42,20 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }   # full history for the merge-base changed-file diff
       - uses: mbeacom/adrkit/packages/ci@v0     # @adrkit/ci Action (runs.using: node24)
-        env:
-          # Required only through v0.6.0, which `@v0` still resolves to; a no-op after.
-          GITHUB_TOKEN: ${{ github.token }}
         with:
           dir: docs/adr
           # token defaults to ${{ github.token }} — no other secret required
 ```
 
-The `env:` block is a transitional requirement, not part of the design. Through v0.6.0
-this workflow needed it to keep one comment, because comment identity was gated on
-recognising the default token by comparing it against that variable — a comparison the
-documented workflow could never satisfy
+An `env: GITHUB_TOKEN: ${{ github.token }}` block was a transitional requirement here,
+not part of the design. Through v0.6.0 this workflow needed it to keep one comment,
+because comment identity was gated on recognising the default token by comparing it
+against that variable — a comparison the documented workflow could never satisfy
 ([#107](https://github.com/mbeacom/adrkit/issues/107)). Identity is now taken from what
-the token proves at the API, so from the first release after v0.6.0 the variable is not
-read for that purpose and the block may be dropped
+the token proves at the API, so as of v0.7.0 the variable is not read for that purpose
 ([ADR-0026](../../docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md)).
-It is kept in this snippet until `@v0` moves, so the workflow above is runnable as
-written today.
+`@v0` resolves to v0.7.0, so the snippet above drops the block; a workflow that still
+carries it is unaffected.
 
 On a PR, the Action extracts the changed files, resolves the governing decisions,
 validates the changed records, and posts (or updates) a single comment.


### PR DESCRIPTION
Cuts **v0.7.0**. The npm surface is comment-only this cycle — the release exists to move the `v0` Action tag.

## Why now

The governing-decisions Action is distributed by **git tag**, so the #107 comment-upsert fix ([ADR-0026](https://github.com/mbeacom/adrkit/blob/main/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md)) that landed in #134 is **unreachable to adopters** until `v0` moves. That is the case for cutting.

Since v0.6.0 the only change under a published package is the JSDoc on `QueueReport.totalItems`. Everything else is `packages/ci` (private, tag-distributed), docs, site, and scripts.

**0.7.0 rather than 0.6.1** because the Unreleased section carries `Added` entries (DCO enforcement, the badges guide) and two newly accepted ADRs — 0025 and 0026.

## Version bumps

The four lockstep manifests, plus the three places the version is restated: `CLI_VERSION`, the MCP `SERVER_INFO`, and both fields in `server.json`. Changelog `Unreleased` rolls into `[0.7.0] - 2026-08-12` with matching compare links. The badges recipe pin moves to `@adrkit/cli@0.7.0`. `bun.lock`'s four workspace entries move too — see below.

## Documentation

Bringing the docs in step turned up drift that **predates this release**:

- **Transitional prose written *for* this tag.** `ci.mdx` and `specs/004-ci-surface/quickstart.md` said the `env: GITHUB_TOKEN` block was "needed only through v0.6.0, which `@v0` still resolves to". Once `@v0` moves to v0.7.0 that stops being true, so the workaround now leaves the recommended snippets and the prose is past-tense.
- **The site was two releases stale.** `Hero.astro`, `index.mdx`, and `quickstart.mdx` all advertised **v0.5.0**, as did README's status section, `docs/RELEASING.md`'s artifact table and lede, and `CLAUDE.md`. None moved at v0.6.0.
- **`docs/DISTRIBUTION.md` corrected against the live registry**, which I queried rather than assumed: `dev.adrkit/mcp` is listed at **0.6.0** with `isLatest: true`, and `v0` peels to `c5dc677`.

### The full version sweep

A pass over every version-bearing string outside the manifests found two more, both stale for reasons unrelated to this release:

- **`MANIFEST.md` never recorded ADR-0026.** Its inventory stopped at 0025 and its Verification block claimed 26 files / 25 records / 23 accepted against an actual 27 / 26 / 24. Exactly the hand-maintenance drift #131 describes — `adr lint` passes either way, because the manifest is *prose about* the corpus rather than part of it.
- **The bug-report template suggested `0.4.0`**, three releases back. Only an example, but it's the example every reporter sees while typing their own version.

Everything else the sweep surfaced is correct and deliberately untouched: Spec Kit's pinned 0.13.0/0.15.1 range, the frozen v0.13.0 spike target in specs/008, the `009-spike-0.1.0` envelope string, schema 0.1.0, the spec-kit adapter at 0.1.2, private `@adrkit/ci` at 0.1.0, and historical references like "expanded in v0.5.0" — which record *when things happened* and stay true.

### One deliberate omission

`docs/DISTRIBUTION.md` is **not** advanced to 0.7.0. Re-publishing to the MCP registry is a manual `mcp-publisher publish` step that no workflow performs, so claiming 0.7.0 there would assert something untrue until a human runs it — which that file's own binding honesty guardrail forbids. It now states the per-release manual step explicitly instead.

## The lockfile trap (worth reading before the next release)

The first push failed `clean-clone-builds` and both `node-smoke` legs with:

```
@adrkit/evaluator must resolve @adrkit/core to 0.7.0, got 0.6.0
```

`release:pack` validates packed manifests **through the lockfile**, and `bun.lock` mirrors each workspace package's `version`. `bun install` does not refresh those fields when only the version changed — the graph is unchanged, `workspace:*` still resolves to the same paths, so the install is a no-op and **`--frozen-lockfile` reports no drift even though the file is stale**.

Deleting `bun.lock` does regenerate them, but it re-resolves everything and pulled in octokit 7.0.7, jose 6.2.8, undici 6.28.0, and @types/node 26.2.0 — a dependency upgrade wearing a release commit's clothes. I reverted that and edited the four fields directly, giving the same 4-line diff v0.6.0 (`c5dc677`) carried.

`docs/RELEASING.md` now documents this as step 2, adds a step 4 for the version-narrative sweep (now including MANIFEST.md and the commands that produce its numbers), splits the manual MCP publish out as step 9, and fixes the duplicated step number the list already had.

## Verification

- `bun test` — **2064 pass, 0 fail**
- All 11 PR checks green
- Locally reproduced every failing job's steps: typecheck, build, `release:pack` (now `prepared 5 package(s) for v0.7.0`), lint, schema emit, Action bundle, `check:deps`, `check:freeze-hashes`, `check:doc-pins`, `check:changelog`, `check:dco`, `adr lint`, and all three Node smoke scripts on v22.22.2
- `adr --version` → `0.7.0`; `adr lint` → 26 records, 0 errors; queue depth 1
- MANIFEST counts re-derived from the corpus, not recounted by eye
- Site builds 37 pages clean

## After merge

Tag `v0.7.0` and approve the protected `npm` environment.

On the MCP registry: **`@adrkit/mcp` is a version-number-only change this cycle.** Its sole diff is the version string in `package.json`, `server.json`, and `SERVER_INFO`; its `@adrkit/core` dependency changed by a JSDoc comment alone. Re-publishing keeps the registry pointing at current and makes the server report `0.7.0` over the protocol, but it ships no behavior. If you do run it, it must come **after** npm publish succeeds — `mcp-publisher` validates that the version named in `server.json` already exists on npm carrying `mcpName`.

Also worth noting: **#136 / #122 — the moving `v0` tag still has no documented rollback path**, and this is the release that moves it to carry a behavioral Action change.
