### PR TITLE
release: v0.9.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: adrkit version
       description: Output of `adr --version` (or the package version you installed).
-      placeholder: '0.8.0'
+      placeholder: '0.9.0'
     validations:
       required: true
   - type: dropdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Decision memory for human- and agent-authored plans — machine-readable ADRs
 that are enforceable in CI and legible to agents, without leaving git.
-Status: early — phases 0–6 landed and v0.8.0 is public. `@adrkit/core`,
+Status: early — phases 0–6 landed and v0.9.0 is public. `@adrkit/core`,
 `@adrkit/evaluator`, `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
 `check`, `queue`, `migrate --from madr`, `evaluate`) are published on npm, as is
 the independently versioned `@adrkit/spec-kit` Spec Kit extension (0.1.2); the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-24
+
 ### Added
 
-- **Two new `@adrkit/core` runtime exports, pinned by the package surface test:**
-  `resolveAsOf` and its `AsOfResolution` type
+- **A new `@adrkit/core` runtime export, plus its result type:**
+  `resolveAsOf` (pinned by the package surface test) and `AsOfResolution`
   (`packages/core/src/queue/as-of.ts`). This is the rule that turns an `--as-of`
   input into the UTC calendar date `buildQueueReport` computes SLA state against —
   a bare `YYYY-MM-DD`, or an ISO datetime carrying an explicit timezone, with a
@@ -64,6 +66,15 @@ Until `1.0.0`, minor releases may include breaking changes
   directly.
 
 ### Fixed
+
+- **Path normalization now preserves literal backslashes on POSIX.**
+  `checkChanges` converts backslashes only where the runtime platform treats them
+  as separators, and applies that same rule to changed paths and the ADR corpus
+  directory. This prevents one POSIX filename from being reported or governed as
+  a different path, and prevents a root-level file such as
+  `docs\adr\0001-x.md` from being mistaken for an ADR under `docs/adr`. The
+  committed governing-decisions Action bundle carries the same fix
+  ([#160](https://github.com/mbeacom/adrkit/pull/160)).
 
 - **`--as-of` accepted two classes of input that produced a wrong date rather than
   an error.** An expanded-year datetime (`+010000-01-01T00:00:00Z`) was truncated to
@@ -1058,7 +1069,8 @@ against live Spec Kit, rather than reasoning about it:
 - Node-targeted published distribution of all packages, smoke-tested under Node
   22 and 24.
 
-[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/mbeacom/adrkit/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mbeacom/adrkit/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mbeacom/adrkit/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mbeacom/adrkit/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ different artifact from a heading convention. That is the whole thesis.
 
 Early, under active development, and deliberately honest about what is proven.
 
-- **Published — v0.8.0 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
+- **Published — v0.9.0 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
   the deterministic Pass 0 `@adrkit/evaluator`, and the read-only `@adrkit/mcp`
   server are all implemented and released. The MCP server speaks both protocol
   eras and passed real-session dogfood against the published artifact on each,

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "bin": {
         "adr": "./dist/index.js",
         "adrkit": "./dist/index.js",
@@ -70,7 +70,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -85,7 +85,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -96,7 +96,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,12 +9,12 @@ Action:
 | `@adrkit/evaluator` | npm |
 | `@adrkit/cli` (`adr`, `adrkit`) | npm |
 | `@adrkit/mcp` (`adrkit-mcp`) | npm |
-| `packages/ci/action.yml` | Git tag (latest immutable release `v0.8.0`, moving `v0`) |
+| `packages/ci/action.yml` | Git tag (latest immutable release `v0.9.0`, moving `v0`) |
 
 `@adrkit/ci` stays private because GitHub executes the committed Action bundle
 directly from the referenced repository ref.
 
-The coordinated lockstep surface is published; the current release is `v0.8.0`. `@adrkit/core`,
+The coordinated lockstep surface is published; the current release is `v0.9.0`. `@adrkit/core`,
 `@adrkit/evaluator`, and `@adrkit/cli` use GitHub Actions Trusted Publishing.
 `@adrkit/mcp` was created with the isolated one-time bootstrap path below; its
 Trusted Publisher and token-restriction cleanup must be completed before the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Decision memory for human and agent-authored plans \u2014 machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,7 +37,7 @@ import { isMainModule } from './main-module.ts';
  * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
  * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
  */
-export const CLI_VERSION = '0.8.0';
+export const CLI_VERSION = '0.9.0';
 
 function writeStdout(text: string): void {
   process.stdout.write(text);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adrkit/mcp",
   "mcpName": "dev.adrkit/mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetDecisionContext } from './tools/get-decision-context.ts';
 import { registerListSuperseded } from './tools/list-superseded.ts';
 import type { ToolConfig } from './tools/shared.ts';
 
-export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.8.0' } as const;
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.9.0' } as const;
 
 /**
  * The MCP protocol revision this server serves through `serveStdio`'s modern era.

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -14,7 +14,7 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
 				</svg>
 				CLI works today
 			</span>
-			<span>v0.8.0 on npm · decision memory in git</span>
+			<span>v0.9.0 on npm · decision memory in git</span>
 		</div>
 
 		<h1 id="_top" data-page-title set:html={title} />

--- a/site/src/content/docs/badges.mdx
+++ b/site/src/content/docs/badges.mdx
@@ -92,8 +92,8 @@ jobs:
       # current release.
       - run: |
           mkdir -p .adrkit
-          npx @adrkit/cli@0.8.0 queue --format json > .adrkit/queue.json.tmp
-          npx @adrkit/cli@0.8.0 lint --json  > .adrkit/lint.json.tmp
+          npx @adrkit/cli@0.9.0 queue --format json > .adrkit/queue.json.tmp
+          npx @adrkit/cli@0.9.0 lint --json  > .adrkit/lint.json.tmp
 
       # A truncated or malformed write renders as `no result` on the badge, which
       # reads as a bug in your tooling. Fail here instead of committing it.

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -43,7 +43,7 @@ The Action finds the comment it posted on an earlier push and edits it in place,
 pull request carries one governing-decisions comment however many times you push
 ([ADR-0026](/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows/)). Releases **through `v0.6.0` could not do this on their own** and
 needed an `env: GITHUB_TOKEN: ${{ github.token }}` block
-([#107](https://github.com/mbeacom/adrkit/issues/107)). `@v0` now resolves to `v0.8.0`,
+([#107](https://github.com/mbeacom/adrkit/issues/107)). `@v0` now resolves to `v0.9.0`,
 so that block is no longer required — and costs nothing if you still have it, because
 the Action never reads the variable to identify its token.
 
@@ -55,8 +55,8 @@ updated in place. The runner log confirms the variable was genuinely absent rath
 merely deleted from a file. The observation covers the **default `GITHUB_TOKEN`**; a
 custom GitHub App token takes the same code path but has not been observed separately.
 
-`v0` is a moving major tag, and it now resolves to a `v0.8.0` build. Pin the
-immutable `v0.8.0` tag or a commit SHA for maximum reproducibility.
+`v0` is a moving major tag, and it now resolves to a `v0.9.0` build. Pin the
+immutable `v0.9.0` tag or a commit SHA for maximum reproducibility.
 
 Every same-repository, non-Dependabot pull request in the adrkit repository runs this
 Action against itself and asserts the result. Fork and Dependabot pull requests are
@@ -73,14 +73,14 @@ open for both.
 </Aside>
 
 <Aside type="caution" title="Pinning a release tag by SHA">
-	The `v*` release tags are **annotated**, so `refs/tags/v0.8.0` resolves to a tag
+	The `v*` release tags are **annotated**, so `refs/tags/v0.9.0` resolves to a tag
 	object rather than a commit, and `uses:` rejects that SHA. Pin the commit the tag
 	points *at*:
 
 	```sh
