### PR TITLE
release: v0.8.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: adrkit version
       description: Output of `adr --version` (or the package version you installed).
-      placeholder: '0.7.0'
+      placeholder: '0.8.0'
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-15
+
 ### Changed
 
 - **`action-dogfood` is a required status check on `main`** (2026-08-15), added once it
@@ -943,7 +945,8 @@ against live Spec Kit, rather than reasoning about it:
 - Node-targeted published distribution of all packages, smoke-tested under Node
   22 and 24.
 
-[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/mbeacom/adrkit/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mbeacom/adrkit/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mbeacom/adrkit/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mbeacom/adrkit/compare/v0.4.0...v0.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Decision memory for human- and agent-authored plans — machine-readable ADRs
 that are enforceable in CI and legible to agents, without leaving git.
-Status: early — phases 0–6 landed and v0.7.0 is public. `@adrkit/core`,
+Status: early — phases 0–6 landed and v0.8.0 is public. `@adrkit/core`,
 `@adrkit/evaluator`, `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
 `check`, `queue`, `migrate --from madr`, `evaluate`) are published on npm, as is
 the independently versioned `@adrkit/spec-kit` Spec Kit extension (0.1.2); the

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -24,9 +24,12 @@ adrkit/
 ├── packages/
 │   ├── core/                      @adrkit/core — schema (SOURCE OF TRUTH:
 │   │                              src/schema/adr.schema.ts), resolver, queue kernel
-│   ├── cli/                       @adrkit/cli — the `adr` binary
+│   ├── cli/                       @adrkit/cli — the `adr` and `adrkit` binaries
 │   ├── evaluator/                 @adrkit/evaluator — deterministic Pass 0
 │   ├── mcp/                       @adrkit/mcp — read-only stdio MCP server
+│   ├── adrkit/                    adrkit — unscoped forwarder to @adrkit/cli;
+│   │                              owns the bare name so `npx adrkit` cannot
+│   │                              resolve to someone else's package
 │   ├── ci/                        private — the two GitHub Actions + bundled dist
 │   └── adapters/
 │       └── spec-kit/              @adrkit/spec-kit — independently versioned

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ different artifact from a heading convention. That is the whole thesis.
 
 Early, under active development, and deliberately honest about what is proven.
 
-- **Published — v0.7.0 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
+- **Published — v0.8.0 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
   the deterministic Pass 0 `@adrkit/evaluator`, and the read-only `@adrkit/mcp`
   server are all implemented and released. The MCP server speaks both protocol
   eras and passed real-session dogfood against the published artifact on each,

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/adrkit": {
       "name": "adrkit",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "bin": {
         "adrkit": "./dist/index.js",
       },
@@ -64,7 +64,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "bin": {
         "adr": "./dist/index.js",
         "adrkit": "./dist/index.js",
@@ -79,7 +79,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -94,7 +94,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -105,7 +105,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -10,12 +10,12 @@ Action:
 | `@adrkit/cli` (`adr`, `adrkit`) | npm |
 | `@adrkit/mcp` (`adrkit-mcp`) | npm |
 | `adrkit` (forwarder to `@adrkit/cli`) | npm |
-| `packages/ci/action.yml` | Git tag (latest immutable release `v0.7.0`, moving `v0`) |
+| `packages/ci/action.yml` | Git tag (latest immutable release `v0.8.0`, moving `v0`) |
 
 `@adrkit/ci` stays private because GitHub executes the committed Action bundle
 directly from the referenced repository ref.
 
-The coordinated lockstep surface is published; the current release is `v0.7.0`. `@adrkit/core`,
+The coordinated lockstep surface is published; the current release is `v0.8.0`. `@adrkit/core`,
 `@adrkit/evaluator`, and `@adrkit/cli` use GitHub Actions Trusted Publishing.
 `@adrkit/mcp` was created with the isolated one-time bootstrap path below; its
 Trusted Publisher and token-restriction cleanup must be completed before the
@@ -364,7 +364,7 @@ Three more from the v0.4.0 cutover, all of which cost time:
   independently versioned package rides along in a lockstep pack. The registry
   idempotency check that skips an already-published artifact is gated behind
   `!dryRun`, so the dry run tries to republish `@adrkit/spec-kit` at its current
-  version. The four lockstep packages dry-run cleanly first, and the real run
+  version. The five lockstep packages dry-run cleanly first, and the real run
   skips the adapter because the packed tarball's integrity matches the registry.
   Tracked in [#104](https://github.com/mbeacom/adrkit/issues/104).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Decision memory for human and agent-authored plans \u2014 machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/packages/adrkit/package.json
+++ b/packages/adrkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "The adrkit CLI under its unscoped name — forwards to @adrkit/cli.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,7 +37,7 @@ import { isMainModule } from './main-module.ts';
  * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
  * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
  */
-export const CLI_VERSION = '0.7.0';
+export const CLI_VERSION = '0.8.0';
 
 function writeStdout(text: string): void {
   process.stdout.write(text);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adrkit/mcp",
   "mcpName": "dev.adrkit/mcp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetDecisionContext } from './tools/get-decision-context.ts';
 import { registerListSuperseded } from './tools/list-superseded.ts';
 import type { ToolConfig } from './tools/shared.ts';
 
-export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.7.0' } as const;
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.8.0' } as const;
 
 /**
  * The MCP protocol revision this server serves through `serveStdio`'s modern era.

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -14,7 +14,7 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
 				</svg>
 				CLI works today
 			</span>
-			<span>v0.7.0 on npm · decision memory in git</span>
+			<span>v0.8.0 on npm · decision memory in git</span>
 		</div>
 
 		<h1 id="_top" data-page-title set:html={title} />

--- a/site/src/content/docs/badges.mdx
+++ b/site/src/content/docs/badges.mdx
@@ -92,8 +92,8 @@ jobs:
       # current release.
       - run: |
           mkdir -p .adrkit
-          npx @adrkit/cli@0.7.0 queue --format json > .adrkit/queue.json.tmp
-          npx @adrkit/cli@0.7.0 lint --json  > .adrkit/lint.json.tmp
+          npx @adrkit/cli@0.8.0 queue --format json > .adrkit/queue.json.tmp
+          npx @adrkit/cli@0.8.0 lint --json  > .adrkit/lint.json.tmp
 
       # A truncated or malformed write renders as `no result` on the badge, which
       # reads as a bug in your tooling. Fail here instead of committing it.

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -43,7 +43,7 @@ The Action finds the comment it posted on an earlier push and edits it in place,
 pull request carries one governing-decisions comment however many times you push
 ([ADR-0026](/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows/)). Releases **through `v0.6.0` could not do this on their own** and
 needed an `env: GITHUB_TOKEN: ${{ github.token }}` block
-([#107](https://github.com/mbeacom/adrkit/issues/107)). `@v0` now resolves to `v0.7.0`,
+([#107](https://github.com/mbeacom/adrkit/issues/107)). `@v0` now resolves to `v0.8.0`,
 so that block is no longer required — and costs nothing if you still have it, because
 the Action never reads the variable to identify its token.
 
@@ -55,8 +55,8 @@ updated in place. The runner log confirms the variable was genuinely absent rath
 merely deleted from a file. The observation covers the **default `GITHUB_TOKEN`**; a
 custom GitHub App token takes the same code path but has not been observed separately.
 
-`v0` is a moving major tag, and it now resolves to a `v0.7.0` build. Pin the
-immutable `v0.7.0` tag or a commit SHA for maximum reproducibility.
+`v0` is a moving major tag, and it now resolves to a `v0.8.0` build. Pin the
+immutable `v0.8.0` tag or a commit SHA for maximum reproducibility.
 
 Every same-repository, non-Dependabot pull request in the adrkit repository runs this
 Action against itself and asserts the result. Fork and Dependabot pull requests are
@@ -73,14 +73,14 @@ open for both.
 </Aside>
 
 <Aside type="caution" title="Pinning a release tag by SHA">
-	The `v*` release tags are **annotated**, so `refs/tags/v0.7.0` resolves to a tag
+	The `v*` release tags are **annotated**, so `refs/tags/v0.8.0` resolves to a tag
 	object rather than a commit, and `uses:` rejects that SHA. Pin the commit the tag
 	points *at*:
 
 	```sh
-	git rev-parse v0.7.0^{commit}
+	git rev-parse v0.8.0^{commit}
 	# or, over the API — this endpoint peels the tag for you:
-	gh api repos/mbeacom/adrkit/commits/v0.7.0 --jq .sha
+	gh api repos/mbeacom/adrkit/commits/v0.8.0 --jq .sha
 	```
 
 	Note that `GET /git/ref/tags/{tag}` does **not** peel: its `object.sha` is the tag

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
 <div class="adr-home">
 	<section class="adr-status-band" aria-label="Project status">
 		<div class="adr-status-band__item">
-			<span class="adr-status adr-status--current">Published · v0.7.0</span>
+			<span class="adr-status adr-status--current">Published · v0.8.0</span>
 			<p><code>@adrkit/core</code>, <code>@adrkit/cli</code>, <code>@adrkit/evaluator</code>, and <code>@adrkit/mcp</code> are on npm, plus the independently versioned <code>@adrkit/spec-kit</code> extension; the CI Action ships at <code>mbeacom/adrkit/packages/ci@v0</code>.</p>
 		</div>
 		<div class="adr-status-band__item">

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -10,7 +10,7 @@ decisions govern a file, renders the decision graph, migrates an existing MADR
 corpus in place, emits the ARB operations queue, and runs the deterministic
 evaluator.
 
-<Aside type="tip" title="Published on npm (v0.7.0)">
+<Aside type="tip" title="Published on npm (v0.8.0)">
 	`@adrkit/cli` is live. Consumers install it with your Node package manager and
 	run the `adr` binary — no clone required. Published artifacts are Node-targeted
 	([ADR-0010](/adr/0010-bun-toolchain/)); Bun is used for developing adrkit


### PR DESCRIPTION
Bumps the lockstep surface to `0.8.0`, ready to tag.

**Why minor, not patch:** the release adds a public package. Pre-1.0, introducing `@adrkit/mcp` shipped as `v0.2.0` for the same reason, and the unscoped `adrkit` forwarder joins the lockstep set on the same rule.

**Contents of the release:** the `adrkit` binary alias in `@adrkit/cli` (#153), the unscoped `adrkit` forwarder package, the install-path docs from #151, and the site work in #152.

## Mechanical scope

Following `docs/RELEASING.md` → "Subsequent releases":

- **Six manifests** — root plus the five public packages, now including `packages/adrkit`.
- **Three restated versions** — `CLI_VERSION`, `SERVER_INFO`, and both `version` fields in `packages/mcp/server.json`. The first two each have a test binding them to their manifest, so a miss fails `bun test` rather than shipping.
- **Five `bun.lock` fields**, hand-edited. `bun install` doesn't maintain these and `--frozen-lockfile` reports no drift when they're stale — it surfaces later as `@adrkit/evaluator must resolve @adrkit/core to <version>`. Diff is exactly **five** lines, the first release where that number isn't four.
- **The badges pin** → `@adrkit/cli@0.8.0`, pinned deliberately because that snippet runs in a job holding `contents: write` (ADR-0025).

## Version narrative

The step no check enforces, and which shipped stale in v0.6.0: `Hero.astro`, `index.mdx`, `quickstart.mdx`, `ci.mdx`, README status, `CLAUDE.md`, RELEASING's artifact table and lede, and the bug-report placeholder. `ci.mdx` needed six updates because `v0` will resolve to this build.

Historical statements deliberately left alone — "releases through v0.6.0 could not do this", "when v0.7.0 was cut", and the lockfile note about the four-line diff *through* v0.7.0 are records of what happened and remain true.

**MANIFEST.md:** ADR counts were already correct (28 files, 27 records, 25 accepted, 2 superseded, template at draft — no records added), but the package tree omitted `packages/adrkit` and still described the CLI as shipping one binary. Both fixed.

## Pre-tag verification

Beyond the standard gates:

- `release:pack` → six tarballs at `0.8.0`, with `@adrkit/spec-kit` correctly left at its independent `0.1.2`.
- `release:publish --dry-run` → all five lockstep packages publish cleanly, **including `adrkit@0.8.0`**, failing only on the adapter — the known dry-run-only behavior of #104.
- That failure was **confirmed benign the way RELEASING.md prescribes rather than assumed**: the registry's `dist.shasum` for `@adrkit/spec-kit@0.1.2` (`a2dca70f95667f8552fece58f57b750445cbc00c`) matches the tarball the dry run just packed, so the real run skips it on integrity.

`bun test` 2141 pass, typecheck, `check:changelog`, `check:doc-pins`, `check:deps`, `bun install --frozen-lockfile` clean, 38-page site build.

## After merging

1. Tag `v0.8.0` and push.
2. Approve the protected `npm` environment deployment.
3. Confirm all five packages published and `v0` moved.
4. Configure Trusted Publishing for `adrkit` on npmjs.com.
5. Remove `adrkit` from `BOOTSTRAP_PACKAGES` and delete `NPM_BOOTSTRAP_TOKEN`.
6. **Then** flip the `npx adrkit` docs — only after `npm view adrkit version` succeeds.

⚠️ If your granular token is scoped to `@adrkit`, it will not cover the unscoped `adrkit` and the publish will fail on the last package.