### PR TITLE
docs(adr): record action-dogfood as required, and correct the ruleset fact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+### Changed
+
+- **`action-dogfood` is a required status check on `main`** (2026-08-15), added once it
+  had run green across several commits of #143 — it could not be required before that,
+  since it skips on the pull requests that cannot satisfy it. Checked while adding it:
+  `clean-clone-builds` was **already** required, which closes the hole the second operator
+  review raised conditionally. That coupling is now recorded on
+  [ADR-0026](docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md),
+  because it is invisible from both sides — `action-dogfood` declares
+  `needs: clean-clone-builds`, a job skipped for a failed dependency reports success
+  exactly like one skipped by an `if:`, and nothing in `ci.yml` says that dropping
+  `clean-clone-builds` from the ruleset would silently weaken the comment gate.
+
 ### Added
 
 - **The comment-posting Action now has an end-to-end signal**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ Until `1.0.0`, minor releases may include breaking changes
   exactly like one skipped by an `if:`, and nothing in `ci.yml` says that dropping
   `clean-clone-builds` from the ruleset would silently weaken the comment gate.
 
+- **The comment path is `reference-verified`** — reviewed and passed by `@mbeacom` on
+  2026-08-15, completing the last of ADR-0014's four rung-2 criteria. Still **not**
+  `externally validated`; the reference repository is maintainer-owned, so rung 3 remains
+  absent, and the index's stated limitations are part of the verdict rather than footnotes
+  to it.
+
+### Fixed
+
+- **The rung-2 evidence index shipped in #143 with a header contradicting its own body** —
+  `NOT YET OBSERVED` and `Reviewer verdict: none. No run has occurred.` directly above a
+  table of observed runs with comment ids and content hashes. The cause was a scripted
+  `.replace()` written without an assertion, against text a previous edit had already
+  changed: it matched nothing, did nothing, and reported success. That is the failure this
+  index exists to make visible, committed in the index itself, so the corrected header
+  records it rather than quietly overwriting it.
+
 ### Added
 
 - **The comment-posting Action now has an end-to-end signal**
@@ -84,8 +100,10 @@ Until `1.0.0`, minor releases may include breaking changes
   the step with `ENOTDIR` leaving the comment set byte-identical; and a
   `pull-requests: read` token produced the FR-014 degrade — a log notice, a green job,
   nothing written. That degrade path had **never been observed anywhere**; it had only
-  ever been read from source. A reviewer verdict is still outstanding, so the comment
-  path is `implemented`, not yet `reference-verified`.
+  ever been read from source. Reviewed and passed by `@mbeacom` on 2026-08-15, which
+  completes ADR-0014's rung-2 criteria: the comment path is **landed /
+  reference-verified**, and still **not** `externally validated` — the reference
+  repository is maintainer-owned, so rung 3 stays absent.
 
   **Running it found four defects in the artifact, all invisible to static review.**
   `path: .adrkit` deleted the contents of a directory the reference repository tracks
@@ -166,9 +184,9 @@ Until `1.0.0`, minor releases may include breaking changes
   `pull-requests: read` that must stay green. Shipped as a workflow file rather than as
   a task, per ADR-0016 clause 4 — it is the mechanism for ADR-0026 action item 8, which
   stays open until it is run. Its evidence index
-  (`specs/004-ci-surface/checklists/reference-verification-evidence.md`) is created
-  **empty and explicitly `NOT YET OBSERVED`**: the comment path remains `implemented`,
-  not `reference-verified`, until a real run fills it in.
+  (`specs/004-ci-surface/checklists/reference-verification-evidence.md`) was created
+  **empty and explicitly `NOT YET OBSERVED`**, and has since been filled from real runs
+  and reviewed.
 
 ## [0.7.0] - 2026-08-12
 