-	git rev-parse v0.8.0^{commit}
+	git rev-parse v0.9.0^{commit}
 	# or, over the API — this endpoint peels the tag for you:
-	gh api repos/mbeacom/adrkit/commits/v0.8.0 --jq .sha
+	gh api repos/mbeacom/adrkit/commits/v0.9.0 --jq .sha
 	```
 
 	Note that `GET /git/ref/tags/{tag}` does **not** peel: its `object.sha` is the tag

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
 <div class="adr-home">
 	<section class="adr-status-band" aria-label="Project status">
 		<div class="adr-status-band__item">
-			<span class="adr-status adr-status--current">Published · v0.8.0</span>
+			<span class="adr-status adr-status--current">Published · v0.9.0</span>
 			<p><code>@adrkit/core</code>, <code>@adrkit/cli</code>, <code>@adrkit/evaluator</code>, and <code>@adrkit/mcp</code> are on npm, plus the independently versioned <code>@adrkit/spec-kit</code> extension; the CI Action ships at <code>mbeacom/adrkit/packages/ci@v0</code>.</p>
 		</div>
 		<div class="adr-status-band__item">

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -10,7 +10,7 @@ decisions govern a file, renders the decision graph, migrates an existing MADR
 corpus in place, emits the ARB operations queue, and runs the deterministic
 evaluator.
 
-<Aside type="tip" title="Published on npm (v0.8.0)">
+<Aside type="tip" title="Published on npm (v0.9.0)">
 	`@adrkit/cli` is live. Consumers install it with your Node package manager and
 	run the `adr` binary — no clone required. Published artifacts are Node-targeted
 	([ADR-0010](/adr/0010-bun-toolchain/)); Bun is used for developing adrkit


### PR DESCRIPTION
## Summary

- bump the four lockstep npm packages, CLI/MCP runtime metadata, and root release version to `0.9.0`
- finalize the `v0.9.0` changelog, including the `resolveAsOf` API and correctness fixes plus PR #160's POSIX path-identity fix
- advance current-version references and executable CLI pins across the README, release runbook, issue template, and site
- keep the proposed `@adrkit/sdk` sketch at `0.0.0` and outside `RELEASE_PACKAGES`

## Release validation

- Bun 1.3.14 frozen install, typecheck, build, lint, and full test suite
- schema emit drift, dependency boundaries, ADR lint, freeze hashes, site grammar, changelog, and published-doc pin guards
- release pack prepared all five expected artifacts for `v0.9.0`
- installed-tarball smoke passed on Node 22
- packed consumer tree: `npm audit` found 0 vulnerabilities
- Astro documentation site built successfully
- publish dry-run completed for all four `0.9.0` packages, then reached the documented dry-run-only `@adrkit/spec-kit@0.1.2` republish refusal; the real workflow skips that unchanged artifact after its registry integrity matches

## After merge

1. Create and push the annotated release tag from the merged release commit:

   ```sh
   git switch main
   git pull --ff-only
   git tag -a v0.9.0 -m "v0.9.0"
   git push origin v0.9.0
   ```

2. Approve the protected `npm` environment deployment. Confirm the workflow publishes the four lockstep npm packages, creates the immutable GitHub release, and advances the moving `v0` Action tag.

3. After npm publication is visible, publish the version-pinned official MCP registry entry manually—no workflow performs this step:

   ```sh
   npm view @adrkit/mcp@0.9.0 version
   npm view @adrkit/mcp@0.9.0 mcpName
   cd packages/mcp
   mcp-publisher publish
   ```

4. Verify `dev.adrkit/mcp` reports version `0.9.0`, status `active`, and `isLatest: true`:

   ```sh
   curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=dev.adrkit/mcp"
   ```

See `docs/RELEASING.md` steps 5–9 and `docs/DISTRIBUTION.md` §A for the complete cutover procedure.