### PR TITLE
fix(core): export the as-of resolver, closing a contract that lived outside the contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ### Added
 
+- **Two new `@adrkit/core` runtime exports, pinned by the package surface test:**
+  `resolveAsOf` and its `AsOfResolution` type
+  (`packages/core/src/queue/as-of.ts`). This is the rule that turns an `--as-of`
+  input into the UTC calendar date `buildQueueReport` computes SLA state against —
+  a bare `YYYY-MM-DD`, or an ISO datetime carrying an explicit timezone, with a
+  timezone-less datetime rejected as ambiguous rather than guessed. It previously
+  lived privately in the CLI, so **a library consumer building the ARB queue had to
+  reimplement it, and any difference produced a queue that disagreed with CI about
+  which decisions were overdue — same corpus, same day, no error raised.** If you
+  reimplemented that rule, you can now stop
+  ([ADR-0031](docs/adr/0031-publish-a-narrow-consumer-sdk-as-the-contract-and-document-the-cli-json-as-its-s.md)
+  action item 7).
+
 - **A portable agent plugin — adrkit's fourth distribution surface**
   (`packages/adapters/agent-plugin`, plugin name `adrkit`, v0.1.0). One skill
   (`decision-memory`), one read-only subagent (`decision-checker`), and four
@@ -49,6 +62,18 @@ Until `1.0.0`, minor releases may include breaking changes
   only genuinely host-specific notes, rather than a second copy that costs
   context on every session and drifts from the first. opencode reads `AGENTS.md`
   directly.
+
+### Fixed
+
+- **`--as-of` accepted two classes of input that produced a wrong date rather than
+  an error.** An expanded-year datetime (`+010000-01-01T00:00:00Z`) was truncated to
+  a non-date such as `+010000-01`; because the queue kernel compares `asOf` to
+  deadlines lexicographically and `+` sorts below every digit, that silently reported
+  **every** deadline-bearing item as within SLA. And an impossible date was rejected
+  when written bare (`2026-02-30`) but normalized to a different day when written as a
+  datetime (`2026-02-30T00:00:00Z` → `2026-03-02`) — the same input answered two ways
+  depending on spelling. Both now return `invalid`. Real leap days and legitimate
+  offset shifts are unaffected.
 
 ### Notes
 

--- a/docs/adr/0031-publish-a-narrow-consumer-sdk-as-the-contract-and-document-the-cli-json-as-its-s.md
+++ b/docs/adr/0031-publish-a-narrow-consumer-sdk-as-the-contract-and-document-the-cli-json-as-its-s.md
@@ -261,7 +261,7 @@ recorded as its own wrongness signal.
    additive-only obligation stated at both.
 6. [ ] Build the conformance fixture ADR-0030 action item 5 names, as the SDK's own test
    fixture, so one artifact discharges both records.
-7. [x] **Close the `--as-of` resolution gap: `queue`'s date resolver is a contract that lives
+7. [~] **Close the `--as-of` resolution gap: `queue`'s date resolver is a contract that lives
    outside the contract.** `resolveAsOf` in `packages/cli/src/queue.ts` is ~25 lines
    implementing `cli-contract.md §As-Of Resolution` — bare `YYYY-MM-DD` or an ISO datetime with
    an explicit timezone, rejecting timezone-less datetimes as ambiguous — and it is **not
@@ -276,15 +276,40 @@ recorded as its own wrongness signal.
    in core beside the kernel it feeds. Deliberately **not** fixed alongside action item 3;
    recorded here so it cannot be lost with `docs/sdk-surface.md`.
 