--- a/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
+++ b/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
@@ -335,9 +335,10 @@ have one.
    [`specs/004-ci-surface/checklists/reference-verification-evidence.md`](../../specs/004-ci-surface/checklists/reference-verification-evidence.md);
    the artifact that produced it is
    [`specs/004-ci-surface/evidence/reference-repo/`](../../specs/004-ci-surface/evidence/reference-repo/README.md).
-   **A reviewer verdict is still outstanding**, and ADR-0014 rung 2 requires the evidence
-   to be reviewed, so the comment path remains `implemented` and is not yet
-   `reference-verified`.
+   **Reviewed and passed by `@mbeacom` on 2026-08-15**, which is the last of ADR-0014's
+   four rung-2 criteria, so the comment path is now **landed / reference-verified** on
+   rungs 1–2. It is **not** `externally validated`: the reference repository is
+   maintainer-owned, so rung 3 stays absent.
 
    Three things the run established that reading could not:
 

--- a/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
+++ b/docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md
@@ -489,24 +489,28 @@ have one.
    deleting the prior comment before each run, which would notify every subscriber on
    every push. Stated as a bounded limitation rather than closed badly.
 
-   Still open: making `action-dogfood` a required check on the `main` ruleset, which
-   cannot happen until it has run green at least once, since it skips on the pull
-   requests that cannot satisfy it. Three operational facts belong with that step, because
-   all three live in repository settings rather than in this repository:
+   **Done 2026-08-15**: `action-dogfood` is a required status check on the `main` ruleset,
+   added after it had run green on several commits of #143 — it could not be added before
+   that, since it skips on the pull requests that cannot satisfy it. Three operational
+   facts belong with it, because all three live in repository settings rather than in this
+   repository:
 
    - The check is named by the **job id `action-dogfood`**, so renaming or relocating that
      job leaves every pull request waiting on a check that will never report, which only
      an administrator can clear.
    - Disabling the gate means removing it from the ruleset, not editing `ci.yml`, since a
      workflow edit lands in the same pull request the gate is blocking.
-   - **`clean-clone-builds` must be made required in the same edit.** `action-dogfood`
-     declares `needs: clean-clone-builds`, and a job skipped because its dependency failed
-     is reported exactly like one skipped by an `if:` — as success. So a pull request whose
-     build fails would satisfy the comment gate without the Action ever having run, which
-     is this record's own blind spot reopened through a mechanism nobody would be watching.
-     Dropping `needs` is not the alternative: the bundle-drift check it waits for is only
-     meaningful after `bun run build`, so removing the dependency would mean rebuilding
-     inside this job. Raised by the second operator review.
+   - **`clean-clone-builds` must stay required for this gate to mean anything.**
+     `action-dogfood` declares `needs: clean-clone-builds`, and a job skipped because its
+     dependency failed is reported exactly like one skipped by an `if:` — as success. So a
+     pull request whose build fails would satisfy the comment gate without the Action ever
+     having run, which is this record's own blind spot reopened through a mechanism nobody
+     would be watching. The second operator review raised this conditionally, not knowing
+     the ruleset; it was then checked, and `clean-clone-builds` **is already required**, so
+     the hole is closed today. It is recorded because the coupling is invisible from either
+     side: removing `clean-clone-builds` from the ruleset would silently weaken this gate,
+     and nothing in `ci.yml` says so. Dropping `needs` is not the alternative either — the
+     bundle-drift check it waits for is only meaningful after `bun run build`.
 10. [ ] **Deferred, tracked separately.** `v0` is a moving tag with no documented
     rollback, so recovering from a bad Action release depends on a maintainer knowing
     to force-move it by hand.

--- a/specs/004-ci-surface/checklists/reference-verification-evidence.md
+++ b/specs/004-ci-surface/checklists/reference-verification-evidence.md
@@ -19,19 +19,29 @@ names.
 **Runnable artifact**: [`../evidence/reference-repo/comment-idempotence.yml`](../evidence/reference-repo/comment-idempotence.yml)
 · [how to run it](../evidence/reference-repo/README.md)
 
