### PR TITLE
docs(site): defend the install path against the unrelated `adr` package on npm

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,13 +9,23 @@ bare `npx adr` resolves an unrelated `adr` package on npm):
 npx @adrkit/cli lint
 ```
 
-Or add it as a dev dependency and invoke it through your runner, which puts
-`node_modules/.bin` on PATH — a bare `adr` will not be on an interactive shell's
-PATH:
+Or add it as a dev dependency and invoke it through an npm script. A bare `adr`
+will not be on an interactive shell's PATH, and a bare `npx adr` is worse than
+missing — when the binary is not linked into `node_modules/.bin`, it silently
+downloads and runs the unrelated registry package instead of failing. A script
+resolves `node_modules/.bin` directly and stops with `command not found`:
 
 ```sh
 npm install --save-dev @adrkit/cli    # or: bun add --dev @adrkit/cli
-npx adr lint                          # or: bunx adr lint, or an npm script
+npm pkg set scripts.adr=adr
+npm run adr -- lint
+```
+
+Or install it globally, which does put a bare `adr` on your PATH:
+
+```sh
+npm install -g @adrkit/cli
+adr lint
 ```
 
 The `adr` binary includes `new`, `lint`, `graph`, `explain`, `check`, `queue`,

--- a/site/src/content/docs/commands.mdx
+++ b/site/src/content/docs/commands.mdx
@@ -24,11 +24,15 @@ adr --version             Print the @adrkit/cli version
 ```
 
 <Aside type="caution" title="Invoking these commands">