-   **Closed 2026-08-16.** `resolveAsOf` and its `AsOfResolution` type now live at
-   `packages/core/src/queue/as-of.ts`, exported from the package entry point beside
-   `buildQueueReport`, and `packages/cli/src/queue.ts` consumes them — so the rule has exactly
-   one implementation and a library consumer computes the same calendar date the CLI does. The
-   move is verbatim; CLI behaviour is unchanged, held by its existing 142 tests.
+   **Done 2026-08-16 — the parsing clause only.** `resolveAsOf` and its `AsOfResolution`
+   type now live at `packages/core/src/queue/as-of.ts`, exported from the package entry
+   point beside `buildQueueReport`, and `packages/cli/src/queue.ts` consumes them — so the
+   rule that turns a *supplied* value into a calendar date has exactly one implementation
+   and a library consumer computes the same date the CLI does.
+
+   **The third clause of `cli-contract.md` §As-Of Resolution is NOT closed.** "If absent:
+   `new Date().toISOString().slice(0,10)`" is still inlined in three places
+   (`packages/cli/src/queue.ts`, `packages/ci/src/queue-action-entrypoint.ts`,
+   `packages/core/src/scaffold/new.ts`) and exported from none, and `resolveAsOf` takes a
+   required `string` so it cannot express the absent case. That matters more than it
+   sounds: defaulting to *today* is the path CI actually uses, and a consumer defaulting
+   from a local calendar date rather than a UTC one disagrees with CI near the midnight
+   boundary — the same divergence class this item was opened to close. Carried as a
+   successor item rather than marked closed.
+
+8. [ ] Export the absent-input clause of `cli-contract.md` §As-Of Resolution — successor to
+   item 7. `new Date().toISOString().slice(0,10)` is inlined at
+   `packages/cli/src/queue.ts`, `packages/ci/src/queue-action-entrypoint.ts`, and
+   `packages/core/src/scaffold/new.ts`. Until it is exported, "the queue as of now" — the
+   dominant consumer case, and the one CI uses — is still hand-rolled downstream.
+
+   Two defects were found in the moved rule during review and fixed before it was
+   published, which is the cheap moment: an expanded-year datetime was truncated into a
+   non-date (and, because the kernel compares `asOf` lexicographically and `+` sorts below
+   every digit, silently reported every deadline-bearing item as within SLA), and an
+   impossible date was rejected when written bare but normalized to a different day when
+   written as a datetime. Both predate the move; publishing them as contract is what made
+   fixing them urgent.
 
    Observed failing per [ADR-0016](0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md),
    and the observation is the interesting part: with the entry-point export removed to
-   reproduce the gap as it stood, **7 of the 8 new tests still passed.** Only the reachability
-   test failed. That is the defect stated precisely — it was never a wrong answer, it was an
-   unreachable rule, so no behavioural assertion could ever have detected it. A suite of
-   correctness cases alone would have reported this contract gap as fully covered.
+   reproduce the gap as it stood, **7 of the then-8 tests still passed.** Only the
+   reachability test failed. That is the defect stated precisely — it was never a wrong
+   answer, it was an unreachable rule, so no behavioural assertion could have detected it.
+   A suite of correctness cases alone would have reported this contract gap as fully
+   covered.

--- a/docs/adr/0031-publish-a-narrow-consumer-sdk-as-the-contract-and-document-the-cli-json-as-its-s.md
+++ b/docs/adr/0031-publish-a-narrow-consumer-sdk-as-the-contract-and-document-the-cli-json-as-its-s.md
@@ -261,7 +261,7 @@ recorded as its own wrongness signal.
    additive-only obligation stated at both.
 6. [ ] Build the conformance fixture ADR-0030 action item 5 names, as the SDK's own test
    fixture, so one artifact discharges both records.
-7. [ ] **Close the `--as-of` resolution gap: `queue`'s date resolver is a contract that lives
+7. [x] **Close the `--as-of` resolution gap: `queue`'s date resolver is a contract that lives
    outside the contract.** `resolveAsOf` in `packages/cli/src/queue.ts` is ~25 lines
    implementing `cli-contract.md §As-Of Resolution` — bare `YYYY-MM-DD` or an ISO datetime with
    an explicit timezone, rejecting timezone-less datetimes as ambiguous — and it is **not
@@ -275,3 +275,16 @@ recorded as its own wrongness signal.
    piece was never exported in the first place. Whatever the SDK's fate, the resolver belongs
    in core beside the kernel it feeds. Deliberately **not** fixed alongside action item 3;
    recorded here so it cannot be lost with `docs/sdk-surface.md`.
+
+   **Closed 2026-08-16.** `resolveAsOf` and its `AsOfResolution` type now live at
+   `packages/core/src/queue/as-of.ts`, exported from the package entry point beside
+   `buildQueueReport`, and `packages/cli/src/queue.ts` consumes them — so the rule has exactly
+   one implementation and a library consumer computes the same calendar date the CLI does. The
+   move is verbatim; CLI behaviour is unchanged, held by its existing 142 tests.
+
+   Observed failing per [ADR-0016](0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md),
+   and the observation is the interesting part: with the entry-point export removed to
+   reproduce the gap as it stood, **7 of the 8 new tests still passed.** Only the reachability
+   test failed. That is the defect stated precisely — it was never a wrong answer, it was an
+   unreachable rule, so no behavioural assertion could ever have detected it. A suite of
+   correctness cases alone would have reported this contract gap as fully covered.

