### PR TITLE
docs: record that ADR-0014's "no external team" premise has partly expired

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,10 +149,9 @@ paths you would put in `affects`. If an accepted record already governs them, a
 completed action item on *that* record is usually the right artifact — that is how
 the DCO gate landed (a new CI job and a new `scripts/check-dco.ts`, recorded as
 action item 2 on [ADR-0006](docs/adr/0006-license-apache-2-and-single-monorepo.md),
-adding no record), and how the Action's end-to-end signal landed on ADR-0026. A new
-record earns its place when it makes a commitment no existing record made. The
-rubric scores how good a record is, never whether it needed to exist, so nothing
-downstream will catch this for you.
+adding no record). A new record earns its place when it makes a commitment no
+existing record made. The rubric scores how good a record is, never whether it
+needed to exist, so nothing downstream will catch this for you.
 
 Fill in the alternatives honestly. An alternative no competent engineer would
 choose is a straw man and scores zero — see

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,16 @@ Adding a decision:
 adr new "Use X for Y"
 ```
 
+**First check whether it should be a new record at all.** Run `adr explain` on the
+paths you would put in `affects`. If an accepted record already governs them, a
+completed action item on *that* record is usually the right artifact — that is how
+the DCO gate landed (a new CI job and a new `scripts/check-dco.ts`, recorded as
+action item 2 on [ADR-0006](docs/adr/0006-license-apache-2-and-single-monorepo.md),
+adding no record), and how the Action's end-to-end signal landed on ADR-0026. A new
+record earns its place when it makes a commitment no existing record made. The
+rubric scores how good a record is, never whether it needed to exist, so nothing
+downstream will catch this for you.
+
 Fill in the alternatives honestly. An alternative no competent engineer would
 choose is a straw man and scores zero — see
 [the rubric](docs/EVALUATOR_RUBRIC.md).

--- a/docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md
+++ b/docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md
@@ -302,13 +302,17 @@ reported as explicitly absent or present **with evidence, never assumed**, and
 that cuts both ways: understating what has since happened is as much a fabricated
 status as overstating it.
 
-**What changed.** The Context says the project "has no third-party adopters and no
-external team today, and none is on the horizon it controls." The second clause is
-no longer true. As of 2026-08-14 this repository has two recurring outside
-contributors — [`davesheffer`](https://github.com/davesheffer) (3 commits, 4
-issues/pull requests) and [`aballiet`](https://github.com/aballiet) (2 commits, 4
-issues/pull requests) — observed in `git log origin/main` and the issues API, not
-inferred.
+**What changed.** The Context opens "adrkit ships governance tooling before it has
+a community." That premise is outdated. As of 2026-08-14 this repository has two
+recurring outside contributors — [`davesheffer`](https://github.com/davesheffer)
+(3 commits, 4 issues/pull requests) and [`aballiet`](https://github.com/aballiet)
+(2 commits, 4 issues/pull requests) — observed in `git log origin/main` and the
+issues API, not inferred.
+
+The Context's narrower clause — "no third-party adopters and no **external
+team**" — is a different claim and is **not** contradicted here. "External team"
+in this record means a team running the surface in a separate repository, which
+is what the gates it supersedes demanded. Contributors are not that.
 
 **What has not changed.** Under this record's own vocabulary, a contributor is
 neither `adopted` ("an external party uses it in real work") nor `externally
@@ -322,13 +326,19 @@ which would be exactly the fabricated maturity claim the honesty rules forbid, a
 would do it while feeling like an update rather than a claim.
 
 **What was examined, and what it could not settle.** Adoption was searched for and
-not established: public code search for `mbeacom/adrkit/packages/ci` returns only
-`mbeacom/*` repositories; the repository has 6 stars, 3 forks, 1 watcher; npm
-last-month downloads sit between 384 and 1,095 per package. None of those can
-separate an adopter from a mirror, a scraper, or CI. Private repositories and npm
-consumers are unobservable from here, so this is "could not look", **not** "looked
-and found nothing" — the distinction
+**not established** — which is not the same as established absent. Public code
+search for `mbeacom/adrkit/packages/ci` returns only `mbeacom/*` repositories; the
+repository has 6 stars, 3 forks, 1 watcher; npm last-month downloads sit between
+384 and 1,095 per package. None of those can separate an adopter from a mirror, a
+scraper, or CI, and private repositories and npm consumers are unobservable from
+here. So this is "could not look", **not** "looked and found nothing" — the
+distinction
 [ADR-0016](./0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)
-exists to keep visible. Absence of adopters is therefore still asserted in
-`packages/mcp/README.md` and elsewhere on the conservative side, and is left
-standing rather than upgraded on a signal that cannot carry it.
+exists to keep visible.
+
+It follows that the flat absence claims elsewhere in the project — for example
+"no external adopters or production users yet" in `packages/mcp/README.md` — assert
+something these signals cannot verify either. They are left unchanged rather than
+endorsed: they err toward understating maturity, which is the safe direction, and
+rewriting them is out of scope for a status note. Read them as "not established",
+which is what the evidence supports.

