### PR TITLE
feat(cli): mature help and error guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+### Changed
+
+- **The CLI help is now task-oriented and suitable for discovery.** Top-level
+  help names and describes each command, shows common workflows, links to the
+  command reference, and no longer exposes an internal ADR citation. Every
+  command now documents its arguments and examples; usage errors point to the
+  relevant command instead of dumping unrelated global help; likely command
+  typos receive a suggestion; and invoking `adr` without arguments shows help
+  successfully.
+
 ## [0.9.0] - 2026-08-24
 
 ### Added

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,0 +1,42 @@
+import { isAbsolute, resolve } from 'node:path';
+
+export type CorpusDirectoryErrorKind = 'not-found' | 'not-readable';
+
+const CORPUS_DIRECTORY_NOT_FOUND_CODES = new Set(['ENOENT', 'ENOTDIR']);
+const CORPUS_DIRECTORY_NOT_READABLE_CODES = new Set(['EACCES', 'EPERM', 'ELOOP', 'ENAMETOOLONG']);
+const CORPUS_DIRECTORY_ROOT_READ_CODES = new Set(['EIO', 'ESTALE']);
+
+export function formatUsageError(message: string, usage: string, command?: string): string {
+  const header = `Error: ${message}\n`;
+  if (!command) return `${header}\n${usage}`;
+
+  const usageLine = usage.split('\n', 1)[0] ?? `Usage: adr ${command} [options]`;
+  return `${header}\n${usageLine}\nRun 'adr help ${command}' for more information.\n`;
+}
+
+export function corpusDirectoryErrorMessage(dir: string, kind: CorpusDirectoryErrorKind): string {
+  const state = kind === 'not-readable' ? 'not readable' : 'not found';
+  return `Corpus directory ${state}: "${dir}".`;
+}
+
+export function corpusDirectoryErrorKind(
+  error: unknown,
+  dir: string,
+  cwd = process.cwd(),
+): CorpusDirectoryErrorKind | undefined {
+  const code = typeof error === 'object' && error !== null && 'code' in error ? String(error.code) : undefined;
+  if (
+    code === undefined ||
+    (!CORPUS_DIRECTORY_NOT_FOUND_CODES.has(code) &&
+      !CORPUS_DIRECTORY_NOT_READABLE_CODES.has(code) &&
+      !CORPUS_DIRECTORY_ROOT_READ_CODES.has(code))
+  ) {
+    return undefined;
+  }
+
+  const path = typeof error === 'object' && error !== null && 'path' in error ? error.path : undefined;
+  const resolveFromCwd = (value: string): string => (isAbsolute(value) ? value : resolve(cwd, value));
+  if (CORPUS_DIRECTORY_ROOT_READ_CODES.has(code) && typeof path !== 'string') return undefined;
+  if (typeof path === 'string' && resolveFromCwd(path) !== resolveFromCwd(dir)) return undefined;
+  return CORPUS_DIRECTORY_NOT_FOUND_CODES.has(code) ? 'not-found' : 'not-readable';
+}

--- a/packages/cli/src/evaluate.ts
+++ b/packages/cli/src/evaluate.ts
@@ -23,6 +23,10 @@ import {
   evaluatePass0,
   type Pass0Input,
 } from '@adrkit/evaluator';
