### PR TITLE
feat(cli): Add shell completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ Until `1.0.0`, minor releases may include breaking changes
   `graph --format`, `migrate --from`, and `queue --format` give near-miss
   hints without changing the existing exit codes or stdout/stderr split.
 
+- **`adr completion` now prints deterministic shell scripts for Bash, Zsh, and
+  Fish.** The command writes to stdout only, covers top-level commands plus each
+  command's documented options, and the CLI README now includes copy-paste
+  activation examples for both `adr` and `adrkit`, including Fish instructions
+  that install or symlink both `adr.fish` and `adrkit.fish`.
+
 ## [0.9.0] - 2026-08-24
 
 ### Added

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -44,8 +44,30 @@ registry and would run whatever anyone publishes under it — and in CI, where n
 assumes `--yes` on a non-TTY, it would install and run it without prompting. Use
 `npx @adrkit/cli` for zero-install.
 
+## Shell completions
+
+`adr completion <bash|zsh|fish>` prints a deterministic completion script to
+stdout. The generated script registers both `adr` and `adrkit` where the shell
+format permits.
+
+```sh
+adr completion bash > ~/.local/share/bash-completion/completions/adr
+cp ~/.local/share/bash-completion/completions/adr ~/.local/share/bash-completion/completions/adrkit
+adr completion zsh > ~/.zsh/completions/_adr
+cp ~/.zsh/completions/_adr ~/.zsh/completions/_adrkit
+adr completion fish > ~/.config/fish/completions/adr.fish
+cp ~/.config/fish/completions/adr.fish ~/.config/fish/completions/adrkit.fish
+```
+
+If you prefer symlinks, point both Fish entry points at the same generated file:
+
+```sh
+ln -sf ~/.config/fish/completions/adr.fish ~/.config/fish/completions/adrkit.fish
+```
+
 The `adr` binary includes `new`, `lint`, `graph`, `explain`, `check`, `queue`,
-`migrate --from madr`, and the offline deterministic `evaluate` command.
+`migrate --from madr`, `completion`, and the offline deterministic `evaluate`
+command.
 
 Run `adr --help` for the command list, `adr help <command>` for one command's
 flags, and `adr --version` to print the installed version.

--- a/packages/cli/src/command-registry.ts
+++ b/packages/cli/src/command-registry.ts
@@ -1,0 +1,121 @@
+export const COMMAND_ORDER = ['new', 'lint', 'check', 'explain', 'graph', 'queue', 'evaluate', 'migrate', 'completion', 'help'] as const;
+
+export type CommandName = (typeof COMMAND_ORDER)[number];
+
+export const COMMAND_SUMMARIES: Record<CommandName, string> = {
+  new: 'Create a decision record',
+  lint: 'Validate ADR files and corpus rules',
+  check: 'Review changed files against governing decisions',
+  explain: 'Explain which decisions govern a path',
+  graph: 'Render decision relationships',
+  queue: 'Show the architecture review board queue',
+  evaluate: 'Evaluate a proposal from an offline snapshot',
+  migrate: 'Import a MADR corpus into adrkit',
+  completion: 'Generate shell completion scripts',
+  help: 'Show help for a command',
+};
+
+export const TOP_LEVEL_OPTIONS = ['--help', '--version'] as const;
+export const TOP_LEVEL_COMPLETION_OPTIONS = ['-h', '--help', '-V', '--version'] as const;
+
+export const COMMAND_OPTIONS = {
+  new: ['--status', '--dir', '--json', '--help'],
+  lint: ['--json', '--dir', '--help'],
+  check: ['--json', '--dir', '--help'],
+  explain: ['--json', '--dir', '--help'],
+  graph: ['--dir', '--format', '--help'],
+  queue: ['--dir', '--as-of', '--format', '--help'],
+  evaluate: ['--snapshot', '--date', '--json', '--dir', '--help'],
+  migrate: ['--from', '--dir', '--dry-run', '--rename', '--json', '--help'],
+  completion: ['--help'],
+  help: ['--help'],
+} as const satisfies Record<CommandName, readonly string[]>;
+
+export const COMMAND_COMPLETION_OPTIONS = {
+  new: ['-h', '--help', '--status', '--dir', '--json'],
+  lint: ['-h', '--help', '--json', '--dir'],
+  check: ['-h', '--help', '--json', '--dir'],
+  explain: ['-h', '--help', '--json', '--dir'],
+  graph: ['-h', '--help', '--dir', '--format'],
+  queue: ['-h', '--help', '--dir', '--as-of', '--format'],
+  evaluate: ['-h', '--help', '--snapshot', '--date', '--json', '--dir'],
+  migrate: ['-h', '--help', '--from', '--dir', '--dry-run', '--rename', '--json'],
+  completion: ['-h', '--help'],
+  help: ['-h', '--help'],
+} as const satisfies Record<CommandName, readonly string[]>;
+
+export const COMMAND_VALUE_CHOICES = {
+  new: { '--status': ['draft', 'proposed', 'rejected', 'deprecated'] },
+  graph: { '--format': ['dot', 'json'] },
+  queue: { '--format': ['markdown', 'json'] },
+  migrate: { '--from': ['madr'] },
+} as const satisfies Partial<Record<CommandName, Record<string, readonly string[]>>>;
+
+export const COMMAND_POSITIONAL_CHOICES = {
+  help: COMMAND_ORDER,
+  completion: ['bash', 'zsh', 'fish'],
+} as const satisfies Partial<Record<CommandName, readonly string[]>>;
+
+export function commandOptions(command: CommandName): readonly string[] {
+  return COMMAND_OPTIONS[command];
+}
+
+export function commandCompletionOptions(command: CommandName): readonly string[] {
+  return COMMAND_COMPLETION_OPTIONS[command];
+}
+
+export function commandValueChoices(command: CommandName, option: string): readonly string[] | undefined {
+  const choiceMap = COMMAND_VALUE_CHOICES[command as keyof typeof COMMAND_VALUE_CHOICES] as
+    | Record<string, readonly string[]>
+    | undefined;
+  return choiceMap?.[option];
+}
+
+export function commandValueChoiceMap(command: CommandName): Record<string, readonly string[]> | undefined {
+  return COMMAND_VALUE_CHOICES[command as keyof typeof COMMAND_VALUE_CHOICES] as
+    | Record<string, readonly string[]>
+    | undefined;
+}
+
+export function requiredCommandValueChoices(command: CommandName, option: string): readonly string[] {
+  const choices = commandValueChoices(command, option);
+  if (!choices) {
+    throw new Error(`Missing command registry value choices for ${command} ${option}.`);
+  }
+  return choices;
+}
+
+export function commandPositionalChoices(command: CommandName): readonly string[] | undefined {
+  return COMMAND_POSITIONAL_CHOICES[command as keyof typeof COMMAND_POSITIONAL_CHOICES];
+}
+
+export function renderTopLevelUsage(version: string): string {
+  const width = Math.max(...COMMAND_ORDER.map((command) => command.length));
+  const commandLines = COMMAND_ORDER.map(
+    (command) => `  ${command.padEnd(width)}  ${COMMAND_SUMMARIES[command]}`,
+  ).join('\n');
+
+  return `adrkit ${version}
+Decision memory for human- and agent-authored plans.
+
+Usage:
+  adr <command> [options]
+
+Commands:
+${commandLines}
+
+Options:
+  -h, --help       Show help
+  -V, --version    Show version
+
+Examples:
+  adr new "Adopt PostgreSQL"
+  adr lint
+  adr explain src/auth/session.ts
+  adr check src/auth/session.ts package.json
+  adr completion bash
+
+Run 'adr help <command>' for command-specific options and examples.
+Documentation: https://adrkit.dev/commands/
+`;
+}