-## Status: NOT YET OBSERVED
+## Status: REFERENCE-VERIFIED — observed 2026-08-14, reviewed 2026-08-15
 
-**Reviewer verdict: none. No run has occurred.**
+**Reviewer verdict: PASS — maintainer `@mbeacom`, 2026-08-15.** ADR-0014's four rung-2
+criteria are met: *reproducible* (every run pins an immutable adrkit commit and its inputs
+are committed), *self-verifying* (each job asserts its own expected outcome, so divergence
+fails the run rather than needing a human to read a log), *fail-closed* (scenario 3 proves
+the Action fails before any write and mutates nothing, byte-for-byte), and *reviewed*
+(this entry).
 
-Nothing below is claimed as evidence. The `Observed` column is empty on purpose, and
-this file must not be read as satisfying rung 2 until it is filled from real runs with
-immutable links. ADR-0014's honesty rules make `landed / reference-verified` a distinct
-claim from `implemented`, and the comment path is currently **implemented** with
-continuous rung-1 evidence only.
+The comment path is therefore **landed / reference-verified** on rungs 1–2. It is **not**
+`externally validated`: the reference repository is maintainer-owned, so rung 3 remains
+absent. The *Known limitations* below are part of this verdict rather than footnotes to
+it — in particular, no rung-2 assertion has been observed catching a real #107 regression,
+and the retry paths have never executed an iteration.
 
-The distinction this index exists to keep visible: an empty `Observed` column is
-*visibly* unverified, whereas the state before this index existed — was
-indistinguishable from verified to anyone who did not go looking.
+> **This header was wrong when PR #143 merged.** It read `NOT YET OBSERVED` and
+> `Reviewer verdict: none. No run has occurred.` directly above the run table below. The
+> cause: a scripted `.replace()` intended to update it was written without an assertion,
+> and an earlier edit had already altered text inside the block it was matching, so it
+> silently did nothing and the run reported success. Fixed in #147. Recorded rather than
+> quietly overwritten, because it is this index's own subject matter — an operation that
+> failed to look, rendered identically to one that looked and found nothing, in the
+> document that exists to make that distinction visible.
 
 ## Tool versions / environment
 


### PR DESCRIPTION
Follow-up to #143. Records that `action-dogfood` is now a **required status check** on `main`, and corrects a fact I got wrong in that PR.

## The correction

The second operator review raised — conditionally, without ruleset access — that `clean-clone-builds` must be made required too. The reasoning is sound: `action-dogfood` declares `needs: clean-clone-builds`, a job skipped for a *failed dependency* reports success exactly like one skipped by `if:`, so a failed build would satisfy the comment gate on a pull request where the Action never ran.

I wrote that into ADR-0026 as an instruction for a future reader. **Checked against the live ruleset while adding `action-dogfood`: `clean-clone-builds` is already required.** The hole is closed today, and the record now says so instead of asking someone to make an edit that was already made.

Kept rather than deleted, because the coupling is invisible from both sides — removing `clean-clone-builds` from the ruleset would silently weaken this gate, and nothing in `ci.yml` says so.

## Ruleset change made

`main` ruleset required checks, before → after:

```
  clean-clone-builds, node-smoke-built-artifacts (22.x), node-smoke-built-artifacts (24.x),
  audit, self-dogfood, Analyze (actions), Analyze (javascript-typescript), dco
+ action-dogfood
```

Everything else preserved — enforcement, bypass actors, conditions, and the `deletion` / `non_fast_forward` rules — and verified by re-reading the ruleset after the write.

Ordering was load-bearing: the job had to run green on #143 first (it skips on fork and Dependabot PRs, so it had to be observed reporting before it could be depended on), and #143 had to merge before the check became required, or any open PR without the job in its `ci.yml` would have been blocked on a check that never reports.

## Verification

`bun test` 2134 pass / 0 fail · `adr lint` 27 records, 0 errors · `check:changelog`.