-	Every command below is written as bare `adr …`. That works when `@adrkit/cli`
-	is installed in the project. Running one-off, name the package —
-	`npx @adrkit/cli lint` — because a bare `npx adr` resolves an **unrelated**
-	`adr` package on npm that does not implement these commands. See the
-	[quickstart](/quickstart/#install).
+	Every command below is written as bare `adr …`, which works as written only
+	if you installed `@adrkit/cli` **globally**. A project-local install puts the
+	binary in `node_modules/.bin/`, not on your `PATH`, so drive it from an npm
+	script (`npm run adr -- lint`).
+
+	With nothing installed, name the package — `npx @adrkit/cli lint`. Avoid bare
+	`npx adr`: it resolves an **unrelated** `adr` package on npm whenever the
+	binary is not linked locally, and runs that other tool rather than failing.
+	See the [quickstart](/quickstart/#install).
 </Aside>
 
 ## adr lint

--- a/site/src/content/docs/commands.mdx
+++ b/site/src/content/docs/commands.mdx
@@ -3,6 +3,8 @@ title: Command reference
 description: Every adrkit CLI command, its options, and its documented exit codes.
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 The `adr` binary (published as `@adrkit/cli`) is a small set of deterministic
 commands. Run any of them with `--help`, or `adr help <command>`, to print the
 same text shown here. Global synopsis:
@@ -20,6 +22,14 @@ adr queue [--dir docs/adr] [--as-of YYYY-MM-DD] [--format markdown|json]
 adr help [command]        Show help, or help for one command
 adr --version             Print the @adrkit/cli version
 ```
+
+<Aside type="caution" title="Invoking these commands">
+	Every command below is written as bare `adr …`. That works when `@adrkit/cli`
+	is installed in the project. Running one-off, name the package —
+	`npx @adrkit/cli lint` — because a bare `npx adr` resolves an **unrelated**
+	`adr` package on npm that does not implement these commands. See the
+	[quickstart](/quickstart/#install).
+</Aside>
 
 ## adr lint
 

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -21,28 +21,42 @@ evaluator.
 
 Add the CLI to a project, or run it one-off. It exposes the `adr` binary.
 
+<Aside type="caution" title="Name the package: @adrkit/cli">
+	adrkit's binary is `adr`, but the bare name `adr` on npm belongs to an
+	**unrelated package**. A bare `npx adr …` / `bunx adr …` downloads that other
+	tool, which has no `lint`, `explain`, `graph`, or `migrate` — but does ship
+	its own `new`, so it can look like it works before failing on everything
+	else.
+
+	Either name the package every time — `npx @adrkit/cli lint` — or install
+	`@adrkit/cli` into the project first. Once it is a local dependency,
+	`npx adr …` resolves your installed binary instead of the registry.
+</Aside>
+
 <Tabs>
 <TabItem label="npm / npx">
 
 ```sh
-# add to a project
-npm install --save-dev @adrkit/cli
-npx adr lint
-
-# one-off, no install
+# one-off, no install — name the package
+npx @adrkit/cli lint
 npx @adrkit/cli explain src/payments/api.ts
+
+# or add it to the project first
+npm install --save-dev @adrkit/cli
+npx adr lint   # now resolves the locally installed binary
 ```
 
 </TabItem>
 <TabItem label="Bun">
 
 ```sh
-# add to a project
-bun add --dev @adrkit/cli
-bunx adr lint
-
-# one-off, no install
+# one-off, no install — name the package
+bunx @adrkit/cli lint
 bunx @adrkit/cli explain src/payments/api.ts
+
+# or add it to the project first
+bun add --dev @adrkit/cli
+bunx adr lint   # now resolves the locally installed binary
 ```
 
 </TabItem>
@@ -67,11 +81,10 @@ npm install @adrkit/core @adrkit/evaluator
 	```
 </Aside>
 
-The examples below use the `adr` binary. From a project that has `@adrkit/cli`
-installed, `npx adr …` / `bunx adr …` resolves the local binary. Without an
-install you must name the package — `npx @adrkit/cli lint`, `bunx @adrkit/cli
-lint` — because a bare `npx adr` resolves an unrelated `adr` package on npm. From
-a source checkout, use `bun run adr`.
+The examples below are written as bare `adr …` for readability. Unless you have
+installed `@adrkit/cli` into the project, run them as `npx @adrkit/cli …` /
+`bunx @adrkit/cli …` — see the caution above. From a source checkout, use
+`bun run adr`.
 
 ## Validate a corpus — `adr lint`
 

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -21,42 +21,55 @@ evaluator.
 
 Add the CLI to a project, or run it one-off. It exposes the `adr` binary.
 
-<Aside type="caution" title="Name the package: @adrkit/cli">
+<Aside type="caution" title="Always name the package: @adrkit/cli">
 	adrkit's binary is `adr`, but the bare name `adr` on npm belongs to an
-	**unrelated package**. A bare `npx adr …` / `bunx adr …` downloads that other
-	tool, which has no `lint`, `explain`, `graph`, or `migrate` — but does ship
-	its own `new`, so it can look like it works before failing on everything
-	else.
+	**unrelated package**. It has no `lint`, `explain`, `graph`, or `migrate` —
+	but does ship its own `new`, so it can look like it works before failing on
+	everything else.
 
-	Either name the package every time — `npx @adrkit/cli lint` — or install
-	`@adrkit/cli` into the project first. Once it is a local dependency,
-	`npx adr …` resolves your installed binary instead of the registry.
+	**Avoid bare `npx adr …` / `bunx adr …` entirely.** It only reaches adrkit if
+	the binary happens to be linked into `node_modules/.bin`, and when it is not
+	— which is common in workspaces and monorepos — it does not fail. It
+	silently downloads and runs the other tool instead.
+
+	Name the package (`npx @adrkit/cli lint`), or install `@adrkit/cli` and drive
+	it from an npm script — a script resolves `node_modules/.bin` directly and
+	fails loudly with `command not found` rather than reaching the registry.
 </Aside>
 
 <Tabs>
 <TabItem label="npm / npx">
 
 ```sh
-# one-off, no install — name the package
+# one-off, no install — always name the package
 npx @adrkit/cli lint
 npx @adrkit/cli explain src/payments/api.ts
 
-# or add it to the project first
+# or add it to the project and drive it from a script
 npm install --save-dev @adrkit/cli
-npx adr lint   # now resolves the locally installed binary
+npm pkg set scripts.adr=adr
+npm run adr -- lint
+
+# or install globally, for a bare `adr` on your PATH
+npm install -g @adrkit/cli
+adr lint
 ```
 
 </TabItem>
 <TabItem label="Bun">
 
 ```sh
-# one-off, no install — name the package
+# one-off, no install — always name the package
 bunx @adrkit/cli lint
 bunx @adrkit/cli explain src/payments/api.ts
 
-# or add it to the project first
+# or add it to the project and drive it from a script
 bun add --dev @adrkit/cli
-bunx adr lint   # now resolves the locally installed binary
+bun run adr lint   # with "adr": "adr" in package.json scripts
+
+# or install globally, for a bare `adr` on your PATH
+bun add --global @adrkit/cli
+adr lint
 ```
 
 </TabItem>
@@ -81,10 +94,23 @@ npm install @adrkit/core @adrkit/evaluator
 	```
 </Aside>
 
-The examples below are written as bare `adr …` for readability. Unless you have
-installed `@adrkit/cli` into the project, run them as `npx @adrkit/cli …` /
-`bunx @adrkit/cli …` — see the caution above. From a source checkout, use
-`bun run adr`.
+The examples below are written as bare `adr …` for readability. A local install
+does **not** put `adr` on your shell `PATH` — it lands in `node_modules/.bin/`
+— so translate them to whichever way you installed:
+
+| How you installed | Run the examples as |
+|---|---|
+| Nothing installed (one-off) | `npx @adrkit/cli lint` / `bunx @adrkit/cli lint` |
+| Project dev dependency | an npm script — `npm run adr -- lint` |
+| Global (`npm i -g @adrkit/cli`) | `adr lint` — bare, as written |
+| Source checkout | `bun run adr lint` |
+
+Only the global install makes the bare form work in a normal shell. Note that
+`npx adr lint` is absent from that table deliberately: it reaches adrkit only
+when the binary is linked into `node_modules/.bin`, and otherwise silently runs
+the unrelated registry package instead of failing. An npm script has no such
+ambiguity — it resolves `node_modules/.bin` and stops with `command not found`
+if the dependency is missing.
 
 ## Validate a corpus — `adr lint`
 


### PR DESCRIPTION
## What prompted this

A report that `adr lint`, `adr explain`, `adr graph`, and `adr migrate --from madr` are advertised on the site but "mostly not available."

**They are all available.** Verified against the published `@adrkit/cli@0.7.0` artifact from npm, not just this source tree:

| Command | Result against published artifact |
|---|---|
| `adr lint` | `checked 27 records, 0 errors, 0 warnings` |
| `adr graph --format dot\|json` | emits real DOT / JSON |
| `adr explain <path>` | resolves governing decisions + `@adr` markers |
| `adr migrate --from madr` | `migrated 1, updated 0, unchanged 0…` |

24/24 CLI tests pass. No implementation gap — so this PR changes no code.

## The actual defect

The bare name `adr` on npm belongs to an **unrelated package** (v1.5.2, a separate ADR tool). Its command set is:

```
compress, export, generate, init, list, logs, new, search, status, update
```

No `lint`, no `explain`, no `graph`, no `migrate` — but it *does* ship its own `new`.

That overlap is what makes the collision expensive rather than merely annoying. A reader who runs `npx adr new "..."` gets a plausible-looking result from the wrong tool, then finds that four of the five commands the site advertises don't exist, and reasonably concludes our "works today" claims are false.

`quickstart.mdx` already carried this warning — but as prose ~40 lines *below* the install tabs, after the point where a reader has copied a command and moved on. **Position, not content, was the defect.**

## Changes

`site/src/content/docs/quickstart.mdx`
- Warning promoted to a `caution` Aside directly under `## Install`, above the tabs. It now names the failure mode explicitly, including the `new` overlap that lets the wrong tool look like it works.
- Both tab blocks lead with the fully-qualified zero-install form (`npx @adrkit/cli lint`). The project-install path comes second, with its bare `npx adr lint` annotated as resolving the *local* binary. Previously the bare form came first — the riskiest invocation was the most copyable one.
- Trailing paragraph no longer restates the collision; it states the page convention and points at the caution.

`site/src/content/docs/commands.mdx`
- This is where a reader lands when looking up a single command, and every synopsis is written as bare `adr …`. Added the same caution under the global synopsis, linking to `/quickstart/#install`.

## Deliberate choices

- **Unpinned invocations.** `check:doc-pins` only governs `@adrkit/cli@<version>` forms; these are the get-latest install path. `badges.mdx` keeps its `@0.7.0` pins, which exist for CI reproducibility and are documented as such.
- **READMEs untouched.** `packages/cli/README.md` already has the best-worded version of this warning inline, and the root `README.md` is fully qualified throughout.

## Verification

- `bun run build` — 38 pages, clean
- Grepped the **built HTML** to confirm both asides render and that the `#install` anchor the cross-link targets actually exists
- `check:doc-pins` ok, `check:dco` ok

## Still open

This fixes the docs. It does not fix the collision for anyone who never reads them — someone guessing `npx adr` from a blog post or an agent suggestion still lands on the wrong package. Publishing a placeholder/deprecated `adr` that points at `@adrkit/cli` is the only thing that catches those. Flagging as a namespace decision, not proposing it here.