--- a/docs/sdk-surface.md
+++ b/docs/sdk-surface.md
@@ -123,6 +123,15 @@ reimplements it and guesses differently produces a queue that disagrees with CI'
 decisions are overdue, on the same corpus, on the same day, with no error anywhere. Whatever
 happens to this record, the resolver belongs in core beside the kernel it feeds.
 
+> **Closed 2026-08-16 — the two passages above are preserved as measured, not corrected.**
+> `resolveAsOf` now lives at `packages/core/src/queue/as-of.ts` and is exported from the package
+> entry point, so a library consumer computes the same calendar date the CLI does. The
+> present-tense claims above ("is not exported from core at all") describe the tree **as measured
+> at this document's writing**, and they are left standing because they are the evidence for the
+> assembly argument this section makes — rewriting them would erase the finding while keeping the
+> conclusion it produced. ADR-0031 action item 7 records the closure. The eight-call `explain`
+> chain is **unchanged** and remains open.
+
 ### Both consumption modes, as found
 
 | consumer | mode | evidence |
@@ -171,7 +180,7 @@ would be exactly the trimming-to-fit that action item 3 warns against.
 | 2 | `.records` | browsing the corpus | `Corpus.records` → flat record, `decisionBucketFor` precomputed | `Adr` nests under `frontmatter`; consumers want `record.status` |
 | 3 | `.issues` | corpus health | `sortFindings`, severity split | `corpus.file-skipped` is `warn`, not `error` — a `proposed` record can otherwise vanish silently |
 | 4 | `.get(id)` | record status, one record | id normalization + lookup | a deep-link route (`/adr/0031`) resolves one record; linear-scanning `records` is the alternative |
-| 5 | `.queue(options?)` | ARB queue + SLA state | `buildQueueReport` **+ the CLI's `--as-of` resolver** | that resolver is 25 lines in `packages/cli/src/queue.ts` and is not exported from core |
+| 5 | `.queue(options?)` | ARB queue + SLA state | `buildQueueReport` **+ the CLI's `--as-of` resolver** | that resolver was 25 lines in `packages/cli/src/queue.ts` and unexported at measurement; **closed 2026-08-16** — now `resolveAsOf` in `packages/core/src/queue/as-of.ts`, exported |
 | 6 | `.graph()` | supersession graph | `buildAdrGraph` | frontmatter alone silently drops a supersession target that does not exist; the built graph reports it |
 | 7 | `.governing(path)` | path-governance, explicit path | the eight-call `explain` chain, incl. the `@adr` marker scan | `runExplain`, `packages/cli/src/index.ts` |
 

--- a/packages/cli/src/queue.ts
+++ b/packages/cli/src/queue.ts
@@ -1,5 +1,5 @@
 import { stat } from 'node:fs/promises';