+import {
+  corpusDirectoryErrorKind,
+  type CorpusDirectoryErrorKind,
+} from './errors.ts';
 import { loadSnapshotBundle, SnapshotContractError, type NormalizedSnapshot } from './evaluate-snapshot.ts';
 
 /**
@@ -47,6 +51,10 @@ export interface EvaluateOutput {
   readonly exitCode: 0 | 1 | 2;
   readonly stdout: string;
   readonly stderr: string;
+  readonly corpusDirectoryError?: {
+    readonly dir: string;
+    readonly kind: CorpusDirectoryErrorKind;
+  };
 }
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
@@ -60,24 +68,12 @@ export function isValidIsoDate(value: string): boolean {
   return date.getUTCFullYear() === y && date.getUTCMonth() === m - 1 && date.getUTCDate() === d;
 }
 
-type CorpusDirectoryErrorKind = 'not-found' | 'not-readable';
-
 function resolveFromCwd(path: string, cwd: string): string {
   return isAbsolute(path) ? path : resolve(cwd, path);
 }
 
 function corpusDirectoryOutput(dir: string, kind: CorpusDirectoryErrorKind): EvaluateOutput {
-  const state = kind === 'not-readable' ? 'not readable' : 'not found';
-  return { exitCode: 2, stdout: '', stderr: `Corpus directory ${state}: '${dir}'.\n` };
-}
-
-function corpusDirectoryErrorKind(error: unknown, dir: string, cwd: string): CorpusDirectoryErrorKind | undefined {
-  const code = typeof error === 'object' && error !== null && 'code' in error ? String(error.code) : undefined;
-  if (code !== 'ENOENT' && code !== 'ENOTDIR' && code !== 'EACCES' && code !== 'EPERM') return undefined;
-
-  const path = typeof error === 'object' && error !== null && 'path' in error ? error.path : undefined;
-  if (typeof path === 'string' && resolveFromCwd(path, cwd) !== resolveFromCwd(dir, cwd)) return undefined;
-  return code === 'EACCES' || code === 'EPERM' ? 'not-readable' : 'not-found';
+  return { exitCode: 2, stdout: '', stderr: '', corpusDirectoryError: { dir, kind } };
 }
 
 function handleCorpusDirectoryError(error: unknown, dir: string, cwd: string): EvaluateOutput | undefined {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,6 @@
 
 import { parseArgs, type ParseArgsConfig } from 'node:util';
 import { readdir } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import {
   buildAdrGraph,
   bucketDecisions,
@@ -29,6 +28,12 @@ import {
   type SourceMarkerScan,
 } from '@adrkit/core';
 import { evaluate } from './evaluate.ts';
+import {
+  corpusDirectoryErrorKind,
+  corpusDirectoryErrorMessage,
+  formatUsageError,
+  type CorpusDirectoryErrorKind,
+} from './errors.ts';
 import { QUEUE_USAGE, runQueue } from './queue.ts';
 import { isMainModule } from './main-module.ts';
 
@@ -47,34 +52,21 @@ function writeStderr(text: string): void {
   process.stderr.write(text);
 }
 
-type CorpusDirectoryErrorKind = 'not-found' | 'not-readable';
-
-function corpusDirectoryUsageError(dir: string, kind: CorpusDirectoryErrorKind): number {
-  const state = kind === 'not-readable' ? 'not readable' : 'not found';
-  writeStderr(`Corpus directory ${state}: '${dir}'.\n`);
-  return 2;
+function corpusDirectoryUsageError(dir: string, kind: CorpusDirectoryErrorKind, command: string): number {
+  return usageError(corpusDirectoryErrorMessage(dir, kind), command);
 }
 
-function corpusDirectoryErrorKind(error: unknown, dir: string): CorpusDirectoryErrorKind | undefined {
-  const code = typeof error === 'object' && error !== null && 'code' in error ? String(error.code) : undefined;
-  if (code !== 'ENOENT' && code !== 'ENOTDIR' && code !== 'EACCES' && code !== 'EPERM') return undefined;
-
-  const path = typeof error === 'object' && error !== null && 'path' in error ? error.path : undefined;
-  if (typeof path === 'string' && resolve(path) !== resolve(dir)) return undefined;
-  return code === 'EACCES' || code === 'EPERM' ? 'not-readable' : 'not-found';
-}
-
-function handleCorpusDirectoryError(error: unknown, dir: string): number | undefined {
+function handleCorpusDirectoryError(error: unknown, dir: string, command: string): number | undefined {
   const kind = corpusDirectoryErrorKind(error, dir);
-  return kind ? corpusDirectoryUsageError(dir, kind) : undefined;
+  return kind ? corpusDirectoryUsageError(dir, kind, command) : undefined;
 }
 
-async function ensureCorpusDirectoryReadable(dir: string): Promise<number | undefined> {
+async function ensureCorpusDirectoryReadable(dir: string, command: string): Promise<number | undefined> {
   try {
     await readdir(dir);
     return undefined;
   } catch (error) {
-    const exitCode = handleCorpusDirectoryError(error, dir);
+    const exitCode = handleCorpusDirectoryError(error, dir, command);
     if (exitCode !== undefined) return exitCode;
     throw error;
   }
@@ -88,20 +80,35 @@ function hasValueFlag(args: readonly string[], flag: string): boolean {
   return false;
 }
 
-const USAGE = `Usage:
-  adr lint [paths...] [--json] [--dir docs/adr]
-  adr migrate --from madr [--dir docs/adr] [--dry-run] [--rename] [--json]
-  adr new <title> [--status draft] [--dir docs/adr] [--json]
-  adr graph [--dir docs/adr] [--format dot|json]
-  adr explain <path> [--dir docs/adr] [--json]
-  adr check <files...> [--dir docs/adr] [--json]
-  adr evaluate <proposal-path> --snapshot <bundle.json> --date YYYY-MM-DD [--json] [--dir docs/adr]
-  adr queue [--dir docs/adr] [--as-of YYYY-MM-DD] [--format markdown|json]
+const USAGE = `adrkit ${CLI_VERSION}
+Decision memory for human- and agent-authored plans.
 
-  adr help [command]        Show this help, or help for one command
-  adr --version             Print the @adrkit/cli version
+Usage:
+  adr <command> [options]
 
-Round-trip sync is explicitly unsupported (ADR-0008); migrate is one-way and non-destructive.
+Commands:
+  new       Create a decision record
+  lint      Validate ADR files and corpus rules
+  check     Review changed files against governing decisions
+  explain   Explain which decisions govern a path
+  graph     Render decision relationships
+  queue     Show the architecture review board queue
+  evaluate  Evaluate a proposal from an offline snapshot
+  migrate   Import a MADR corpus into adrkit
+  help      Show help for a command
+
+Options:
+  -h, --help       Show help
+  -V, --version    Show version
+
+Examples:
+  adr new "Adopt PostgreSQL"
+  adr lint
+  adr explain src/auth/session.ts
+  adr check src/auth/session.ts package.json
+
+Run 'adr help <command>' for command-specific options and examples.
+Documentation: https://adrkit.dev/commands/
 `;
 
 /**
@@ -109,58 +116,65 @@ Round-trip sync is explicitly unsupported (ADR-0008); migrate is one-way and non
  * `queue` reuses its own richer usage text so there is a single source for it.
  */
 const COMMAND_USAGE: Record<string, string> = {
+  new: `Usage: adr new <title> [options]
+
+Create a decision record with the next available numeric ID.
+
+Arguments:
+  <title>             Decision title
+
+Options:
+  --status <status>   Initial status: draft|proposed|rejected|deprecated
+                      (default: draft)
+  --dir <path>        ADR corpus directory (default: docs/adr)
+  --json              Emit { id, path } as JSON
+  -h, --help          Show this help and exit
+
+Examples:
+  adr new "Adopt PostgreSQL"
+  adr new "Trial a regional cache" --status proposed
+
+Exit codes: 0 = created; 1 = refused to overwrite an existing file; 2 = usage error.
+`,
   lint: `Usage: adr lint [paths...] [options]
 
 Validate the ADR corpus. With no paths, every discoverable record under --dir is checked.
 
+Arguments:
+  [paths...]      Optional ADR files to validate
+
 Options:
   --dir <path>    ADR corpus directory (default: docs/adr)
   --json          Emit { checked, findings } as JSON
-  --help          Show this help and exit
+  -h, --help      Show this help and exit
+
+Examples:
+  adr lint
+  adr lint docs/adr/0012-adopt-postgresql.md
+  adr lint --json
 
 Exit codes: 0 = no error findings; 1 = one or more error findings;
 2 = usage error (invalid invocation or unreachable corpus directory).
 `,
-  migrate: `Usage: adr migrate --from madr [options]
+  check: `Usage: adr check [files...] [options]
 
-Migrate a MADR corpus in place, adding adrkit frontmatter and leaving the body untouched.
-One-way and non-destructive; round-trip sync is unsupported (ADR-0008).
+Report the decisions governing changed files and validate changed ADRs.
+With no files, the command performs a successful no-op.
+
+Arguments:
+  [files...]      Optional repo-relative paths to review
 
 Options:
-  --from madr     Source format (required; only madr is supported)
   --dir <path>    ADR corpus directory (default: docs/adr)
-  --dry-run       Report what would change without writing
-  --rename        Rename each migrated file to <id>-<slug>.md so corpus discovery
-                  can see it. Off by default, because migration is in place.
-  --json          Emit the migration result as JSON
-  --help          Show this help and exit
+  --json          Emit the CheckOutcome as JSON
+  -h, --help      Show this help and exit
 
-Exit codes: 0 = migration ran (findings are reported but do not fail the run);
-2 = usage error (missing or unsupported --from, unknown flag, positional argument,
-or unreachable corpus directory).
-`,
-  new: `Usage: adr new <title> [options]
+Examples:
+  adr check src/auth/session.ts package.json
+  adr check --json src/auth/session.ts
 
-Scaffold a new ADR record.
-
-Options:
-  --status <status>   Initial status (default: draft)
-  --dir <path>        ADR corpus directory (default: docs/adr)
-  --json              Emit { id, path } as JSON
-  --help              Show this help and exit
-
-Exit codes: 0 = created; 1 = refused to overwrite an existing file; 2 = usage error.
-`,
-  graph: `Usage: adr graph [options]
-
-Render the decision graph (supersedes, relatesTo, conflictsWith) for the corpus.
-
-Options:
-  --dir <path>            ADR corpus directory (default: docs/adr)
-  --format dot|json       Output format (default: dot)
-  --help                  Show this help and exit
-
-Exit codes: 0 = rendered; 2 = usage error (invalid invocation or unreachable corpus directory).
+Exit codes: 0 = ok; 1 = a changed record has an error finding;
+2 = usage error (invalid invocation or unreachable corpus directory).
 `,
   explain: `Usage: adr explain <path> [options]
 
@@ -173,46 +187,98 @@ comment ("declared by src/sync.ts:3 (@adr 0012)"). If <path> exists, at most its
 last complete line inside that bound, and --json reports the extent it reached. A marker
 naming a record the corpus does not have is reported as a dangling-marker warning.
 
+Arguments:
+  <path>          Repo-relative path to explain
+
 Options:
   --dir <path>    ADR corpus directory (default: docs/adr)
   --json          Emit { path, governedBy, governing, activeProposals, history,
                   markers, findings }. Pattern matches carry "firedMatchers";
                   file declarations carry "declaredBy".
-  --help          Show this help and exit
+  -h, --help      Show this help and exit
+
+Examples:
+  adr explain src/auth/session.ts
+  adr explain --json src/auth/session.ts
 
 Exit codes: 0 = explained; 1 = corpus has error findings;
 2 = usage error (invalid invocation or unreachable corpus directory).
 `,
-  check: `Usage: adr check <files...> [options]
+  graph: `Usage: adr graph [options]
 
-Report the decisions governing a set of changed files, and validate any changed records.
+Render supersedes, relatesTo, and conflictsWith relationships for the corpus.
 
 Options:
-  --dir <path>    ADR corpus directory (default: docs/adr)
-  --json          Emit the CheckOutcome as JSON
-  --help          Show this help and exit
+  --dir <path>          ADR corpus directory (default: docs/adr)
+  --format dot|json     Output format (default: dot)
+  -h, --help            Show this help and exit
 
-Exit codes: 0 = ok; 1 = a changed record has an error finding;
-2 = usage error (invalid invocation or unreachable corpus directory).
+Examples:
+  adr graph > decisions.dot
+  adr graph --format json
+
+Exit codes: 0 = rendered; 2 = usage error (invalid invocation or unreachable corpus directory).
 `,
+  queue: QUEUE_USAGE,
   evaluate: `Usage: adr evaluate <proposal-path> --snapshot <bundle.json> --date YYYY-MM-DD [options]
 
 Run the deterministic evaluator over one proposal against an offline snapshot bundle.
 
+Arguments:
+  <proposal-path>      Proposed ADR to evaluate
+
 Options:
   --snapshot <path>   Snapshot bundle (required)
   --date <date>       Evaluation date, YYYY-MM-DD (required)
-  --dir <path>        ADR corpus directory
+  --dir <path>        ADR corpus directory (default: proposal directory)
   --json              Emit the evaluation report as JSON
-  --help              Show this help and exit
+  -h, --help          Show this help and exit
 
 The evaluator routes; it never approves, persists, or writes. There is no --write.
+
+Examples:
+  adr evaluate docs/adr/0042-adopt-postgresql.md \\
+    --snapshot evidence/bundle.json --date 2026-08-24
+  adr evaluate proposals/0042-adopt-postgresql.md --dir docs/adr \\
+    --snapshot evidence/bundle.json --date 2026-08-24
 
 Exit codes: 0 = evaluated (including warn/info/inert and escalation);
 1 = the proposal was returned on a rubric error; 2 = usage error, unreachable
 corpus directory, or malformed snapshot bundle.
 `,
-  queue: QUEUE_USAGE,
+  migrate: `Usage: adr migrate --from madr [options]
+
+Import a MADR corpus in place by adding adrkit frontmatter and preserving each body.
+Migration is one-way: adrkit does not sync later changes back to MADR.
+
+Options:
+  --from madr     Source format (required; only madr is supported)
+  --dir <path>    ADR corpus directory (default: docs/adr)
+  --dry-run       Report what would change without writing
+  --rename        Rename each migrated file to <id>-<slug>.md so corpus discovery
+                  can see it. Off by default, because migration is in place.
+  --json          Emit the migration result as JSON
+  -h, --help      Show this help and exit
+
+Examples:
+  adr migrate --from madr --dry-run
+  adr migrate --from madr --rename
+
+Exit codes: 0 = migration ran (findings are reported but do not fail the run);
+2 = usage error (missing or unsupported --from, unknown flag, positional argument,
+or unreachable corpus directory).
+`,
+  help: `Usage: adr help [command]
+
+Show top-level help or detailed help for one command.
+
+Arguments:
+  [command]       Optional command to describe
+
+Examples:
+  adr help
+  adr help check
+`,
 };
 
 const COMMANDS = Object.keys(COMMAND_USAGE);
