### PR TITLE
docs(sdk): enumerate the consumer SDK's first surface, and fix the criterion measuring it proved wrong

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,16 @@
         "@types/bun": "latest",
       },
     },
+    "packages/sdk": {
+      "name": "@adrkit/sdk",
+      "version": "0.0.0",
+      "dependencies": {
+        "@adrkit/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
   },
   "packages": {
     "@actions/core": ["@actions/core@3.0.1", "", { "dependencies": { "@actions/exec": "^3.0.0", "@actions/http-client": "^4.0.0" } }, "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA=="],
@@ -137,6 +147,8 @@
     "@adrkit/evaluator": ["@adrkit/evaluator@workspace:packages/evaluator"],
 
     "@adrkit/mcp": ["@adrkit/mcp@workspace:packages/mcp"],
+
+    "@adrkit/sdk": ["@adrkit/sdk@workspace:packages/sdk"],
 
     "@adrkit/spec-kit": ["@adrkit/spec-kit@workspace:packages/adapters/spec-kit"],
 

--- a/docs/adr/0029-scope-backstage-publication-as-a-downstream-consumer-tiered-on-the-entity-owners.md
+++ b/docs/adr/0029-scope-backstage-publication-as-a-downstream-consumer-tiered-on-the-entity-owners.md
@@ -232,9 +232,14 @@ from unnumbered prose, which would be a corpus-wide convention needing its own r
 > and the surface adrkit's additive-only obligation attaches to, are `@adrkit/sdk` and the
 > documented CLI JSON — **not** `@adrkit/core`'s exported API. As written above, clause 11
 > promised stability across core's **173** exported symbols to protect a consumer surface of
-> roughly **three** (`@adrkit/ci` imports that many), which is keepable only by freezing the
-> engine or by breaking the promise silently. ADR-0031 amends these clauses by reference and
-> does not supersede this record; every other clause here stands unchanged.
+> roughly **17** (`@adrkit/ci` imports 14; `@adrkit/catalog-envelope` imports 3), which is
+> keepable only by freezing the engine or by breaking the promise silently. ADR-0031 amends
+> these clauses by reference and does not supersede this record; every other clause here stands
+> unchanged.
+>
+> *This note originally said the consumer surface was "roughly three (`@adrkit/ci` imports that
+> many)." Corrected 2026-08-16 against a measurement — see `docs/sdk-surface.md`. The narrowing
+> argument is unchanged; the ratio it rests on is 5.7×, not 58×.*
 
 **This record does not amend or supersede ADR-0013.** Clause 7 routes the only part of this
 surface that touches the ingest direction *through* ADR-0013's mechanism rather than around

--- a/docs/adr/0031-publish-a-narrow-consumer-sdk-as-the-contract-and-document-the-cli-json-as-its-s.md
+++ b/docs/adr/0031-publish-a-narrow-consumer-sdk-as-the-contract-and-document-the-cli-json-as-its-s.md
@@ -215,11 +215,31 @@ recorded as its own wrongness signal.
   stop being governance events; out-of-repo surfaces get one documented way in; ADR-0030's
   conformance fixture and the SDK's test fixture are the same artifact.
 - **Harder:** one more package, a mapping layer, and two contracts to keep honest.
-- **How we would know this was wrong:** if the SDK's surface has to grow past roughly a dozen
-  entry points to serve its first real consumer, then it is not a facade but a re-export of
-  core under another name, and the insulation is fictional. A second signal: if the first
-  real consumer needs something the SDK lacks and reaches into `@adrkit/core` directly, the
-  facade failed at its only job.
+- **How we would know this was wrong:** if more than a third of the SDK's declared **object
+  shapes** are structurally identical — same member names, same member types — to a type
+  `@adrkit/core` exports, then the facade is an alias for core under another name and the
+  insulation is fictional. Measured baseline at the surface's first enumeration: **0 of 12
+  object shapes identical**, 7 diverged, and 5 with no core counterpart at all. The three
+  **vocabulary unions** (`DecisionStatus`, `DecisionStanding`, `SlaState`) are identical, 3 of
+  3, and are deliberately excluded from this test: they are `schema/adr.schema.json`'s
+  vocabulary rather than core's, ADR-0029 clause 6 commits it separately, and clause 3 above
+  does not narrow it. Re-deriving those values under new spellings would add a translation
+  table that can drift from the schema, and buy no insulation for doing it. A second signal: if
+  the first real consumer needs something the SDK lacks and reaches into `@adrkit/core`
+  directly, the facade failed at its only job.
+
+  > **This criterion was corrected before ratification, and the correction is itself evidence.**
+  > It originally read: *"if the SDK's surface has to grow past roughly a dozen entry points to
+  > serve its first real consumer, then it is not a facade but a re-export of core under another
+  > name."* Action item 3 enumerated the surface at **7 callable entry points and 17 exported
+  > symbols including types**, and the original criterion fired on the second count while the
+  > structural measurement showed no aliasing whatsoever. It was testing the wrong property: it
+  > counted symbols while its stated concern was aliasing, so as written it would have condemned
+  > a facade that demonstrably insulates — and, worse, it never said which of the two counts it
+  > meant, leaving the record's own falsification test to be settled by whoever read it. A
+  > criterion that cannot be evaluated without a judgment call is not a falsification test.
+  > Both counts are retained above so a ratifier sees what was measured rather than only the
+  > conclusion drawn from it.
 - **Revisit if:** a non-JavaScript consumer appears, which would make clause 6's CLI adapter
   worth building rather than merely worth keeping cheap.
 
@@ -229,15 +249,29 @@ recorded as its own wrongness signal.
 2. [ ] Land the amendment note on ADR-0029 recording that clauses 6 and 11 are narrowed by
    this record's clause 3, per the mechanism ADR-0013 used on ADR-0007.
 3. [x] Enumerate the SDK's first surface from what a real consumer needs — the Tier 1
-   capabilities of ADR-0029 clause 1 — rather than from what core exports. Record the count;
-   if it exceeds a dozen entry points, the wrongness signal above has already fired.
-   **Done 2026-08-16: [`docs/sdk-surface.md`](../sdk-surface.md), sketched at `packages/sdk/`.
-   7 callable entry points; 17 exported symbols. The signal fires on the second count and not
-   the first, and the record does not say which it meant — see that document's verdict, which
-   recommends restating this criterion before ratification.**
+   capabilities of ADR-0029 clause 1 — rather than from what core exports, and record the
+   count. **Done 2026-08-16: [`docs/sdk-surface.md`](../sdk-surface.md), sketched at
+   `packages/sdk/`. 7 callable entry points; 17 exported symbols including types; 0 of 12
+   object shapes structurally identical to a core type. Measuring it is what revealed that this
+   record's own wrongness criterion tested the wrong property — see *Consequences*, where the
+   criterion is replaced and the correction recorded.**
 4. [ ] Converge `explain`, `lint`, and `new` `--json` onto core formatters, as `queue` is,
    so the two modes describe the same shapes.
 5. [ ] Document the CLI JSON contract and the SDK surface in `docs/RELEASING.md`, with the
    additive-only obligation stated at both.
 6. [ ] Build the conformance fixture ADR-0030 action item 5 names, as the SDK's own test
    fixture, so one artifact discharges both records.
+7. [ ] **Close the `--as-of` resolution gap: `queue`'s date resolver is a contract that lives
+   outside the contract.** `resolveAsOf` in `packages/cli/src/queue.ts` is ~25 lines
+   implementing `cli-contract.md §As-Of Resolution` — bare `YYYY-MM-DD` or an ISO datetime with
+   an explicit timezone, rejecting timezone-less datetimes as ambiguous — and it is **not
+   exported from `@adrkit/core`**. `buildQueueReport` takes an already-resolved `asOf` string,
+   so a library consumer computing the ARB queue today either reimplements that resolver or
+   silently gets a different answer than CI produces for the same corpus on the same day.
+
+   This is a live defect **independent of whether this record is ratified**, and it is the
+   clearest evidence for clause 3's narrowing: it is a contract gap that additive-only
+   discipline on `@adrkit/core`'s exported API could never have caught, because the missing
+   piece was never exported in the first place. Whatever the SDK's fate, the resolver belongs
+   in core beside the kernel it feeds. Deliberately **not** fixed alongside action item 3;
+   recorded here so it cannot be lost with `docs/sdk-surface.md`.

--- a/docs/adr/0031-publish-a-narrow-consumer-sdk-as-the-contract-and-document-the-cli-json-as-its-s.md
+++ b/docs/adr/0031-publish-a-narrow-consumer-sdk-as-the-contract-and-document-the-cli-json-as-its-s.md
@@ -59,10 +59,17 @@ clause 11 binds adrkit to additive-only change on "the consumed shapes," definin
 |---|---|
 | symbols exported from `@adrkit/core` | **173** |
 | re-export lines in its `index.ts` | 23 |
-| symbols the only existing consumer (`@adrkit/ci`) imports | **3** |
+| symbols its in-repo library consumers import | **17** (`@adrkit/ci` 14, `@adrkit/catalog-envelope` 3) |
+
+> **Corrected 2026-08-16**, under action item 3. This table originally read "symbols the only
+> existing consumer (`@adrkit/ci`) imports — **3**." Both halves were wrong: `@adrkit/ci`
+> imports **14** unique symbols (7 values, 7 types), and it is not the only consumer —
+> `@adrkit/catalog-envelope` imports 3 more. The conclusion is unaffected (17 « 173) but the
+> ratio is 5.7×, not 58×, and a record arguing for a narrower surface is the last place an
+> unverified count belongs. Method: `docs/sdk-surface.md` §Measurements.
 
 Clause 11 therefore promises stability across a 173-symbol internal engine to protect a
-consumer surface of roughly three. There are only two ways that resolves: freeze the engine
+consumer surface of roughly seventeen. There are only two ways that resolves: freeze the engine
 against ordinary refactoring, or break the promise quietly. The second is what happens in
 practice, and a governing clause that is routinely and invisibly violated is worse than no
 clause — it is the failure ADR-0016 and ADR-0014 exist to prevent, expressed as an API.
@@ -73,7 +80,7 @@ purpose; reducing consumer boilerplate is secondary.
 ### Two consumption modes already exist, and they do not agree
 
 Both are in production in this repository today: `@adrkit/ci` consumes the **library**
-(three imports from `@adrkit/core`), and `@adrkit/spec-kit` consumes the **CLI**
+(fourteen imports from `@adrkit/core`), and `@adrkit/spec-kit` consumes the **CLI**
 (`scripts/context.sh` shells out to `adr check`). But the CLI's JSON is only sometimes a
 core shape:
 
@@ -221,9 +228,13 @@ recorded as its own wrongness signal.
 1. [ ] Ratify or reject this record. It is `proposed` and agent-drafted with no `ratifiedBy`.
 2. [ ] Land the amendment note on ADR-0029 recording that clauses 6 and 11 are narrowed by
    this record's clause 3, per the mechanism ADR-0013 used on ADR-0007.
-3. [ ] Enumerate the SDK's first surface from what a real consumer needs — the Tier 1
+3. [x] Enumerate the SDK's first surface from what a real consumer needs — the Tier 1
    capabilities of ADR-0029 clause 1 — rather than from what core exports. Record the count;
    if it exceeds a dozen entry points, the wrongness signal above has already fired.
+   **Done 2026-08-16: [`docs/sdk-surface.md`](../sdk-surface.md), sketched at `packages/sdk/`.
+   7 callable entry points; 17 exported symbols. The signal fires on the second count and not
+   the first, and the record does not say which it meant — see that document's verdict, which
+   recommends restating this criterion before ratification.**
 4. [ ] Converge `explain`, `lint`, and `new` `--json` onto core formatters, as `queue` is,
    so the two modes describe the same shapes.
 5. [ ] Document the CLI JSON contract and the SDK surface in `docs/RELEASING.md`, with the

--- a/docs/sdk-surface.md
+++ b/docs/sdk-surface.md
@@ -1,0 +1,234 @@
+# The consumer SDK's first surface
+
+**ADR-0031 action item 3.** Enumerate `@adrkit/sdk`'s first surface from what a real consumer
+needs — the Tier 1 capabilities of ADR-0029 clause 1 — rather than from what `@adrkit/core`
+happens to export, and record the count.
+
+> **Status: investigation, against an unratified record.**
+> [ADR-0031](adr/0031-publish-a-narrow-consumer-sdk-as-the-contract-and-document-the-cli-json-as-its-s.md)
+> is `proposed`, agent-drafted, and awaiting `@mbeacom`'s decision in the ARB queue. Nothing
+> here ratifies it. `packages/sdk/` is a **types-only** sketch: no runtime, no build, no
+> release, absent from `RELEASE_PACKAGES`. If the record is rejected, that directory is deleted
+> and nothing else changes.
+
+## Verdict, first
+
+**The wrongness signal fires on one of the two counts the record could mean, and the record
+does not say which. On the claim the signal actually stands for, direct measurement says it did
+not fire.**
+
+| | count | vs "roughly a dozen" |
+|---|---|---|
+| (A) callable entry points — functions and methods | **7** | under |
+| (B) all exported symbols, including types | **17** | **over** |
+
+ADR-0031's falsification criterion reads:
+
+> if the SDK's surface has to grow past roughly a dozen **entry points** to serve its first real
+> consumer, then it is not a facade but a re-export of core under another name, and the
+> insulation is fictional.
+
+"Entry point" is undefined. Reading (B) is the one consistent with the record's own comparison
+table, which counted *symbols* (173 vs 3). On that reading, 17 > 12 and the signal has fired.
+
+But the count is a **proxy**. The claim it stands for is stated in the same sentence: *it is a
+re-export of core under another name, and the insulation is fictional.* That claim is directly
+measurable, and it comes back negative:
+
+| structural comparison against the nearest `@adrkit/core` counterpart | result |
+|---|---|
+| object shapes structurally identical to a core type | **0 of 12** |
+| object shapes diverged from a core counterpart | 7 |
+| object shapes with no core counterpart at all | 5 |
+| vocabulary unions identical to a core union | 3 of 3 — *deliberate; see below* |
+
+Not one of the twelve object types is a re-export of a core type under another name. Seven
+diverge in member names and member types; five (`DecisionSet`, `PathGovernance`,
+`OpenDecisionsOptions`, `QueueOptions`, `GoverningOptions`) have no counterpart in core
+whatsoever, because they describe a consumption model core does not have.
+
+**Recommendation for ratification.** The wrongness signal as written would condemn a facade
+that demonstrably insulates, because it counts symbols while its stated concern is aliasing.
+Two possible amendments, either of which is cheap now and expensive after ratification:
+
+1. Say **callable entry points**, not "entry points" — the count a consumer experiences as
+   surface area. Result types are consequences of the capabilities, not independent
+   commitments, and a rule that penalizes them pushes toward returning `unknown`.
+2. Better: replace the count with the structural test above. *"If more than a third of the
+   SDK's declared types are structurally identical to a core type, the facade is an alias."*
+   That measures the actual concern rather than a proxy for it, and it is scriptable.
+
+The honest summary for `@mbeacom`: **the surface is 7 callable entry points and 17 symbols; the
+insulation is real and measured; the record's own falsification criterion is the part that needs
+fixing.**
+
+## Measurements
+
+All figures were derived by script against this revision, not asserted. This matters here
+specifically: the record's own asserted count was wrong, which is what prompted measuring rather
+than restating.
+
+### Correction to ADR-0031's premise
+
+| claim | as written | measured | status |
+|---|---|---|---|
+| `@adrkit/core` exports 173 symbols | 173 | 98 runtime values; ~166 incl. types by static walk | credible |
+| `@adrkit/ci` imports **3** core symbols | 3 | **14** (7 values, 7 types) | **wrong by 11** |
+| `@adrkit/ci` is *the only* existing consumer | "the only" | `@adrkit/catalog-envelope` imports 3 more | **incomplete** |
+
+The 14: `ChangedDependency`, `CheckLintResult`, `CheckOutcome`, `Finding`, `GoverningDecision`,
+`QueueReport`, `SourceMarkerBatchScan`, `buildQueueReport`, `checkChanges`, `compareCodeUnits`,
+`deriveChangedDependenciesFromBunLockDiff`, `formatQueueReportMarkdown`, `lintCorpus`,
+`readSourceMarkersBatch`.
+
+**The conclusion survives; the framing does not.** 17 consumed symbols against 173 exported is
+still a promise kept only by freezing the engine or breaking it quietly — the argument holds. But
+the ratio is 5.7×, not 58×, and "protecting a consumer surface of roughly three" was the phrase
+doing the rhetorical work in both ADR-0031 and the amendment note it added to the *accepted*
+ADR-0029. Both are corrected, each with a visible correction note rather than a silent edit.
+
+### The strongest argument is assembly, not symbol count
+
+This is the finding that most changes how the SDK should be justified, and it is not the
+argument ADR-0031 leads with.
+
+Core's exports are **pure kernels**. They are not capabilities. Answering one Tier 1 question
+today — *which decisions govern this path* — takes eight core calls in a specific order:
+
+```text
+lintCorpus → readSourceMarkers → resolveAffects → resolveSourceMarkers
+  → mergeSourceDeclarations → toGoverningDecisions → bucketDecisions → sortFindings
+```
+
+*(measured from `runExplain` in `packages/cli/src/index.ts`)*
+
+And the ARB queue needs a **25-line `--as-of` resolver that lives in `packages/cli/src/queue.ts`
+and is not exported from core at all**. A library consumer building the queue today therefore
+either reimplements that resolver or gets a different answer than CI does, for the same corpus
+on the same day. That is a contract gap that no amount of additive-only discipline on core's
+exports would have caught, because the missing piece was never in core to begin with.
+
+So: a consumer importing `@adrkit/core` does not receive Tier 1 capabilities. It receives the
+parts, plus the obligation to assemble them correctly and to keep assembling them correctly as
+core changes. **The mapping layer is the product.** ADR-0031 clause 4 asserts this; the eight-call
+chain is the evidence for it.
+
+### Both consumption modes, as found
+
+| consumer | mode | evidence |
+|---|---|---|
+| `@adrkit/ci` | library | 14 symbols from `@adrkit/core` across 6 files |
+| `@adrkit/catalog-envelope` | library | 3 symbols (`CatalogSnapshot`, `CatalogSnapshotEntity`, `canonicalStringify`) |
+| `@adrkit/spec-kit` | CLI | `scripts/context.sh` shells to `adr check --json` / `adr queue --format json` |
+
+`context.sh` is 16 lines and needs no types at all — it forwards paths to `adr check` and falls
+back to `adr queue`. It is the clearest evidence for ADR-0031 clause 5's position that the CLI
+JSON is a **sibling contract rather than an SDK adapter**: nothing this consumer needs would be
+improved by a JavaScript package.
+
+## The surface
+
+Seven callable entry points. One I/O door, six projections of the already-loaded corpus.
+
+```text
+openDecisions(options?)              -> Promise<DecisionSet>
+DecisionSet.records                     browsing the corpus
+DecisionSet.issues                      corpus health
+DecisionSet.get(id)                     record status, one record
+DecisionSet.queue(options?)             the ARB queue and its SLA state
+DecisionSet.graph()                     the supersession graph
+DecisionSet.governing(path, options?)   path-governance, explicitly supplied path
+```
+
+Declared at [`packages/sdk/src/index.ts`](../packages/sdk/src/index.ts).
+
+### Why a handle, not free functions
+
+The known first consumer is a Backstage backend serving many requests against one corpus. Free
+functions would re-read and re-validate the corpus on every request; a handle loads once. It
+also concentrates every filesystem touch except the marker scan into a single entry point,
+which is what makes the other six synchronous and trivially testable.
+
+**Methods are counted as entry points.** The handle is a caching and cohesion decision, not a
+counting trick — collapsing six functions into six methods and then reporting "1 entry point"
+would be exactly the trimming-to-fit that action item 3 warns against.
+
+### Per-entry evidence
+
+| # | Entry point | Tier 1 capability (ADR-0029 cl. 1) | Absorbs | Evidence |
+|---|---|---|---|---|
+| 1 | `openDecisions` | all — single I/O door | `lintCorpus`, dir resolution, unreachable-dir handling | `runQueue` and `runExplain` each re-implement the unreachable-dir case separately |
+| 2 | `.records` | browsing the corpus | `Corpus.records` → flat record, `decisionBucketFor` precomputed | `Adr` nests under `frontmatter`; consumers want `record.status` |
+| 3 | `.issues` | corpus health | `sortFindings`, severity split | `corpus.file-skipped` is `warn`, not `error` — a `proposed` record can otherwise vanish silently |
+| 4 | `.get(id)` | record status, one record | id normalization + lookup | a deep-link route (`/adr/0031`) resolves one record; linear-scanning `records` is the alternative |
+| 5 | `.queue(options?)` | ARB queue + SLA state | `buildQueueReport` **+ the CLI's `--as-of` resolver** | that resolver is 25 lines in `packages/cli/src/queue.ts` and is not exported from core |
+| 6 | `.graph()` | supersession graph | `buildAdrGraph` | frontmatter alone silently drops a supersession target that does not exist; the built graph reports it |
+| 7 | `.governing(path)` | path-governance, explicit path | the eight-call `explain` chain, incl. the `@adr` marker scan | `runExplain`, `packages/cli/src/index.ts` |
+
+### What is deliberately excluded, and why
+
+Exclusions are the load-bearing half of a narrowing exercise, so each carries its reason:
+
+- **The document layer** (ADR-0029 clause 9) — rendering ADR prose belongs to
+  `@backstage-community/plugin-adr` via its `contentDecorators` / `statusComponent` extension
+  points. It reads markdown; it does not want a JavaScript API. `DecisionRecord` therefore
+  carries no `body`.
+- **Anything needing the entity-ownership mapping** — Tier 2, not authorized. ADR-0029 clause 2:
+  *"where clauses 1 and 2 both admit a capability, clause 2 governs."*
+- **`resolveAffects` against a *derived* path.** Clause 1 admits path-governance only for a path
+  that is *explicitly supplied* — typed by a person, or set in configuration a person wrote.
+  **This surface cannot enforce that**: a `string` does not carry its provenance, so
+  `.governing(path)` will answer for a path derived from a catalog entity just as readily as for
+  a typed one. The obligation sits with the caller. It is stated in the method's own doc comment
+  because an unstated obligation is one that gets discharged by accident — and this is the
+  precise gap ADR-0029's context section calls *"exploitable rather than merely untidy."*
+- **All writers** — `adr new`, `migrate`, `evaluate`. Not Tier 1, and a read-only first surface
+  is a smaller one-way door.
+- **Findings/lint detail beyond `CorpusIssue`** — `adr lint`'s full finding vocabulary is a CI
+  concern, and ADR-0031 clause 6 has not yet converged `lint --json` onto a core formatter.
+
+### On the three identical unions
+
+`DecisionStatus`, `DecisionStanding`, and `SlaState` are structurally identical to unions core
+also exports. That is deliberate, and it is the one place the divergence discipline is
+consciously not applied.
+
+They are not *core's* vocabulary — they are `schema/adr.schema.json`'s and the queue contract's.
+**ADR-0029 clause 6 names that schema as a contract in its own right, and ADR-0031 does not
+narrow it.** Those values are therefore already committed to consumers by a different record.
+Re-deriving them under new names here would buy no insulation; it would add a translation table
+that can drift from the schema it claims to describe, and a consumer switching on
+`'accepted'` would have to learn a second spelling of a word the schema already published.
+
+The rule this expresses, stated so it can be applied to the next type: **diverge from core's
+implementation shapes; converge on the schema's published vocabulary.** Where core and the
+schema agree, matching core is a consequence rather than a re-export.
+
+## What was verified
+
+- `bun test` — full suite, including 4 new `packages/sdk/test/packaging.test.ts` assertions and
+  3 new `check-deps` cases.
+- `bun run typecheck`, `bun run adr lint`, `bun run check:deps`.
+- **ADR-0016 clause 2 — three new checks, each observed failing first:**
+  - `check:deps` had **no allowlist entry** for `@adrkit/sdk`, which means
+    `allowedDependenciesFor()` returned `undefined` and the allowed-surface guard was skipped
+    entirely — a green check that meant nothing, exactly as `check-deps.ts`'s own comment warns.
+    Confirmed by watching `undici: '^6'` pass, then adding the entry and watching it fail.
+  - The clause-8 no-release assertion, confirmed by temporarily adding `@adrkit/sdk` to
+    `scripts/release-pack.ts` and watching it fail.
+  - The clause-4 no-re-export assertion, confirmed by temporarily adding
+    `export type { Adr } from '@adrkit/core';` and watching it fail.
+
+## What this does not establish
+
+- **ADR-0014 rung 0.** No consumer has exercised this surface, because the one it was designed
+  for does not exist yet. ADR-0031's own trade-off — *"the risk is that the guess hardens before
+  the Backstage plugin tests it"* — is not mitigated by this work, only made concrete enough to
+  criticize.
+- **Nothing is implemented.** Every entry point is a `declare` or an interface member. The
+  eight-call assembly it claims to absorb has not been written, so its feasibility is argued from
+  reading `runExplain`, not from a passing test.
+- **No release, and none prepared.** ADR-0031 clause 7 specifies `versioning: 'independent'`
+  *when* released; wiring that into `scripts/release-pack.ts` now would prepare an act clause 8
+  does not authorize, so it is deliberately absent — and asserted absent by test, so its absence
+  is a fact rather than an oversight.

--- a/docs/sdk-surface.md
+++ b/docs/sdk-surface.md
@@ -47,20 +47,22 @@ diverge in member names and member types; five (`DecisionSet`, `PathGovernance`,
 `OpenDecisionsOptions`, `QueueOptions`, `GoverningOptions`) have no counterpart in core
 whatsoever, because they describe a consumption model core does not have.
 
-**Recommendation for ratification.** The wrongness signal as written would condemn a facade
-that demonstrably insulates, because it counts symbols while its stated concern is aliasing.
-Two possible amendments, either of which is cheap now and expensive after ratification:
+**Recommendation for ratification — adopted.** The wrongness signal as written would condemn a
+facade that demonstrably insulates, because it counts symbols while its stated concern is
+aliasing. Worse, it never said which of the two counts it meant, so the record's own
+falsification test could not be evaluated without a judgment call.
 
-1. Say **callable entry points**, not "entry points" — the count a consumer experiences as
-   surface area. Result types are consequences of the capabilities, not independent
-   commitments, and a rule that penalizes them pushes toward returning `unknown`.
-2. Better: replace the count with the structural test above. *"If more than a third of the
-   SDK's declared types are structurally identical to a core type, the facade is an alias."*
-   That measures the actual concern rather than a proxy for it, and it is scriptable.
+**ADR-0031's criterion has been replaced** (see that record's *Consequences*), on `@mbeacom`'s
+decision, before ratification rather than after. It now reads: *more than a third of the SDK's
+declared object shapes being structurally identical to a core type* — scriptable, with the
+measured baseline of 0 of 12 recorded in the record itself, and with the three vocabulary unions
+explicitly excluded for the reason given below. The second signal — a consumer reaching into
+`@adrkit/core` directly — was sound and is kept unchanged. Both counts stay in the record so a
+ratifier sees what was measured, not only the conclusion.
 
 The honest summary for `@mbeacom`: **the surface is 7 callable entry points and 17 symbols; the