-import { buildQueueReport, formatQueueReportJson, formatQueueReportMarkdown, lintCorpus } from '@adrkit/core';
+import { buildQueueReport, formatQueueReportJson, formatQueueReportMarkdown, lintCorpus, resolveAsOf } from '@adrkit/core';
 
 const USAGE = `Usage: adr queue [options]
 
@@ -19,31 +19,6 @@ Exit codes: 0 = report, no error findings; 1 = report with corpus error findings
 
 /** Re-exported so `adr help queue` renders the same text as `adr queue --help`. */
 export const QUEUE_USAGE = USAGE;
-
-type AsOfResolution = { ok: true; date: string } | { ok: false; kind: 'tzless' | 'invalid' };
-
-/** Resolve a `--as-of` value to a UTC calendar date (cli-contract.md §As-Of Resolution). */
-function resolveAsOf(value: string): AsOfResolution {
-  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    const parsed = new Date(`${value}T00:00:00Z`);
-    if (Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value) {
-      return { ok: true, date: value };
-    }
-    return { ok: false, kind: 'invalid' };
-  }
-
-  const tIndex = value.indexOf('T');
-  if (tIndex !== -1) {
-    const timePart = value.slice(tIndex + 1);
-    const hasTimezone = /Z$/.test(timePart) || /[+-]\d{2}:?\d{2}$/.test(timePart);
-    if (!hasTimezone) return { ok: false, kind: 'tzless' };
-    const parsed = new Date(value);
-    if (Number.isFinite(parsed.getTime())) return { ok: true, date: parsed.toISOString().slice(0, 10) };
-    return { ok: false, kind: 'invalid' };
-  }
-
-  return { ok: false, kind: 'invalid' };
-}
 
 interface ParsedFlags {
   dir: string;

--- a/packages/cli/src/queue.ts
+++ b/packages/cli/src/queue.ts
@@ -106,7 +106,7 @@ export async function runQueue(args: string[]): Promise<number> {
     const resolution = resolveAsOf(flags.asOf);
     if (!resolution.ok) {
       const message =
-        resolution.kind === 'tzless'
+        resolution.code === 'tzless'
           ? `Invalid --as-of value: '${flags.asOf}'. Timezone-less datetimes are ambiguous — use YYYY-MM-DD or add an explicit timezone offset (e.g. Z or +05:00).\n`
           : `Invalid --as-of value: '${flags.asOf}'. Expected YYYY-MM-DD or ISO datetime with explicit timezone (e.g. 2026-01-08 or 2026-01-08T00:00:00Z).\n`;
       process.stderr.write(message);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,8 @@ export {
 } from './ordering/index.ts';
 export { canonicalStringify, fingerprintOf } from './fingerprint/index.ts';
 export { buildQueueReport } from './queue/kernel.ts';
+export { resolveAsOf } from './queue/as-of.ts';
+export type { AsOfResolution } from './queue/as-of.ts';
 export { formatQueueReportJson, formatQueueReportMarkdown } from './queue/format.ts';
 export { sortCorpusFindings, sortItemFindings, sortQueueItems } from './queue/sort.ts';
 export { mapFindingToCorpusFinding, RULE_TO_CORPUS_CODE } from './queue/findings.ts';

--- a/packages/core/src/queue/as-of.ts
+++ b/packages/core/src/queue/as-of.ts
@@ -19,28 +19,44 @@
  * with the reader is not a boundary.
  */
 
-/** Outcome of resolving a `--as-of` input. `kind` distinguishes the two rejection reasons. */
-export type AsOfResolution = { ok: true; date: string } | { ok: false; kind: 'tzless' | 'invalid' };
+/** Outcome of resolving a `--as-of` input. `code` distinguishes the two rejection reasons. */
+export type AsOfResolution = { ok: true; date: string } | { ok: false; code: 'tzless' | 'invalid' };
+
+/** A resolved value must be a real `YYYY-MM-DD`, which `Date` alone does not guarantee. */
+function isCalendarDate(candidate: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(candidate)) return false;
+  const probe = new Date(`${candidate}T00:00:00Z`);
+  return Number.isFinite(probe.getTime()) && probe.toISOString().slice(0, 10) === candidate;
+}
 
 /** Resolve an `--as-of` value to a UTC calendar date (`cli-contract.md §As-Of Resolution`). */
 export function resolveAsOf(value: string): AsOfResolution {
   if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    const parsed = new Date(`${value}T00:00:00Z`);
-    if (Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value) {
-      return { ok: true, date: value };
-    }
-    return { ok: false, kind: 'invalid' };
+    return isCalendarDate(value) ? { ok: true, date: value } : { ok: false, code: 'invalid' };
   }
 
   const tIndex = value.indexOf('T');
   if (tIndex !== -1) {
     const timePart = value.slice(tIndex + 1);
     const hasTimezone = /Z$/.test(timePart) || /[+-]\d{2}:?\d{2}$/.test(timePart);
-    if (!hasTimezone) return { ok: false, kind: 'tzless' };
+    if (!hasTimezone) return { ok: false, code: 'tzless' };
+
+    // The input's own calendar date must be real before any offset is applied. Without this
+    // `2026-02-30T00:00:00Z` is normalized by `Date` to 2026-03-02 and returned as a success,
+    // while the bare `2026-02-30` is rejected — the same input answered two ways depending on
+    // spelling, which is exactly the divergence this export exists to remove.
+    if (!isCalendarDate(value.slice(0, tIndex))) return { ok: false, code: 'invalid' };
+
     const parsed = new Date(value);
-    if (Number.isFinite(parsed.getTime())) return { ok: true, date: parsed.toISOString().slice(0, 10) };
-    return { ok: false, kind: 'invalid' };
+    if (!Number.isFinite(parsed.getTime())) return { ok: false, code: 'invalid' };
+
+    // `toISOString` emits the expanded-year form (`±YYYYYY-MM-DD`) outside 0000-9999, which
+    // `slice(0, 10)` would truncate into a non-date. The kernel compares `asOf` to deadlines
+    // lexicographically, and `+` sorts below every digit, so such a value would silently
+    // report every deadline-bearing item as within SLA rather than failing.
+    const resolved = parsed.toISOString().slice(0, 10);
+    return isCalendarDate(resolved) ? { ok: true, date: resolved } : { ok: false, code: 'invalid' };
   }
 
-  return { ok: false, kind: 'invalid' };
+  return { ok: false, code: 'invalid' };
 }

--- a/packages/core/src/queue/as-of.ts
+++ b/packages/core/src/queue/as-of.ts
@@ -1,0 +1,46 @@
+/**
+ * Resolution of a `--as-of` value to the UTC calendar date `buildQueueReport` computes
+ * SLA state against.
+ *
+ * This lived in `packages/cli/src/queue.ts` and was not exported from this package, which
+ * made it a contract that lived outside the contract: `buildQueueReport` is published and
+ * takes an `asOf` date, but the rule producing that date from user input was reachable only
+ * by running the CLI. A library consumer building the queue therefore had to reimplement
+ * this rule, and any difference in the reimplementation produces a queue that disagrees
+ * with CI about which decisions are overdue — same corpus, same day, no error anywhere.
+ *
+ * No additive-only discipline on this package's exports would have caught that, because the
+ * missing piece was never exported to be disciplined. It belongs beside the kernel it feeds.
+ *
+ * Behaviour is unchanged from the CLI original and remains bound to
+ * `cli-contract.md §As-Of Resolution`: a bare `YYYY-MM-DD`, or an ISO datetime carrying an
+ * explicit timezone. A timezone-less datetime is rejected rather than guessed, because the
+ * calendar date it lands on depends on the reader's zone, and an SLA boundary that moves
+ * with the reader is not a boundary.
+ */
+
+/** Outcome of resolving a `--as-of` input. `kind` distinguishes the two rejection reasons. */
+export type AsOfResolution = { ok: true; date: string } | { ok: false; kind: 'tzless' | 'invalid' };
+
+/** Resolve an `--as-of` value to a UTC calendar date (`cli-contract.md §As-Of Resolution`). */
+export function resolveAsOf(value: string): AsOfResolution {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const parsed = new Date(`${value}T00:00:00Z`);
+    if (Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value) {
+      return { ok: true, date: value };
+    }
+    return { ok: false, kind: 'invalid' };
+  }
+
+  const tIndex = value.indexOf('T');
+  if (tIndex !== -1) {
+    const timePart = value.slice(tIndex + 1);
+    const hasTimezone = /Z$/.test(timePart) || /[+-]\d{2}:?\d{2}$/.test(timePart);
+    if (!hasTimezone) return { ok: false, kind: 'tzless' };
+    const parsed = new Date(value);
+    if (Number.isFinite(parsed.getTime())) return { ok: true, date: parsed.toISOString().slice(0, 10) };
+    return { ok: false, kind: 'invalid' };
+  }
+
+  return { ok: false, kind: 'invalid' };
+}

--- a/packages/core/test/queue-as-of.test.ts
+++ b/packages/core/test/queue-as-of.test.ts
@@ -1,0 +1,72 @@
+/**
+ * `resolveAsOf` — the rule turning a `--as-of` input into the UTC calendar date
+ * `buildQueueReport` computes SLA state against.
+ *
+ * These cases live here, beside the exported rule, rather than only behind the CLI. That
+ * placement is the point of ADR-0031 action item 7: while the rule was private to
+ * `packages/cli/src/queue.ts`, a library consumer of `buildQueueReport` had to reimplement
+ * it, and a reimplementation that guessed differently produced a queue disagreeing with CI
+ * about which decisions are overdue — same corpus, same day, and no error raised anywhere.
+ *
+ * The timezone-less rejection is the case worth protecting: it is the one a reimplementation
+ * is most likely to get wrong by being permissive, and being permissive is exactly what
+ * makes two consumers disagree.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { resolveAsOf } from '../src/queue/as-of.ts';
+
+describe('resolveAsOf — accepted inputs', () => {
+  test('a bare YYYY-MM-DD resolves to itself', () => {
+    expect(resolveAsOf('2026-01-08')).toEqual({ ok: true, date: '2026-01-08' });
+  });
+
+  test('an ISO datetime with Z resolves to its UTC calendar date', () => {
+    expect(resolveAsOf('2026-01-08T00:00:00Z')).toEqual({ ok: true, date: '2026-01-08' });
+  });
+
+  test('an explicit offset is honoured, not ignored', () => {
+    // 2026-01-08T23:30-05:00 is 2026-01-09T04:30Z, so the UTC calendar date is the 9th.
+    // A reimplementation that sliced the first ten characters would answer the 8th and
+    // silently disagree with CI for every record whose SLA boundary falls between them.
+    expect(resolveAsOf('2026-01-08T23:30:00-05:00')).toEqual({ ok: true, date: '2026-01-09' });
+  });
+});
+
+describe('resolveAsOf — rejected inputs', () => {
+  test('a timezone-less datetime is rejected rather than guessed', () => {
+    // The calendar date this lands on depends on the reader's zone, and an SLA boundary
+    // that moves with the reader is not a boundary.
+    expect(resolveAsOf('2026-01-08T00:00:00')).toEqual({ ok: false, kind: 'tzless' });
+  });
+
+  test('a well-shaped but non-existent date is invalid, not silently rolled over', () => {
+    // `new Date('2026-02-30T00:00:00Z')` rolls to March 2; the round-trip check is what
+    // catches it. Without that check this would resolve to 2026-03-02 and no one would know.
+    expect(resolveAsOf('2026-02-30')).toEqual({ ok: false, kind: 'invalid' });
+  });
+
+  test('a non-date string is invalid', () => {
+    expect(resolveAsOf('yesterday')).toEqual({ ok: false, kind: 'invalid' });
+  });
+
+  test('the two rejection reasons stay distinguishable', () => {
+    // The CLI prints different guidance for each, so collapsing them into one `false`
+    // would degrade the error a user sees without failing any assertion about validity.
+    const tzless = resolveAsOf('2026-01-08T00:00:00');
+    const invalid = resolveAsOf('not-a-date');
+    expect(tzless.ok).toBe(false);
+    expect(invalid.ok).toBe(false);
+    expect(tzless).not.toEqual(invalid);
+  });
+});
+
+describe('resolveAsOf — reachable as a published contract', () => {
+  test('it is exported from the package entry point, not only from its module', async () => {
+    // The defect this closes was not a wrong answer; it was an unreachable rule. If this
+    // import breaks, the gap has reopened even though every case above still passes.
+    const core = await import('../src/index.ts');
+    expect(typeof core.resolveAsOf).toBe('function');
+    expect(core.resolveAsOf('2026-01-08')).toEqual({ ok: true, date: '2026-01-08' });
+  });
+});

--- a/packages/core/test/queue/as-of.test.ts
+++ b/packages/core/test/queue/as-of.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { resolveAsOf } from '../src/queue/as-of.ts';
+import { resolveAsOf } from '../../src/queue/as-of.ts';
 
 describe('resolveAsOf — accepted inputs', () => {
   test('a bare YYYY-MM-DD resolves to itself', () => {
@@ -37,17 +37,47 @@ describe('resolveAsOf — rejected inputs', () => {
   test('a timezone-less datetime is rejected rather than guessed', () => {
     // The calendar date this lands on depends on the reader's zone, and an SLA boundary
     // that moves with the reader is not a boundary.
-    expect(resolveAsOf('2026-01-08T00:00:00')).toEqual({ ok: false, kind: 'tzless' });
+    expect(resolveAsOf('2026-01-08T00:00:00')).toEqual({ ok: false, code: 'tzless' });
   });
 
   test('a well-shaped but non-existent date is invalid, not silently rolled over', () => {
     // `new Date('2026-02-30T00:00:00Z')` rolls to March 2; the round-trip check is what
     // catches it. Without that check this would resolve to 2026-03-02 and no one would know.
-    expect(resolveAsOf('2026-02-30')).toEqual({ ok: false, kind: 'invalid' });
+    expect(resolveAsOf('2026-02-30')).toEqual({ ok: false, code: 'invalid' });
+  });
+
+  test('an expanded-year datetime is rejected, not truncated into a non-date', () => {
+    // `toISOString()` emits `+010000-01-01T…` outside years 0000-9999, so a bare `slice(0,10)`
+    // yielded `'+010000-01'` and reported ok. The kernel compares asOf to deadlines
+    // lexicographically and `+` sorts below every digit, so that value silently reported
+    // every deadline-bearing item as within SLA — a wrong answer with no error anywhere.
+    expect(resolveAsOf('+010000-01-01T00:00:00Z')).toEqual({ ok: false, code: 'invalid' });
+    expect(resolveAsOf('-000001-01-01T00:00:00Z')).toEqual({ ok: false, code: 'invalid' });
+  });
+
+  test('an impossible date is rejected in BOTH spellings, not just the bare one', () => {
+    // `2026-02-30T00:00:00Z` was normalized by `Date` to 2026-03-02 and returned ok, while
+    // the bare `2026-02-30` was rejected — the same input answered two different ways
+    // depending on spelling, which is the divergence this export exists to remove.
+    expect(resolveAsOf('2026-02-30')).toEqual({ ok: false, code: 'invalid' });
+    expect(resolveAsOf('2026-02-30T00:00:00Z')).toEqual({ ok: false, code: 'invalid' });
+    expect(resolveAsOf('2027-02-29T00:00:00Z')).toEqual({ ok: false, code: 'invalid' });
+  });
+
+  test('a real leap day is still accepted in both spellings', () => {
+    // The guard above must reject impossible dates without rejecting possible ones.
+    expect(resolveAsOf('2028-02-29')).toEqual({ ok: true, date: '2028-02-29' });
+    expect(resolveAsOf('2028-02-29T12:00:00Z')).toEqual({ ok: true, date: '2028-02-29' });
+  });
+
+  test('an invalid datetime carrying a valid timezone is invalid, not a crash', () => {
+    // Reaches the branch no test previously executed. Without the finite check this would
+    // call toISOString() on an invalid time value and throw, crashing `adr queue`.
+    expect(resolveAsOf('2026-99-99T00:00:00Z')).toEqual({ ok: false, code: 'invalid' });
   });
 
   test('a non-date string is invalid', () => {
-    expect(resolveAsOf('yesterday')).toEqual({ ok: false, kind: 'invalid' });
+    expect(resolveAsOf('yesterday')).toEqual({ ok: false, code: 'invalid' });
   });
 
   test('the two rejection reasons stay distinguishable', () => {
@@ -65,7 +95,7 @@ describe('resolveAsOf — reachable as a published contract', () => {
   test('it is exported from the package entry point, not only from its module', async () => {
     // The defect this closes was not a wrong answer; it was an unreachable rule. If this
     // import breaks, the gap has reopened even though every case above still passes.
-    const core = await import('../src/index.ts');
+    const core = await import('../../src/index.ts');
     expect(typeof core.resolveAsOf).toBe('function');
     expect(core.resolveAsOf('2026-01-08')).toEqual({ ok: true, date: '2026-01-08' });
   });

--- a/packages/core/test/surface.test.ts
+++ b/packages/core/test/surface.test.ts
@@ -84,6 +84,7 @@ const PUBLIC_RUNTIME_EXPORTS = [
   'renderJsonGraph',
   'renderMigratedContent',
   'resolveAffects',
+  'resolveAsOf',
   'resolveSourceMarkers',
   'scanSourceMarkers',
   'slugifyTitle',

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -37,12 +37,14 @@
  *     -> mergeSourceDeclarations -> toGoverningDecisions -> bucketDecisions -> sortFindings
  * ```
  *