--- a/packages/cli/src/completion.ts
+++ b/packages/cli/src/completion.ts
@@ -1,0 +1,357 @@
+import { closestCandidate } from './recovery.ts';
+import {
+  COMMAND_ORDER,
+  TOP_LEVEL_COMPLETION_OPTIONS,
+  commandCompletionOptions,
+  commandPositionalChoices,
+  commandValueChoiceMap,
+} from './command-registry.ts';
+import { formatUsageError } from './errors.ts';
+
+const COMPLETION_SHELLS = ['bash', 'zsh', 'fish'] as const;
+type CompletionShell = (typeof COMPLETION_SHELLS)[number];
+
+export const COMPLETION_USAGE = `Usage: adr completion <shell>
+
+Write a deterministic shell completion script to stdout.
+The generated script registers both the \`adr\` and \`adrkit\` binaries where the shell format permits.
+
+Arguments:
+  <shell>         Completion shell: bash|zsh|fish
+
+Options:
+  -h, --help      Show this help and exit
+
+Examples:
+  adr completion bash
+  adr completion zsh > ~/.zsh/completions/_adr
+  adr completion fish > ~/.config/fish/completions/adr.fish
+
+Exit codes: 0 = script emitted; 2 = usage error (missing or unsupported shell).
+`;
+
+function usageError(message: string): number {
+  process.stderr.write(formatUsageError(message, COMPLETION_USAGE, 'completion'));
+  return 2;
+}
+
+function formatChoiceList(values: readonly string[]): string {
+  if (values.length === 1) return `"${values[0]}"`;
+  if (values.length === 2) return `"${values[0]}" or "${values[1]}"`;
+  return `${values.slice(0, -1).map((value) => `"${value}"`).join(', ')}, or "${values[values.length - 1]}"`;
+}
+
+function shellWords(values: readonly string[]): string {
+  return values.join(' ');
+}
+
+function unknownOptionMessage(option: string): string {
+  const suggestion = closestCandidate(option, ['--help']);
+  return suggestion ? `Unknown option "${option}". Did you mean "${suggestion}"?` : `Unknown option "${option}".`;
+}
+
+function unknownShellMessage(shell: string): string {
+  const suggestion = closestCandidate(shell, COMPLETION_SHELLS);
+  const expected = formatChoiceList(COMPLETION_SHELLS);
+  return suggestion
+    ? `Invalid shell "${shell}". Did you mean "${suggestion}"? Expected ${expected}.`
+    : `Invalid shell "${shell}". Expected ${expected}.`;
+}
+
+type ParsedArgs =
+  | { ok: true; help: boolean; shell?: string }
+  | { ok: false; unknown: string }
+  | { ok: false; positional: string }
+  | { ok: false; missing: true };
+
+function parseFlags(args: string[]): ParsedArgs {
+  let shell: string | undefined;
+  let help = false;
+
+  for (const arg of args) {
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+      continue;
+    }
+
+    if (arg.startsWith('-')) return { ok: false, unknown: arg };
+    if (shell !== undefined) return { ok: false, positional: arg };
+    shell = arg;
+  }
+
+  if (!help && shell === undefined) return { ok: false, missing: true };
+  return { ok: true, help, shell };
+}
+
+function renderBashWordHelper(): string {
+  return `__adr_complete_words() {
+  local prefix=$1
+  shift
+  COMPREPLY=( $(compgen -W "$*" -- "$prefix") )
+}
+
+__adr_complete_prefixed_words() {
+  local prefix=$1
+  local value_prefix=$2
+  shift 2
+  COMPREPLY=()
+  local candidate
+  for candidate in "$@"; do
+    [[ $candidate == "$value_prefix"* ]] && COMPREPLY+=("\${prefix}\${candidate}")
+  done
+}
+`;
+}
+
+function renderZshWordHelper(): string {
+  return `__adr_complete_words() {
+  local prefix=$1
+  shift
+  local -a matches=()
+  local candidate
+  for candidate in "$@"; do
+    [[ $candidate == "$prefix"* ]] && matches+=("$candidate")
+  done
+  if (( \${#matches[@]} )); then
+    compadd -Q -- "\${matches[@]}"
+  fi
+}
+
+__adr_complete_prefixed_words() {
+  local prefix=$1
+  local value_prefix=$2
+  shift 2
+  local -a matches=()
+  local candidate
+  for candidate in "$@"; do
+    [[ $candidate == "$value_prefix"* ]] && matches+=("\${prefix}\${candidate}")
+  done
+  if (( \${#matches[@]} )); then
+    compadd -Q -- "\${matches[@]}"
+  fi
+}
+`;
+}
+
+function renderBashValueBranch(flag: string, choices: readonly string[]): string {
+  return `      if [[ $cur == ${flag}=* ]]; then
+        local value_prefix="\${cur#${flag}=}"
+        __adr_complete_prefixed_words "${flag}=" "$value_prefix" ${shellWords(choices)}
+        return 0
+      fi
+      if [[ $prev == ${flag} ]]; then
+        __adr_complete_words "$cur" ${shellWords(choices)}
+        return 0
+      fi
+`;
+}
+
+function renderZshValueBranch(flag: string, choices: readonly string[]): string {
+  return `      if [[ $cur == ${flag}=* ]]; then
+        local value_prefix="\${cur#${flag}=}"
+        __adr_complete_prefixed_words "${flag}=" "$value_prefix" ${shellWords(choices)}
+        return 0
+      fi
+      if [[ $prev == ${flag} ]]; then
+        __adr_complete_words "$cur" ${shellWords(choices)}
+        return 0
+      fi
+`;
+}
+
+function renderCommandBranch(shell: 'bash' | 'zsh', command: string): string {
+  const options = commandCompletionOptions(command as never);
+  const valueChoices = commandValueChoiceMap(command as never) ?? {};
+  const positionalChoices = commandPositionalChoices(command as never);
+  const valueBranch =
+    shell === 'bash'
+      ? Object.entries(valueChoices).map(([flag, choices]) => renderBashValueBranch(flag, choices)).join('')
+      : Object.entries(valueChoices).map(([flag, choices]) => renderZshValueBranch(flag, choices)).join('');
+  const optionHelper = shell === 'bash' ? '__adr_complete_words' : '__adr_complete_words';
+  const firstPositional =
+    command === 'help'
+      ? COMMAND_ORDER
+      : command === 'completion'
+        ? COMPLETION_SHELLS
+        : positionalChoices;
+  const firstPositionalBlock = firstPositional
+    ? shell === 'bash'
+      ? `      if [[ $COMP_CWORD -eq 2 ]]; then
+        if [[ $cur == -* ]]; then
+          ${optionHelper} "$cur" -h --help
+        else
+          ${optionHelper} "$cur" ${shellWords(firstPositional)}
+        fi
+        return 0
+      fi
+`
+      : `      if (( CURRENT == 3 )); then
+        if [[ $cur == -* ]]; then
+          ${optionHelper} "$cur" -h --help
+        else
+          ${optionHelper} "$cur" ${shellWords(firstPositional)}
+        fi
+        return 0
+      fi
+`
+    : '';
+
+  if (command === 'help' || command === 'completion') {
+    return `    ${command})
+${valueBranch}${firstPositionalBlock}      return 0
+      ;;
+`;
+  }
+
+  return `    ${command})
+${valueBranch}${firstPositionalBlock}      if [[ -z $cur || $cur == -* ]]; then
+        ${optionHelper} "$cur" ${shellWords(options)}
+        return 0
+      fi
+      ;;
+`;
+}
+
+function renderBashCompletion(): string {
+  const rootCandidates = [...TOP_LEVEL_COMPLETION_OPTIONS, ...COMMAND_ORDER];
+  const commandBranches = COMMAND_ORDER.map((command) => renderCommandBranch('bash', command)).join('');
+
+  return `# shellcheck shell=bash
+${renderBashWordHelper()}
+_adr_completion() {
+  local cur prev command
+  COMPREPLY=()
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  prev="\${COMP_WORDS[COMP_CWORD-1]}"
+  command="\${COMP_WORDS[1]}"
+
+  if [[ $COMP_CWORD -le 1 ]]; then
+    __adr_complete_words "$cur" ${shellWords(rootCandidates)}
+    return 0
+  fi
+
+  case "$command" in
+${commandBranches}  esac
+}
+
+complete -F _adr_completion adr adrkit
+`;
+}
+
+function renderZshCompletion(): string {
+  const rootCandidates = [...TOP_LEVEL_COMPLETION_OPTIONS, ...COMMAND_ORDER];
+  const commandBranches = COMMAND_ORDER.map((command) => renderCommandBranch('zsh', command)).join('');
+
+  return `#compdef adr adrkit
+${renderZshWordHelper()}
+_adr_completion() {
+  emulate -L zsh
+  setopt localoptions noshwordsplit
+  local cur prev command
+  cur="\${words[CURRENT]}"
+  prev="\${words[CURRENT-1]}"
+  command="\${words[2]}"
+
+  if (( CURRENT <= 2 )); then
+    __adr_complete_words "$cur" ${shellWords(rootCandidates)}
+    return 0
+  fi
+
+  case "$command" in
+${commandBranches}  esac
+}
+
+compdef _adr_completion adr adrkit
+`;
+}
+
+function renderFishCompletion(): string {
+  const lines: string[] = [];
+  const binaryTargets = '-c adr -c adrkit';
+  const rootCandidates = [...TOP_LEVEL_COMPLETION_OPTIONS, ...COMMAND_ORDER];
+
+  lines.push(`function __adr_root_position`);
+  lines.push(`    set -l tokens (commandline -opc)`);
+  lines.push(`    test (count $tokens) -eq 1`);
+  lines.push(`end`);
+  lines.push(``);
+  lines.push(`function __adr_subcommand_is`);
+  lines.push(`    set -l tokens (commandline -opc)`);
+  lines.push(`    test (count $tokens) -ge 2; and test "$tokens[2]" = "$argv[1]"`);
+  lines.push(`end`);
+  lines.push(``);
+  lines.push(`function __adr_first_positional`);
+  lines.push(`    set -l tokens (commandline -opc)`);
+  lines.push(`    test (count $tokens) -eq 2`);
+  lines.push(`end`);
+  lines.push(``);
+  lines.push(`function __adr_current_token_is_option`);
+  lines.push(`    set -l token (commandline -ct)`);
+  lines.push(`    test -n "$token"; and test (string sub -s 1 -l 1 -- $token) = '-'`);
+  lines.push(`end`);
+  lines.push(``);
+  lines.push(`complete ${binaryTargets} -n '__adr_root_position' -f -a "${shellWords(rootCandidates)}"`);
+  lines.push(`complete ${binaryTargets} -n '__adr_root_position' -s h -l help -d 'Show help'`);
+  lines.push(`complete ${binaryTargets} -n '__adr_root_position' -s V -l version -d 'Show version'`);
+
+  for (const command of COMMAND_ORDER) {
+    const options = commandCompletionOptions(command as never).filter((option) => option !== '-h' && option !== '--help');
+    const valueChoices = commandValueChoiceMap(command as never) ?? {};
+    const guard = `__adr_subcommand_is ${command}`;
+
+    if (command === 'help' || command === 'completion') {
+      const firstChoices = command === 'help' ? COMMAND_ORDER : COMPLETION_SHELLS;
+      lines.push(`complete ${binaryTargets} -n '${guard}; and __adr_first_positional; and not __adr_current_token_is_option' -f -a "${shellWords(firstChoices)}"`);
+      lines.push(`complete ${binaryTargets} -n '${guard}; and __adr_first_positional' -s h -l help -d 'Show help'`);
+      continue;
+    }
+
+    lines.push(`complete ${binaryTargets} -n '${guard}' -s h -l help -d 'Show help'`);
+    lines.push(`complete ${binaryTargets} -n '${guard}' -f -a "${shellWords(options)}"`);
+
+    for (const [flag, choices] of Object.entries(valueChoices)) {
+      lines.push(`complete ${binaryTargets} -n '${guard}' -r -l ${flag.slice(2)} -a "${shellWords(choices)}"`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function renderCompletionScript(shell: CompletionShell): string {
+  if (shell === 'bash') return renderBashCompletion();
+  if (shell === 'zsh') return renderZshCompletion();
+  return renderFishCompletion();
+}
+
+function parseCompletionArgs(args: string[]): ParsedArgs {
+  const parsed = parseFlags(args);
+  if (!parsed.ok) return parsed;
+  if (parsed.help) return parsed;
+  if (parsed.shell === undefined) return { ok: false, missing: true };
+  return parsed;
+}
+
+export async function runCompletion(args: string[]): Promise<number> {
+  const parsed = parseCompletionArgs(args);
+  if (!parsed.ok) {
+    if ('missing' in parsed) return usageError('adr completion requires exactly one shell: bash, zsh, or fish.');
+    if ('positional' in parsed) return usageError(`Positional argument "${parsed.positional}" is not supported. Use adr completion <shell>.`);
+    return usageError(unknownOptionMessage(parsed.unknown));
+  }
+
+  if (parsed.help) {
+    process.stdout.write(COMPLETION_USAGE);
+    return 0;
+  }
+
+  if (parsed.shell === undefined) {
+    return usageError('adr completion requires exactly one shell: bash, zsh, or fish.');
+  }
+
+  if (!COMPLETION_SHELLS.includes(parsed.shell as CompletionShell)) {
+    return usageError(unknownShellMessage(parsed.shell));
+  }
+
+  process.stdout.write(renderCompletionScript(parsed.shell as CompletionShell));
+  return 0;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,15 @@ import {
 import { evaluate } from './evaluate.ts';
 import { closestCandidate } from './recovery.ts';
 import {
+  COMMAND_ORDER,
+  TOP_LEVEL_OPTIONS,
+  commandOptions,
+  renderTopLevelUsage,
+  requiredCommandValueChoices,
+  type CommandName,
+} from './command-registry.ts';
+import { COMPLETION_USAGE, runCompletion } from './completion.ts';
+import {
   corpusDirectoryErrorKind,
   corpusDirectoryErrorMessage,
   formatUsageError,
@@ -91,42 +100,13 @@ function hasValueFlag(args: readonly string[], flag: string): boolean {
   return false;
 }
 
-const USAGE = `adrkit ${CLI_VERSION}
-Decision memory for human- and agent-authored plans.
-
-Usage:
-  adr <command> [options]
-
-Commands:
-  new       Create a decision record
-  lint      Validate ADR files and corpus rules
-  check     Review changed files against governing decisions
-  explain   Explain which decisions govern a path
-  graph     Render decision relationships
-  queue     Show the architecture review board queue
-  evaluate  Evaluate a proposal from an offline snapshot
-  migrate   Import a MADR corpus into adrkit
-  help      Show help for a command
-
-Options:
-  -h, --help       Show help
-  -V, --version    Show version
-
-Examples:
-  adr new "Adopt PostgreSQL"
-  adr lint
-  adr explain src/auth/session.ts
-  adr check src/auth/session.ts package.json
-
-Run 'adr help <command>' for command-specific options and examples.
-Documentation: https://adrkit.dev/commands/
-`;
+const USAGE = renderTopLevelUsage(CLI_VERSION);
 
 /**
  * Per-command help, printed by `adr <command> --help` and `adr help <command>`.
  * `queue` reuses its own richer usage text so there is a single source for it.
  */
-const COMMAND_USAGE: Record<string, string> = {
+const COMMAND_USAGE = {
   new: `Usage: adr new <title> [options]
 
 Create a decision record with the next available numeric ID.
@@ -290,22 +270,24 @@ Examples:
   adr help
   adr help check
 `,
-};
+  completion: COMPLETION_USAGE,
+} satisfies Record<CommandName, string>;
 
-const COMMANDS = Object.keys(COMMAND_USAGE);
-const TOP_LEVEL_OPTIONS = ['--help', '--version'] as const;
-const LINT_OPTIONS = ['--json', '--dir', '--help'] as const;
-const MIGRATE_OPTIONS = ['--from', '--dir', '--dry-run', '--rename', '--json', '--help'] as const;
-const NEW_OPTIONS = ['--status', '--dir', '--json', '--help'] as const;
-const GRAPH_OPTIONS = ['--dir', '--format', '--help'] as const;
-const EXPLAIN_OPTIONS = ['--json', '--dir', '--help'] as const;
-const CHECK_OPTIONS = ['--json', '--dir', '--help'] as const;
-const EVALUATE_OPTIONS = ['--snapshot', '--date', '--json', '--dir', '--help'] as const;
-const NEW_ALLOWED_STATUSES = ['draft', 'proposed', 'rejected', 'deprecated'] as const;
+const COMMANDS = COMMAND_ORDER;
+const LINT_OPTIONS = commandOptions('lint');
+const MIGRATE_OPTIONS = commandOptions('migrate');
+const NEW_OPTIONS = commandOptions('new');
+const GRAPH_OPTIONS = commandOptions('graph');
+const EXPLAIN_OPTIONS = commandOptions('explain');
+const CHECK_OPTIONS = commandOptions('check');
+const EVALUATE_OPTIONS = commandOptions('evaluate');
+const NEW_ALLOWED_STATUSES = requiredCommandValueChoices('new', '--status');
+const GRAPH_FORMAT_CHOICES = requiredCommandValueChoices('graph', '--format');
+const MIGRATE_FROM_CHOICES = requiredCommandValueChoices('migrate', '--from');
 
 /** Own-property lookup: `adr help constructor` must be a usage error, not a crash. */
 function commandUsageFor(command: string): string | undefined {
-  return Object.hasOwn(COMMAND_USAGE, command) ? COMMAND_USAGE[command] : undefined;
+  return Object.hasOwn(COMMAND_USAGE, command) ? COMMAND_USAGE[command as CommandName] : undefined;
 }
 
 /** Usage error: concise guidance on stderr, exit 2. Explicit help goes to stdout at 0. */
@@ -484,8 +466,8 @@ async function runMigrate(args: string[]): Promise<number> {
 
   if (parsed.positionals.length > 0) return usageError('adr migrate does not accept positional arguments.', 'migrate');
   const from = parsed.values.from;
-  if (from !== 'madr') {
-    const suggestion = typeof from === 'string' ? closestCandidate(from, ['madr']) : undefined;
+  if (typeof from !== 'string' || !MIGRATE_FROM_CHOICES.includes(from)) {
+    const suggestion = typeof from === 'string' ? closestCandidate(from, MIGRATE_FROM_CHOICES) : undefined;
     return usageError(
       from
         ? suggestion
@@ -580,8 +562,8 @@ async function runGraph(args: string[]): Promise<number> {
 
   if (parsed.positionals.length > 0) return usageError('adr graph does not accept positional arguments.', 'graph');
   const format = String(parsed.values.format);
-  if (format !== 'dot' && format !== 'json') {
-    const suggestion = closestCandidate(format, ['dot', 'json']);
+  if (!GRAPH_FORMAT_CHOICES.includes(format)) {
+    const suggestion = closestCandidate(format, GRAPH_FORMAT_CHOICES);
     return usageError(
       suggestion
         ? `adr graph --format must be "dot" or "json". Did you mean "${suggestion}"?`
@@ -963,8 +945,9 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
     if (command.startsWith('-')) return usageError(unknownOptionMessage(command, TOP_LEVEL_OPTIONS));
 
     // `adr <command> --help` prints that command's usage to stdout at 0. `queue`
-    // parses `--help` itself, so it is excluded here to keep one code path for it.
-    const commandUsage = command === 'queue' ? undefined : commandUsageFor(command);
+    // and `completion` parse `--help` themselves, so they are excluded here to keep
+    // one code path for each.
+    const commandUsage = command === 'queue' || command === 'completion' ? undefined : commandUsageFor(command);
     if (commandUsage && args.some(isHelpFlag)) {
       writeStdout(commandUsage);
       return 0;
@@ -978,6 +961,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
     if (command === 'check') return await runCheck(args);
     if (command === 'evaluate') return await runEvaluate(args);
     if (command === 'queue') return await runQueue(args);
+    if (command === 'completion') return await runCompletion(args);
     return usageError(unknownCommandMessage(command));
   } catch (error) {
     writeStderr(`${error instanceof Error ? error.message : String(error)}\n`);

--- a/packages/cli/src/queue.ts
+++ b/packages/cli/src/queue.ts
@@ -5,6 +5,7 @@ import {
   lintCorpus,
   resolveAsOf,
 } from '@adrkit/core';
+import { commandOptions, requiredCommandValueChoices } from './command-registry.ts';
 import { corpusDirectoryErrorKind, corpusDirectoryErrorMessage, formatUsageError } from './errors.ts';
 import { closestCandidate } from './recovery.ts';
 
@@ -44,7 +45,8 @@ interface ParsedFlags {
   help: boolean;
 }
 
-const QUEUE_OPTIONS = ['--dir', '--as-of', '--format', '--help'] as const;
+const QUEUE_OPTIONS = commandOptions('queue');
+const QUEUE_FORMAT_CHOICES = requiredCommandValueChoices('queue', '--format');
 
 function formatChoiceList(values: readonly string[]): string {
   if (values.length === 1) return `"${values[0]}"`;
@@ -58,8 +60,8 @@ function unknownOptionMessage(option: string): string {
 }
 
 function formatMessage(value: string): string {
-  const suggestion = closestCandidate(value, ['markdown', 'json']);
-  const expected = formatChoiceList(['markdown', 'json']);
+  const suggestion = closestCandidate(value, QUEUE_FORMAT_CHOICES);
+  const expected = formatChoiceList(QUEUE_FORMAT_CHOICES);
   const hint = suggestion ? ` Did you mean "${suggestion}"?` : '';
   return `Invalid --format value "${value}".${hint} Expected ${expected}.`;
 }

--- a/packages/cli/test/completion.test.ts
+++ b/packages/cli/test/completion.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { COMMAND_VALUE_CHOICES } from '../src/command-registry.ts';
+
+const CLI_PATH = resolve(process.cwd(), 'packages/cli/src/index.ts');
+const SHELLS = {
+  bash: Bun.which('bash'),
+  zsh: Bun.which('zsh'),
+  fish: Bun.which('fish'),
+} as const;
+
+type Shell = keyof typeof SHELLS;
+
+async function runAdr(args: string[]) {
+  const proc = Bun.spawn([process.execPath, CLI_PATH, ...args], {
+    cwd: process.cwd(),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+async function writeCompletionScript(shell: Shell): Promise<{ dir: string; stdout: string }> {
+  const result = await runAdr(['completion', shell]);
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.stdout).toContain('adrkit');
+  return {
+    dir: await mkdtemp(join(tmpdir(), `adr-completion-${shell}-`)),
+    stdout: result.stdout,
+  };
+}
+
+async function withCompletionScript(shell: Shell, run: (scriptPath: string) => Promise<void>): Promise<void> {
+  const { dir, stdout } = await writeCompletionScript(shell);
+  const scriptPath = join(dir, `adr.${shell}`);
+  await writeFile(scriptPath, stdout, 'utf8');
+
+  try {
+    await run(scriptPath);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function runShell(command: string[], cwd = process.cwd()) {
+  const proc = Bun.spawn(command, { cwd, stdout: 'pipe', stderr: 'pipe' });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+function lines(text: string): string[] {
+  return text.split('\n').map((line) => line.trim()).filter(Boolean);
+}
+
+function fishScript(scriptPath: string, tokens: string[], body: string[]): string {
+  return [
+    `source ${JSON.stringify(scriptPath)}`,
+    'function commandline',
+    '    switch $argv[1]',
+    '        case -opc',
+    '            printf "%s\\n" $TEST_TOKENS',
+    '        case -ct',
+    '            printf "%s" $TEST_CTOKEN',
+    '    end',
+    'end',
+    `set -g TEST_TOKENS ${tokens.join(' ')}`,
+    'set -g TEST_CTOKEN ""',
+    ...body,
+  ].join('\n');
+}
+
+describe('adr completion CLI', () => {
+  for (const shell of ['bash', 'zsh', 'fish'] as const) {
+    test(`generates a deterministic ${shell} completion script`, async () => {
+      const first = await runAdr(['completion', shell]);
+      const second = await runAdr(['completion', shell]);
+
+      expect(first.exitCode).toBe(0);
+      expect(first.stderr).toBe('');
+      expect(first.stdout).toBe(second.stdout);
+      expect(first.stdout.length).toBeGreaterThan(0);
+      expect(first.stdout).toContain('adrkit');
+      expect(first.stdout).toContain('help');
+      expect(first.stdout).toContain('completion');
+    });
+  }
+
+  test('rejects an unknown completion shell with a recovery hint', async () => {
+    const result = await runAdr(['completion', 'bsh']);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Invalid shell "bsh". Did you mean "bash"?');
+    expect(result.stderr).toContain('Expected "bash", "zsh", or "fish".');
+  });
+
+  test('completion value metadata stays aligned with the shared registry', async () => {
+    const result = await runAdr(['completion', 'bash']);
+
+    expect(result.exitCode).toBe(0);
+    for (const choices of Object.values(COMMAND_VALUE_CHOICES)) {
+      for (const valueChoices of Object.values(choices)) {
+        for (const choice of valueChoices) {
+          expect(result.stdout).toContain(choice);
+        }
+      }
+    }
+  });
+
+  test('requires a shell argument', async () => {
+    const result = await runAdr(['completion']);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('adr completion requires exactly one shell');
+  });
+
+  test('bash completion passes syntax checks and covers first-slot and value completions', async () => {
+    if (!SHELLS.bash) return;
+
+    await withCompletionScript('bash', async (scriptPath) => {
+      const syntax = await runShell([SHELLS.bash!, '--noprofile', '--norc', '-n', scriptPath]);
+      expect(syntax.exitCode).toBe(0);
+      expect(syntax.stderr).toBe('');
+
+      const shellNames = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr completion "")',
+          'COMP_CWORD=2',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(shellNames.stdout)).toEqual(expect.arrayContaining(['bash', 'zsh', 'fish']));
+
+      const commandNames = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr help "")',
+          'COMP_CWORD=2',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(commandNames.stdout)).toEqual(expect.arrayContaining(['new', 'lint', 'completion']));
+
+      const secondSlot = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr help lint "")',
+          'COMP_CWORD=3',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(secondSlot.stdout)).toEqual([]);
+
+      const statusValues = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr new --status=)',
+          'COMP_CWORD=2',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(statusValues.stdout)).toEqual(expect.arrayContaining(['--status=draft', '--status=proposed', '--status=rejected', '--status=deprecated']));
+
+      const formatValues = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr queue --format "")',
+          'COMP_CWORD=3',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(formatValues.stdout)).toEqual(expect.arrayContaining(['markdown', 'json']));
+
+      const emptyTokenOptions = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr migrate "")',
+          'COMP_CWORD=2',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(emptyTokenOptions.stdout)).toEqual(expect.arrayContaining(['--from', '--dir', '--dry-run']));
+    });
+  });
+
+  test('zsh completion passes syntax checks and uses native prefix matching', async () => {
+    if (!SHELLS.zsh) return;
+
+    await withCompletionScript('zsh', async (scriptPath) => {
+      const syntax = await runShell([SHELLS.zsh!, '-f', '-n', scriptPath]);
+      expect(syntax.exitCode).toBe(0);
+      expect(syntax.stderr).toBe('');
+
+      const firstSlot = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr completion "")',
+          'CURRENT=3',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(firstSlot.stdout)).toEqual(expect.arrayContaining(['bash', 'zsh', 'fish']));
+
+      const noSecondSlot = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr help lint "")',
+          'CURRENT=4',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(noSecondSlot.stdout)).toEqual([]);
+
+      const statusValues = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr new --status=)',
+          'CURRENT=3',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(statusValues.stdout)).toEqual(expect.arrayContaining(['--status=draft', '--status=proposed', '--status=rejected', '--status=deprecated']));
+
+      const emptyTokenOptions = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr migrate "")',
+          'CURRENT=3',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(emptyTokenOptions.stdout)).toEqual(expect.arrayContaining(['--from', '--dir', '--dry-run']));
+    });
+  });
+
+  test('fish completion derives the real subcommand position', async () => {
+    if (!SHELLS.fish) return;
+
+    await withCompletionScript('fish', async (scriptPath) => {
+      const syntax = await runShell([SHELLS.fish!, '-n', scriptPath]);
+      expect(syntax.exitCode).toBe(0);
+      expect(syntax.stderr).toBe('');
+
+      const falsePositive = await runShell([
+        SHELLS.fish!,
+        '-c',
+        fishScript(scriptPath, ['adr', 'new', 'help'], [
+          'if __adr_subcommand_is help',
+          '    echo match',
+          'end',
+          'if __adr_first_positional',
+          '    echo first',
+          'end',
+        ]),
+      ]);
+      expect(falsePositive.stdout).toBe('');
+
+      const firstPositional = await runShell([
+        SHELLS.fish!,
+        '-c',
+        fishScript(scriptPath, ['adr', 'help'], [
+          'if __adr_subcommand_is help',
+          '    echo match',
+          'end',
+          'if __adr_first_positional',
+          '    echo first',
+          'end',
+        ]),
+      ]);
+      expect(lines(firstPositional.stdout)).toEqual(['match', 'first']);
+
+      const secondPositional = await runShell([
+        SHELLS.fish!,
+        '-c',
+        fishScript(scriptPath, ['adr', 'help', 'lint'], [
+          'if __adr_subcommand_is help',
+          '    echo match',
+          'end',
+          'if __adr_first_positional',
+          '    echo first',
+          'end',
+        ]),
+      ]);
+      expect(lines(secondPositional.stdout)).toEqual(['match']);
+
+      const optionToken = await runShell([
+        SHELLS.fish!,
+        '-c',
+        fishScript(scriptPath, ['adr', 'help'], [
+          'set -g TEST_CTOKEN "-"',
+          'if __adr_current_token_is_option',
+          '    echo option',
+          'end',
+        ]),
+      ]);
+      expect(lines(optionToken.stdout)).toEqual(['option']);
+
+      const generated = await runAdr(['completion', 'fish']);
+      expect(generated.stdout).toContain('not __adr_current_token_is_option');
+
+      const leadingDashSuppression = await runShell([
+        SHELLS.fish!,
+        '-c',
+        `source ${JSON.stringify(scriptPath)}; complete -C "adr help -"`,
+      ]);
+      expect(lines(leadingDashSuppression.stdout)).not.toEqual(expect.arrayContaining(['new', 'lint', 'completion']));
+    });
+  });
+});

--- a/packages/cli/test/help-version.test.ts
+++ b/packages/cli/test/help-version.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, test } from 'bun:test';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { COMMAND_ORDER } from '../src/command-registry.ts';
 import { CLI_VERSION } from '../src/index.ts';
 
 const CLI_PATH = resolve(process.cwd(), 'packages/cli/src/index.ts');
@@ -67,6 +68,8 @@ describe('adr help (#42)', () => {
     expect(result.stdout).toContain('Commands:');
     expect(result.stdout).toContain('Create a decision record');
     expect(result.stdout).toContain('Review changed files against governing decisions');
+    expect(result.stdout).toContain('Generate shell completion scripts');
+    expect(result.stdout).toContain('adr completion bash');
     expect(result.stdout).toContain('Examples:');
     expect(result.stdout).toContain("Run 'adr help <command>'");
     expect(result.stdout).toContain('Documentation: https://adrkit.dev/commands/');
@@ -128,13 +131,23 @@ describe('adr help (#42)', () => {
   });
 
   test('adr <command> --help matches adr help <command>', async () => {
-    for (const command of ['lint', 'migrate', 'new', 'graph', 'explain', 'check', 'evaluate', 'queue']) {
+    for (const command of COMMAND_ORDER) {
       const [viaFlag, viaHelp] = await Promise.all([runAdr([command, '--help']), runAdr(['help', command])]);
 
       expect(viaFlag.exitCode).toBe(0);
+      expect(viaHelp.exitCode).toBe(0);
       expect(viaFlag.stderr).toBe('');
-      expect(viaFlag.stdout).toBe(viaHelp.stdout);
       expect(viaFlag.stdout).toContain('Examples:');
+
+      expect(viaHelp.stderr).toBe('');
+
+      if (command === 'help') {
+        expect(viaFlag.stdout).toContain('adrkit');
+        expect(viaHelp.stdout).toContain('Usage: adr help [command]');
+        continue;
+      }
+
+      expect(viaFlag.stdout).toBe(viaHelp.stdout);
     }
   });
 


### PR DESCRIPTION
Adds deterministic `adr completion <bash|zsh|fish>` output, wires it into help/registry/recovery, and updates CLI docs plus focused tests.

Base: `mbeacom-cli-mistake-recovery`