-insulation is real and measured; the record's own falsification criterion is the part that needs
-fixing.**
+insulation is real and measured; the record's own falsification criterion was the part that
+needed fixing, and measuring it is what found that out.**
 
 ## Measurements
 
@@ -112,6 +114,14 @@ So: a consumer importing `@adrkit/core` does not receive Tier 1 capabilities. It
 parts, plus the obligation to assemble them correctly and to keep assembling them correctly as
 core changes. **The mapping layer is the product.** ADR-0031 clause 4 asserts this; the eight-call
 chain is the evidence for it.
+
+The `--as-of` half of that is not merely inconvenient — it is a **live defect independent of the
+SDK's fate**, and it is now ADR-0031 action item 7 so it survives this document. `resolveAsOf` is
+not a helper; it implements `cli-contract.md §As-Of Resolution`, including the rule that a
+timezone-less datetime is rejected as ambiguous rather than guessed at. A consumer that
+reimplements it and guesses differently produces a queue that disagrees with CI's about which
+decisions are overdue, on the same corpus, on the same day, with no error anywhere. Whatever
+happens to this record, the resolver belongs in core beside the kernel it feeds.
 
 ### Both consumption modes, as found
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@adrkit/sdk",
+  "version": "0.0.0",
+  "description": "The narrow, typed consumer contract for adrkit's decision corpus. Declares its own shapes over @adrkit/core; never re-exports them.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "homepage": "https://adrkit.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mbeacom/adrkit.git",
+    "directory": "packages/sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/mbeacom/adrkit/issues"
+  },
+  "keywords": [
+    "adr",
+    "architecture-decision-records",
+    "governance",
+    "sdk"
+  ],
+  "//status": "Types-only design sketch for ADR-0031 action item 3. There is no runtime here \u2014 src/index.ts declares the proposed surface and nothing implements it. The purpose is to make the entry-point count a *measured* number rather than an asserted one, because ADR-0031's own asserted count of @adrkit/ci's core imports was wrong by 11 (3 claimed, 14 measured). ADR-0031 is `proposed` and unratified; if it is rejected, this directory is deleted and nothing else changes.",
+  "//release": "Not released, and no release is prepared. ADR-0031 clause 8 authorizes the SDK's design and construction but explicitly withholds its release, which ADR-0029 clause 10 reserves to a later record. Absent from RELEASE_PACKAGES in scripts/release-pack.ts, ships no dist, declares no exports map, version 0.0.0. Clause 7 specifies `versioning: 'independent'` *when* released; wiring that now would prepare an act that is not authorized.",
+  "//boundary": "This package declares its own types rather than re-exporting @adrkit/core's (ADR-0031 clause 4). The duplication is deliberate and is the entire point: a facade that re-exports is an alias, and the first core rename would reach every consumer through it. This follows packages/catalog-envelope, whose //boundary note records the identical choice for the same reason \u2014 that independence is what makes the boundary a boundary rather than a tautology. The one-way edge is sdk -> core; core, cli, and schema/ must never import from here.",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "bun run typecheck",
+    "lint": "bun run typecheck",
+    "typecheck": "tsc --noEmit --customConditions bun --project ../../tsconfig.json"
+  },
+  "dependencies": {
+    "@adrkit/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,387 @@
+/**
+ * `@adrkit/sdk` — the proposed consumer contract for adrkit's decision corpus.
+ *
+ * **This module is types only. Nothing here is implemented.** It exists to answer
+ * [ADR-0031](../../../docs/adr/0031-publish-a-narrow-consumer-sdk-as-the-contract-and-document-the-cli-json-as-its-s.md)
+ * action item 3 — *"enumerate the SDK's first surface from what a real consumer needs, and
+ * record the count"* — with a number that can be **measured from real TypeScript** rather than
+ * asserted in prose. That distinction is not pedantry: ADR-0031's own asserted count of the
+ * existing consumer's core imports was wrong by 11 (it says 3; the measured figure is 14), and
+ * an argument for a narrower surface is exactly the kind of argument that should not rest on an
+ * unverified count.
+ *
+ * ADR-0031 is `proposed`, agent-drafted, and **unratified**. If it is rejected, this directory
+ * is deleted and nothing else in the repository changes.
+ *
+ * ## What the surface is derived from
+ *
+ * ADR-0029 clause 1 — the Tier 1 capabilities, which are the ones authorized without the
+ * entity-ownership mapping:
+ *
+ * > Browsing the corpus, the ARB queue and its SLA state, the supersession graph, record
+ * > status, the document layer of clause 9, and path-governance for a path that is
+ * > **explicitly supplied**.
+ *
+ * Every entry point below traces to one of those. Nothing below traces to "core happens to
+ * export it," which is the failure mode the action item exists to avoid.
+ *
+ * ## Why a facade is worth anything at all
+ *
+ * The weak argument is symbol count — that a consumer importing `@adrkit/core` faces 166+
+ * exported symbols. The strong argument is **assembly**. Answering one Tier 1 question today
+ * takes eight core calls in a specific order:
+ *
+ * ```text
+ * adr explain <path>:
+ *   lintCorpus -> readSourceMarkers -> resolveAffects -> resolveSourceMarkers
+ *     -> mergeSourceDeclarations -> toGoverningDecisions -> bucketDecisions -> sortFindings
+ * ```
+ *
+ * and the ARB queue additionally needs a 25-line `--as-of` resolver that lives in
+ * `packages/cli/src/queue.ts` and **is not exported from core at all**. A consumer that imports
+ * core does not receive these capabilities; it receives the parts, plus the obligation to
+ * assemble them correctly and to keep assembling them correctly as core changes. The mapping
+ * layer is the product. ADR-0031 clause 4 says as much, and this file is what that claim looks
+ * like when it is written down.
+ *
+ * ## The boundary
+ *
+ * **These types are declared here, not re-exported from `@adrkit/core`** (ADR-0031 clause 4).
+ * The duplication is deliberate and is the entire point: a facade that re-exports is an alias,
+ * and the first core rename would travel through it to every consumer. This follows
+ * `packages/catalog-envelope`, whose own `//boundary` note records the identical choice for the
+ * identical reason — the independence is what makes the boundary a boundary rather than a
+ * tautology.
+ *
+ * Note what this file therefore does **not** contain: an `import` from `@adrkit/core`. The edge
+ * is one-way and would exist only in an implementation; the *contract* has no edge at all.
+ *
+ * @see `docs/sdk-surface.md` — the enumeration, the counts, and the wrongness-signal verdict.
+ */
+
+/* ------------------------------------------------------------------ *
+ * Vocabulary
+ * ------------------------------------------------------------------ *
+ * These three unions are structurally identical to unions `@adrkit/core` also exports, and
+ * that is deliberate rather than an oversight in the divergence discipline above.
+ *
+ * They are not core's vocabulary. They are `schema/adr.schema.json`'s — the statuses are the
+ * schema's `status` enum, and the SLA states are the queue contract's. ADR-0029 clause 6 names
+ * that schema as a contract in its own right, one which ADR-0031 does not narrow. So these
+ * values are already committed to consumers by a different record, and re-deriving them under
+ * new names here would not buy insulation; it would only add a translation table that can drift
+ * from the schema it claims to describe.
+ *
+ * The rule this expresses: **diverge from core's implementation shapes, converge on the
+ * schema's published vocabulary.** Where core and the schema agree, matching core is a
+ * consequence, not a re-export.
+ */
+
+/**
+ * A decision's lifecycle status — the `status` enum of `schema/adr.schema.json`.
+ *
+ * `rejected` is load-bearing rather than vestigial: the decision *not* to do something is the
+ * one most often re-litigated, so a consumer browsing the corpus must be able to surface it.
+ */
+export type DecisionStatus = 'draft' | 'proposed' | 'accepted' | 'rejected' | 'superseded' | 'deprecated';
+
+/**
+ * Which of the three governance groups a record falls in — the distinction a consumer needs
+ * before it can render a record, because {@link DecisionStatus} alone does not say whether a
+ * decision *binds*.
+ *
+ * - `governing` — binds now.
+ * - `activeProposals` — under consideration; does not bind yet.
+ * - `history` — superseded, rejected, or deprecated; binds nothing, and deleting it would
+ *   destroy the "we tried that in 2023" record that is the corpus's main long-run value.
+ */
+export type DecisionStanding = 'governing' | 'activeProposals' | 'history';
+
+/**
+ * Where a queued decision stands against its review SLA, in ascending urgency.
+ *
+ * `not-queued` and `missing-sla` are distinct on purpose: the first is a record that never
+ * entered review, the second is one that entered review without a deadline. Collapsing them
+ * would hide the second, which is the one that needs a human.
+ */
+export type SlaState =
+  | 'overdue'
+  | 'escalated'
+  | 'due'
+  | 'within-sla'
+  | 'missing-sla'
+  | 'not-queued'
+  | 'decided';
+
+/* ------------------------------------------------------------------ *
+ * Entry point 1 — opening the corpus
+ * ------------------------------------------------------------------ */
+
+/** Options for {@link openDecisions}. */
+export interface OpenDecisionsOptions {
+  /** Corpus directory, repo-relative. Defaults to `docs/adr`. */
+  dir?: string;
+  /** Directory the corpus directory is resolved against. Defaults to the process cwd. */
+  cwd?: string;
+}
+
+/**
+ * Read and validate a decision corpus once, returning a handle onto it.
+ *
+ * **The only I/O door in this surface.** Every other entry point is a projection of the
+ * already-loaded corpus, which is why they are methods on {@link DecisionSet} rather than
+ * free functions: the known first consumer is a Backstage backend serving many requests
+ * against one corpus, and a surface of free functions would re-read and re-validate on every
+ * one of them.
+ *
+ * Absorbs `lintCorpus`, corpus-directory resolution, and the unreachable-directory case that
+ * `adr queue` and `adr explain` each handle separately today.
+ *
+ * **Does not throw for a corpus that fails to parse.** A consumer rendering a governance UI
+ * needs to show *that* the corpus is broken alongside whatever it could still read, not to
+ * catch an exception and render nothing. Problems arrive as {@link DecisionSet.issues}.
+ * Reserved for the case where the corpus directory cannot be read at all.
+ */
+export declare function openDecisions(options?: OpenDecisionsOptions): Promise<DecisionSet>;
+
+/* ------------------------------------------------------------------ *
+ * Entry points 2-7 — the handle
+ * ------------------------------------------------------------------ */
+
+/**
+ * A loaded corpus, and the five projections of it that Tier 1 needs.
+ *
+ * Methods here are counted as entry points in `docs/sdk-surface.md`, not hidden behind the
+ * handle. The handle is a caching and cohesion decision, not a counting one.
+ */
+export interface DecisionSet {
+  /**
+   * **Entry point 2 — browsing the corpus.** Every record that loaded, in a stable order.
+   *
+   * Records that did *not* load are absent from here and present in {@link issues}; a
+   * consumer that renders this list without also surfacing those is showing a corpus that
+   * looks smaller and healthier than it is.
+   */
+  readonly records: readonly DecisionRecord[];
+
+  /**
+   * **Entry point 3 — corpus health.** Everything discovery or validation could not resolve.
+   *
+   * Named `issues` rather than `findings` because `findings` in this project already means
+   * the lint/check finding type, and a consumer type that borrows the name would be assumed
+   * to be that type.
+   */
+  readonly issues: readonly CorpusIssue[];
+
+  /**
+   * **Entry point 4 — record status for one record.** Look up a single decision by id.
+   *
+   * Present because a consumer's deep-link route (`/adr/0031`) resolves one record and should
+   * not have to linear-scan {@link records} or reimplement id normalization to do it. Accepts
+   * the zero-padded form the corpus uses.
+   */
+  get(id: string): DecisionRecord | undefined;
+
+  /** **Entry point 5 — the ARB queue and its SLA state.** */
+  queue(options?: QueueOptions): QueueView;
+
+  /** **Entry point 6 — the supersession graph.** */
+  graph(): DecisionGraph;
+
+  /**
+   * **Entry point 7 — path governance for an explicitly supplied path.**
+   *
+   * Absorbs the eight-call `adr explain` assembly, including the inbound `@adr` marker scan.
+   * Asynchronous because that scan reads the file at `path`; the corpus itself is already
+   * loaded.
+   *
+   * **The Tier 1/Tier 2 line runs through this method's argument, not its body.** ADR-0029
+   * clause 1 admits this capability only for a path that is *explicitly supplied* — typed by
+   * a person, or set in configuration a person wrote. A path a caller derived from a catalog
+   * entity field is Tier 2 and is not authorized. This surface cannot enforce that: a string
+   * does not carry its provenance. The obligation sits with the caller, and it is stated here
+   * because an unstated obligation is one that gets discharged by accident.
+   */
+  governing(path: string, options?: GoverningOptions): Promise<PathGovernance>;
+}
+
+/* ------------------------------------------------------------------ *
+ * Result shapes
+ * ------------------------------------------------------------------ */
+
+/**
+ * One decision record, flattened.
+ *
+ * Diverges from core's `Adr` deliberately and in three ways, each of which is the kind of
+ * change that would otherwise reach consumers as a break:
+ *
+ * 1. **Flat.** Core nests the metadata under `frontmatter`; a consumer reads `record.status`,
+ *    not `record.frontmatter.status`.
+ * 2. **Narrowed.** The schema carries ~20 frontmatter fields. Tier 1 needs these. Adding one
+ *    later is additive; the reverse is not, which is the whole argument for starting small.
+ * 3. **`standing` is precomputed.** Core requires the caller to call `decisionBucketFor`.
+ *    Making it a field means "does this bind?" cannot be got wrong by forgetting a call.
+ *
+ * The body is deliberately absent: rendering ADR prose is the document layer (ADR-0029
+ * clause 9), which extends `@backstage-community/plugin-adr` and reads the markdown itself.
+ */
+export interface DecisionRecord {
+  /** Zero-padded record id, e.g. `"0031"`. */
+  readonly id: string;
+  readonly title: string;
+  readonly status: DecisionStatus;
+  /** Precomputed from {@link status}; see the note above on why this is a field. */
+  readonly standing: DecisionStanding;
+  /** ISO calendar date, `YYYY-MM-DD`. */
+  readonly date: string;
+  /** Repo-relative path to the record, e.g. `docs/adr/0031-....md`. */
+  readonly path: string;
+  readonly tags: readonly string[];
+  /** Ids this record supersedes. The outbound half of the supersession edge. */
+  readonly supersedes: readonly string[];
+  /** Id of the record that superseded this one, when one did. */
+  readonly supersededBy?: string;
+}
+
+/**
+ * Something the corpus could not resolve.
+ *
+ * `severity` is on the type because a `warn` and an `error` mean genuinely different things
+ * here and a consumer must be able to tell them apart: a record that could not be *parsed* is
+ * an error, while a record discovery could not *see* — misnamed, or nested below the corpus
+ * root — is a warning, because that is a governance gap rather than a broken corpus. Flattening
+ * the two would let a `proposed` record vanish from the queue with nothing shown to anyone.
+ */
+export interface CorpusIssue {
+  /** Stable machine-readable code, e.g. `corpus.file-skipped`. */
+  readonly code: string;
+  readonly severity: 'error' | 'warn' | 'info';
+  readonly message: string;
+  /** Repo-relative path the issue is about, when it is about one file. */
+  readonly path?: string;
+}
+
+/** Options for {@link DecisionSet.queue}. */
+export interface QueueOptions {
+  /**
+   * UTC calendar date, `YYYY-MM-DD`, that SLA state is computed against. Defaults to today.
+   *
+   * A bare calendar date only — no datetime, and no `Date`. Both alternatives carry a timezone
+   * question, and this contract answers it once here instead of at every call site. The CLI
+   * already resolves the equivalent flag this way; that resolver lives in the CLI and is not
+   * exported from core, so a library consumer building the queue today either reimplements it
+   * or gets a different answer than CI does for the same corpus on the same day.
+   */
+  readonly asOf?: string;
+}
+
+/**
+ * The ARB queue at a point in time.
+ *
+ * `asOf` is echoed back because an SLA state is meaningless without the date it was computed
+ * against, and a consumer that caches this view needs to know what it cached.
+ */
+export interface QueueView {
+  readonly asOf: string;
+  readonly entries: readonly QueueEntry[];
+  /** Corpus issues that prevented records from reaching {@link entries}. */
+  readonly issues: readonly CorpusIssue[];
+}
+
+/** One decision awaiting review. */
+export interface QueueEntry {
+  readonly id: string;
+  readonly title: string;
+  readonly path: string;
+  /** Review routing tier, when the record declares one. */
+  readonly tier: 'auto' | 'async' | 'arb' | null;
+  readonly slaState: SlaState;
+  /** The date {@link slaState} was computed against, `YYYY-MM-DD`; null when no SLA applies. */
+  readonly deadline: string | null;
+}
+
+/**
+ * The supersession graph.
+ *
+ * Edges are separate from {@link DecisionRecord.supersedes} rather than derived from it by the
+ * consumer, because the two disagree in exactly the case that matters: a record may name a
+ * supersession target that does not exist. Reading the frontmatter alone silently drops that;
+ * a graph built by the SDK reports it in {@link DecisionSet.issues}.
+ */
+export interface DecisionGraph {
+  readonly nodes: readonly DecisionRecord[];
+  readonly edges: readonly SupersessionEdge[];
+}
+
+/** A directed supersession edge: `from` supersedes `to`. */
+export interface SupersessionEdge {
+  readonly from: string;
+  readonly to: string;
+}
+
+/** Options for {@link DecisionSet.governing}. */
+export interface GoverningOptions {
+  /**
+   * Whether to read the inbound `@adr` marker in the file at the supplied path. Defaults to
+   * `true`.
+   *
+   * Opt-out exists because the marker scan is the only filesystem read in this method, and a
+   * consumer resolving governance for a path that does not exist on its disk — a path typed
+   * into a search box, say — should be able to skip it rather than absorb a failed read.
+   */
+  readonly readMarkers?: boolean;
+}
+
+/**
+ * Which decisions govern one path, grouped by whether they bind.
+ *
+ * The grouping is the surface rather than a flat list because the question a consumer is really
+ * asking is "may I do this," and a flat list of five matched records — two accepted, one
+ * proposed, two superseded — answers that wrongly by default. `governing` is the answer;
+ * the other two are context.
+ */
+export interface PathGovernance {
+  /** The path this was resolved for, echoed back. */
+  readonly path: string;
+  /** Decisions that bind this path now. */
+  readonly governing: readonly GoverningDecision[];
+  /** Proposals that would bind it if accepted. */
+  readonly activeProposals: readonly GoverningDecision[];
+  /** Superseded, rejected, and deprecated decisions that once governed it. */
+  readonly history: readonly GoverningDecision[];
+  /** Problems encountered while resolving — an unresolvable marker reference, for instance. */
+  readonly issues: readonly CorpusIssue[];
+}
+
+/**
+ * A decision that governs a path, and the evidence for why.
+ *
+ * `matchedBy` is not decoration. Governance here is claimed from two independent directions —
+ * the record's own `affects:` matchers reaching out to the path, and an `@adr` marker in the
+ * file reaching back — and a consumer showing a human "ADR-0031 governs this file" should be
+ * able to say which, because the two fail in different ways and are fixed in different files.
+ */
+export interface GoverningDecision {
+  readonly id: string;
+  readonly title: string;
+  readonly status: DecisionStatus;
+  readonly standing: DecisionStanding;
+  readonly matchedBy: readonly GovernanceEvidence[];
+}
+
+/** How a decision came to govern a path. */
+export type GovernanceEvidence =
+  | {
+      /** The record's `affects:` matcher fired against the path. */
+      readonly kind: 'affects';
+      /** Matcher type, e.g. `path`. */
+      readonly type: string;
+      /** The matcher's pattern, verbatim, so a human can see what actually matched. */
+      readonly pattern: string;
+    }
+  | {
+      /** The file declared the record with an inbound `@adr` marker. */
+      readonly kind: 'marker';
+      /** 1-based line the marker was found on. */
+      readonly line: number;
+    };

--- a/packages/sdk/test/packaging.test.ts
+++ b/packages/sdk/test/packaging.test.ts
@@ -1,0 +1,67 @@
+/**
+ * `@adrkit/sdk` — packaging and boundary invariants.
+ *
+ * Two of ADR-0031's clauses are enforceable as facts about files, and both fail silently
+ * if they are not. These are those two.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const repoRoot = dirname(dirname(packageRoot));
+
+describe('ADR-0031 clause 8 — no release is authorized', () => {
+  // Clause 8 authorizes the SDK's design and construction and explicitly withholds its
+  // release, which ADR-0029 clause 10 reserves to a later record. A published package
+  // cannot be withdrawn, only deprecated, so this is a one-way door that must not be
+  // opened by an unrelated edit to the release manifest.
+  //
+  // ADR-0016 clause 2: observed failing. With `@adrkit/sdk` temporarily added to
+  // RELEASE_PACKAGES, this test reported the package present and failed; the retained
+  // input is that manifest edit, reverted.
+  test('the sdk is absent from RELEASE_PACKAGES', async () => {
+    const releasePack = await readFile(join(repoRoot, 'scripts', 'release-pack.ts'), 'utf8');
+    expect(releasePack).not.toContain('@adrkit/sdk');
+  });
+
+  test('the manifest declares version 0.0.0, no exports map, and no files list', async () => {
+    const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
+    expect(manifest.version).toBe('0.0.0');
+    expect(manifest.exports).toBeUndefined();
+    expect(manifest.files).toBeUndefined();
+    expect(manifest.private ?? false).toBe(false);
+  });
+});
+
+describe('ADR-0031 clause 4 — the sdk declares its own types', () => {
+  // The record's central mechanism: "a facade that re-exports is an alias and insulates
+  // nothing — the first core rename would reach every consumer." A single
+  // `export ... from '@adrkit/core'` would convert this package into the thing it exists
+  // to replace, and it would do so invisibly, because a re-export typechecks perfectly.
+  //
+  // The assertion is on `export ... from` specifically rather than on any mention of core:
+  // an *implementation* of this surface will legitimately import from core, and forbidding
+  // that would forbid the package from ever being built. What must never appear is core's
+  // types leaving through this module's public surface.
+  //
+  // ADR-0016 clause 2: observed failing. With
+  // `export type { Adr } from '@adrkit/core';` added to src/index.ts, this test failed on
+  // the re-export assertion; the retained input is that line, removed.
+  test('no core symbol is re-exported through the public surface', async () => {
+    const source = await readFile(join(packageRoot, 'src', 'index.ts'), 'utf8');
+    const reExports = [...source.matchAll(/^export\s[^;]*\sfrom\s+['"]([^'"]+)['"]/gm)].map(
+      (match) => match[1],
+    );
+    expect(reExports).toEqual([]);
+  });
+
+  test('the three schema vocabulary unions are declared here, not imported', async () => {
+    const source = await readFile(join(packageRoot, 'src', 'index.ts'), 'utf8');
+    for (const name of ['DecisionStatus', 'DecisionStanding', 'SlaState']) {
+      expect(source).toContain(`export type ${name} =`);
+    }
+  });
+});

--- a/scripts/check-deps.test.ts
+++ b/scripts/check-deps.test.ts
@@ -442,6 +442,80 @@ describe('catalog adapter and consumer dependency boundary (feature 010)', () =>
   });
 });
 
+describe('sdk dependency boundary (ADR-0031)', () => {
+  const SDK_MANIFEST = 'packages/sdk/package.json';
+
+  function sdkManifest(extra: Record<string, string> = {}): string {
+    return JSON.stringify(
+      {
+        name: '@adrkit/sdk',
+        version: '0.0.0',
+        dependencies: { '@adrkit/core': 'workspace:*', ...extra },
+        devDependencies: { '@types/bun': 'latest' },
+      },
+      null,
+      2,
+    );
+  }
+
+  test('allows exactly the workspace core, plus @types/bun', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, SDK_MANIFEST), sdkManifest());
+    await expect(checkDependencyRules(root)).resolves.toEqual({ ok: true, violations: [] });
+  });
+
+  // The only proof the `@adrkit/sdk` allowlist entry exists at all. Without it,
+  // `allowedDependenciesFor()` returns undefined, the allowed-surface guard is skipped,
+  // and `check:deps` reports the same `ok` for a package declaring `undici` as for a clean
+  // one — the trap the sibling suite above demonstrates directly.
+  //
+  // ADR-0016 clause 2: observed failing before the entry was added. With the entry absent,
+  // this test returned `{ ok: true, violations: [] }`; the retained input is the manifest
+  // below, unchanged.
+  test('proves the sdk allowlist entry exists, by rejecting a disallowed dependency', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, SDK_MANIFEST), sdkManifest({ undici: '^6' }));
+
+    const result = await checkDependencyRules(root);
+    expect(result.ok).toBe(false);
+    expect(result.violations.map((violation) => `${violation.dependency}: ${violation.reason}`)).toEqual([
+      'undici: @adrkit/sdk declares a dependency outside its allowed public surface',
+    ]);
+  });
+
+  // ADR-0031's facade is worth nothing if the engine can reach back through it: a cycle
+  // would make a core refactor a consumer-visible change again, which is the exact
+  // condition the SDK exists to remove.
+  test('rejects @adrkit/core depending on the sdk', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, SDK_MANIFEST), sdkManifest());
+    await writeText(
+      join(root, 'packages/core/package.json'),
+      JSON.stringify(
+        {
+          name: '@adrkit/core',
+          version: '0.1.0',
+          dependencies: {
+            picomatch: '^4',
+            semver: '^7',
+            yaml: 'latest',
+            zod: '^4',
+            '@adrkit/sdk': 'workspace:*',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = await checkDependencyRules(root);
+    expect(result.ok).toBe(false);
+    expect(result.violations.map((violation) => violation.reason)).toEqual([
+      '@adrkit/core declares a dependency outside its allowed public surface',
+    ]);
+  });
+});
+
 describe('mcp dependency boundary (Phase 5)', () => {
   test('allows exactly core, the pinned SDK server, and zod, plus the dev-only SDK client and @types/bun', async () => {
     const root = await resetTestDir(DIR_NAME);

--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -181,6 +181,26 @@ function allowedDependenciesFor(packageName: string): Record<DependencySection, 
     };
   }
 
+  if (packageName === '@adrkit/sdk') {
+    // ADR-0031's proposed consumer facade — a non-adapter workspace library by
+    // *location* (`packages/sdk/`, outside `packages/adapters/`), like
+    // `@adrkit/catalog-envelope` above. Its allowed surface is the workspace core
+    // and nothing else, which is what makes it cheap enough to satisfy ADR-0030
+    // clause 1: a facade that added an install cost would not be one.
+    //
+    // The edge is one-way. `@adrkit/core` must never depend on this package — a
+    // cycle would put the engine back inside the consumer contract and undo the
+    // narrowing that is the record's entire purpose. That direction is caught by
+    // core's own entry above, and is covered by a negative case in
+    // `check-deps.test.ts` rather than assumed.
+    return {
+      dependencies: new Set(['@adrkit/core']),
+      devDependencies: new Set(['@types/bun']),
+      peerDependencies: new Set(),
+      optionalDependencies: new Set(),
+    };
+  }
+
   if (packageName === '@adrkit/catalog-envelope') {
     // Feature 010's envelope consumer — a non-adapter workspace library, which it
     // is by *location* (`packages/catalog-envelope/`, outside `packages/adapters/`)


### PR DESCRIPTION
Enumerates `@adrkit/sdk`'s first surface from **what a real consumer needs** — ADR-0029 clause 1's Tier 1 capabilities — rather than from what `@adrkit/core` happens to export, and records the count. Then fixes the criterion that measurement proved wrong.

> **ADR-0031 remains `proposed`, agent-drafted, and unratified.** Nothing here ratifies it. This work *informs* ratification; it does not assume it. `packages/sdk/` is a types-only sketch — no runtime, no build, absent from `RELEASE_PACKAGES` and asserted absent by test, per clause 8. If the record is rejected, that directory is deleted and nothing else changes.

Deliverable: [`docs/sdk-surface.md`](https://github.com/mbeacom/adrkit/blob/mbeacom-consumer-sdk-surface/docs/sdk-surface.md).

## The surface

Seven callable entry points — one I/O door, six projections of the already-loaded corpus.

```text
openDecisions(options?)              -> Promise<DecisionSet>
DecisionSet.records                     browsing the corpus
DecisionSet.issues                      corpus health
DecisionSet.get(id)                     record status, one record
DecisionSet.queue(options?)             the ARB queue and its SLA state
DecisionSet.graph()                     the supersession graph
DecisionSet.governing(path, options?)   path-governance, explicitly supplied path
```

A handle rather than free functions because the known first consumer is a Backstage backend serving many requests against one corpus, and free functions would re-read and re-validate on each. **Methods are counted as entry points** — collapsing six functions into six methods and reporting "1" would be exactly the trimming-to-fit the action item warns against.

## The verdict, and why the criterion changed

| reading | count | vs "roughly a dozen" |
|---|---|---|
| (A) callable entry points | **7** | under |
| (B) all exported symbols, incl. types | **17** | **over** |

The original criterion fired on (B) and not (A), and **the record never said which it meant**. Reading (B) is the one consistent with its own comparison table, which counted symbols.

But the count was a *proxy*. The claim it stood for is in the same sentence — *"it is a re-export of core under another name, and the insulation is fictional"* — and that is directly measurable:

| structural comparison vs nearest `@adrkit/core` counterpart | result |
|---|---|
| object shapes structurally identical to a core type | **0 of 12** |
| object shapes diverged from a core counterpart | 7 |
| object shapes with no core counterpart at all | 5 |
| vocabulary unions identical | 3 of 3 — deliberate |

Not one of the twelve object types is a re-export. Five (`DecisionSet`, `PathGovernance`, and the three option types) have no counterpart in core whatsoever, because they describe a consumption model core does not have. The three identical unions are `schema/adr.schema.json`'s vocabulary, not core's — ADR-0029 clause 6 commits that schema separately and ADR-0031 does not narrow it, so re-spelling those values would buy no insulation and add a translation table that can drift.

**So the criterion was testing the wrong property**, and on @mbeacom's decision it is replaced in this PR — before ratification, which is the cheap moment:

> if more than a third of the SDK's declared **object shapes** are structurally identical — same member names, same member types — to a type `@adrkit/core` exports, then the facade is an alias

Scriptable, with the measured baseline (0 of 12) recorded in the record, and the vocabulary unions explicitly excluded with the reason. The second signal — a consumer reaching into `@adrkit/core` directly — was sound and is unchanged. Both counts stay in the record so a ratifier sees what was measured, not only the conclusion. The reasoning is recorded in the record itself, not only in the commit: a criterion that cannot be evaluated without a judgment call is not a falsification test.

## Two corrections to the record's premise

Found while measuring it:

| claim | as written | measured |
|---|---|---|
| `@adrkit/ci` imports **3** core symbols | 3 | **14** (7 values, 7 types) |
| `@adrkit/ci` is *the only* existing consumer | "the only" | `@adrkit/catalog-envelope` imports 3 more |

**The conclusion survives; the framing does not.** 17 consumed against 173 exported is still a promise kept only by freezing the engine or breaking it quietly. But the ratio is **5.7×, not 58×**, and "protecting a consumer surface of roughly three" was the phrase doing the rhetorical work — in ADR-0031's table *and* in the amendment note it added to the **accepted** ADR-0029. Both corrected, each with a visible correction note rather than a silent edit.

## The finding that most changes the argument

**The strongest case for a facade is assembly, not symbol count** — and it isn't the case ADR-0031 leads with. Core's exports are pure kernels, not capabilities. Answering one Tier 1 question takes eight core calls in order:

```text
lintCorpus → readSourceMarkers → resolveAffects → resolveSourceMarkers
  → mergeSourceDeclarations → toGoverningDecisions → bucketDecisions → sortFindings
```

And the ARB queue needs `resolveAsOf` — ~25 lines in `packages/cli/src/queue.ts` implementing `cli-contract.md §As-Of Resolution`, including the rule that a timezone-less datetime is *rejected as ambiguous* rather than guessed at — which is **not exported from core at all**. `buildQueueReport` takes an already-resolved date, so a library consumer computing the queue today either reimplements that resolver or silently disagrees with CI about which decisions are overdue, on the same corpus, on the same day, with no error anywhere.

That is a live defect **independent of this record's fate**, and the clearest evidence for clause 3's narrowing: a contract gap that additive-only discipline on core's exported API could never have caught, **because the missing piece was never exported**. Added as ADR-0031 action item 7 so it survives `docs/sdk-surface.md`. Deliberately **not** fixed here — scope creep.

## Verification

`bun test` 2180 pass / 0 fail · `typecheck` · `adr lint` (31 records, 0 errors) · `check:deps` — all clean, re-run after the record edits. No new ADR, so no id-collision risk.

**Three new checks, each observed failing first (ADR-0016 clause 2):**

- **`check:deps` had no allowlist entry for `@adrkit/sdk`** — so `allowedDependenciesFor()` returned `undefined`, the allowed-surface guard was **skipped entirely**, and `undici` passed silently. This is the exact trap that file's own comment describes: *"omitting an entry does not produce a failure; it produces a green check that means nothing."* Caught only by watching the check fail before adding the entry.
- Clause 8's no-release assertion — confirmed by temporarily adding `@adrkit/sdk` to `scripts/release-pack.ts`.
- Clause 4's no-re-export assertion — confirmed by temporarily adding `export type { Adr } from '@adrkit/core';`.

A dogfood note: `adr explain packages/sdk/src/index.ts` reports *"No accepted decision governs… Active proposals (not yet binding): 0031."* The tool correctly says the package exists under a proposal rather than a decision.

## What this does not establish

- **ADR-0014 rung 0.** No consumer has exercised this surface; the one it was designed for does not exist yet. The record's own trade-off — *"the risk is that the guess hardens before the Backstage plugin tests it"* — is not mitigated here, only made concrete enough to criticize.
- **Nothing is implemented.** Every entry point is a `declare` or an interface member. The eight-call assembly it claims to absorb is argued from reading `runExplain`, not from a passing test.
- **No release, and none prepared.** Clause 7's `versioning: 'independent'` is deliberately not wired into `scripts/release-pack.ts` — that would prepare an act clause 8 does not authorize — and its absence is asserted by test so it is a fact rather than an oversight.
