### PR TITLE
feat(cli): Smarter mistake recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Until `1.0.0`, minor releases may include breaking changes
   typos receive a suggestion; and invoking `adr` without arguments shows help
   successfully.
 
+- **CLI mistake recovery is now smarter across commands.** Mistyped long options
+  now suggest the intended flag, and the closed value sets for `new --status`,
+  `graph --format`, `migrate --from`, and `queue --format` give near-miss
+  hints without changing the existing exit codes or stdout/stderr split.
+
 ## [0.9.0] - 2026-08-24
 
 ### Added

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ import {
   type SourceMarkerScan,
 } from '@adrkit/core';
 import { evaluate } from './evaluate.ts';
+import { closestCandidate } from './recovery.ts';
 import {
   corpusDirectoryErrorKind,
   corpusDirectoryErrorMessage,
@@ -50,6 +51,16 @@ function writeStdout(text: string): void {
 
 function writeStderr(text: string): void {
   process.stderr.write(text);
+}
+
+function extractUnknownOption(message: string): string | undefined {
+  const match = /^Unknown option ['"`]([^'"`]+)['"`]/.exec(message);
+  return match?.[1];
+}
+
+function unknownOptionMessage(option: string, candidates: readonly string[]): string {
+  const suggestion = closestCandidate(option, candidates);
+  return suggestion ? `Unknown option "${option}". Did you mean "${suggestion}"?` : `Unknown option "${option}".`;
 }
 
 function corpusDirectoryUsageError(dir: string, kind: CorpusDirectoryErrorKind, command: string): number {
@@ -282,6 +293,15 @@ Examples:
 };
 
 const COMMANDS = Object.keys(COMMAND_USAGE);
+const TOP_LEVEL_OPTIONS = ['--help', '--version'] as const;
+const LINT_OPTIONS = ['--json', '--dir', '--help'] as const;
+const MIGRATE_OPTIONS = ['--from', '--dir', '--dry-run', '--rename', '--json', '--help'] as const;
+const NEW_OPTIONS = ['--status', '--dir', '--json', '--help'] as const;
+const GRAPH_OPTIONS = ['--dir', '--format', '--help'] as const;
+const EXPLAIN_OPTIONS = ['--json', '--dir', '--help'] as const;
+const CHECK_OPTIONS = ['--json', '--dir', '--help'] as const;
+const EVALUATE_OPTIONS = ['--snapshot', '--date', '--json', '--dir', '--help'] as const;
+const NEW_ALLOWED_STATUSES = ['draft', 'proposed', 'rejected', 'deprecated'] as const;
 
 /** Own-property lookup: `adr help constructor` must be a usage error, not a crash. */
 function commandUsageFor(command: string): string | undefined {
@@ -301,7 +321,7 @@ function isHelpFlag(arg: string): boolean {
 /** `adr help [command]` — usage on stdout at 0; unknown command is still a usage error. */
 function runHelp(args: string[]): number {
   const unsupportedFlag = args.find((arg) => arg.startsWith('-') && !isHelpFlag(arg));
-  if (unsupportedFlag) return usageError(`Unknown option "${unsupportedFlag}".`);
+  if (unsupportedFlag) return usageError(unknownOptionMessage(unsupportedFlag, ['--help']));
 
   const positionals = args.filter((arg) => !arg.startsWith('-'));
   if (positionals.length > 1) return usageError('adr help accepts at most one command.');
@@ -321,32 +341,24 @@ function runHelp(args: string[]): number {
   return 0;
 }
 
-function editDistance(left: string, right: string): number {
-  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
-  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
-    const current = [leftIndex];
-    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
-      const substitution = previous[rightIndex - 1]! + (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1);
-      current[rightIndex] = Math.min(previous[rightIndex]! + 1, current[rightIndex - 1]! + 1, substitution);
-    }
-    previous.splice(0, previous.length, ...current);
-  }
-  return previous[right.length]!;
-}
-
 function unknownCommandMessage(command: string): string {
-  const suggestion = COMMANDS
-    .map((candidate) => ({ candidate, distance: editDistance(command, candidate) }))
-    .sort((left, right) => left.distance - right.distance || left.candidate.localeCompare(right.candidate))[0];
-  const hint = suggestion && suggestion.distance <= 2 ? ` Did you mean "${suggestion.candidate}"?` : '';
-  return `Unknown command "${command}".${hint}`;
+  const suggestion = closestCandidate(command, COMMANDS);
+  return suggestion ? `Unknown command "${command}". Did you mean "${suggestion}"?` : `Unknown command "${command}".`;
 }
 
 function parseCommandArgs(
   args: string[],
   options: ParseArgsConfig['options'],
+  allowedOptions: readonly string[],
 ): ReturnType<typeof parseArgs> {
-  return parseArgs({ args, options, allowPositionals: true, strict: true });
+  try {
+    return parseArgs({ args, options, allowPositionals: true, strict: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const unsupported = extractUnknownOption(message);
+    if (unsupported) throw new Error(unknownOptionMessage(unsupported, allowedOptions));
+    throw error;
+  }
 }
 
 function renderFinding(finding: Finding): string {
@@ -384,7 +396,7 @@ async function runLint(args: string[]): Promise<number> {
     parsed = parseCommandArgs(args, {
       json: { type: 'boolean', default: false },
       dir: { type: 'string', default: 'docs/adr' },
-    });
+    }, LINT_OPTIONS);
   } catch (error) {
     return usageError(error instanceof Error ? error.message : String(error), 'lint');
   }
@@ -465,7 +477,7 @@ async function runMigrate(args: string[]): Promise<number> {
       'dry-run': { type: 'boolean', default: false },
       rename: { type: 'boolean', default: false },
       json: { type: 'boolean', default: false },
-    });
+    }, MIGRATE_OPTIONS);
   } catch (error) {
     return usageError(error instanceof Error ? error.message : String(error), 'migrate');
   }
@@ -473,9 +485,12 @@ async function runMigrate(args: string[]): Promise<number> {
   if (parsed.positionals.length > 0) return usageError('adr migrate does not accept positional arguments.', 'migrate');
   const from = parsed.values.from;
   if (from !== 'madr') {
+    const suggestion = typeof from === 'string' ? closestCandidate(from, ['madr']) : undefined;
     return usageError(
       from
-        ? `Unsupported --from value "${String(from)}". Only "madr" is available; migration is one-way.`
+        ? suggestion
+          ? `Unsupported --from value "${String(from)}". Did you mean "${suggestion}"? Only "madr" is available; migration is one-way.`
+          : `Unsupported --from value "${String(from)}". Only "madr" is available; migration is one-way.`
         : 'adr migrate requires --from madr.',
       'migrate',
     );
@@ -514,18 +529,26 @@ async function runNew(args: string[]): Promise<number> {
       json: { type: 'boolean', default: false },
       dir: { type: 'string', default: 'docs/adr' },
       status: { type: 'string', default: 'draft' },
-    });
+    }, NEW_OPTIONS);
   } catch (error) {
     return usageError(error instanceof Error ? error.message : String(error), 'new');
   }
 
   const title = parsed.positionals.join(' ').trim();
   if (!title) return usageError('adr new requires a title.', 'new');
+  const status = String(parsed.values.status);
+  const suggestion = closestCandidate(status, NEW_ALLOWED_STATUSES);
+  if (suggestion && !NEW_ALLOWED_STATUSES.includes(status as (typeof NEW_ALLOWED_STATUSES)[number])) {
+    return usageError(
+      `Invalid status "${status}". Did you mean "${suggestion}"?`,
+      'new',
+    );
+  }
 
   try {
     const result = await createAdr({
       title,
-      status: String(parsed.values.status),
+      status,
       dir: String(parsed.values.dir),
     });
     if (parsed.values.json) {
@@ -550,7 +573,7 @@ async function runGraph(args: string[]): Promise<number> {
     parsed = parseCommandArgs(args, {
       dir: { type: 'string', default: 'docs/adr' },
       format: { type: 'string', default: 'dot' },
-    });
+    }, GRAPH_OPTIONS);
   } catch (error) {
     return usageError(error instanceof Error ? error.message : String(error), 'graph');
   }
@@ -558,7 +581,13 @@ async function runGraph(args: string[]): Promise<number> {
   if (parsed.positionals.length > 0) return usageError('adr graph does not accept positional arguments.', 'graph');
   const format = String(parsed.values.format);
   if (format !== 'dot' && format !== 'json') {
-    return usageError('adr graph --format must be "dot" or "json".', 'graph');
+    const suggestion = closestCandidate(format, ['dot', 'json']);
+    return usageError(
+      suggestion
+        ? `adr graph --format must be "dot" or "json". Did you mean "${suggestion}"?`
+        : 'adr graph --format must be "dot" or "json".',
+      'graph',
+    );
   }
 
   const dir = String(parsed.values.dir);
@@ -581,7 +610,7 @@ async function runExplain(args: string[]): Promise<number> {
     parsed = parseCommandArgs(args, {
       json: { type: 'boolean', default: false },
       dir: { type: 'string', default: 'docs/adr' },
-    });
+    }, EXPLAIN_OPTIONS);
   } catch (error) {
     return usageError(error instanceof Error ? error.message : String(error), 'explain');
   }
@@ -846,7 +875,7 @@ async function runCheck(args: string[]): Promise<number> {
     parsed = parseCommandArgs(args, {
       json: { type: 'boolean', default: false },
       dir: { type: 'string', default: 'docs/adr' },
-    });
+    }, CHECK_OPTIONS);
   } catch (error) {
     return usageError(error instanceof Error ? error.message : String(error), 'check');
   }
@@ -880,7 +909,7 @@ async function runEvaluate(args: string[]): Promise<number> {
       date: { type: 'string' },
       json: { type: 'boolean', default: false },
       dir: { type: 'string' },
-    });
+    }, EVALUATE_OPTIONS);
   } catch (error) {
     return usageError(error instanceof Error ? error.message : String(error), 'evaluate');
   }
@@ -931,6 +960,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
       writeStdout(`${CLI_VERSION}\n`);
       return 0;
     }
+    if (command.startsWith('-')) return usageError(unknownOptionMessage(command, TOP_LEVEL_OPTIONS));
 
     // `adr <command> --help` prints that command's usage to stdout at 0. `queue`
     // parses `--help` itself, so it is excluded here to keep one code path for it.

--- a/packages/cli/src/queue.ts
+++ b/packages/cli/src/queue.ts
@@ -1,5 +1,12 @@
-import { buildQueueReport, formatQueueReportJson, formatQueueReportMarkdown, lintCorpus, resolveAsOf } from '@adrkit/core';
+import {
+  buildQueueReport,
+  formatQueueReportJson,
+  formatQueueReportMarkdown,
+  lintCorpus,
+  resolveAsOf,
+} from '@adrkit/core';
 import { corpusDirectoryErrorKind, corpusDirectoryErrorMessage, formatUsageError } from './errors.ts';
+import { closestCandidate } from './recovery.ts';
 
 const USAGE = `Usage: adr queue [options]
 
@@ -35,6 +42,26 @@ interface ParsedFlags {
   asOf?: string;
   format: string;
   help: boolean;
+}
+
+const QUEUE_OPTIONS = ['--dir', '--as-of', '--format', '--help'] as const;
+
+function formatChoiceList(values: readonly string[]): string {
+  if (values.length === 1) return `"${values[0]}"`;
+  if (values.length === 2) return `"${values[0]}" or "${values[1]}"`;
+  return `${values.slice(0, -1).map((value) => `"${value}"`).join(', ')}, or "${values[values.length - 1]}"`;
+}
+
+function unknownOptionMessage(option: string): string {
+  const suggestion = closestCandidate(option, QUEUE_OPTIONS);
+  return suggestion ? `Unknown option "${option}". Did you mean "${suggestion}"?` : `Unknown option "${option}".`;
+}
+
+function formatMessage(value: string): string {
+  const suggestion = closestCandidate(value, ['markdown', 'json']);
+  const expected = formatChoiceList(['markdown', 'json']);
+  const hint = suggestion ? ` Did you mean "${suggestion}"?` : '';
+  return `Invalid --format value "${value}".${hint} Expected ${expected}.`;
 }
 
 type ParseResult =
@@ -96,7 +123,7 @@ export async function runQueue(args: string[]): Promise<number> {
     if ('positional' in parsed) {
       return usageError(`Positional argument "${parsed.positional}" is not supported. Use --dir <path> to select the ADR corpus.`);
     }
-    return usageError(`Unknown option "${parsed.unknown}".`);
+    return usageError(unknownOptionMessage(parsed.unknown));
   }
 
   const { flags } = parsed;
@@ -106,7 +133,7 @@ export async function runQueue(args: string[]): Promise<number> {
   }
 
   if (flags.format !== 'markdown' && flags.format !== 'json') {
-    return usageError(`Invalid --format value "${flags.format}". Expected "markdown" or "json".`);
+    return usageError(formatMessage(flags.format));
   }
 
   let asOf: string;

--- a/packages/cli/src/recovery.ts
+++ b/packages/cli/src/recovery.ts
@@ -1,0 +1,28 @@
+function editDistance(left: string, right: string): number {
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    const current = [leftIndex];
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      const substitution = previous[rightIndex - 1]! + (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1);
+      current[rightIndex] = Math.min(previous[rightIndex]! + 1, current[rightIndex - 1]! + 1, substitution);
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+  return previous[right.length]!;
+}
+
+export function closestCandidate(input: string, candidates: readonly string[], maxDistance = 2): string | undefined {
+  let bestCandidate: string | undefined;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (const candidate of candidates) {
+    const distance = editDistance(input, candidate);
+    if (distance > maxDistance) continue;
+    if (distance < bestDistance || (distance === bestDistance && (bestCandidate === undefined || candidate < bestCandidate))) {
+      bestCandidate = candidate;
+      bestDistance = distance;
+    }
+  }
+
+  return bestCandidate;
+}

--- a/packages/cli/test/mistake-recovery.test.ts
+++ b/packages/cli/test/mistake-recovery.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { resolve } from 'node:path';
+import { cleanupTestDir, resetTestDir } from '../../core/test/helpers.ts';
+
+const CLI_PATH = resolve(process.cwd(), 'packages/cli/src/index.ts');
+const DIR_NAME = 'cli-mistake-recovery';
+
+async function runAdr(args: string[], cwd = process.cwd()) {
+  const proc = Bun.spawn([process.execPath, CLI_PATH, ...args], { cwd, stdout: 'pipe', stderr: 'pipe' });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+afterEach(async () => {
+  await cleanupTestDir(DIR_NAME);
+});
+
+describe('CLI mistake recovery', () => {
+  test('suggests the intended top-level long option', async () => {
+    const result = await runAdr(['--hepl']);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Unknown option "--hepl". Did you mean "--help"?');
+  });
+
+  test('suggests a mistyped command option for lint', async () => {
+    const result = await runAdr(['lint', '--jsoon']);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Unknown option "--jsoon". Did you mean "--json"?');
+  });
+
+  test('suggests a near-miss graph format but not a far miss', async () => {
+    const near = await runAdr(['graph', '--format', 'jsn']);
+    expect(near.exitCode).toBe(2);
+    expect(near.stdout).toBe('');
+    expect(near.stderr).toContain('Did you mean "json"?');
+
+    const far = await runAdr(['graph', '--format', 'svg']);
+    expect(far.exitCode).toBe(2);
+    expect(far.stdout).toBe('');
+    expect(far.stderr).toContain('adr graph --format must be "dot" or "json".');
+    expect(far.stderr).not.toContain('Did you mean');
+  });
+
+  test('suggests a near-miss migrate source but not a far miss', async () => {
+    const near = await runAdr(['migrate', '--from', 'mard']);
+    expect(near.exitCode).toBe(2);
+    expect(near.stdout).toBe('');
+    expect(near.stderr).toContain('Did you mean "madr"?');
+
+    const far = await runAdr(['migrate', '--from', 'agent-log']);
+    expect(far.exitCode).toBe(2);
+    expect(far.stdout).toBe('');
+    expect(far.stderr).toContain('Only "madr" is available; migration is one-way.');
+    expect(far.stderr).not.toContain('Did you mean');
+  });
+
+  test('suggests queue options and format values, but not unrelated flags', async () => {
+    const option = await runAdr(['queue', '--formatt']);
+    expect(option.exitCode).toBe(2);
+    expect(option.stdout).toBe('');
+    expect(option.stderr).toContain('Unknown option "--formatt". Did you mean "--format"?');
+
+    const format = await runAdr(['queue', '--format', 'jsn']);
+    expect(format.exitCode).toBe(2);
+    expect(format.stdout).toBe('');
+    expect(format.stderr).toContain('Did you mean "json"?');
+
+    const far = await runAdr(['queue', '--format', 'csv']);
+    expect(far.exitCode).toBe(2);
+    expect(far.stdout).toBe('');
+    expect(far.stderr).toContain('Invalid --format value "csv". Expected "markdown" or "json".');
+    expect(far.stderr).not.toContain('Did you mean');
+  });
+
+  test('suggests a near-miss scaffold status but not a far miss', async () => {
+    const root = await resetTestDir(DIR_NAME);
+
+    const near = await runAdr(['new', 'Propose a better decision', '--status', 'propoed'], root);
+    expect(near.exitCode).toBe(2);
+    expect(near.stdout).toBe('');
+    expect(near.stderr).toContain('Did you mean "proposed"?');
+
+    const far = await runAdr(['new', 'Propose a better decision', '--status', 'active'], root);
+    expect(far.exitCode).toBe(2);
+    expect(far.stdout).toBe('');
+    expect(far.stderr).toContain('Invalid status "active"');
+    expect(far.stderr).not.toContain('Did you mean');
+  });
+
+  test('keeps the existing scaffold error for statuses outside the closed set', async () => {
+    const root = await resetTestDir(DIR_NAME);
+
+    const result = await runAdr(['new', 'Accepted status stays a core error', '--status', 'accepted'], root);
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('adr new cannot scaffold status "accepted" without additional required fields');
+    expect(result.stderr).not.toContain('Did you mean');
+  });
+});


### PR DESCRIPTION
Adds recovery hints for mistyped long options and near-miss closed values across the CLI, including queue parsing and scaffold status validation.

Includes focused tests and an Unreleased changelog entry.