@@ -222,10 +288,9 @@ function commandUsageFor(command: string): string | undefined {
   return Object.hasOwn(COMMAND_USAGE, command) ? COMMAND_USAGE[command] : undefined;
 }
 
-/** Usage error: message + usage on stderr, exit 2. Explicit help goes to stdout at 0. */
-function usage(message?: string): number {
-  if (message) writeStderr(`${message}\n`);
-  writeStderr(USAGE);
+/** Usage error: concise guidance on stderr, exit 2. Explicit help goes to stdout at 0. */
+function usageError(message: string, command?: string): number {
+  writeStderr(formatUsageError(message, command ? commandUsageFor(command) ?? '' : USAGE, command));
   return 2;
 }
 
@@ -235,7 +300,13 @@ function isHelpFlag(arg: string): boolean {
 
 /** `adr help [command]` — usage on stdout at 0; unknown command is still a usage error. */
 function runHelp(args: string[]): number {
-  const requested = args.find((arg) => !arg.startsWith('-'));
+  const unsupportedFlag = args.find((arg) => arg.startsWith('-') && !isHelpFlag(arg));
+  if (unsupportedFlag) return usageError(`Unknown option "${unsupportedFlag}".`);
+
+  const positionals = args.filter((arg) => !arg.startsWith('-'));
+  if (positionals.length > 1) return usageError('adr help accepts at most one command.');
+
+  const requested = positionals[0];
   if (requested === undefined) {
     writeStdout(USAGE);
     return 0;
@@ -243,11 +314,32 @@ function runHelp(args: string[]): number {
 
   const commandUsage = commandUsageFor(requested);
   if (!commandUsage) {
-    return usage(`Unknown command "${requested}". Known commands: ${COMMANDS.join(', ')}`);
+    return usageError(unknownCommandMessage(requested));
   }
 
   writeStdout(commandUsage);
   return 0;
+}
+
+function editDistance(left: string, right: string): number {
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    const current = [leftIndex];
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      const substitution = previous[rightIndex - 1]! + (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1);
+      current[rightIndex] = Math.min(previous[rightIndex]! + 1, current[rightIndex - 1]! + 1, substitution);
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+  return previous[right.length]!;
+}
+
+function unknownCommandMessage(command: string): string {
+  const suggestion = COMMANDS
+    .map((candidate) => ({ candidate, distance: editDistance(command, candidate) }))
+    .sort((left, right) => left.distance - right.distance || left.candidate.localeCompare(right.candidate))[0];
+  const hint = suggestion && suggestion.distance <= 2 ? ` Did you mean "${suggestion.candidate}"?` : '';
+  return `Unknown command "${command}".${hint}`;
 }
 
 function parseCommandArgs(
@@ -294,12 +386,12 @@ async function runLint(args: string[]): Promise<number> {
       dir: { type: 'string', default: 'docs/adr' },
     });
   } catch (error) {
-    return usage(error instanceof Error ? error.message : String(error));
+    return usageError(error instanceof Error ? error.message : String(error), 'lint');
   }
 
   const dir = String(parsed.values.dir);
   if (parsed.positionals.length > 0 && hasValueFlag(args, '--dir')) {
-    const exitCode = await ensureCorpusDirectoryReadable(dir);
+    const exitCode = await ensureCorpusDirectoryReadable(dir, 'lint');
     if (exitCode !== undefined) return exitCode;
   }
 
@@ -310,7 +402,7 @@ async function runLint(args: string[]): Promise<number> {
       paths: parsed.positionals,
     });
   } catch (error) {
-    const exitCode = handleCorpusDirectoryError(error, dir);
+    const exitCode = handleCorpusDirectoryError(error, dir, 'lint');
     if (exitCode !== undefined) return exitCode;
     throw error;
   }
@@ -375,21 +467,22 @@ async function runMigrate(args: string[]): Promise<number> {
       json: { type: 'boolean', default: false },
     });
   } catch (error) {
-    return usage(error instanceof Error ? error.message : String(error));
+    return usageError(error instanceof Error ? error.message : String(error), 'migrate');
   }
 
