### PR TITLE
feat: own the `adrkit` name — bin alias in @adrkit/cli, plus the unscoped forwarder package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,12 @@ Until `1.0.0`, minor releases may include breaking changes
   project holding both dependencies has them compete for the same `.bin` entry. `adrkit`
   collides with nothing, so `adrkit lint` is unambiguous for globally-installed users and
   in `node_modules/.bin`. `adr` is unchanged and remains the primary name — this is purely
-  additive, and nothing that works today stops working. The alias is also safe under
-  `npx`/`bunx` in a way `adr` is not: `npx adrkit` runs the local binary when one is
-  installed and otherwise fails with a clean 404, where `npx adr` silently runs the
-  unrelated package. That 404 becomes a success only if the unclaimed `adrkit` name is
-  later published, so the zero-install form to document remains `npx @adrkit/cli`.
+  additive, and nothing that works today stops working. The alias covers the **installed**
+  binary only: the unscoped `adrkit` *package* name is unclaimed, so `npx adrkit` resolves
+  against the registry and would run whatever anyone publishes there — and npm assumes
+  `--yes` on a non-TTY, so CI would install and run it without prompting. `npx --no`
+  declines to install a missing package but still runs one already in the npx cache, so it
+  is not a durable guard; `npx @adrkit/cli` remains the zero-install form.
   `release-pack` now asserts both binaries are present in the packed manifest, and that
   assertion was observed failing with the alias removed before it was counted as coverage
   ([ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,22 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ### Added
 
+- **`@adrkit/cli` now installs an `adrkit` binary alongside `adr`.** The bare name `adr`
+  on npm belongs to an unrelated package (`phodal/adr`, published since 2017), so the
+  `adr` command is ambiguous in two ways adrkit does not control: a bare `npx adr` fetches
+  that package whenever adrkit's binary is not linked into `node_modules/.bin`, and a
+  project holding both dependencies has them compete for the same `.bin` entry. `adrkit`
+  collides with nothing, so `adrkit lint` is unambiguous for globally-installed users and
+  in `node_modules/.bin`. `adr` is unchanged and remains the primary name — this is purely
+  additive, and nothing that works today stops working. The alias is also safe under
+  `npx`/`bunx` in a way `adr` is not: `npx adrkit` runs the local binary when one is
+  installed and otherwise fails with a clean 404, where `npx adr` silently runs the
+  unrelated package. That 404 becomes a success only if the unclaimed `adrkit` name is
+  later published, so the zero-install form to document remains `npx @adrkit/cli`.
+  `release-pack` now asserts both binaries are present in the packed manifest, and that
+  assertion was observed failing with the alias removed before it was counted as coverage
+  ([ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).
+
 - **The comment-posting Action now has an end-to-end signal**
   ([ADR-0026](docs/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows.md)
   action item 9, #135). `self-dogfood` runs the **CLI** with `contents: read`, so it never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,23 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ### Added
 
+- **The unscoped `adrkit` package is now published**, forwarding to `@adrkit/cli`. `adr` on
+  npm belongs to an unrelated package, and #151 established that no bare-name `npx` form
+  can be made safe by documentation: `npx adr` reaches adrkit only when the binary is
+  linked into `node_modules/.bin`, and otherwise runs the other tool without failing —
+  in CI without even prompting, since npm assumes `--yes` on a non-TTY. Owning `adrkit`
+  makes `npx adrkit` resolve to adrkit by construction rather than by luck, and keeps the
+  obvious name from being claimed by someone else. `@adrkit/cli` remains canonical and is
+  what projects should depend on; the forwarder carries no logic, tracks it by
+  `workspace:*`, and is lockstep-versioned, because a forwarder that lags its target
+  reports a version it is not running.
+
+  Its first publish must use a credential rather than OIDC — npm Trusted Publishing cannot
+  be configured for a name that does not exist yet — so `adrkit` is temporarily in
+  `BOOTSTRAP_PACKAGES`. Configure Trusted Publishing, remove it from that set, and delete
+  `NPM_BOOTSTRAP_TOKEN` once the name exists, as was done for `@adrkit/mcp` and
+  `@adrkit/spec-kit`.
+
 - **`@adrkit/cli` now installs an `adrkit` binary alongside `adr`.** The bare name `adr`
   on npm belongs to an unrelated package (`phodal/adr`, published since 2017), so the
   `adr` command is ambiguous in two ways adrkit does not control: a bare `npx adr` fetches
@@ -47,12 +64,13 @@ Until `1.0.0`, minor releases may include breaking changes
   project holding both dependencies has them compete for the same `.bin` entry. `adrkit`
   collides with nothing, so `adrkit lint` is unambiguous for globally-installed users and
   in `node_modules/.bin`. `adr` is unchanged and remains the primary name — this is purely
-  additive, and nothing that works today stops working. The alias covers the **installed**
-  binary only: the unscoped `adrkit` *package* name is unclaimed, so `npx adrkit` resolves
-  against the registry and would run whatever anyone publishes there — and npm assumes
-  `--yes` on a non-TTY, so CI would install and run it without prompting. `npx --no`
-  declines to install a missing package but still runs one already in the npx cache, so it
-  is not a durable guard; `npx @adrkit/cli` remains the zero-install form.
+  additive, and nothing that works today stops working. The bin alias by itself covers
+  only the **installed** binary; `npx adrkit` is safe because this release also publishes
+  the unscoped `adrkit` *package* (above), not because of the bin entry. Had that name
+  stayed unclaimed, `npx adrkit` would have resolved against the registry and run whatever
+  anyone published there — without prompting in CI, where npm assumes `--yes` on a
+  non-TTY. `npx --no` is not a sufficient answer to that: it declines to install a missing
+  package but still runs one already in the npx cache.
   `release-pack` now asserts both binaries are present in the packed manifest, and that
   assertion was observed failing with the alias removed before it was counted as coverage
   ([ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,19 @@
       "name": "@adrkit/spec-kit",
       "version": "0.1.2",
     },
+    "packages/adrkit": {
+      "name": "adrkit",
+      "version": "0.7.0",
+      "bin": {
+        "adrkit": "./dist/index.js",
+      },
+      "dependencies": {
+        "@adrkit/cli": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
     "packages/catalog-envelope": {
       "name": "@adrkit/catalog-envelope",
       "version": "0.0.0",
@@ -54,6 +67,7 @@
       "version": "0.7.0",
       "bin": {
         "adr": "./dist/index.js",
+        "adrkit": "./dist/index.js",
       },
       "dependencies": {
         "@adrkit/core": "workspace:*",
@@ -166,6 +180,8 @@
     "@types/picomatch": ["@types/picomatch@4.0.3", "", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
 
     "@types/semver": ["@types/semver@7.8.0", "", {}, "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ=="],
+
+    "adrkit": ["adrkit@workspace:packages/adrkit"],
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,14 +1,15 @@
 # Releasing adrkit
 
-adrkit distributes four public npm packages and one repository-backed GitHub
+adrkit distributes five public npm packages and one repository-backed GitHub
 Action:
 
 | Artifact | Distribution |
 |---|---|
 | `@adrkit/core` | npm |
 | `@adrkit/evaluator` | npm |
-| `@adrkit/cli` (`adr`) | npm |
+| `@adrkit/cli` (`adr`, `adrkit`) | npm |
 | `@adrkit/mcp` (`adrkit-mcp`) | npm |
+| `adrkit` (forwarder to `@adrkit/cli`) | npm |
 | `packages/ci/action.yml` | Git tag (latest immutable release `v0.7.0`, moving `v0`) |
 
 `@adrkit/ci` stays private because GitHub executes the committed Action bundle
@@ -23,13 +24,16 @@ temporary `NPM_TOKEN` is removed from the protected `npm` environment.
 ## Release guarantees
 
 - All public package versions are identical. Introducing `@adrkit/mcp` as a
-  fourth public package therefore requires bumping `@adrkit/core`,
+  fourth public package therefore required bumping `@adrkit/core`,
   `@adrkit/evaluator`, and `@adrkit/cli` to the same version in the same
-  coordinated release. The first MCP release shipped as v0.2.0.
+  coordinated release. The first MCP release shipped as v0.2.0. The unscoped
+  `adrkit` forwarder joins the same rule as the fifth: it restates the CLI's
+  version to whoever installs it, so it may never lag behind one.
 - The tag is exactly `v<package version>`.
-- Packages publish in dependency order: core, evaluator, CLI, MCP (`@adrkit/mcp`
-  depends only on core, so it is appended last to preserve the list's
-  chronological order).
+- Packages publish in dependency order: core, evaluator, CLI, MCP, `adrkit`
+  (`@adrkit/mcp` depends only on core, so it sits after the CLI to preserve the
+  list's chronological order; the `adrkit` forwarder depends on the CLI and is
+  published last).
 - Bun 1.3.14 builds and packs the artifacts.
 - Packed manifests contain no `workspace:` protocols.
 - Tarballs include compiled ESM, declarations, README, LICENSE, and NOTICE.
@@ -44,10 +48,10 @@ temporary `NPM_TOKEN` is removed from the protected `npm` environment.
 
 ## SemVer and export-surface policy
 
-Until adrkit reaches `1.0.0`, the four public npm packages still move in
+Until adrkit reaches `1.0.0`, the five public npm packages still move in
 lockstep: every release uses the same `0.x.y` version for `@adrkit/core`,
-`@adrkit/evaluator`, `@adrkit/cli`, and `@adrkit/mcp`, even when only one
-package changed.
+`@adrkit/evaluator`, `@adrkit/cli`, `@adrkit/mcp`, and `adrkit`, even when only
+one package changed.
 
 The public surface is:
 
@@ -98,7 +102,7 @@ resolved tree and does **not** audit consumer installs of the published
 `@adrkit/*` manifests
 ([ADR-0017](adr/0017-keep-dependency-audit-scope-explicit-and-release-scoped.md)).
 That audit is release evidence, so it runs here, against the packed tarballs —
-**all four of them**. `release:pack` already builds `.release/smoke/` with every
+**all five of them**. `release:pack` already builds `.release/smoke/` with every
 artifact in the release manifest wired as a `file:` dependency, so auditing there
 covers the whole published set and cannot drift out of sync with what was packed:
 
@@ -110,7 +114,7 @@ covers the whole published set and cannot drift out of sync with what was packed
 )
 ```
 
-Audit **all four** packages, not a subset. `@adrkit/evaluator` is the only path to
+Audit **all five** packages, not a subset. `@adrkit/evaluator` is the only path to
 `jsonpath-rfc9535`, and `@adrkit/cli` is the only path to the evaluator, so an
 audit of `@adrkit/core` + `@adrkit/mcp` alone never sees that subtree at all
 (ADR-0017 action item 2).
@@ -257,11 +261,11 @@ bootstrap described below.
 
 ## Subsequent releases
 
-1. Update the version in all four public package manifests, and the three places
+1. Update the version in all five public package manifests, and the three places
    the version is restated outside them: `CLI_VERSION` in
    `packages/cli/src/index.ts`, `SERVER_INFO` in `packages/mcp/src/server.ts`, and
    both `version` fields in `packages/mcp/server.json`.
-2. Update `bun.lock`'s four `packages/*` `version` fields to match. **`bun install`
+2. Update `bun.lock`'s five `packages/*` `version` fields to match. **`bun install`
    will not do this for you.** The dependency graph is unchanged — `workspace:*`
    still resolves to the same paths — so the install is a no-op, and
    `bun install --frozen-lockfile` reports no drift even though the file is stale.
@@ -269,9 +273,10 @@ bootstrap described below.
    `@adrkit/evaluator must resolve @adrkit/core to <version>, got <previous>`,
    because it validates packed manifests through the lockfile rather than the
    manifests. Deleting `bun.lock` does regenerate those fields, but it re-resolves
-   the entire tree and silently upgrades transitive dependencies — edit the four
+   the entire tree and silently upgrades transitive dependencies — edit the five
    fields directly instead, then confirm with `bun install --frozen-lockfile`. The
-   diff should be exactly four lines, as in v0.6.0 (`c5dc677`) and v0.7.0.
+   diff was exactly four lines through v0.7.0 (`c5dc677` for v0.6.0); the
+   unscoped `adrkit` forwarder makes it five from the next release on.
 3. Bump the pinned `@adrkit/cli@<version>` in the published badges recipe
    (`site/src/content/docs/badges.mdx`). It is pinned deliberately — the snippet
    runs inside a job holding `contents: write` (ADR-0025) — so it cannot float

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -185,7 +185,8 @@ npm Trusted Publishing cannot be configured for a package name that does not
 exist yet, so the very first publish needs a credential:
 
 1. Add `NPM_BOOTSTRAP_TOKEN` to the `npm` environment — a granular token with
-   publish rights for the `@adrkit` scope.
+   publish rights for the `@adrkit` scope. An unscoped name such as `adrkit`
+   is not covered by a scope-limited token; grant that one explicitly.
 2. Add the package name to `BOOTSTRAP_PACKAGES` in `scripts/release-publish.ts`.
    It is scrubbed from every other package's environment.
 3. Release.
@@ -198,6 +199,29 @@ An empty `BOOTSTRAP_PACKAGES` is the correct steady state, not an oversight. A
 name belongs in it only between "does not exist on the registry" and "Trusted
 Publishing is configured". `@adrkit/mcp` passed through it for 0.2.0 and
 `@adrkit/spec-kit` for 0.1.0; both publish over OIDC now.
+
+#### Pending: `adrkit`, and the doc flip that must follow it
+
+`adrkit` — the unscoped forwarder — is in `BOOTSTRAP_PACKAGES` now, awaiting its
+first publish. It carries one extra step that the adapter names did not, and the
+ordering is not interchangeable.
+
+The site deploys on **every push to `main`**, while packages publish only on a
+**release tag**. So documentation describing `npx adrkit` as usable goes live
+before the name exists, and until the release lands that command resolves
+against the registry to whatever anyone else has published there. For that
+window the docs deliberately tell readers *not* to use `npx adrkit`, which is
+correct while the name is unclaimed and wrong the moment it is not.
+
+After `adrkit` appears on the registry, and not before, update the three places
+that carry the warning:
+
+- `site/src/content/docs/quickstart.mdx` — the "unambiguous installed alias" tip
+- `packages/cli/README.md` — the paragraph after the `adrkit lint` example
+- `packages/adrkit/README.md` — already written for the published state
+
+Confirm with `npm view adrkit version` first. Leaving the warning up is merely
+stale; removing it early is a recommendation to run an unowned name.
 
 ## One-time npm bootstrap (completed for v0.1.0)
 

--- a/packages/adrkit/README.md
+++ b/packages/adrkit/README.md
@@ -1,0 +1,33 @@
+# adrkit
+
+The [adrkit](https://adrkit.dev) CLI under its unscoped name. This package
+contains no logic of its own — it forwards to
+[`@adrkit/cli`](https://www.npmjs.com/package/@adrkit/cli), which is the
+canonical package and the one to depend on directly.
+
+```sh
+npx adrkit lint
+npx adrkit explain src/payments/api.ts
+```
+
+## Why this package exists
+
+`adr` on npm belongs to an unrelated package. That makes a bare `npx adr`
+unsafe in a way documentation cannot fix: it reaches adrkit only when the
+binary happens to be linked into `node_modules/.bin`, and otherwise runs the
+other tool *without failing*. In CI it does not even prompt, because npm
+assumes `--yes` when stdin is not a TTY.
+
+Publishing `adrkit` makes the unscoped name resolve to adrkit by construction
+rather than by luck, and keeps it from being claimed by anyone else.
+
+## Which package should I install?
+
+Depend on `@adrkit/cli`. It installs both an `adr` and an `adrkit` binary, and
+it is where versions, changelog, and documentation live.
+
+This package is for the zero-install path — `npx adrkit …` — and for anyone who
+reaches for the unscoped name by reflex. It tracks `@adrkit/cli` exactly: same
+version, same commands, same exit codes.
+
+Full documentation: <https://adrkit.dev>

--- a/packages/adrkit/package.json
+++ b/packages/adrkit/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "adrkit",
+  "version": "0.7.0",
+  "description": "The adrkit CLI under its unscoped name — forwards to @adrkit/cli.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "homepage": "https://adrkit.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mbeacom/adrkit.git",
+    "directory": "packages/adrkit"
+  },
+  "bugs": {
+    "url": "https://github.com/mbeacom/adrkit/issues"
+  },
+  "keywords": [
+    "adr",
+    "architecture-decision-records",
+    "cli",
+    "governance"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "adrkit": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && bun build ./src/index.ts --target=node --outdir=dist --packages=external && tsc --project tsconfig.build.json && bun ../../scripts/normalize-dts-imports.ts dist && cp ../../LICENSE ../../NOTICE dist/ && chmod +x dist/index.js",
+    "lint": "bun run typecheck",
+    "prepack": "bun run build",
+    "typecheck": "tsc --noEmit --customConditions bun --project ../../tsconfig.json"
+  },
+  "dependencies": {
+    "@adrkit/cli": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "src"
+  ]
+}

--- a/packages/adrkit/src/index.ts
+++ b/packages/adrkit/src/index.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/**
+ * The unscoped `adrkit` package: a forwarder to `@adrkit/cli`, and the reason
+ * the name is not available to anyone else.
+ *
+ * `adr` on npm belongs to an unrelated package, so `npx adr` reaches a
+ * different tool whenever adrkit's binary is not linked into
+ * `node_modules/.bin` — silently, and in CI without a prompt, because npm
+ * assumes `--yes` on a non-TTY. Publishing this name is what makes
+ * `npx adrkit` resolve to adrkit by construction rather than by luck.
+ *
+ * It forwards in-process rather than spawning: `@adrkit/cli` exports `main`,
+ * and its entry only self-executes when it is the process's main module, so
+ * importing it here is inert until this module calls it. That keeps one
+ * process, one exit code, and the caller's stdio.
+ */
+import { existsSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { main } from '@adrkit/cli';
+
+export { main };
+
+/**
+ * True when this module is the process entry rather than an import.
+ *
+ * Compares real paths because every install invokes this through a symlinked
+ * `node_modules/.bin/adrkit`, which would otherwise never equal the module URL
+ * it resolves to.
+ */
+export function isMainModule(moduleUrl: string, argvPath: string | undefined): boolean {
+  if (!argvPath || !existsSync(argvPath)) return false;
+  return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvPath);
+}
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  process.exitCode = await main();
+}

--- a/packages/adrkit/test/packaging.test.ts
+++ b/packages/adrkit/test/packaging.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const packageRoot = dirname(import.meta.dir);
+const repoRoot = dirname(dirname(packageRoot));
+
+type Manifest = {
+  name?: string;
+  version?: string;
+  bin?: Record<string, string>;
+  dependencies?: Record<string, string>;
+};
+
+const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as Manifest;
+const cliManifest = JSON.parse(
+  readFileSync(join(repoRoot, 'packages', 'cli', 'package.json'), 'utf8'),
+) as Manifest;
+
+/**
+ * This package exists to own a name and to run one command. Both of those are
+ * properties of the *published* artifact rather than of any code path, so they
+ * are asserted here rather than exercised.
+ */
+describe('adrkit forwarder packaging', () => {
+  test('claims the unscoped name, which is the entire point', () => {
+    expect(manifest.name).toBe('adrkit');
+  });
+
+  test('exposes exactly the adrkit binary', () => {
+    expect(manifest.bin).toEqual({ adrkit: './dist/index.js' });
+  });
+
+  /**
+   * A forwarder that lags its target is a forwarder that lies: `adrkit@0.7.0`
+   * resolving to some other `@adrkit/cli` would report a version it is not
+   * running. `workspace:*` keeps them equal by construction in development, and
+   * release-pack rewrites it to the exact version at pack time.
+   */
+  test('tracks @adrkit/cli exactly, by workspace protocol', () => {
+    expect(manifest.dependencies).toEqual({ '@adrkit/cli': 'workspace:*' });
+  });
+
+  test('is lockstep-versioned with @adrkit/cli', () => {
+    expect(manifest.version).toBe(cliManifest.version);
+  });
+
+  /**
+   * Regression: the first build of this package omitted the shebang, because
+   * `bun build` only preserves one that is present in the entry source. npm
+   * still linked `node_modules/.bin/adrkit`, and the shell then ran an ES
+   * module as a shell script — `import { main } ...` resolved to `/usr/bin/
+   * import`, so the binary "worked" by launching ImageMagick and exited 2. A
+   * missing first line is invisible in every unit test and fatal on install,
+   * which is exactly the class of defect this file is for.
+   */
+  test('entry source carries the node shebang on its first line', () => {
+    const source = readFileSync(join(packageRoot, 'src', 'index.ts'), 'utf8');
+    expect(source.split('\n')[0]).toBe('#!/usr/bin/env node');
+  });
+});

--- a/packages/adrkit/tsconfig.build.json
+++ b/packages/adrkit/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adrkit/tsconfig.json
+++ b/packages/adrkit/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,14 +29,19 @@ adr lint
 ```
 
 Every install also provides `adrkit`, an identical alias for the same binary.
-Nothing else on npm claims that name, so prefer it wherever a silent
+Nothing else on npm claims that binary name, so prefer it wherever a silent
 wrong-tool substitution would be hard to notice — CI, `Makefile`s, and agent
 instructions:
 
 ```sh
 adrkit lint          # same binary, unambiguous name
-npx adrkit lint      # local binary, or a clean 404 — never the wrong tool
 ```
+
+That applies to the installed binary only. Do not use `npx adrkit` / `bunx
+adrkit`: the unscoped `adrkit` *package* name is unclaimed, so that form
+resolves against the registry and would run whatever anyone publishes under it
+— and in CI, where npm assumes `--yes` on a non-TTY, it would install and run it
+without prompting. Use `npx @adrkit/cli` for zero-install.
 
 The `adr` binary includes `new`, `lint`, `graph`, `explain`, `check`, `queue`,
 `migrate --from madr`, and the offline deterministic `evaluate` command.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,6 +28,16 @@ npm install -g @adrkit/cli
 adr lint
 ```
 
+Every install also provides `adrkit`, an identical alias for the same binary.
+Nothing else on npm claims that name, so prefer it wherever a silent
+wrong-tool substitution would be hard to notice — CI, `Makefile`s, and agent
+instructions:
+
+```sh
+adrkit lint          # same binary, unambiguous name
+npx adrkit lint      # local binary, or a clean 404 — never the wrong tool
+```
+
 The `adr` binary includes `new`, `lint`, `graph`, `explain`, `check`, `queue`,
 `migrate --from madr`, and the offline deterministic `evaluate` command.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,8 @@
     "access": "public"
   },
   "bin": {
-    "adr": "./dist/index.js"
+    "adr": "./dist/index.js",
+    "adrkit": "./dist/index.js"
   },
   "exports": {
     ".": {

--- a/scripts/release-pack.test.ts
+++ b/scripts/release-pack.test.ts
@@ -200,6 +200,7 @@ describe('release package validation — @adrkit/mcp (Phase 5)', () => {
       '@adrkit/evaluator',
       '@adrkit/cli',
       '@adrkit/mcp',
+      'adrkit',
       '@adrkit/spec-kit',
     ]);
     const mcp = RELEASE_PACKAGES.find((p) => p.name === '@adrkit/mcp');
@@ -212,6 +213,35 @@ describe('release package validation — @adrkit/mcp (Phase 5)', () => {
     expect(mcp?.expectedFiles).toContain('src/index.ts');
     // No internal test/builder export leaks into the packed file list.
     expect(mcp?.expectedFiles).not.toContain('dist/server.js');
+  });
+
+  /**
+   * The forwarder is the first *unscoped* release package, which is not a
+   * cosmetic difference. `npm pack` derives a tarball name by dropping a
+   * leading `@`, and the pack step reproduced that with `name.slice(1)` — a
+   * transformation indistinguishable from correct across five scoped names and
+   * one that silently ate the first letter of the sixth, packing `adrkit` as
+   * `drkit-0.7.0.tgz`. This pins the shape of the definition; the naming rule
+   * itself is asserted directly below.
+   */
+  test('adrkit is the unscoped forwarder, tracking @adrkit/cli in lockstep', () => {
+    const forwarder = RELEASE_PACKAGES.find((p) => p.name === 'adrkit');
+    expect(forwarder).toBeDefined();
+    expect(forwarder?.directory).toBe('packages/adrkit');
+    expect(forwarder?.workspaceDependencies).toEqual(['@adrkit/cli']);
+    expect(forwarder?.versioning).toBe('lockstep');
+    expect(forwarder?.shipsNodeArtifact).toBe(true);
+    expect(forwarder?.expectedFiles).toContain('dist/index.js');
+    expect(forwarder?.expectedFiles).toContain('dist/index.d.ts');
+    expect(forwarder?.expectedFiles).toContain('src/index.ts');
+  });
+
+  test('a tarball name drops only the scope sigil, never a real first letter', () => {
+    const tarballName = (name: string, version: string) =>
+      `${name.replace(/^@/, '').replace('/', '-')}-${version}.tgz`;
+    expect(tarballName('@adrkit/cli', '0.7.0')).toBe('adrkit-cli-0.7.0.tgz');
+    expect(tarballName('adrkit', '0.7.0')).toBe('adrkit-0.7.0.tgz');
+    expect(tarballName('adrkit', '0.7.0')).not.toBe('drkit-0.7.0.tgz');
   });
 
   test('every lockstep manifest must share one identical stable SemVer', () => {

--- a/scripts/release-pack.ts
+++ b/scripts/release-pack.ts
@@ -595,6 +595,10 @@ export async function packRelease(args = Bun.argv.slice(2)): Promise<ReleaseMani
     validatePackedManifest(definition, packedManifest, packageVersion, versionOfDependency);
     if (definition.name === '@adrkit/cli') {
       assert(packedManifest.bin?.adr === './dist/index.js', 'Packed CLI must expose the adr binary');
+      assert(
+        packedManifest.bin?.adrkit === './dist/index.js',
+        'Packed CLI must expose the adrkit binary, which is the unambiguous alias for the `adr` name npm already assigns to an unrelated package',
+      );
     }
     if (definition.name === '@adrkit/mcp') {
       assert(packedManifest.bin?.['adrkit-mcp'] === './dist/bin.js', 'Packed MCP must expose the adrkit-mcp binary');

--- a/scripts/release-pack.ts
+++ b/scripts/release-pack.ts
@@ -165,6 +165,26 @@ export const RELEASE_PACKAGES: readonly ReleasePackageDefinition[] = [
     shipsNodeArtifact: true,
   },
   {
+    // The unscoped name, published so that `npx adrkit` resolves to adrkit by
+    // construction rather than by luck — and so nobody else can claim it. It
+    // forwards to @adrkit/cli and carries no logic, but it is lockstep-versioned
+    // because a forwarder that lags its target is a forwarder that lies.
+    name: 'adrkit',
+    directory: 'packages/adrkit',
+    expectedFiles: [
+      'README.md',
+      'dist/LICENSE',
+      'dist/NOTICE',
+      'dist/index.d.ts',
+      'dist/index.js',
+      'package.json',
+      'src/index.ts',
+    ],
+    workspaceDependencies: ['@adrkit/cli'],
+    versioning: 'lockstep',
+    shipsNodeArtifact: true,
+  },
+  {
     // The first independently versioned package. Not a Node library: it ships a
     // Spec Kit manifest, three command files, and the shell scripts behind them.
     name: '@adrkit/spec-kit',
@@ -572,7 +592,12 @@ export async function packRelease(args = Bun.argv.slice(2)): Promise<ReleaseMani
 
   for (const definition of selected) {
     const packageVersion = versionFor(definition, sourceManifests, version);
-    const filename = `${definition.name.slice(1).replace('/', '-')}-${packageVersion}.tgz`;
+    // `npm pack` drops a leading `@` and turns the scope separator into a dash,
+    // so `@adrkit/cli` becomes `adrkit-cli-<version>.tgz`. Strip only the `@`:
+    // an unconditional `slice(1)` is indistinguishable from correct for every
+    // scoped name and silently eats the first letter of an unscoped one, which
+    // is how `adrkit` first packed itself as `drkit-0.7.0.tgz`.
+    const filename = `${definition.name.replace(/^@/, '').replace('/', '-')}-${packageVersion}.tgz`;
     const packageDir = join(RELEASE_ROOT, definition.directory);
     await run(
       [
@@ -598,6 +623,12 @@ export async function packRelease(args = Bun.argv.slice(2)): Promise<ReleaseMani
       assert(
         packedManifest.bin?.adrkit === './dist/index.js',
         'Packed CLI must expose the adrkit binary, which is the unambiguous alias for the `adr` name npm already assigns to an unrelated package',
+      );
+    }
+    if (definition.name === 'adrkit') {
+      assert(
+        packedManifest.bin?.adrkit === './dist/index.js',
+        'Packed adrkit forwarder must expose the adrkit binary — it is the only reason the package is published',
       );
     }
     if (definition.name === '@adrkit/mcp') {

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -18,8 +18,15 @@ const REGISTRY = 'https://registry.npmjs.org';
  * long-lived token to a package that no longer needs one — the credential
  * sprawl the set exists to bound. `@adrkit/mcp` was bootstrapped for 0.2.0 and
  * `@adrkit/spec-kit` for 0.1.0/0.1.1; both now publish over OIDC.
+ *
+ * `adrkit` — the unscoped forwarder — is the current occupant, and is expected
+ * to leave. Its first publish claims a name nobody owns yet, which is the whole
+ * point of shipping it, and that publish cannot use OIDC. Immediately after it
+ * lands: configure Trusted Publishing for `adrkit` on npmjs.com, remove it from
+ * this set, and delete the `NPM_BOOTSTRAP_TOKEN` secret. Until all three are
+ * done the release workflow is holding a token it no longer needs.
  */
-const BOOTSTRAP_PACKAGES: ReadonlySet<string> = new Set();
+const BOOTSTRAP_PACKAGES: ReadonlySet<string> = new Set(['adrkit']);
 type RegistryFetch = (url: string) => Promise<Response>;
 
 function assert(condition: unknown, message: string): asserts condition {

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -112,17 +112,23 @@ the unrelated registry package instead of failing. An npm script has no such
 ambiguity — it resolves `node_modules/.bin` and stops with `command not found`
 if the dependency is missing.
 
-<Aside type="tip" title="`adrkit` — the unambiguous alias">
+<Aside type="tip" title="`adrkit` — the unambiguous installed alias">
 	`@adrkit/cli` installs a second binary, `adrkit`, identical to `adr`. Nothing
-	else on npm claims that name, so it is never ambiguous: `adrkit lint` works
-	wherever `adr lint` does, and `npx adrkit lint` either runs your locally
-	installed binary or fails with a clean `404` — it can never reach the
-	unrelated package the way `npx adr` does.
+	else on npm claims that binary name, so once installed it is unambiguous:
+	`adrkit lint` works wherever `adr lint` does, without competing for the
+	`.bin` entry that `adr` shares with the unrelated package.
 
 	Prefer it in anything shared or long-lived — CI, `Makefile`s, READMEs, and
 	agent instructions — where a silent wrong-tool substitution is hardest to
-	notice. Zero-install still needs `npx @adrkit/cli`, since no `adrkit`
-	*package* is published.
+	notice.
+
+	This applies to the **installed** binary only. Do not reach for
+	`npx adrkit` / `bunx adrkit`: the unscoped `adrkit` *package* name is
+	unclaimed, so that form resolves against the registry and would run whatever
+	someone else publishes there. `npx --no` declines to install a missing
+	package, but it still runs one already in the npx cache, so it is not a
+	durable guard either. For zero-install, name the scoped package —
+	`npx @adrkit/cli lint`.
 </Aside>
 
 ## Validate a corpus — `adr lint`

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -112,6 +112,19 @@ the unrelated registry package instead of failing. An npm script has no such
 ambiguity — it resolves `node_modules/.bin` and stops with `command not found`
 if the dependency is missing.
 
+<Aside type="tip" title="`adrkit` — the unambiguous alias">
+	`@adrkit/cli` installs a second binary, `adrkit`, identical to `adr`. Nothing
+	else on npm claims that name, so it is never ambiguous: `adrkit lint` works
+	wherever `adr lint` does, and `npx adrkit lint` either runs your locally
+	installed binary or fails with a clean `404` — it can never reach the
+	unrelated package the way `npx adr` does.
+
+	Prefer it in anything shared or long-lived — CI, `Makefile`s, READMEs, and
+	agent instructions — where a silent wrong-tool substitution is hardest to
+	notice. Zero-install still needs `npx @adrkit/cli`, since no `adrkit`
+	*package* is published.
+</Aside>
+
 ## Validate a corpus — `adr lint`
 
 Validate every record under `docs/adr/` against the schema, enforce unique ids,

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -75,6 +75,25 @@ adr lint
 </TabItem>
 </Tabs>
 
+<Aside type="tip" title="`adrkit` — the unambiguous installed alias">
+	Every install above also provides a second binary, `adrkit`, identical to
+	`adr`. Nothing else on npm claims that binary name, so once installed it is
+	unambiguous: `adrkit lint` works wherever `adr lint` does, without competing
+	for the `.bin` entry that `adr` shares with the unrelated package.
+
+	Prefer it in anything shared or long-lived — CI, `Makefile`s, READMEs, and
+	agent instructions — where a silent wrong-tool substitution is hardest to
+	notice.
+
+	This applies to the **installed** binary only. Do not reach for
+	`npx adrkit` / `bunx adrkit`: the unscoped `adrkit` *package* name is
+	unclaimed, so that form resolves against the registry and would run whatever
+	someone else publishes there. `npx --no` declines to install a missing
+	package, but it still runs one already in the npx cache, so it is not a
+	durable guard either. For zero-install, name the scoped package —
+	`npx @adrkit/cli lint`.
+</Aside>
+
 The pure library surfaces are independently installable when you only need the
 resolver or the evaluator:
 
@@ -111,25 +130,6 @@ when the binary is linked into `node_modules/.bin`, and otherwise silently runs
 the unrelated registry package instead of failing. An npm script has no such
 ambiguity — it resolves `node_modules/.bin` and stops with `command not found`
 if the dependency is missing.
-
-<Aside type="tip" title="`adrkit` — the unambiguous installed alias">
-	`@adrkit/cli` installs a second binary, `adrkit`, identical to `adr`. Nothing
-	else on npm claims that binary name, so once installed it is unambiguous:
-	`adrkit lint` works wherever `adr lint` does, without competing for the
-	`.bin` entry that `adr` shares with the unrelated package.
-
-	Prefer it in anything shared or long-lived — CI, `Makefile`s, READMEs, and
-	agent instructions — where a silent wrong-tool substitution is hardest to
-	notice.
-
-	This applies to the **installed** binary only. Do not reach for
-	`npx adrkit` / `bunx adrkit`: the unscoped `adrkit` *package* name is
-	unclaimed, so that form resolves against the registry and would run whatever
-	someone else publishes there. `npx --no` declines to install a missing
-	package, but it still runs one already in the npx cache, so it is not a
-	durable guard either. For zero-install, name the scoped package —
-	`npx @adrkit/cli lint`.
-</Aside>
 
 ## Validate a corpus — `adr lint`
 


### PR DESCRIPTION
Follow-up to #151. Two commits: the `adrkit` **binary** alias, and the `adrkit` **package** that owns the unscoped name.

## Why

`adr` is not a name adrkit controls. On npm it belongs to [`phodal/adr`](https://github.com/phodal/adr) — created 2017-03-15, still maintained, same problem domain. It can't be acquired, and a dispute would rightly fail. So the ambiguity is permanent, and the fix is to stop depending on the contested name.

#151 fixed the reader-facing half in docs. This fixes the half docs can't reach:

- `npx adr` reaches adrkit only when the binary is linked into `node_modules/.bin`, and otherwise runs the other tool **without failing**. Per `npm help exec`, CI doesn't even prompt — `--yes` is assumed when stdin isn't a TTY.
- A project depending on both packages has them compete for the same `.bin` entry, resolved by install order rather than intent.

## What

**1. `bin.adrkit` in `@adrkit/cli`** — additive; `adr` untouched and still primary.

**2. The unscoped `adrkit` package** — a forwarder that owns the name. Review feedback on this PR showed the bin alias alone wasn't enough: while `adrkit` stayed unclaimed, `npx adrkit` resolved against the registry, so its "clean 404" was a fact about today's registry rather than a property of the system. Owning it closes that.

`@adrkit/cli` stays canonical. The forwarder carries no logic — it imports `main` and calls it, in-process rather than spawning, since the CLI entry self-executes only as main module. One process, one exit code, caller's stdio. Lockstep-versioned, because a forwarder that lags its target reports a version it isn't running.

Verified against a packed tarball in a clean project: `--version` → `0.7.0`, `lint` completes a 27-record run and exits `0`, a usage error still exits `2`, `explain` and `--help` identical to `adr`. Packed manifest confirms `workspace:*` → `"@adrkit/cli": "0.7.0"`.

## Two defects found while building it

Both invisible to the existing suite, both now covered:

- **No shebang.** `bun build` only preserves one present in the entry source. npm still linked `node_modules/.bin/adrkit`, so the shell ran an ES module as a shell script — `import { main }` resolved to `/usr/bin/import` and the binary "worked" by launching ImageMagick, exiting 2. Fatal on install, unobservable in a unit test.
- **`release-pack` mangled unscoped names.** It derived tarball names with `name.slice(1)` — correct for five scoped names, eats the first letter of an unscoped one. `adrkit` packed as `drkit-0.7.0.tgz`. Pre-existing latent bug that no package before this one could expose.

Per [ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md) both new checks were observed failing first — shebang assertion with the line removed, and the packed-bin assertion stopping the pack with `Packed adrkit forwarder must expose the adrkit binary`.

`release-pack.test.ts` pinned the release roster as an exact list, so adding a package failed it by design. Updated rather than loosened, and extended with coverage for the new definition.

## Publishing — and one ordering constraint

`adrkit` is temporarily in `BOOTSTRAP_PACKAGES`, since Trusted Publishing can't be configured for a name that doesn't exist. Same path `@adrkit/mcp` and `@adrkit/spec-kit` took. Note a token scoped to `@adrkit` does **not** cover an unscoped name — `RELEASING.md` now says so.

**The docs are deliberately not flipped in this PR.** The site deploys on every push to `main`, but packages publish only on a release tag. Recommending `npx adrkit` here would put that advice on adrkit.dev while the name is still unowned — exactly the window this change exists to close. The three surfaces carrying the warning, and the instruction to update them only after `npm view adrkit version` succeeds, are recorded in `RELEASING.md`.

Remaining manual steps are yours: create the token, add `NPM_BOOTSTRAP_TOKEN`, release, configure Trusted Publishing, then remove from `BOOTSTRAP_PACKAGES` and delete the secret.

## Verification

2141 tests, typecheck, `check:deps`, `check:changelog`, `check:doc-pins`, `check:dco`, a 6-package `release:pack`, and a 38-page site build. All CI green.
