### PR TITLE
fix(core): normalize separators only where the platform has them

### DIFF
--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -48437,10 +48437,11 @@ function mergeSourceDeclarations(patternDecisions, records, markerMatches) {
   return [...merged, ...markerOnly].sort((a, b) => compareCodeUnits(a.recordId, b.recordId));
 }
 // ../core/src/check/index.ts
+import { sep as sep4 } from "node:path";
 var RECORD_BASENAME = /^\d{4,}-.+\.md$/;
 var TEMPLATE_BASENAME = "0000-template.md";
 function normalizeDir(dir) {
-  const forward = (dir ?? "docs/adr").replace(/\\/g, "/");
+  const forward = toForwardSlash(dir ?? "docs/adr");
   let end = forward.length;
   while (end > 0 && forward.charCodeAt(end - 1) === 47)
     end -= 1;
@@ -48448,7 +48449,7 @@ function normalizeDir(dir) {
   return stripped === "." ? "" : stripped;
 }
 function toForwardSlash(path) {
-  return path.replace(/\\/g, "/");
+  return sep4 === "\\" ? path.replace(/\\/g, "/") : path;
 }
 function isCorpusRecordPath(file2, dir) {
   const prefix = dir ? `${dir}/` : "";

--- a/packages/core/src/check/index.ts
+++ b/packages/core/src/check/index.ts
@@ -3,6 +3,7 @@
 // same record. It is kept because it is the repository's own working example of the
 // declaration rendering; it does not demonstrate the marker-only case, which needs a
 // file the corpus reaches by no pattern at all.
+import { sep } from 'node:path';
 import type { Adr } from '../schema/adr.schema.ts';
 import { resolveAffects, type ResolutionSnapshots } from '../affects/index.ts';
 import { mergeSourceDeclarations, resolveSourceMarkers } from '../markers/resolve.ts';
@@ -91,7 +92,7 @@ const RECORD_BASENAME = /^\d{4,}-.+\.md$/;
 const TEMPLATE_BASENAME = '0000-template.md';
 
 function normalizeDir(dir: string | undefined): string {
-  const forward = (dir ?? 'docs/adr').replace(/\\/g, '/');
+  const forward = toForwardSlash(dir ?? 'docs/adr');
   // Strip trailing slashes without a regex (avoids super-linear scanning on
   // pathological input — the changed-file paths are attacker-controlled).
   let end = forward.length;
@@ -102,8 +103,20 @@ function normalizeDir(dir: string | undefined): string {
   return stripped === '.' ? '' : stripped;
 }
 
+/**
+ * Normalize separators only where the platform has them.
+ *
+ * A backslash is a separator on Windows and an ordinary filename character on POSIX.
+ * Rewriting it unconditionally invented a path identity: a real file named
+ * `src/we\ird.ts` was matched against `affects` globs — and reported in
+ * `changedFiles` — as `src/we/ird.ts`, which may be an entirely different file.
+ *
+ * This is the same rule `normalizeMarkerPath` applies on the marker side
+ * (`../markers/read.ts`). The two resolvers must agree about path identity, and the
+ * marker side is the one that was already correct.
+ */
 function toForwardSlash(path: string): string {
-  return path.replace(/\\/g, '/');
+  return sep === '\\' ? path.replace(/\\/g, '/') : path;
 }
 
 /**

--- a/packages/core/test/check.test.ts
+++ b/packages/core/test/check.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { sep } from 'node:path';
 import { checkChanges, type CheckLintResult } from '../src/check/index.ts';
 import type { SourceMarkerScan } from '../src/markers/read.ts';
 import type { Adr } from '../src/schema/adr.schema.ts';
@@ -119,14 +120,53 @@ describe('checkChanges (core)', () => {
     expect(outcome.changedRecords).toEqual(['docs/adr/0001-x.md']);
   });
 
-  test('Windows-style backslash changed paths are normalized to forward slashes', () => {
+  test.skipIf(sep !== '\\')('Windows-style backslash changed paths are normalized to forward slashes', () => {
+    const outcome = checkChanges({
+      lint: emptyLint(),
+      changedFiles: ['docs\\adr\\0001-x.md'],
+      dir: 'docs\\adr',
+    });
+    expect(outcome.changedFiles).toEqual(['docs/adr/0001-x.md']);
+    expect(outcome.changedRecords).toEqual(['docs/adr/0001-x.md']);
+  });
+
+  // On POSIX a backslash is an ordinary filename character, so rewriting it invents a
+  // path identity: `src/we\ird.ts` would be matched against `affects` globs — and
+  // reported in `changedFiles` — as `src/we/ird.ts`, which may be a different file.
+  // The marker side already gets this right (`normalizeMarkerPath`); this is the half
+  // that disagreed with it.
+  test.skipIf(sep === '\\')('a literal backslash in a POSIX filename survives normalization', () => {
+    const outcome = checkChanges({
+      lint: emptyLint(),
+      changedFiles: ['src/we\\ird.ts'],
+      dir: 'docs/adr',
+    });
+    expect(outcome.changedFiles).toEqual(['src/we\\ird.ts']);
+  });
+
+  test.skipIf(sep === '\\')('a POSIX backslash path is not mistaken for a corpus record', () => {
+    // `docs\adr\0001-x.md` is one oddly-named file at the repo root on POSIX, not a
+    // record inside `docs/adr`. Rewriting it would make an unrelated file count as a
+    // changed ADR record.
     const outcome = checkChanges({
       lint: emptyLint(),
       changedFiles: ['docs\\adr\\0001-x.md'],
       dir: 'docs/adr',
     });
-    expect(outcome.changedFiles).toEqual(['docs/adr/0001-x.md']);
-    expect(outcome.changedRecords).toEqual(['docs/adr/0001-x.md']);
+    expect(outcome.changedRecords).toEqual([]);
+  });
+
+  test.skipIf(sep === '\\')('a POSIX corpus directory preserves its literal backslash', () => {
+    // `docs\adr` is a directory name containing a literal backslash. The slash before
+    // the record remains the real path separator, so both sides must preserve the same
+    // directory identity.
+    const outcome = checkChanges({
+      lint: emptyLint(),
+      changedFiles: ['docs\\adr/0001-x.md'],
+      dir: 'docs\\adr',
+    });
+    expect(outcome.changedFiles).toEqual(['docs\\adr/0001-x.md']);
+    expect(outcome.changedRecords).toEqual(['docs\\adr/0001-x.md']);
   });
 
   test('resolves pre-scanned markers without performing I/O and reports scan state', () => {


### PR DESCRIPTION
Closes #114.

`toForwardSlash` replaced every backslash unconditionally. On POSIX a backslash is an ordinary filename character, so a real file named `src/we\ird.ts` was matched against `affects` globs — and reported in `outcome.changedFiles` — as `src/we/ird.ts`, a path that may belong to an entirely different file. The sharper consequence: an unrelated root-level file named `docs\adr\0001-x.md` was counted as a changed ADR record purely because normalization invented the `docs/adr/` prefix.

The fix adopts the rule `normalizeMarkerPath` already applies on the marker side (`sep === '\\'`), per the issue's guidance — and deliberately not the reverse, which would have reintroduced the bug #106 fixed.

Per ADR-0016, both regression tests were observed failing against the pre-fix tree:

- *a literal backslash in a POSIX filename survives normalization* — expected `["src/we\\ird.ts"]`, received `["src/we/ird.ts"]`
- *a POSIX backslash path is not mistaken for a corpus record* — expected `[]`, received `["docs/adr/0001-x.md"]`

The existing Windows test asserted the old unconditional behavior, so it is now `skipIf(sep !== '\\')` and the new POSIX pair is `skipIf(sep === '\\')` — each platform asserts its own rule. `packages/core`: 373 pass, 1 skip (the Windows case on a POSIX host), 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)