-  if (parsed.positionals.length > 0) return usage('adr migrate does not accept positional arguments');
+  if (parsed.positionals.length > 0) return usageError('adr migrate does not accept positional arguments.', 'migrate');
   const from = parsed.values.from;
   if (from !== 'madr') {
-    return usage(
+    return usageError(
       from
-        ? `adr migrate --from ${String(from)} is not supported yet; only --from madr is available, and round-trip sync is unsupported (ADR-0008)`
-        : 'adr migrate requires --from madr; non-MADR sources and round-trip sync are unsupported in this phase (ADR-0008)',
+        ? `Unsupported --from value "${String(from)}". Only "madr" is available; migration is one-way.`
+        : 'adr migrate requires --from madr.',
+      'migrate',
     );
   }
 
   const dir = String(parsed.values.dir);
-  const dirExitCode = await ensureCorpusDirectoryReadable(dir);
+  const dirExitCode = await ensureCorpusDirectoryReadable(dir, 'migrate');
   if (dirExitCode !== undefined) return dirExitCode;
 
   let result: Awaited<ReturnType<typeof migrateMadr>>;
@@ -400,7 +493,7 @@ async function runMigrate(args: string[]): Promise<number> {
       rename: parsed.values.rename === true,
     });
   } catch (error) {
-    const exitCode = handleCorpusDirectoryError(error, dir);
+    const exitCode = handleCorpusDirectoryError(error, dir, 'migrate');
     if (exitCode !== undefined) return exitCode;
     throw error;
   }
@@ -423,11 +516,11 @@ async function runNew(args: string[]): Promise<number> {
       status: { type: 'string', default: 'draft' },
     });
   } catch (error) {
-    return usage(error instanceof Error ? error.message : String(error));
+    return usageError(error instanceof Error ? error.message : String(error), 'new');
   }
 
   const title = parsed.positionals.join(' ').trim();
-  if (!title) return usage('adr new requires a title');
+  if (!title) return usageError('adr new requires a title.', 'new');
 
   try {
     const result = await createAdr({
@@ -443,8 +536,9 @@ async function runNew(args: string[]): Promise<number> {
     return 0;
   } catch (error) {
     if (error instanceof ScaffoldError) {
+      if (error.code === 'usage') return usageError(error.message, 'new');
       writeStderr(`${error.message}\n`);
-      return error.code === 'exists' ? 1 : 2;
+      return 1;
     }
     throw error;
   }
@@ -458,19 +552,21 @@ async function runGraph(args: string[]): Promise<number> {
       format: { type: 'string', default: 'dot' },
     });
   } catch (error) {
-    return usage(error instanceof Error ? error.message : String(error));
+    return usageError(error instanceof Error ? error.message : String(error), 'graph');
   }
 
-  if (parsed.positionals.length > 0) return usage('adr graph does not accept positional arguments');
+  if (parsed.positionals.length > 0) return usageError('adr graph does not accept positional arguments.', 'graph');
   const format = String(parsed.values.format);
-  if (format !== 'dot' && format !== 'json') return usage('adr graph --format must be dot or json');
+  if (format !== 'dot' && format !== 'json') {
+    return usageError('adr graph --format must be "dot" or "json".', 'graph');
+  }
 
   const dir = String(parsed.values.dir);
   let result: Awaited<ReturnType<typeof lintCorpus>>;
   try {
     result = await lintCorpus({ dir });
   } catch (error) {
-    const exitCode = handleCorpusDirectoryError(error, dir);
+    const exitCode = handleCorpusDirectoryError(error, dir, 'graph');
     if (exitCode !== undefined) return exitCode;
     throw error;
   }
@@ -487,19 +583,19 @@ async function runExplain(args: string[]): Promise<number> {
       dir: { type: 'string', default: 'docs/adr' },
     });
   } catch (error) {
-    return usage(error instanceof Error ? error.message : String(error));
+    return usageError(error instanceof Error ? error.message : String(error), 'explain');
   }
 
-  if (parsed.positionals.length !== 1) return usage('adr explain requires exactly one path');
+  if (parsed.positionals.length !== 1) return usageError('adr explain requires exactly one path.', 'explain');
   const path = parsed.positionals[0];
-  if (!path) return usage('adr explain requires exactly one path');
+  if (!path) return usageError('adr explain requires exactly one path.', 'explain');
 
   const dir = String(parsed.values.dir);
   let corpus: Awaited<ReturnType<typeof lintCorpus>>;
   try {
     corpus = await lintCorpus({ dir });
   } catch (error) {
-    const exitCode = handleCorpusDirectoryError(error, dir);
+    const exitCode = handleCorpusDirectoryError(error, dir, 'explain');
     if (exitCode !== undefined) return exitCode;
     throw error;
   }