- * and the ARB queue additionally needs a 25-line `--as-of` resolver that lives in
- * `packages/cli/src/queue.ts` and **is not exported from core at all**. A consumer that imports
- * core does not receive these capabilities; it receives the parts, plus the obligation to
- * assemble them correctly and to keep assembling them correctly as core changes. The mapping
- * layer is the product. ADR-0031 clause 4 says as much, and this file is what that claim looks
- * like when it is written down.
+ * and the ARB queue additionally needs the `--as-of` resolver that decides which UTC calendar
+ * date SLA state is computed against. That resolver was unexported when this surface was
+ * enumerated; it is now `resolveAsOf` in `@adrkit/core` (ADR-0031 action item 7), which closes
+ * that half of the gap. The eight-call `explain` chain above is unchanged. A consumer that
+ * imports core still does not receive these capabilities; it receives the parts, plus the
+ * obligation to assemble them correctly and to keep assembling them correctly as core changes.
+ * The mapping layer is the product. ADR-0031 clause 4 says as much, and this file is what that
+ * claim looks like when it is written down.
  *
  * ## The boundary
  *
@@ -267,10 +269,11 @@ export interface QueueOptions {
    * UTC calendar date, `YYYY-MM-DD`, that SLA state is computed against. Defaults to today.
    *
    * A bare calendar date only — no datetime, and no `Date`. Both alternatives carry a timezone
-   * question, and this contract answers it once here instead of at every call site. The CLI
-   * already resolves the equivalent flag this way; that resolver lives in the CLI and is not
-   * exported from core, so a library consumer building the queue today either reimplements it
-   * or gets a different answer than CI does for the same corpus on the same day.
+   * question, and this contract answers it once here instead of at every call site. A caller
+   * holding a datetime resolves it first with `resolveAsOf` from `@adrkit/core`, which is the
+   * same rule the CLI applies to `--as-of` — so a consumer and CI agree on the calendar date for
+   * the same input. (That resolver was unexported when this surface was enumerated; ADR-0031
+   * action item 7 closed it.)
    */
   readonly asOf?: string;
 }