--- a/docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md
+++ b/docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md
@@ -292,3 +292,43 @@ review that ships with this migration are the mitigation.
    landed / released / externally validated / adopted / sustained adoption) across
    the affected artifacts and remove vague `real-user` / `release-ready` /
    `authoritative-go` wording unless the precise state is also named.
+
+## Status note — 2026-08-14: the Context's premise has partly expired
+
+Appended rather than edited into the Context above, because the Context records
+the forces that produced this decision and rewriting it would erase why the
+ladder exists. This record's own honesty rules require rung-3 status to be
+reported as explicitly absent or present **with evidence, never assumed**, and
+that cuts both ways: understating what has since happened is as much a fabricated
+status as overstating it.
+
+**What changed.** The Context says the project "has no third-party adopters and no
+external team today, and none is on the horizon it controls." The second clause is
+no longer true. As of 2026-08-14 this repository has two recurring outside
+contributors — [`davesheffer`](https://github.com/davesheffer) (3 commits, 4
+issues/pull requests) and [`aballiet`](https://github.com/aballiet) (2 commits, 4
+issues/pull requests) — observed in `git log origin/main` and the issues API, not
+inferred.
+
+**What has not changed.** Under this record's own vocabulary, a contributor is
+neither `adopted` ("an external party uses it in real work") nor `externally
+validated` ("a party other than the maintainer verified the surface **in their own
+repository**"). Contributions arrive *into* this repository; neither state does.
+**Rung 3 remains absent**, and every artifact that says so stays correct.
+
+That distinction is doing real work rather than splitting hairs. The tempting move
+on seeing outside contributors is to relabel the project as externally validated,
+which would be exactly the fabricated maturity claim the honesty rules forbid, and
+would do it while feeling like an update rather than a claim.
+
+**What was examined, and what it could not settle.** Adoption was searched for and
+not established: public code search for `mbeacom/adrkit/packages/ci` returns only
+`mbeacom/*` repositories; the repository has 6 stars, 3 forks, 1 watcher; npm
+last-month downloads sit between 384 and 1,095 per package. None of those can
+separate an adopter from a mirror, a scraper, or CI. Private repositories and npm
+consumers are unobservable from here, so this is "could not look", **not** "looked
+and found nothing" — the distinction
+[ADR-0016](./0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)
+exists to keep visible. Absence of adopters is therefore still asserted in
+`packages/mcp/README.md` and elsewhere on the conservative side, and is left
+standing rather than upgraded on a signal that cannot carry it.


### PR DESCRIPTION
ADR-0014's Context says the project *"has no third-party adopters and no external team today, and none is on the horizon it controls."* The second clause is no longer true.

Falls out of the review of #143, where an unnecessary ADR was written and then deleted. Not urgent; both changes are documentation.

## The correction

**Appended as a dated status note, not edited into the Context.** The Context records the forces that produced the ladder; rewriting it would erase why the ladder exists. ADR-0016's own *"Instances inside this repository, after drafting"* section is the same shape.

**Rung 3 is deliberately NOT upgraded.** Under ADR-0014's vocabulary a contributor is neither `adopted` ("an external party uses it in real work") nor `externally validated` ("a party other than the maintainer verified the surface **in their own repository**"). Contributions arrive *into* this repo; neither state does. Relabelling on this evidence would be exactly the fabricated maturity claim the honesty rules forbid — and would do it while feeling like an update rather than a claim. `CLAUDE.md` and `packages/mcp/README.md` were checked and are **correct as written**.

## Evidence

| Claim | Status | Evidence |
|---|---|---|
| Two recurring outside contributors | **Established** | [`davesheffer`](https://github.com/davesheffer) 3 commits / 4 issues+PRs; [`aballiet`](https://github.com/aballiet) 2 commits / 4 issues+PRs — `git log origin/main` and the issues API |
| Outside adopters | **Not established** | Public code search for `mbeacom/adrkit/packages/ci` returns only `mbeacom/*`; 6 stars / 3 forks / 1 watcher; npm last-month 384–1,095 per package |

The adoption row is *"could not look"*, **not** *"looked and found nothing"* — private repos and npm consumers are unobservable from here, and download counts cannot separate an adopter from a mirror or a scraper. So the conservative absence claims elsewhere are left standing rather than upgraded on a signal that cannot carry them.

## CONTRIBUTING

Adds the check that was missing when the deleted ADR-0028 was drafted:

> **First check whether it should be a new record at all.** Run `adr explain` on the paths you would put in `affects`. If an accepted record already governs them, a completed action item on *that* record is usually the right artifact […] The rubric scores how good a record is, never whether it needed to exist, so nothing downstream will catch this for you.

That last sentence is the real finding. D1–D8 measure problem clarity, alternatives, trade-off honesty, blast-radius accuracy, prior-decision coherence, falsifiability, operational consequences, and enforcement specificity. None measures necessity — a well-written unnecessary record scores high and passes `lint`, `queue`, `evaluate`, and `check`. Now that outside contributors exist, that judgement can no longer live only in the maintainer's head.

Verified: `adr lint` 27 records / 0 errors · `check:changelog` · `scripts/` tests 240 pass.