@@ -752,7 +848,7 @@ async function runCheck(args: string[]): Promise<number> {
       dir: { type: 'string', default: 'docs/adr' },
     });
   } catch (error) {
-    return usage(error instanceof Error ? error.message : String(error));
+    return usageError(error instanceof Error ? error.message : String(error), 'check');
   }
 
   const dir = String(parsed.values.dir);
@@ -760,7 +856,7 @@ async function runCheck(args: string[]): Promise<number> {
   try {
     lint = await lintCorpus({ dir });
   } catch (error) {
-    const exitCode = handleCorpusDirectoryError(error, dir);
+    const exitCode = handleCorpusDirectoryError(error, dir, 'check');
     if (exitCode !== undefined) return exitCode;
     throw error;
   }
@@ -786,19 +882,21 @@ async function runEvaluate(args: string[]): Promise<number> {
       dir: { type: 'string' },
     });
   } catch (error) {
-    return usage(error instanceof Error ? error.message : String(error));
+    return usageError(error instanceof Error ? error.message : String(error), 'evaluate');
   }
 
-  if (parsed.positionals.length !== 1) return usage('adr evaluate requires exactly one proposal path');
+  if (parsed.positionals.length !== 1) {
+    return usageError('adr evaluate requires exactly one proposal path.', 'evaluate');
+  }
   const proposalPath = parsed.positionals[0];