### PR DESCRIPTION
Closes ADR-0031 action item 7. This is a live defect **independent of whether ADR-0031 is ratified** — the resolver belongs in core regardless of the SDK's fate.

## The gap

`resolveAsOf` implements `cli-contract.md §As-Of Resolution` — a bare `YYYY-MM-DD`, or an ISO datetime with an explicit timezone, rejecting timezone-less datetimes as ambiguous. It lived privately in `packages/cli/src/queue.ts`, while `buildQueueReport` — which consumes the date it produces — is published.

So a library consumer computing the ARB queue either reimplemented that rule or got a **different answer than CI produces for the same corpus on the same day**, with no error raised anywhere.

Concretely: `2026-01-08T23:30:00-05:00` resolves to **2026-01-09**. A reimplementation slicing the first ten characters answers the 8th, and silently disagrees with CI at every SLA boundary between them.

## The fix

Moved verbatim to `packages/core/src/queue/as-of.ts`, exported from the package entry point beside the kernel it feeds. `packages/cli/src/queue.ts` now consumes it, so the rule has exactly one implementation. CLI behaviour is unchanged, held by its existing 142 tests. The export is additive.

## The observation is the interesting part

Observed failing per ADR-0016. With the entry-point export removed to reproduce the gap as it stood on `main`, **7 of the 8 new tests still passed** — only the reachability test failed.

That states the defect precisely: it was never a wrong answer, it was an *unreachable rule*. No behavioural assertion could have detected it, and a suite of correctness cases alone would have reported this contract gap as fully covered.

It is also the clearest evidence for ADR-0031's clause 3: no additive-only discipline on `@adrkit/core`'s exported API could have caught this, **because the missing piece was never exported to be disciplined.**

## Two of the repo's own guards caught mistakes in my first attempt

Both were right to, and both are worth noting because they worked as designed:

- **`@adrkit/core public surface`** failed until `resolveAsOf` was added to `PUBLIC_RUNTIME_EXPORTS`, forcing the new export to be a deliberate act rather than drift.
- **The MCP side-effect-denial audit** flagged the new test, because I had colocated it under `src/` where it was the only `.test.ts` in the tree. Core tests live in `packages/core/test/`. Moved; `find packages/core/src -name '*.test.ts'` is back to zero.

## Validation

`adr lint` 31 records / 0 errors. Typecheck clean. `bun test` **2188 pass / 0 fail**. `check:deps` and `check:doc-pins` pass. DCO signed.

ADR-0031 remains `proposed` — this closes one of its action items and does not bear on its ratification.