-  if (!proposalPath) return usage('adr evaluate requires a proposal path');
+  if (!proposalPath) return usageError('adr evaluate requires a proposal path.', 'evaluate');
   const snapshot = parsed.values.snapshot;
   if (typeof snapshot !== 'string' || snapshot.length === 0) {
-    return usage('adr evaluate requires --snapshot <bundle.json>');
+    return usageError('adr evaluate requires --snapshot <bundle.json>.', 'evaluate');
   }
   const date = parsed.values.date;
   if (typeof date !== 'string' || date.length === 0) {
-    return usage('adr evaluate requires --date YYYY-MM-DD');
+    return usageError('adr evaluate requires --date YYYY-MM-DD.', 'evaluate');
   }
 
   const result = await evaluate({
@@ -808,6 +906,12 @@ async function runEvaluate(args: string[]): Promise<number> {
     json: parsed.values.json === true,
     ...(typeof parsed.values.dir === 'string' ? { dir: parsed.values.dir } : {}),
   });
+  if (result.corpusDirectoryError) {
+    return usageError(
+      corpusDirectoryErrorMessage(result.corpusDirectoryError.dir, result.corpusDirectoryError.kind),
+      'evaluate',
+    );
+  }
   if (result.stderr) writeStderr(result.stderr);
   if (result.stdout) writeStdout(result.stdout);
   return result.exitCode;
@@ -817,7 +921,10 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   const [command, ...args] = argv;
 
   try {
-    if (command === undefined) return usage();
+    if (command === undefined) {
+      writeStdout(USAGE);
+      return 0;
+    }
     if (command === 'help') return runHelp(args);
     if (isHelpFlag(command)) return runHelp(args);
     if (command === '--version' || command === '-V') {
@@ -841,7 +948,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
     if (command === 'check') return await runCheck(args);
     if (command === 'evaluate') return await runEvaluate(args);
     if (command === 'queue') return await runQueue(args);
-    return usage(`Unknown command "${command}"`);
+    return usageError(unknownCommandMessage(command));
   } catch (error) {
     writeStderr(`${error instanceof Error ? error.message : String(error)}\n`);
     return 1;

--- a/packages/cli/src/queue.ts
+++ b/packages/cli/src/queue.ts
@@ -1,9 +1,9 @@
-import { stat } from 'node:fs/promises';
 import { buildQueueReport, formatQueueReportJson, formatQueueReportMarkdown, lintCorpus, resolveAsOf } from '@adrkit/core';
+import { corpusDirectoryErrorKind, corpusDirectoryErrorMessage, formatUsageError } from './errors.ts';
 
 const USAGE = `Usage: adr queue [options]
 
-Emit the ARB operations queue report for the local ADR corpus to stdout.
+Show the architecture review board operations queue for the local ADR corpus.
 
 Options:
   --dir <path>              ADR corpus directory (default: docs/adr)
@@ -11,7 +11,12 @@ Options:
                             Accepts YYYY-MM-DD or an ISO datetime with an explicit
                             timezone (e.g. 2026-01-08 or 2026-01-08T00:00:00Z).
   --format markdown|json    Output format (default: markdown)
-  --help                    Show this help and exit
+  -h, --help                Show this help and exit
+
+Examples:
+  adr queue
+  adr queue --as-of 2026-08-24
+  adr queue --format json
 
 Exit codes: 0 = report, no error findings; 1 = report with corpus error findings;
 2 = usage error (invalid flag/value or unreachable corpus directory).
@@ -20,6 +25,11 @@ Exit codes: 0 = report, no error findings; 1 = report with corpus error findings
 /** Re-exported so `adr help queue` renders the same text as `adr queue --help`. */
 export const QUEUE_USAGE = USAGE;
 
+function usageError(message: string): number {
+  process.stderr.write(formatUsageError(message, USAGE, 'queue'));
+  return 2;
+}
+
 interface ParsedFlags {
   dir: string;
   asOf?: string;
@@ -27,7 +37,11 @@ interface ParsedFlags {
   help: boolean;
 }
 
-type ParseResult = { ok: true; flags: ParsedFlags } | { ok: false; unknown: string } | { ok: false; missing: string };
+type ParseResult =
+  | { ok: true; flags: ParsedFlags }
+  | { ok: false; unknown: string }
+  | { ok: false; positional: string }
+  | { ok: false; missing: string };
 
 function parseFlags(args: string[]): ParseResult {
   const flags: ParsedFlags = { dir: 'docs/adr', format: 'markdown', help: false };
@@ -45,6 +59,7 @@ function parseFlags(args: string[]): ParseResult {
 
     const valueFlag = name === '--dir' || name === '--as-of' || name === '--format';
     if (!valueFlag) {
+      if (!name.startsWith('-')) return { ok: false, positional: name };
       return { ok: false, unknown: name };
     }
 
@@ -61,6 +76,7 @@ function parseFlags(args: string[]): ParseResult {
       value = next;
       i += 1;
     }
+    if (value.length === 0) return { ok: false, missing: name };
 
     if (name === '--dir') flags.dir = value;
     else if (name === '--as-of') flags.asOf = value;
@@ -70,24 +86,17 @@ function parseFlags(args: string[]): ParseResult {
   return { ok: true, flags };
 }
 
-async function directoryExists(dir: string): Promise<boolean> {
-  try {
-    return (await stat(dir)).isDirectory();
-  } catch {
-    return false;
-  }
-}
-
 /** Entrypoint for the `adr queue` subcommand. Returns the process exit code. */
 export async function runQueue(args: string[]): Promise<number> {
   const parsed = parseFlags(args);
   if (!parsed.ok) {
     if ('missing' in parsed) {
-      process.stderr.write(`Missing value for flag '${parsed.missing}'. See 'adr queue --help'.\n`);
-      return 2;
+      return usageError(`Missing value for option "${parsed.missing}".`);
     }
-    process.stderr.write(`Unknown flag: '${parsed.unknown}'. See 'adr queue --help'.\n`);
-    return 2;
+    if ('positional' in parsed) {
+      return usageError(`Positional argument "${parsed.positional}" is not supported. Use --dir <path> to select the ADR corpus.`);
+    }
+    return usageError(`Unknown option "${parsed.unknown}".`);
   }
 
   const { flags } = parsed;
@@ -97,8 +106,7 @@ export async function runQueue(args: string[]): Promise<number> {
   }
 
   if (flags.format !== 'markdown' && flags.format !== 'json') {
-    process.stderr.write(`Invalid --format value: '${flags.format}'. Expected markdown or json.\n`);
-    return 2;
+    return usageError(`Invalid --format value "${flags.format}". Expected "markdown" or "json".`);
   }
 
   let asOf: string;
@@ -107,22 +115,24 @@ export async function runQueue(args: string[]): Promise<number> {
     if (!resolution.ok) {
       const message =
         resolution.code === 'tzless'
-          ? `Invalid --as-of value: '${flags.asOf}'. Timezone-less datetimes are ambiguous — use YYYY-MM-DD or add an explicit timezone offset (e.g. Z or +05:00).\n`
-          : `Invalid --as-of value: '${flags.asOf}'. Expected YYYY-MM-DD or ISO datetime with explicit timezone (e.g. 2026-01-08 or 2026-01-08T00:00:00Z).\n`;
-      process.stderr.write(message);
-      return 2;
+          ? `Invalid --as-of value "${flags.asOf}". Timezone-less datetimes are ambiguous — use YYYY-MM-DD or add an explicit timezone offset (e.g. Z or +05:00).`
+          : `Invalid --as-of value "${flags.asOf}". Expected YYYY-MM-DD or ISO datetime with explicit timezone (e.g. 2026-01-08 or 2026-01-08T00:00:00Z).`;
+      return usageError(message);
     }
     asOf = resolution.date;
   } else {
     asOf = new Date().toISOString().slice(0, 10);
   }
 
-  if (!(await directoryExists(flags.dir))) {
-    process.stderr.write(`Corpus directory not found: '${flags.dir}'.\n`);
-    return 2;
+  let corpus: Awaited<ReturnType<typeof lintCorpus>>;
+  try {
+    corpus = await lintCorpus({ dir: flags.dir });
+  } catch (error) {
+    const kind = corpusDirectoryErrorKind(error, flags.dir);
+    if (kind) return usageError(corpusDirectoryErrorMessage(flags.dir, kind));
+    throw error;
   }
 
-  const corpus = await lintCorpus({ dir: flags.dir });
   const report = buildQueueReport({ corpus, asOf });
   const output = flags.format === 'json' ? formatQueueReportJson(report) : formatQueueReportMarkdown(report);
   process.stdout.write(output);

--- a/packages/cli/test/corpus-dir.test.ts
+++ b/packages/cli/test/corpus-dir.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { chmod, readdir } from 'node:fs/promises';
+import { chmod, readdir, symlink } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { cleanupTestDir, recordMarkdown, resetTestDir, writeText } from '../../core/test/helpers.ts';
+import { corpusDirectoryErrorKind } from '../src/errors.ts';
 
 const CLI_PATH = resolve(process.cwd(), 'packages/cli/src/index.ts');
 const DIR_NAME = 'cli-corpus-dir';
@@ -21,6 +22,14 @@ afterEach(async () => {
 });
 
 describe('ADR corpus directory usage errors', () => {
+  test('root read failures are classified without hiding nested or unattributed errors', () => {
+    for (const code of ['EIO', 'ESTALE']) {
+      expect(corpusDirectoryErrorKind({ code, path: '/repo/docs/adr' }, 'docs/adr', '/repo')).toBe('not-readable');
+      expect(corpusDirectoryErrorKind({ code, path: '/repo/docs/adr/0001-record.md' }, 'docs/adr', '/repo')).toBeUndefined();
+      expect(corpusDirectoryErrorKind({ code }, 'docs/adr', '/repo')).toBeUndefined();
+    }
+  });
+
   test('commands that read a corpus reject an unreachable --dir consistently', async () => {
     const root = await resetTestDir(DIR_NAME);
     await writeText(
@@ -55,6 +64,7 @@ describe('ADR corpus directory usage errors', () => {
       { name: 'explain', args: ['explain', 'src/x.ts', '--dir', 'missing-adr'] },
       { name: 'check', args: ['check', 'src/x.ts', '--dir', 'missing-adr'] },
       { name: 'migrate', args: ['migrate', '--from', 'madr', '--dir', 'missing-adr'] },
+      { name: 'queue', args: ['queue', '--dir', 'missing-adr'] },
       {
         name: 'evaluate',
         args: ['evaluate', 'proposal.md', '--snapshot', 'snapshot.json', '--date', '2026-07-19', '--dir', 'missing-adr'],
@@ -63,11 +73,10 @@ describe('ADR corpus directory usage errors', () => {
 
     for (const { name, args } of cases) {
       const result = await runAdr(args, root);
-      expect(result, name).toEqual({
-        stdout: '',
-        stderr: "Corpus directory not found: 'missing-adr'.\n",
-        exitCode: 2,
-      });
+      expect(result.stdout, name).toBe('');
+      expect(result.exitCode, name).toBe(2);
+      expect(result.stderr, name).toContain('Error: Corpus directory not found: "missing-adr".');
+      expect(result.stderr, name).toContain(`Run 'adr help ${name}' for more information.`);
       expect(result.stderr, name).not.toContain('ENOENT');
       expect(result.stderr, name).not.toContain(root);
     }
@@ -119,23 +128,20 @@ describe('ADR corpus directory usage errors', () => {
         { name: 'explain', args: ['explain', 'src/x.ts', '--dir', 'noread'] },
         { name: 'check', args: ['check', 'src/x.ts', '--dir', 'noread'] },
         { name: 'migrate', args: ['migrate', '--from', 'madr', '--dir', 'noread'] },
+        { name: 'queue', args: ['queue', '--dir', 'noread'] },
         {
           name: 'evaluate',
           args: ['evaluate', 'proposal.md', '--snapshot', 'snapshot.json', '--date', '2026-07-19', '--dir', 'noread'],
         },
       ];
 
-      const actual = [];
-      for (const { name, args } of cases) actual.push({ name, ...(await runAdr(args, root)) });
-      expect(actual).toEqual(
-        cases.map(({ name }) => ({
-          name,
-          stdout: '',
-          stderr: "Corpus directory not readable: 'noread'.\n",
-          exitCode: 2,
-        })),
-      );
-
+      for (const { name, args } of cases) {
+        const result = await runAdr(args, root);
+        expect(result.stdout, name).toBe('');
+        expect(result.exitCode, name).toBe(2);
+        expect(result.stderr, name).toContain('Error: Corpus directory not readable: "noread".');
+        expect(result.stderr, name).toContain(`Run 'adr help ${name}' for more information.`);
+      }
     } finally {
       await chmod(dir, 0o700).catch(() => {});
     }
@@ -151,5 +157,27 @@ describe('ADR corpus directory usage errors', () => {
     expect(result.stderr).toContain('file-read');
     expect(result.stderr).toContain('--dir');
     expect(result.stderr).not.toContain('Corpus directory not found');
+  });
+
+  test('queue treats a symlink-loop corpus as an unreachable usage error', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await symlink('loop', join(root, 'loop'));
+
+    const result = await runAdr(['queue', '--dir', 'loop'], root);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Error: Corpus directory not readable: "loop".');
+    expect(result.stderr).toContain("Run 'adr help queue' for more information.");
+  });
+
+  test('queue treats an overlong corpus path as an unreachable usage error', async () => {
+    const result = await runAdr(['queue', '--dir', 'x'.repeat(256)]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain(`Error: Corpus directory not readable: "${'x'.repeat(256)}".`);
+    expect(result.stderr).toContain("Run 'adr help queue' for more information.");
+    expect(result.stderr).not.toContain('ENAMETOOLONG');
   });
 });

--- a/packages/cli/test/help-version.test.ts
+++ b/packages/cli/test/help-version.test.ts
@@ -48,6 +48,7 @@ describe('adr help (#42)', () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stderr).toBe('');
+      expect(result.stdout).toContain(`adrkit ${CLI_VERSION}`);
       expect(result.stdout).toContain('Usage:');
       expect(result.stdout).toContain('adr lint');
     });
@@ -60,12 +61,59 @@ describe('adr help (#42)', () => {
     expect(bare.stdout).toBe(dashDash.stdout);
   });
 
+  test('top-level help is task-oriented and does not expose internal ADR references', async () => {
+    const result = await runAdr(['--help']);
+
+    expect(result.stdout).toContain('Commands:');
+    expect(result.stdout).toContain('Create a decision record');
+    expect(result.stdout).toContain('Review changed files against governing decisions');
+    expect(result.stdout).toContain('Examples:');
+    expect(result.stdout).toContain("Run 'adr help <command>'");
+    expect(result.stdout).toContain('Documentation: https://adrkit.dev/commands/');
+    expect(result.stdout).not.toContain('https://adrkit.dev/docs/commands/');
+    expect(result.stdout).not.toContain('ADR-0008');
+  });
+
   test('adr help <command> prints that command\u2019s usage', async () => {
     const result = await runAdr(['help', 'migrate']);
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('Usage: adr migrate --from madr');
     expect(result.stdout).toContain('--rename');
+  });
+
+  test('adr help help documents the help command without suggesting itself', async () => {
+    const result = await runAdr(['help', 'help']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Usage: adr help [command]');
+  });
+
+  test('adr help check documents its successful empty-input behavior', async () => {
+    const result = await runAdr(['help', 'check']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Usage: adr check [files...]');
+    expect(result.stdout).toContain('With no files, the command performs a successful no-op.');
+  });
+
+  test('adr help evaluate documents its proposal-relative corpus default', async () => {
+    const result = await runAdr(['help', 'evaluate']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('--dir <path>        ADR corpus directory (default: proposal directory)');
+    expect(result.stdout).toContain('proposals/0042-adopt-postgresql.md --dir docs/adr');
+  });
+
+  test('adr new reports supported statuses and focused help for an invalid value', async () => {
+    const help = await runAdr(['help', 'new']);
+    const invalid = await runAdr(['new', 'Adopt PostgreSQL', '--status', 'active']);
+
+    expect(help.stdout).toContain('draft|proposed|rejected|deprecated');
+    expect(invalid.exitCode).toBe(2);
+    expect(invalid.stderr).toContain('Error: Invalid status "active"');
+    expect(invalid.stderr).toContain("Run 'adr help new' for more information.");
   });
 
   test('adr help explain states the scan bound as a bound, not as the extent', async () => {
@@ -86,6 +134,7 @@ describe('adr help (#42)', () => {
       expect(viaFlag.exitCode).toBe(0);
       expect(viaFlag.stderr).toBe('');
       expect(viaFlag.stdout).toBe(viaHelp.stdout);
+      expect(viaFlag.stdout).toContain('Examples:');
     }
   });
 
@@ -95,6 +144,13 @@ describe('adr help (#42)', () => {
     expect(result.exitCode).toBe(2);
     expect(result.stdout).toBe('');
     expect(result.stderr).toContain('Unknown command "frobnicate"');
+  });
+
+  test('a likely command typo includes a suggestion', async () => {
+    const result = await runAdr(['lnit']);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('Unknown command "lnit". Did you mean "lint"?');
   });
 
   test('an inherited Object.prototype key is a usage error, not a crash', async () => {
@@ -111,7 +167,7 @@ describe('adr help (#42)', () => {
   });
 });
 
-describe('unknown commands keep the old contract', () => {
+describe('top-level invocation behavior', () => {
   test('an unknown command writes usage to stderr and exits 2', async () => {
     const result = await runAdr(['frobnicate']);
 
@@ -121,10 +177,22 @@ describe('unknown commands keep the old contract', () => {
     expect(result.stderr).toContain('Usage:');
   });
 
-  test('no arguments writes usage to stderr and exits 2', async () => {
+  test('no arguments shows help on stdout and exits 0', async () => {
     const result = await runAdr([]);
 
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Usage:');
+    expect(result.stderr).toBe('');
+  });
+
+  test('command usage errors point to focused help', async () => {
+    const result = await runAdr(['graph', '--format', 'svg']);
+
     expect(result.exitCode).toBe(2);
-    expect(result.stderr).toContain('Usage:');
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Error: adr graph --format must be "dot" or "json".');
+    expect(result.stderr).toContain('Usage: adr graph [options]');
+    expect(result.stderr).toContain("Run 'adr help graph' for more information.");
+    expect(result.stderr).not.toContain('Commands:');
   });
 });

--- a/packages/cli/test/migrate.test.ts
+++ b/packages/cli/test/migrate.test.ts
@@ -44,10 +44,11 @@ describe('adr migrate CLI', () => {
     expect(second.stdout).toContain('unchanged  ');
   });
 
-  test('rejects non-MADR sources and documents unsupported round-trip sync', async () => {
+  test('rejects non-MADR sources and explains that migration is one-way', async () => {
     const result = await runAdr(['migrate', '--from', 'agent-log']);
     expect(result.exitCode).toBe(2);
-    expect(result.stderr).toContain('only --from madr is available');
-    expect(result.stderr).toContain('round-trip sync is unsupported');
+    expect(result.stderr).toContain('Only "madr" is available');
+    expect(result.stderr).toContain('migration is one-way');
+    expect(result.stderr).not.toContain('ADR-0008');
   });
 });

--- a/packages/cli/test/queue.test.ts
+++ b/packages/cli/test/queue.test.ts
@@ -97,7 +97,8 @@ describe('adr queue — usage errors (exit 2, empty stdout)', () => {
     const { stdout, stderr, exitCode } = await runAdr(['queue', '--dir', `${FIX}/within-sla-corpus`, '--format', 'csv']);
     expect(exitCode).toBe(2);
     expect(stdout).toBe('');
-    expect(stderr).toContain("Invalid --format value: 'csv'");
+    expect(stderr).toContain('Invalid --format value "csv"');
+    expect(stderr).toContain("Run 'adr help queue' for more information.");
   });
 
   test('(e) timezone-less --as-of is rejected', async () => {
@@ -123,18 +124,31 @@ describe('adr queue — usage errors (exit 2, empty stdout)', () => {
     expect(stderr).toBe('');
   });
 
-  test('(n) unknown flag → exit 2 with frozen message', async () => {
+  test('(n) unknown option points to focused help', async () => {
     const { stdout, stderr, exitCode } = await runAdr(['queue', '--unknown-flag']);
     expect(exitCode).toBe(2);
     expect(stdout).toBe('');
-    expect(stderr).toBe("Unknown flag: '--unknown-flag'. See 'adr queue --help'.\n");
+    expect(stderr).toBe(
+      `Error: Unknown option "--unknown-flag".\n\nUsage: adr queue [options]\nRun 'adr help queue' for more information.\n`,
+    );
+  });
+
+  test('positional corpus path explains how to use --dir', async () => {
+    const { stdout, stderr, exitCode } = await runAdr(['queue', 'docs/adr']);
+    expect(exitCode).toBe(2);
+    expect(stdout).toBe('');
+    expect(stderr).toBe(
+      `Error: Positional argument "docs/adr" is not supported. Use --dir <path> to select the ADR corpus.\n\nUsage: adr queue [options]\nRun 'adr help queue' for more information.\n`,
+    );
   });
 
   test('(o) missing --dir → corpus-not-found exit 2 (not generic exit 1)', async () => {
     const { stdout, stderr, exitCode } = await runAdr(['queue', '--dir', `${FIX}/does-not-exist`, '--as-of', '2026-01-08']);
     expect(exitCode).toBe(2);
     expect(stdout).toBe('');
-    expect(stderr).toBe(`Corpus directory not found: '${FIX}/does-not-exist'.\n`);
+    expect(stderr).toBe(
+      `Error: Corpus directory not found: "${FIX}/does-not-exist".\n\nUsage: adr queue [options]\nRun 'adr help queue' for more information.\n`,
+    );
   });
 });
 
@@ -143,27 +157,40 @@ describe('adr queue — value-taking flags require a value (exit 2)', () => {
     const { stdout, stderr, exitCode } = await runAdr(['queue', '--as-of']);
     expect(exitCode).toBe(2);
     expect(stdout).toBe('');
-    expect(stderr).toBe("Missing value for flag '--as-of'. See 'adr queue --help'.\n");
+    expect(stderr).toContain('Error: Missing value for option "--as-of".');
+    expect(stderr).toContain("Run 'adr help queue' for more information.");
   });
 
   test('bare --dir (no value) is a usage error', async () => {
     const { stdout, stderr, exitCode } = await runAdr(['queue', '--dir']);
     expect(exitCode).toBe(2);
     expect(stdout).toBe('');
-    expect(stderr).toBe("Missing value for flag '--dir'. See 'adr queue --help'.\n");
+    expect(stderr).toContain('Error: Missing value for option "--dir".');
+    expect(stderr).toContain("Run 'adr help queue' for more information.");
   });
+
+  for (const args of [['--dir', ''], ['--dir=']]) {
+    test(`${args.map((arg) => JSON.stringify(arg)).join(' ')} rejects an empty value`, async () => {
+      const { stdout, stderr, exitCode } = await runAdr(['queue', ...args]);
+      expect(exitCode).toBe(2);
+      expect(stdout).toBe('');
+      expect(stderr).toContain('Error: Missing value for option "--dir".');
+    });
+  }
 
   test('bare --format (no value) is a usage error', async () => {
     const { stdout, stderr, exitCode } = await runAdr(['queue', '--format']);
     expect(exitCode).toBe(2);
     expect(stdout).toBe('');
-    expect(stderr).toBe("Missing value for flag '--format'. See 'adr queue --help'.\n");
+    expect(stderr).toContain('Error: Missing value for option "--format".');
+    expect(stderr).toContain("Run 'adr help queue' for more information.");
   });
 
   test('--as-of does not consume a following flag as its value', async () => {
     const { stdout, stderr, exitCode } = await runAdr(['queue', '--as-of', '--format', 'json']);
     expect(exitCode).toBe(2);
     expect(stdout).toBe('');
-    expect(stderr).toBe("Missing value for flag '--as-of'. See 'adr queue --help'.\n");
+    expect(stderr).toContain('Error: Missing value for option "--as-of".');
+    expect(stderr).toContain("Run 'adr help queue' for more information.");
   });
 });


### PR DESCRIPTION
## Summary

- replace the dense top-level usage dump with task-oriented command discovery, examples, focused help guidance, and the canonical command-reference link
- remove the internal ADR-0008 citation from user-facing migration help and explain one-way migration in product language
- add command-specific arguments, defaults, examples, typo suggestions, and focused usage errors
- make a no-argument invocation print help to stdout and exit successfully
- centralize corpus-directory diagnostics so missing, unreadable, looping, overlong, and root I/O failures preserve the CLI's exit-code and output-stream contracts
- improve queue recovery for positional corpus paths and reject empty option values

## Behavior changes

- `adr` now behaves like `adr --help`: help on stdout, exit `0`
- invalid invocations continue to use stderr and exit `2`, but now point to command-specific help
- `adr queue` reserves exit `1` for a complete emitted report with corpus error findings; unreachable corpus inputs return focused exit `2` errors
- `adr check` help documents its existing successful empty-input no-op

## Validation

- `bun test packages/cli/test` — 155 tests passed
- `bun run typecheck`
- `bun run check:changelog`
- dependency-ordered publish builds for `@adrkit/core`, `@adrkit/evaluator`, and `@adrkit/cli`
- independent adversarial, architect, consumer, and operator review panels with deterministic adjudication; the final exact staged artifact produced zero findings from the affected consumer/operator gate