### PR TITLE
feat(cli): add tty-aware presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Until `1.0.0`, minor releases may include breaking changes
   activation examples for both `adr` and `adrkit`, including Fish instructions
   that install or symlink both `adr.fish` and `adrkit.fish`.
 
+- **Human-facing CLI output now respects TTY color and `NO_COLOR`.** Plain text
+  output stays ANSI-free when piped or redirected, `--color auto|always|never`
+  controls terminal styling, and JSON/completion output remain unchanged.
+
 ## [0.9.0] - 2026-08-24
 
 ### Added

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -44,6 +44,10 @@ registry and would run whatever anyone publishes under it — and in CI, where n
 assumes `--yes` on a non-TTY, it would install and run it without prompting. Use
 `npx @adrkit/cli` for zero-install.
 
+Human-readable CLI output is TTY-aware: it stays ANSI-free when redirected or
+piped, honors `NO_COLOR`, and can be forced with `--color auto|always|never`
+before the command, for example `adr --color always lint`.
+
 ## Shell completions
 
 `adr completion <bash|zsh|fish>` prints a deterministic completion script to
@@ -116,7 +120,7 @@ capped
 at 3,000 normalized paths and 16 concurrent reads; skipped paths warn but never
 fail. The cap matches GitHub's changed-file ceiling, so only a local invocation
 can reach it.
-See [the commands reference](https://adrkit.dev/docs/commands/#inbound-adr-markers).
+See [the commands reference](https://adrkit.dev/commands/#inbound-adr-markers).
 
 The published ESM CLI runs on Node.js 22 or newer; development in the adrkit
 repository uses Bun.

--- a/packages/cli/src/command-registry.ts
+++ b/packages/cli/src/command-registry.ts
@@ -1,3 +1,5 @@
+import type { StreamStyle } from './presentation.ts';
+
 export const COMMAND_ORDER = ['new', 'lint', 'check', 'explain', 'graph', 'queue', 'evaluate', 'migrate', 'completion', 'help'] as const;
 
 export type CommandName = (typeof COMMAND_ORDER)[number];
@@ -15,8 +17,13 @@ export const COMMAND_SUMMARIES: Record<CommandName, string> = {
   help: 'Show help for a command',
 };
 
-export const TOP_LEVEL_OPTIONS = ['--help', '--version'] as const;
-export const TOP_LEVEL_COMPLETION_OPTIONS = ['-h', '--help', '-V', '--version'] as const;
+export const TOP_LEVEL_OPTIONS = ['--help', '--version', '--color'] as const;
+export const GLOBAL_COLOR_OPTIONS = ['--color'] as const;
+export const GLOBAL_COLOR_VALUES = ['auto', 'always', 'never'] as const;
+export const TOP_LEVEL_COMPLETION_OPTIONS = ['-h', '--help', '-V', '--version', ...GLOBAL_COLOR_OPTIONS] as const;
+export const TOP_LEVEL_COMPLETION_VALUE_CHOICES = {
+  '--color': GLOBAL_COLOR_VALUES,
+} as const satisfies Record<string, readonly string[]>;
 
 export const COMMAND_OPTIONS = {
   new: ['--status', '--dir', '--json', '--help'],
@@ -56,6 +63,14 @@ export const COMMAND_POSITIONAL_CHOICES = {
   completion: ['bash', 'zsh', 'fish'],
 } as const satisfies Partial<Record<CommandName, readonly string[]>>;
 
+export function withGlobalColorOption(options: readonly string[]): readonly string[] {
+  return [...new Set([...options, ...GLOBAL_COLOR_OPTIONS])];
+}
+
+export function renderGlobalColorUsageLine(indent = '  '): string {
+  return `${indent}--color <auto|always|never>  Colorize human-readable output (default: auto; honors NO_COLOR)`;
+}
+
 export function commandOptions(command: CommandName): readonly string[] {
   return COMMAND_OPTIONS[command];
 }
@@ -89,33 +104,42 @@ export function commandPositionalChoices(command: CommandName): readonly string[
   return COMMAND_POSITIONAL_CHOICES[command as keyof typeof COMMAND_POSITIONAL_CHOICES];
 }
 
-export function renderTopLevelUsage(version: string): string {
+export function topLevelValueChoices(option: string): readonly string[] | undefined {
+  return TOP_LEVEL_COMPLETION_VALUE_CHOICES[option as keyof typeof TOP_LEVEL_COMPLETION_VALUE_CHOICES];
+}
+
+export function renderTopLevelUsage(version: string, style?: StreamStyle): string {
+  const heading = style?.heading ?? ((text: string) => text);
+  const commandStyle = style?.command ?? ((text: string) => text);
+  const note = style?.note ?? ((text: string) => text);
+  const label = style?.label ?? ((text: string) => text);
   const width = Math.max(...COMMAND_ORDER.map((command) => command.length));
   const commandLines = COMMAND_ORDER.map(
-    (command) => `  ${command.padEnd(width)}  ${COMMAND_SUMMARIES[command]}`,
+    (command) => `  ${commandStyle(command.padEnd(width))}  ${style?.note?.(COMMAND_SUMMARIES[command]) ?? COMMAND_SUMMARIES[command]}`,
   ).join('\n');
 
-  return `adrkit ${version}
-Decision memory for human- and agent-authored plans.
+  return `${heading(`adrkit ${version}`)}
+${note('Decision memory for human- and agent-authored plans.')}
 
-Usage:
+${heading('Usage:')}
   adr <command> [options]
 
-Commands:
+${heading('Commands:')}
 ${commandLines}
 
-Options:
-  -h, --help       Show help
-  -V, --version    Show version
+${heading('Options:')}
+  ${label('--color')} auto|always|never  Colorize human-readable output (default: auto; honors NO_COLOR)
+  ${label('-h, --help')}                 Show help
+  ${label('-V, --version')}              Show version
 
-Examples:
+${heading('Examples:')}
   adr new "Adopt PostgreSQL"
   adr lint
   adr explain src/auth/session.ts
   adr check src/auth/session.ts package.json
   adr completion bash
 
-Run 'adr help <command>' for command-specific options and examples.
-Documentation: https://adrkit.dev/commands/
+${note("Run 'adr help <command>' for command-specific options and examples.")}
+${note('Documentation: https://adrkit.dev/commands/')}
 `;
 }

--- a/packages/cli/src/completion.ts
+++ b/packages/cli/src/completion.ts
@@ -1,12 +1,19 @@
+#!/usr/bin/env node
+
 import { closestCandidate } from './recovery.ts';
 import {
   COMMAND_ORDER,
+  GLOBAL_COLOR_VALUES,
   TOP_LEVEL_COMPLETION_OPTIONS,
+  TOP_LEVEL_COMPLETION_VALUE_CHOICES,
   commandCompletionOptions,
   commandPositionalChoices,
   commandValueChoiceMap,
+  renderGlobalColorUsageLine,
+  withGlobalColorOption,
 } from './command-registry.ts';
 import { formatUsageError } from './errors.ts';
+import { getPresentation, styleUsageBlock } from './presentation.ts';
 
 const COMPLETION_SHELLS = ['bash', 'zsh', 'fish'] as const;
 type CompletionShell = (typeof COMPLETION_SHELLS)[number];
@@ -21,6 +28,7 @@ Arguments:
 
 Options:
   -h, --help      Show this help and exit
+${renderGlobalColorUsageLine()}
 
 Examples:
   adr completion bash
@@ -31,7 +39,7 @@ Exit codes: 0 = script emitted; 2 = usage error (missing or unsupported shell).
 `;
 
 function usageError(message: string): number {
-  process.stderr.write(formatUsageError(message, COMPLETION_USAGE, 'completion'));
+  process.stderr.write(formatUsageError(message, COMPLETION_USAGE, 'completion', getPresentation().stderr));
   return 2;
 }
 
@@ -46,7 +54,7 @@ function shellWords(values: readonly string[]): string {
 }
 
 function unknownOptionMessage(option: string): string {
-  const suggestion = closestCandidate(option, ['--help']);
+  const suggestion = closestCandidate(option, withGlobalColorOption(['--help']));
   return suggestion ? `Unknown option "${option}". Did you mean "${suggestion}"?` : `Unknown option "${option}".`;
 }
 
@@ -83,7 +91,7 @@ function parseFlags(args: string[]): ParsedArgs {
   return { ok: true, help, shell };
 }
 
-function renderBashWordHelper(): string {
+function renderBashScanHelpers(): string {
   return `__adr_complete_words() {
   local prefix=$1
   shift
@@ -100,10 +108,103 @@ __adr_complete_prefixed_words() {
     [[ $candidate == "$value_prefix"* ]] && COMPREPLY+=("\${prefix}\${candidate}")
   done
 }
+
+__adr_after_terminator() {
+  local i=1 token
+  while (( i < COMP_CWORD )); do
+    token="\${COMP_WORDS[i]}"
+    case "$token" in
+      --)
+        return 0
+        ;;
+      --color)
+        (( i += 2 ))
+        continue
+        ;;
+      --color=*)
+        (( i += 1 ))
+        continue
+        ;;
+      -h|--help|-V|--version)
+        (( i += 1 ))
+        continue
+        ;;
+    esac
+    (( i += 1 ))
+  done
+  return 1
+}
+
+__adr_command_index() {
+  local i=1 token
+  while (( i < COMP_CWORD )); do
+    token="\${COMP_WORDS[i]}"
+    case "$token" in
+      --)
+        return 1
+        ;;
+      --color)
+        (( i += 2 ))
+        continue
+        ;;
+      --color=*)
+        (( i += 1 ))
+        continue
+        ;;
+      -h|--help|-V|--version)
+        (( i += 1 ))
+        continue
+        ;;
+    esac
+    if [[ $token != -* ]]; then
+      printf '%s' "$i"
+      return 0
+    fi
+    return 1
+  done
+  return 1
+}
+
+__adr_first_positional() {
+  local i=1 token command_seen=0 positionals=0
+  while (( i < COMP_CWORD )); do
+    token="\${COMP_WORDS[i]}"
+    case "$token" in
+      --color)
+        (( i += 2 ))
+        continue
+        ;;
+      --color=*)
+        (( i += 1 ))
+        continue
+        ;;
+      -h|--help|-V|--version)
+        (( i += 1 ))
+        continue
+        ;;
+      --)
+        if (( command_seen == 0 )); then
+          return 1
+        fi
+        (( i += 1 ))
+        continue
+        ;;
+    esac
+    if [[ $token != -* ]]; then
+      if (( command_seen == 0 )); then
+        command_seen=1
+      else
+        (( positionals += 1 ))
+      fi
+    fi
+    (( i += 1 ))
+  done
+  (( command_seen == 1 && positionals == 0 ))
+}
 `;
 }
 
-function renderZshWordHelper(): string {
+function renderZshScanHelpers(): string {
   return `__adr_complete_words() {
   local prefix=$1
   shift
@@ -130,7 +231,242 @@ __adr_complete_prefixed_words() {
     compadd -Q -- "\${matches[@]}"
   fi
 }
+
+__adr_after_terminator() {
+  local i=2 token
+  while (( i < CURRENT )); do
+    token="\${words[i]}"
+    case "$token" in
+      --)
+        return 0
+        ;;
+      --color)
+        (( i += 2 ))
+        continue
+        ;;
+      --color=*)
+        (( i += 1 ))
+        continue
+        ;;
+      -h|--help|-V|--version)
+        (( i += 1 ))
+        continue
+        ;;
+    esac
+    (( i += 1 ))
+  done
+  return 1
+}
+
+__adr_command_index() {
+  local i=2 token
+  while (( i < CURRENT )); do
+    token="\${words[i]}"
+    case "$token" in
+      --)
+        return 1
+        ;;
+      --color)
+        (( i += 2 ))
+        continue
+        ;;
+      --color=*)
+        (( i += 1 ))
+        continue
+        ;;
+      -h|--help|-V|--version)
+        (( i += 1 ))
+        continue
+        ;;
+    esac
+    if [[ $token != -* ]]; then
+      printf '%s' "$i"
+      return 0
+    fi
+    return 1
+  done
+  return 1
+}
+
+__adr_first_positional() {
+  local i=2 token command_seen=0 positionals=0
+  while (( i < CURRENT )); do
+    token="\${words[i]}"
+    case "$token" in
+      --color)
+        (( i += 2 ))
+        continue
+        ;;
+      --color=*)
+        (( i += 1 ))
+        continue
+        ;;
+      -h|--help|-V|--version)
+        (( i += 1 ))
+        continue
+        ;;
+      --)
+        if (( command_seen == 0 )); then
+          return 1
+        fi
+        (( i += 1 ))
+        continue
+        ;;
+    esac
+    if [[ $token != -* ]]; then
+      if (( command_seen == 0 )); then
+        command_seen=1
+      else
+        (( positionals += 1 ))
+      fi
+    fi
+    (( i += 1 ))
+  done
+  (( command_seen == 1 && positionals == 0 ))
+}
 `;
+}
+
+function renderFishScanHelpers(): string {
+  return [
+    `function __adr_tokens_before_cursor`,
+    `    set -l tokens (commandline -opc)`,
+    `    set -l current (commandline -ct)`,
+    `    if test -n "$current"`,
+    `        if test (count $tokens) -gt 0; and test "$tokens[(count $tokens)]" = "$current"`,
+    `            set -e tokens[(count $tokens)]`,
+    `        end`,
+    `    end`,
+    `    printf '%s\n' $tokens`,
+    `end`,
+    ``,
+    `function __adr_after_terminator`,
+    `    if test (commandline -ct) = '--'`,
+    `        return 0`,
+    `    end`,
+    ``,
+    `    set -l tokens (__adr_tokens_before_cursor)`,
+    `    set -l i 2`,
+    `    while test $i -le (count $tokens)`,
+    `        switch $tokens[$i]`,
+    `            case '--'`,
+    `                return 0`,
+    `            case '--color'`,
+    `                set i (math $i + 2)`,
+    `                continue`,
+    `            case '--color=*'`,
+    `                set i (math $i + 1)`,
+    `                continue`,
+    `            case '-h' '--help' '-V' '--version'`,
+    `                set i (math $i + 1)`,
+    `                continue`,
+    `            case '*'`,
+    `                set i (math $i + 1)`,
+    `        end`,
+    `    end`,
+    `    return 1`,
+    `end`,
+    ``,
+    `function __adr_command_token`,
+    `    set -l tokens (__adr_tokens_before_cursor)`,
+    `    set -l i 2`,
+    `    while test $i -le (count $tokens)`,
+    `        switch $tokens[$i]`,
+    `            case '--'`,
+    `                return 1`,
+    `            case '--color'`,
+    `                set i (math $i + 2)`,
+    `                continue`,
+    `            case '--color=*'`,
+    `                set i (math $i + 1)`,
+    `                continue`,
+    `            case '-h' '--help' '-V' '--version'`,
+    `                set i (math $i + 1)`,
+    `                continue`,
+    `            case '*'`,
+    `                if not string match -q -r '^-' -- $tokens[$i]`,
+    `                    echo $tokens[$i]`,
+    `                    return 0`,
+    `                end`,
+    `                return 1`,
+    `        end`,
+    `    end`,
+    `    return 1`,
+    `end`,
+    ``,
+    `function __adr_root_position`,
+    `    __adr_color_value; and return 1`,
+    `    __adr_after_terminator; and return 1`,
+    `    set -l command (__adr_command_token)`,
+    `    test -z "$command"`,
+    `end`,
+    ``,
+    `function __adr_subcommand_is`,
+    `    set -l command (__adr_command_token)`,
+    `    test -n "$command"; and test "$command" = "$argv[1]"`,
+    `end`,
+    ``,
+    `function __adr_color_value`,
+    `    __adr_after_terminator; and return 1`,
+    `    set -l current (commandline -ct)`,
+    `    if string match -q -- '--color=*' "$current"`,
+    `        return 0`,
+    `    end`,
+    `    set -l tokens (__adr_tokens_before_cursor)`,
+    `    if test (count $tokens) -gt 0; and test "$tokens[(count $tokens)]" = '--color'`,
+    `        return 0`,
+    `    end`,
+    `    return 1`,
+    `end`,
+    ``,
+    `function __adr_first_positional`,
+    `    set -l tokens (__adr_tokens_before_cursor)`,
+    `    set -l i 2`,
+    `    set -l command_seen 0`,
+    `    set -l positionals 0`,
+    `    while test $i -le (count $tokens)`,
+    `        switch $tokens[$i]`,
+    `            case '--color'`,
+    `                set i (math $i + 2)`,
+    `                continue`,
+    `            case '--color=*'`,
+    `                set i (math $i + 1)`,
+    `                continue`,
+    `            case '-h' '--help' '-V' '--version'`,
+    `                set i (math $i + 1)`,
+    `                continue`,
+    `            case '--'`,
+    `                if test $command_seen -eq 0`,
+    `                    return 1`,
+    `                end`,
+    `                set i (math $i + 1)`,
+    `                continue`,
+    `            case '*'`,
+    `                if not string match -q -r '^-' -- $tokens[$i]`,
+    `                    if test $command_seen -eq 0`,
+    `                        set command_seen 1`,
+    `                    else`,
+    `                        set positionals (math $positionals + 1)`,
+    `                    end`,
+    `                end`,
+    `                set i (math $i + 1)`,
+    `        end`,
+    `    end`,
+    `    test $command_seen -eq 1; and test $positionals -eq 0`,
+    `end`,
+    ``,
+    `function __adr_current_token_is_option`,
+    `    set -l token (commandline -ct)`,
+    `    test -n "$token"; and test (string sub -s 1 -l 1 -- $token) = '-'`,
+    `end`,
+    ``,
+  ].join('\n');
+}
+
+function renderValueBranches(shell: 'bash' | 'zsh', values: Record<string, readonly string[]>): string {
+  return Object.entries(values)
+    .map(([flag, choices]) => (shell === 'bash' ? renderBashValueBranch(flag, choices) : renderZshValueBranch(flag, choices)))
+    .join('');
 }
 
 function renderBashValueBranch(flag: string, choices: readonly string[]): string {
@@ -160,51 +496,62 @@ function renderZshValueBranch(flag: string, choices: readonly string[]): string 
 }
 
 function renderCommandBranch(shell: 'bash' | 'zsh', command: string): string {
-  const options = commandCompletionOptions(command as never);
+  const options = withGlobalColorOption(commandCompletionOptions(command as never));
   const valueChoices = commandValueChoiceMap(command as never) ?? {};
   const positionalChoices = commandPositionalChoices(command as never);
-  const valueBranch =
-    shell === 'bash'
-      ? Object.entries(valueChoices).map(([flag, choices]) => renderBashValueBranch(flag, choices)).join('')
-      : Object.entries(valueChoices).map(([flag, choices]) => renderZshValueBranch(flag, choices)).join('');
-  const optionHelper = shell === 'bash' ? '__adr_complete_words' : '__adr_complete_words';
-  const firstPositional =
+  const valueBranch = renderValueBranches(shell, valueChoices);
+  const optionHelper = '__adr_complete_words';
+  const positionalChoicesForCommand =
     command === 'help'
       ? COMMAND_ORDER
       : command === 'completion'
         ? COMPLETION_SHELLS
         : positionalChoices;
-  const firstPositionalBlock = firstPositional
+  const positionalBranch = positionalChoicesForCommand
     ? shell === 'bash'
-      ? `      if [[ $COMP_CWORD -eq 2 ]]; then
+      ? `      if __adr_first_positional; then
         if [[ $cur == -* ]]; then
-          ${optionHelper} "$cur" -h --help
+          ${optionHelper} "$cur" ${shellWords(options)}
         else
-          ${optionHelper} "$cur" ${shellWords(firstPositional)}
+          ${optionHelper} "$cur" ${shellWords(positionalChoicesForCommand)}
         fi
         return 0
       fi
 `
-      : `      if (( CURRENT == 3 )); then
+      : `      if __adr_first_positional; then
         if [[ $cur == -* ]]; then
-          ${optionHelper} "$cur" -h --help
+          ${optionHelper} "$cur" ${shellWords(options)}
         else
-          ${optionHelper} "$cur" ${shellWords(firstPositional)}
+          ${optionHelper} "$cur" ${shellWords(positionalChoicesForCommand)}
         fi
         return 0
       fi
 `
     : '';
+  const lateOptionBranch =
+    command === 'help' || command === 'completion'
+      ? `      if [[ -z $cur || $cur == -* ]]; then
+        ${optionHelper} "$cur" ${shellWords(options)}
+        return 0
+      fi
+`
+      : '';
 
   if (command === 'help' || command === 'completion') {
     return `    ${command})
-${valueBranch}${firstPositionalBlock}      return 0
+      if [[ $cur == -- || $after_terminator -eq 1 ]]; then
+        return 0
+      fi
+${valueBranch}${positionalBranch}${lateOptionBranch}      return 0
       ;;
 `;
   }
 
   return `    ${command})
-${valueBranch}${firstPositionalBlock}      if [[ -z $cur || $cur == -* ]]; then
+      if [[ $cur == -- || $after_terminator -eq 1 ]]; then
+        return 0
+      fi
+${valueBranch}${positionalBranch}      if [[ -z $cur || $cur == -* ]]; then
         ${optionHelper} "$cur" ${shellWords(options)}
         return 0
       fi
@@ -214,21 +561,43 @@ ${valueBranch}${firstPositionalBlock}      if [[ -z $cur || $cur == -* ]]; then
 
 function renderBashCompletion(): string {
   const rootCandidates = [...TOP_LEVEL_COMPLETION_OPTIONS, ...COMMAND_ORDER];
+  const rootValueBranches = renderValueBranches('bash', TOP_LEVEL_COMPLETION_VALUE_CHOICES);
   const commandBranches = COMMAND_ORDER.map((command) => renderCommandBranch('bash', command)).join('');
 
   return `# shellcheck shell=bash
-${renderBashWordHelper()}
+${renderBashScanHelpers()}
 _adr_completion() {
-  local cur prev command
+  local cur prev command_index after_terminator command
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
-  command="\${COMP_WORDS[1]}"
 
-  if [[ $COMP_CWORD -le 1 ]]; then
-    __adr_complete_words "$cur" ${shellWords(rootCandidates)}
+  if __adr_after_terminator; then
+    after_terminator=1
+  else
+    after_terminator=0
+  fi
+
+  if [[ $after_terminator -eq 0 ]]; then
+${rootValueBranches}  fi
+
+  if [[ $cur == -- || $after_terminator -eq 1 ]]; then
     return 0
   fi
+
+  command_index="$(__adr_command_index)"
+  if [[ -z $command_index ]]; then
+    command_index=0
+  fi
+
+  if [[ $command_index -eq 0 ]]; then
+    if [[ $after_terminator -eq 0 ]]; then
+      __adr_complete_words "$cur" ${shellWords(rootCandidates)}
+    fi
+    return 0
+  fi
+
+  command="\${COMP_WORDS[command_index]}"
 
   case "$command" in
 ${commandBranches}  esac
@@ -240,22 +609,44 @@ complete -F _adr_completion adr adrkit
 
 function renderZshCompletion(): string {
   const rootCandidates = [...TOP_LEVEL_COMPLETION_OPTIONS, ...COMMAND_ORDER];
+  const rootValueBranches = renderValueBranches('zsh', TOP_LEVEL_COMPLETION_VALUE_CHOICES);
   const commandBranches = COMMAND_ORDER.map((command) => renderCommandBranch('zsh', command)).join('');
 
   return `#compdef adr adrkit
-${renderZshWordHelper()}
+${renderZshScanHelpers()}
 _adr_completion() {
   emulate -L zsh
   setopt localoptions noshwordsplit
-  local cur prev command
+  local cur prev command_index after_terminator command
   cur="\${words[CURRENT]}"
   prev="\${words[CURRENT-1]}"
-  command="\${words[2]}"
 
-  if (( CURRENT <= 2 )); then
-    __adr_complete_words "$cur" ${shellWords(rootCandidates)}
+  if __adr_after_terminator; then
+    after_terminator=1
+  else
+    after_terminator=0
+  fi
+
+  if [[ $after_terminator -eq 0 ]]; then
+${rootValueBranches}  fi
+
+  if [[ $cur == -- || $after_terminator -eq 1 ]]; then
     return 0
   fi
+
+  command_index="$(__adr_command_index)"
+  if [[ -z $command_index ]]; then
+    command_index=0
+  fi
+
+  if [[ $command_index -eq 0 ]]; then
+    if [[ $after_terminator -eq 0 ]]; then
+      __adr_complete_words "$cur" ${shellWords(rootCandidates)}
+    fi
+    return 0
+  fi
+
+  command="\${words[command_index]}"
 
   case "$command" in
 ${commandBranches}  esac
@@ -270,47 +661,31 @@ function renderFishCompletion(): string {
   const binaryTargets = '-c adr -c adrkit';
   const rootCandidates = [...TOP_LEVEL_COMPLETION_OPTIONS, ...COMMAND_ORDER];
 
-  lines.push(`function __adr_root_position`);
-  lines.push(`    set -l tokens (commandline -opc)`);
-  lines.push(`    test (count $tokens) -eq 1`);
-  lines.push(`end`);
-  lines.push(``);
-  lines.push(`function __adr_subcommand_is`);
-  lines.push(`    set -l tokens (commandline -opc)`);
-  lines.push(`    test (count $tokens) -ge 2; and test "$tokens[2]" = "$argv[1]"`);
-  lines.push(`end`);
-  lines.push(``);
-  lines.push(`function __adr_first_positional`);
-  lines.push(`    set -l tokens (commandline -opc)`);
-  lines.push(`    test (count $tokens) -eq 2`);
-  lines.push(`end`);
-  lines.push(``);
-  lines.push(`function __adr_current_token_is_option`);
-  lines.push(`    set -l token (commandline -ct)`);
-  lines.push(`    test -n "$token"; and test (string sub -s 1 -l 1 -- $token) = '-'`);
-  lines.push(`end`);
-  lines.push(``);
+  lines.push(renderFishScanHelpers());
   lines.push(`complete ${binaryTargets} -n '__adr_root_position' -f -a "${shellWords(rootCandidates)}"`);
   lines.push(`complete ${binaryTargets} -n '__adr_root_position' -s h -l help -d 'Show help'`);
   lines.push(`complete ${binaryTargets} -n '__adr_root_position' -s V -l version -d 'Show version'`);
+  lines.push(`complete ${binaryTargets} -n '__adr_color_value' -r -l color -a "${shellWords(GLOBAL_COLOR_VALUES)}"`);
 
   for (const command of COMMAND_ORDER) {
-    const options = commandCompletionOptions(command as never).filter((option) => option !== '-h' && option !== '--help');
+    const options = withGlobalColorOption(commandCompletionOptions(command as never).filter((option) => option !== '-h' && option !== '--help'));
     const valueChoices = commandValueChoiceMap(command as never) ?? {};
     const guard = `__adr_subcommand_is ${command}`;
 
     if (command === 'help' || command === 'completion') {
       const firstChoices = command === 'help' ? COMMAND_ORDER : COMPLETION_SHELLS;
-      lines.push(`complete ${binaryTargets} -n '${guard}; and __adr_first_positional; and not __adr_current_token_is_option' -f -a "${shellWords(firstChoices)}"`);
-      lines.push(`complete ${binaryTargets} -n '${guard}; and __adr_first_positional' -s h -l help -d 'Show help'`);
+      lines.push(`complete ${binaryTargets} -n '${guard}; and not __adr_color_value; and not __adr_after_terminator; and __adr_first_positional; and not __adr_current_token_is_option' -f -a "${shellWords(firstChoices)}"`);
+      lines.push(`complete ${binaryTargets} -n '${guard}; and not __adr_color_value; and not __adr_after_terminator; and not __adr_first_positional' -f -a "${shellWords(options)}"`);
+      lines.push(`complete ${binaryTargets} -n '${guard}; and not __adr_color_value; and not __adr_after_terminator; and __adr_first_positional; and __adr_current_token_is_option' -l color -d 'Colorize output'`);
+      lines.push(`complete ${binaryTargets} -n '${guard}; and not __adr_color_value; and not __adr_after_terminator; and __adr_first_positional' -s h -l help -d 'Show help'`);
       continue;
     }
 
-    lines.push(`complete ${binaryTargets} -n '${guard}' -s h -l help -d 'Show help'`);
-    lines.push(`complete ${binaryTargets} -n '${guard}' -f -a "${shellWords(options)}"`);
+    lines.push(`complete ${binaryTargets} -n '${guard}; and not __adr_color_value; and not __adr_after_terminator' -s h -l help -d 'Show help'`);
+    lines.push(`complete ${binaryTargets} -n '${guard}; and not __adr_color_value; and not __adr_after_terminator' -f -a "${shellWords(options)}"`);
 
     for (const [flag, choices] of Object.entries(valueChoices)) {
-      lines.push(`complete ${binaryTargets} -n '${guard}' -r -l ${flag.slice(2)} -a "${shellWords(choices)}"`);
+      lines.push(`complete ${binaryTargets} -n '${guard}; and not __adr_color_value; and not __adr_after_terminator' -r -l ${flag.slice(2)} -a "${shellWords(choices)}"`);
     }
   }
 
@@ -340,7 +715,7 @@ export async function runCompletion(args: string[]): Promise<number> {
   }
 
   if (parsed.help) {
-    process.stdout.write(COMPLETION_USAGE);
+    process.stdout.write(styleUsageBlock(COMPLETION_USAGE, getPresentation().stdout));
     return 0;
   }
 

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,4 +1,6 @@
 import { isAbsolute, resolve } from 'node:path';
+import type { StreamStyle } from './presentation.ts';
+import { styleUsageBlock } from './presentation.ts';
 
 export type CorpusDirectoryErrorKind = 'not-found' | 'not-readable';
 
@@ -6,12 +8,16 @@ const CORPUS_DIRECTORY_NOT_FOUND_CODES = new Set(['ENOENT', 'ENOTDIR']);
 const CORPUS_DIRECTORY_NOT_READABLE_CODES = new Set(['EACCES', 'EPERM', 'ELOOP', 'ENAMETOOLONG']);
 const CORPUS_DIRECTORY_ROOT_READ_CODES = new Set(['EIO', 'ESTALE']);
 
-export function formatUsageError(message: string, usage: string, command?: string): string {
-  const header = `Error: ${message}\n`;
-  if (!command) return `${header}\n${usage}`;
+export function formatUsageError(message: string, usage: string, command?: string, style?: StreamStyle): string {
+  const error = style?.red ? style.red('Error:') : 'Error:';
+  if (!command) return `${error} ${message}\n\n${style ? styleUsageBlock(usage, style) : usage}`;
 
   const usageLine = usage.split('\n', 1)[0] ?? `Usage: adr ${command} [options]`;
-  return `${header}\n${usageLine}\nRun 'adr help ${command}' for more information.\n`;
+  const styledUsageLine = style?.heading ? style.heading(usageLine) : usageLine;
+  const helpLine = style?.note
+    ? style.note(`Run 'adr help ${command}' for more information.`)
+    : `Run 'adr help ${command}' for more information.`;
+  return `${error} ${message}\n\n${styledUsageLine}\n${helpLine}\n`;
 }
 
 export function corpusDirectoryErrorMessage(dir: string, kind: CorpusDirectoryErrorKind): string {

--- a/packages/cli/src/evaluate.ts
+++ b/packages/cli/src/evaluate.ts
@@ -28,6 +28,7 @@ import {
   type CorpusDirectoryErrorKind,
 } from './errors.ts';
 import { loadSnapshotBundle, SnapshotContractError, type NormalizedSnapshot } from './evaluate-snapshot.ts';
+import { getPresentation } from './presentation.ts';
 
 /**
  * The trusted deterministic registries, constructed ONLY from composition code —
@@ -117,10 +118,11 @@ function buildInput(
 }
 
 function renderHuman(report: import('@adrkit/evaluator').Pass0Report): string {
-  const lines: string[] = [`Pass 0 evaluation of ${report.proposalPath} — outcome: ${report.outcome}`];
+  const style = getPresentation().stdout;
+  const lines: string[] = [`${style.heading('Pass 0 evaluation of')} ${style.path(report.proposalPath)} — outcome: ${style.status(report.outcome)}`];
   for (const result of report.results) {
-    const severity = result.status === 'fail' && result.severity ? ` (${result.severity})` : '';
-    lines.push(`  ${result.rule}: ${result.status}${severity} — ${result.reason}`);
+    const severity = result.status === 'fail' && result.severity ? ` (${style.severity(result.severity)})` : '';
+    lines.push(`  ${style.label(result.rule)}: ${style.status(result.status)}${severity} — ${result.reason}`);
   }
   const { routing } = report;
   const target =
@@ -128,7 +130,7 @@ function renderHuman(report: import('@adrkit/evaluator').Pass0Report): string {
       ? `${routing.target.human} (via ${routing.target.via})`
       : routing.target.kind;
   lines.push(
-    `  routing: ${routing.escalate ? `escalate [${routing.reasons.join(', ')}]` : 'no escalation'}, target: ${target}`,
+    `  ${style.label('routing')}: ${routing.escalate ? `${style.status('escalate')} [${routing.reasons.join(', ')}]` : style.note('no escalation')}, target: ${target}`,
   );
   return `${lines.join('\n')}\n`;
 }
@@ -141,7 +143,12 @@ export async function evaluate(options: EvaluateOptions): Promise<EvaluateOutput
   const cwd = options.cwd ?? process.cwd();
 
   if (!isValidIsoDate(options.date)) {
-    return { exitCode: 2, stdout: '', stderr: `adr evaluate: --date must be a valid YYYY-MM-DD (got "${options.date}")\n` };
+    const style = getPresentation().stderr;
+    return {
+      exitCode: 2,
+      stdout: '',
+      stderr: `${style.red('adr evaluate:')} --date must be a valid YYYY-MM-DD (got "${options.date}")\n`,
+    };
   }
 
   const dir = options.dir ?? dirname(options.proposalPath);
@@ -155,13 +162,14 @@ export async function evaluate(options: EvaluateOptions): Promise<EvaluateOutput
     const text = await readFile(options.snapshotPath, 'utf8');
     snapshot = loadSnapshotBundle(text);
   } catch (error) {
+    const style = getPresentation().stderr;
     if (error instanceof SnapshotContractError) {
-      return { exitCode: 2, stdout: '', stderr: `adr evaluate: ${error.message}\n` };
+      return { exitCode: 2, stdout: '', stderr: `${style.red('adr evaluate:')} ${error.message}\n` };
     }
     return {
       exitCode: 2,
       stdout: '',
-      stderr: `adr evaluate: could not read snapshot "${options.snapshotPath}": ${error instanceof Error ? error.message : String(error)}\n`,
+      stderr: `${style.red('adr evaluate:')} could not read snapshot "${options.snapshotPath}": ${error instanceof Error ? error.message : String(error)}\n`,
     };
   }
 
@@ -178,10 +186,11 @@ export async function evaluate(options: EvaluateOptions): Promise<EvaluateOutput
   const outcome = evaluatePass0(buildInput(proposalPath, corpus, snapshot, options.date));
 
   if (outcome.kind === 'input-error') {
+    const style = getPresentation().stderr;
     return {
       exitCode: 2,
       stdout: '',
-      stderr: `adr evaluate: ${outcome.error.code} — "${proposalPath}" has status "${outcome.error.actualStatus}", not draft/proposed\n`,
+      stderr: `${style.red('adr evaluate:')} ${outcome.error.code} — "${proposalPath}" has status "${outcome.error.actualStatus}", not draft/proposed\n`,
     };
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,10 +31,13 @@ import { evaluate } from './evaluate.ts';
 import { closestCandidate } from './recovery.ts';
 import {
   COMMAND_ORDER,
+  GLOBAL_COLOR_VALUES,
   TOP_LEVEL_OPTIONS,
   commandOptions,
+  renderGlobalColorUsageLine,
   renderTopLevelUsage,
   requiredCommandValueChoices,
+  withGlobalColorOption,
   type CommandName,
 } from './command-registry.ts';
 import { COMPLETION_USAGE, runCompletion } from './completion.ts';
@@ -46,6 +49,7 @@ import {
 } from './errors.ts';
 import { QUEUE_USAGE, runQueue } from './queue.ts';
 import { isMainModule } from './main-module.ts';
+import { getPresentation, setPresentation, styleUsageBlock, type ColorMode, type StreamStyle } from './presentation.ts';
 
 /**
  * The published `@adrkit/cli` version, reported by `adr --version`. Held as a literal
@@ -54,12 +58,53 @@ import { isMainModule } from './main-module.ts';
  */
 export const CLI_VERSION = '0.9.0';
 
+function topLevelUsage(style?: StreamStyle): string {
+  return renderTopLevelUsage(CLI_VERSION, style);
+}
+
 function writeStdout(text: string): void {
   process.stdout.write(text);
 }
 
 function writeStderr(text: string): void {
   process.stderr.write(text);
+}
+
+function extractColorMode(argv: string[]): { colorMode: ColorMode; args: string[] } | { error: string } {
+  let colorMode: ColorMode = 'auto';
+  const args: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (arg === '--') {
+      args.push(...argv.slice(index));
+      break;
+    }
+    if (arg !== '--color' && !arg.startsWith('--color=')) {
+      args.push(arg);
+      continue;
+    }
+
+    let value = '';
+    if (arg === '--color') {
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith('-')) {
+        return { error: 'Missing value for option "--color".' };
+      }
+      value = next;
+      index += 1;
+    } else {
+      value = arg.slice('--color='.length);
+      if (value.length === 0) return { error: 'Missing value for option "--color".' };
+    }
+
+    if (!GLOBAL_COLOR_VALUES.includes(value as (typeof GLOBAL_COLOR_VALUES)[number])) {
+      return { error: `Invalid --color value "${value}". Expected "auto", "always", or "never".` };
+    }
+    colorMode = value as ColorMode;
+  }
+
+  return { colorMode, args };
 }
 
 function extractUnknownOption(message: string): string | undefined {
@@ -100,7 +145,13 @@ function hasValueFlag(args: readonly string[], flag: string): boolean {
   return false;
 }
 
-const USAGE = renderTopLevelUsage(CLI_VERSION);
+function hasHelpFlagBeforeTerminator(args: readonly string[]): boolean {
+  for (const arg of args) {
+    if (arg === '--') return false;
+    if (isHelpFlag(arg)) return true;
+  }
+  return false;
+}
 
 /**
  * Per-command help, printed by `adr <command> --help` and `adr help <command>`.
@@ -119,6 +170,7 @@ Options:
                       (default: draft)
   --dir <path>        ADR corpus directory (default: docs/adr)
   --json              Emit { id, path } as JSON
+${renderGlobalColorUsageLine()}
   -h, --help          Show this help and exit
 
 Examples:
@@ -137,7 +189,8 @@ Arguments:
 Options:
   --dir <path>    ADR corpus directory (default: docs/adr)
   --json          Emit { checked, findings } as JSON
-  -h, --help      Show this help and exit
+${renderGlobalColorUsageLine()}
+    -h, --help      Show this help and exit
 
 Examples:
   adr lint
@@ -158,6 +211,7 @@ Arguments:
 Options:
   --dir <path>    ADR corpus directory (default: docs/adr)
   --json          Emit the CheckOutcome as JSON
+${renderGlobalColorUsageLine()}
   -h, --help      Show this help and exit
 
 Examples:
@@ -186,6 +240,7 @@ Options:
   --json          Emit { path, governedBy, governing, activeProposals, history,
                   markers, findings }. Pattern matches carry "firedMatchers";
                   file declarations carry "declaredBy".
+${renderGlobalColorUsageLine()}
   -h, --help      Show this help and exit
 
 Examples:
@@ -202,6 +257,7 @@ Render supersedes, relatesTo, and conflictsWith relationships for the corpus.
 Options:
   --dir <path>          ADR corpus directory (default: docs/adr)
   --format dot|json     Output format (default: dot)
+${renderGlobalColorUsageLine()}
   -h, --help            Show this help and exit
 
 Examples:
@@ -223,6 +279,7 @@ Options:
   --date <date>       Evaluation date, YYYY-MM-DD (required)
   --dir <path>        ADR corpus directory (default: proposal directory)
   --json              Emit the evaluation report as JSON
+${renderGlobalColorUsageLine()}
   -h, --help          Show this help and exit
 
 The evaluator routes; it never approves, persists, or writes. There is no --write.
@@ -249,6 +306,7 @@ Options:
   --rename        Rename each migrated file to <id>-<slug>.md so corpus discovery
                   can see it. Off by default, because migration is in place.
   --json          Emit the migration result as JSON
+${renderGlobalColorUsageLine()}
   -h, --help      Show this help and exit
 
 Examples:
@@ -269,18 +327,21 @@ Arguments:
 Examples:
   adr help
   adr help check
+
+Options:
+${renderGlobalColorUsageLine()}
 `,
   completion: COMPLETION_USAGE,
 } satisfies Record<CommandName, string>;
 
 const COMMANDS = COMMAND_ORDER;
-const LINT_OPTIONS = commandOptions('lint');
-const MIGRATE_OPTIONS = commandOptions('migrate');
-const NEW_OPTIONS = commandOptions('new');
-const GRAPH_OPTIONS = commandOptions('graph');
-const EXPLAIN_OPTIONS = commandOptions('explain');
-const CHECK_OPTIONS = commandOptions('check');
-const EVALUATE_OPTIONS = commandOptions('evaluate');
+const LINT_OPTIONS = withGlobalColorOption(commandOptions('lint'));
+const MIGRATE_OPTIONS = withGlobalColorOption(commandOptions('migrate'));
+const NEW_OPTIONS = withGlobalColorOption(commandOptions('new'));
+const GRAPH_OPTIONS = withGlobalColorOption(commandOptions('graph'));
+const EXPLAIN_OPTIONS = withGlobalColorOption(commandOptions('explain'));
+const CHECK_OPTIONS = withGlobalColorOption(commandOptions('check'));
+const EVALUATE_OPTIONS = withGlobalColorOption(commandOptions('evaluate'));
 const NEW_ALLOWED_STATUSES = requiredCommandValueChoices('new', '--status');
 const GRAPH_FORMAT_CHOICES = requiredCommandValueChoices('graph', '--format');
 const MIGRATE_FROM_CHOICES = requiredCommandValueChoices('migrate', '--from');
@@ -292,7 +353,7 @@ function commandUsageFor(command: string): string | undefined {
 
 /** Usage error: concise guidance on stderr, exit 2. Explicit help goes to stdout at 0. */
 function usageError(message: string, command?: string): number {
-  writeStderr(formatUsageError(message, command ? commandUsageFor(command) ?? '' : USAGE, command));
+  writeStderr(formatUsageError(message, command ? commandUsageFor(command) ?? '' : topLevelUsage(getPresentation().stderr), command, getPresentation().stderr));
   return 2;
 }
 
@@ -303,14 +364,14 @@ function isHelpFlag(arg: string): boolean {
 /** `adr help [command]` — usage on stdout at 0; unknown command is still a usage error. */
 function runHelp(args: string[]): number {
   const unsupportedFlag = args.find((arg) => arg.startsWith('-') && !isHelpFlag(arg));
-  if (unsupportedFlag) return usageError(unknownOptionMessage(unsupportedFlag, ['--help']));
+  if (unsupportedFlag) return usageError(unknownOptionMessage(unsupportedFlag, withGlobalColorOption(['--help'])));
 
   const positionals = args.filter((arg) => !arg.startsWith('-'));
   if (positionals.length > 1) return usageError('adr help accepts at most one command.');
 
   const requested = positionals[0];
   if (requested === undefined) {
-    writeStdout(USAGE);
+    writeStdout(topLevelUsage(getPresentation().stdout));
     return 0;
   }
 
@@ -319,7 +380,7 @@ function runHelp(args: string[]): number {
     return usageError(unknownCommandMessage(requested));
   }
 
-  writeStdout(commandUsage);
+  writeStdout(styleUsageBlock(commandUsage, getPresentation().stdout));
   return 0;
 }
 
@@ -343,14 +404,14 @@ function parseCommandArgs(
   }
 }
 
-function renderFinding(finding: Finding): string {
+function renderFinding(finding: Finding, style = getPresentation().stdout): string {
   const field = finding.field ? ` ${finding.field}` : '';
   const id = finding.id ? ` ${finding.id}` : '';
   const pattern = finding.pattern ? ` ${finding.pattern}` : '';
-  return `  ${finding.severity} ${finding.rule}${id}${field}${pattern}: ${finding.message}\n`;
+  return `  ${style.severity(finding.severity)} ${style.label(finding.rule)}${id}${field}${pattern}: ${finding.message}\n`;
 }
 
-function renderHumanLint(findings: readonly Finding[]): string {
+function renderHumanLint(findings: readonly Finding[], style = getPresentation().stdout): string {
   const grouped = new Map<string, Finding[]>();
   for (const finding of findings) {
     const group = finding.path ?? '(corpus)';
@@ -364,9 +425,9 @@ function renderHumanLint(findings: readonly Finding[]): string {
 
   let output = '';
   for (const [path, groupFindings] of [...grouped.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-    output += `${path}\n`;
+    output += `${style.path(path)}\n`;
     for (const finding of groupFindings) {
-      output += renderFinding(finding);
+      output += renderFinding(finding, style);
     }
   }
   return output;
@@ -406,15 +467,17 @@ async function runLint(args: string[]): Promise<number> {
   if (parsed.values.json) {
     writeStdout(`${JSON.stringify({ checked: result.checked, findings }, null, 2)}\n`);
   } else {
-    const humanFindings = renderHumanLint(findings);
+    const humanFindings = renderHumanLint(findings, getPresentation().stderr);
     if (humanFindings) writeStderr(humanFindings);
-    writeStdout(`checked ${result.checked} records, ${counts.errors} errors, ${counts.warnings} warnings\n`);
+    writeStdout(
+      `${getPresentation().stdout.label('checked')} ${result.checked} records, ${counts.errors} errors, ${counts.warnings} warnings\n`,
+    );
   }
 
   return exitCodeForFindings(findings);
 }
 
-function renderHumanMigrate(result: Awaited<ReturnType<typeof migrateMadr>>): string {
+function renderHumanMigrate(result: Awaited<ReturnType<typeof migrateMadr>>, style = getPresentation().stdout): string {
   const counts = {
     migrated: 0,
     updated: 0,
@@ -427,23 +490,23 @@ function renderHumanMigrate(result: Awaited<ReturnType<typeof migrateMadr>>): st
   for (const item of result.results) {
     counts[item.outcome] += 1;
     const renamed = item.renamedTo ? ` -> ${item.renamedTo}` : '';
-    output += `${item.outcome}  ${item.path}${renamed}\n`;
+    output += `${style.outcome(item.outcome)}  ${style.path(item.path)}${renamed}\n`;
   }
 
-  output += `summary: migrated ${counts.migrated}, updated ${counts.updated}, unchanged ${counts.unchanged}, diverged ${counts.diverged}, skipped ${counts.skipped}\n`;
-  output += 'Divergence (report only):\n';
+  output += `${style.label('summary:')} migrated ${counts.migrated}, updated ${counts.updated}, unchanged ${counts.unchanged}, diverged ${counts.diverged}, skipped ${counts.skipped}\n`;
+  output += `${style.heading('Divergence (report only):')}\n`;
   if (result.divergence.length === 0) {
-    output += '  none\n';
+    output += `  ${style.note('none')}\n`;
   } else {
     for (const item of result.divergence) {
-      output += `  ${item.path}  sourceRef=${item.sourceRef}\n`;
+      output += `  ${style.path(item.path)}  ${style.label('sourceRef')}=${item.sourceRef}\n`;
     }
   }
 
   if (result.findings.length > 0) {
-    output += 'Findings:\n';
+    output += `${style.heading('Findings:')}\n`;
     for (const finding of result.findings) {
-      output += renderFinding(finding);
+      output += renderFinding(finding, style);
     }
   }
 
@@ -498,7 +561,7 @@ async function runMigrate(args: string[]): Promise<number> {
   if (parsed.values.json) {
     writeStdout(`${JSON.stringify(result, null, 2)}\n`);
   } else {
-    writeStdout(renderHumanMigrate(result));
+    writeStdout(renderHumanMigrate(result, getPresentation().stdout));
   }
 
   return 0;
@@ -536,7 +599,7 @@ async function runNew(args: string[]): Promise<number> {
     if (parsed.values.json) {
       writeStdout(`${JSON.stringify({ id: result.id, path: result.path }, null, 2)}\n`);
     } else {
-      writeStdout(`${result.path}\n`);
+      writeStdout(`${getPresentation().stdout.path(result.path)}\n`);
     }
     return 0;
   } catch (error) {
@@ -634,9 +697,9 @@ async function runExplain(args: string[]): Promise<number> {
         )}\n`,
       );
     } else {
-      const humanFindings = renderHumanLint(corpusFindings);
+      const humanFindings = renderHumanLint(corpusFindings, getPresentation().stderr);
       if (humanFindings) writeStderr(humanFindings);
-      writeStdout(renderMarkerScanNote(scan));
+      writeStdout(renderMarkerScanNote(scan, getPresentation().stdout));
     }
     return 1;
   }
@@ -659,43 +722,48 @@ async function runExplain(args: string[]): Promise<number> {
   }
 
   if (governedBy.length === 0) {
-    writeStdout(`No decision governs ${path}.\n`);
+    writeStdout(`${getPresentation().stdout.note('No decision governs')} ${getPresentation().stdout.path(path)}.\n`);
   } else {
     if (buckets.governing.length === 0) {
-      writeStdout(`No accepted decision governs ${path}.\n`);
+      writeStdout(`${getPresentation().stdout.note('No accepted decision governs')} ${getPresentation().stdout.path(path)}.\n`);
     } else {
-      writeStdout(renderDecisionGroup(`Decisions governing ${path}:`, buckets.governing));
+      writeStdout(renderDecisionGroup(`Decisions governing ${path}:`, buckets.governing, '  ', getPresentation().stdout));
     }
-    writeStdout(renderDecisionGroup('Active proposals (not yet binding):', buckets.activeProposals));
-    writeStdout(renderDecisionGroup('Historical records (not binding):', buckets.history));
+    writeStdout(renderDecisionGroup('Active proposals (not yet binding):', buckets.activeProposals, '  ', getPresentation().stdout));
+    writeStdout(renderDecisionGroup('Historical records (not binding):', buckets.history, '  ', getPresentation().stdout));
   }
 
-  writeStdout(renderMarkerScanNote(scan));
+  writeStdout(renderMarkerScanNote(scan, getPresentation().stdout));
 
   if (findings.length > 0) {
-    writeStdout('Findings:\n');
+    writeStdout(`${getPresentation().stdout.heading('Findings:')}\n`);
     for (const finding of findings) {
-      writeStdout(renderFinding(finding));
+      writeStdout(renderFinding(finding, getPresentation().stdout));
     }
   }
 
   return 0;
 }
 
-function renderDecisionGroup(heading: string, decisions: readonly ExplainedDecision[], indent = '  '): string {
+function renderDecisionGroup(
+  heading: string,
+  decisions: readonly ExplainedDecision[],
+  indent = '  ',
+  style = getPresentation().stdout,
+): string {
   if (decisions.length === 0) return '';
-  let output = `${heading}\n`;
+  let output = `${style.heading(heading)}\n`;
   for (const decision of decisions) {
     const successor = decision.supersededBy ? ` (superseded by ${decision.supersededBy})` : '';
-    output += `${indent}${decision.recordId}  [${decision.status}] ${decision.title}${successor}\n`;
+    output += `${indent}${style.label(decision.recordId)}  [${style.status(decision.status)}] ${decision.title}${successor}\n`;
     // "via" is the record reaching out through its own `affects` pattern; "declared by"
     // is the file reaching in with an `@adr` marker. The two are never merged, because
     // which end made the claim is the whole point (ADR-0021).
     for (const matcher of decision.firedMatchers) {
-      output += `${indent}  via ${matcher.type}: ${matcher.pattern}\n`;
+      output += `${indent}  ${style.note('via')} ${matcher.type}: ${style.path(matcher.pattern)}\n`;
     }
     for (const declaration of decision.declaredBy ?? []) {
-      output += `${indent}  declared by ${declaration.path}:${declaration.line} (@adr ${declaration.ref})\n`;
+      output += `${indent}  ${style.note('declared by')} ${style.path(declaration.path)}:${declaration.line} (@adr ${style.label(declaration.ref)})\n`;
     }
   }
   return output;
@@ -733,15 +801,15 @@ function markerScanJson(scan: SourceMarkerScan): {
  * identically to "I never opened this file" or "I stopped reading before the marker"
  * (ADR-0016). Silent when the whole file was scanned, which is the common case.
  */
-function renderMarkerScanNote(scan: SourceMarkerScan): string {
+function renderMarkerScanNote(scan: SourceMarkerScan, style = getPresentation().stdout): string {
   if (scan.state === 'absent') {
-    return `Note: ${scan.path} is not a file in this working tree; no @adr markers were scanned.\n`;
+    return `${style.note('Note:')} ${style.path(scan.path)} is not a file in this working tree; no @adr markers were scanned.\n`;
   }
   if (scan.state === 'unreadable') {
-    return `Note: ${scan.path} could not be read; no @adr markers were scanned.\n`;
+    return `${style.note('Note:')} ${style.path(scan.path)} could not be read; no @adr markers were scanned.\n`;
   }
   if (scan.state === 'out-of-tree') {
-    return `Note: ${scan.path} is not a repo-relative path inside this working tree; no @adr markers were scanned.\n`;
+    return `${style.note('Note:')} ${style.path(scan.path)} is not a repo-relative path inside this working tree; no @adr markers were scanned.\n`;
   }
   // The measured extent, not the window constant: the scan stops at the last complete
   // line inside the window, so the two differ for almost every real file. Only a scanned
@@ -749,7 +817,7 @@ function renderMarkerScanNote(scan: SourceMarkerScan): string {
   // conjunction is how the types say that, not a fallback, which is why there is no
   // window-constant default to reprint if it were ever absent.
   if (scan.truncated && scan.scannedBytes !== undefined && scan.fileBytes !== undefined) {
-    return `Note: only the first ${scan.scannedBytes} of ${scan.fileBytes} bytes of ${scan.path} were scanned for @adr markers.\n`;
+    return `${style.note('Note:')} only the first ${scan.scannedBytes} of ${scan.fileBytes} bytes of ${style.path(scan.path)} were scanned for @adr markers.\n`;
   }
   return '';
 }
@@ -776,23 +844,28 @@ function markerScanExtents(batch: SourceMarkerBatchScan): Map<string, string> {
 function renderHumanCheck(
   outcome: ReturnType<typeof checkChanges>,
   extents: Map<string, string> = new Map(),
+  style = getPresentation().stdout,
 ): string {
   let output = '';
   if (outcome.governedBy.length === 0) {
-    output += 'No decisions govern the changed files.\n';
+    output += `${style.note('No decisions govern the changed files.')}\n`;
   } else {
     if (outcome.governing.length === 0) {
-      output += 'No accepted decisions govern the changed files.\n';
+      output += `${style.note('No accepted decisions govern the changed files.')}\n`;
     } else {
-      output += renderDecisionGroup('Decisions governing this change:', outcome.governing);
+      output += renderDecisionGroup('Decisions governing this change:', outcome.governing, '  ', style);
     }
     output += renderDecisionGroup(
       'Active proposals touching this change (not yet binding):',
       outcome.activeProposals,
+      '  ',
+      style,
     );
     output += renderDecisionGroup(
       'Historical records that once covered this change (not binding):',
       outcome.history,
+      '  ',
+      style,
     );
   }
 
@@ -801,7 +874,7 @@ function renderHumanCheck(
   if (outcome.markerScan && outcome.markerScan.totalCandidates > 0) {
     const counts = outcome.markerScan.counts;
     output +=
-      `marker scan: ${counts.scanned} scanned, ${counts.absent} absent, ` +
+      `${style.label('marker scan:')} ${counts.scanned} scanned, ${counts.absent} absent, ` +
       `${counts.unreadable} unreadable, ${counts['out-of-tree']} out-of-tree, ` +
       `${counts.truncated} truncated, ${counts.skipped} skipped\n`;
 
@@ -814,7 +887,7 @@ function renderHumanCheck(
     if (unavailable.length > 0) {
       const shown = unavailable.slice(0, 10);
       const remaining = unavailable.length - shown.length;
-      output += `marker scan unavailable for: ${shown.join(', ')}`;
+      output += `${style.label('marker scan unavailable for:')} ${shown.map((path) => style.path(path)).join(', ')}`;
       if (remaining > 0) output += `, and ${remaining} more (see --json for the complete lists)`;
       output += '\n';
     }
@@ -831,23 +904,23 @@ function renderHumanCheck(
       // constant — reprinting the bound is the error this replaced.
       const labelled = shown.map((path) => {
         const extent = extents.get(path);
-        return extent === undefined ? path : `${path} ${extent}`;
+        return extent === undefined ? style.path(path) : `${style.path(path)} ${extent}`;
       });
-      output += `marker scan truncated (bytes scanned of total): ${labelled.join(', ')}`;
+      output += `${style.label('marker scan truncated (bytes scanned of total):')} ${labelled.join(', ')}`;
       if (remaining > 0) output += `, and ${remaining} more (see --json for the complete list)`;
       output += '\n';
     }
   }
 
   if (outcome.findings.length > 0) {
-    output += 'Findings:\n';
-    output += renderHumanLint(outcome.findings);
+    output += `${style.heading('Findings:')}\n`;
+    output += renderHumanLint(outcome.findings, style);
   }
 
   const changedRecordErrors = outcome.findings.filter(
     (finding) => finding.severity === 'error' && finding.path && outcome.changedRecords.includes(finding.path),
   ).length;
-  output += `checked: ${outcome.governing.length} governing, ${outcome.activeProposals.length} active proposals, ${outcome.history.length} historical, ${outcome.changedRecords.length} changed records, ${changedRecordErrors} changed-record errors\n`;
+  output += `${style.label('checked:')} ${outcome.governing.length} governing, ${outcome.activeProposals.length} active proposals, ${outcome.history.length} historical, ${outcome.changedRecords.length} changed records, ${changedRecordErrors} changed-record errors\n`;
   return output;
 }
 
@@ -929,11 +1002,18 @@ async function runEvaluate(args: string[]): Promise<number> {
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<number> {
-  const [command, ...args] = argv;
+  const color = extractColorMode(argv);
+  if ('error' in color) {
+    writeStderr(formatUsageError(color.error, topLevelUsage(getPresentation().stderr), undefined, getPresentation().stderr));
+    return 2;
+  }
+  setPresentation({ colorMode: color.colorMode });
+
+  const [command, ...args] = color.args;
 
   try {
     if (command === undefined) {
-      writeStdout(USAGE);
+      writeStdout(topLevelUsage(getPresentation().stdout));
       return 0;
     }
     if (command === 'help') return runHelp(args);
@@ -948,8 +1028,8 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
     // and `completion` parse `--help` themselves, so they are excluded here to keep
     // one code path for each.
     const commandUsage = command === 'queue' || command === 'completion' ? undefined : commandUsageFor(command);
-    if (commandUsage && args.some(isHelpFlag)) {
-      writeStdout(commandUsage);
+    if (commandUsage && hasHelpFlagBeforeTerminator(args)) {
+      writeStdout(styleUsageBlock(commandUsage, getPresentation().stdout));
       return 0;
     }
 

--- a/packages/cli/src/presentation.ts
+++ b/packages/cli/src/presentation.ts
@@ -1,0 +1,191 @@
+export type ColorMode = 'auto' | 'always' | 'never';
+
+export interface PresentationOptions {
+  readonly colorMode?: ColorMode;
+  readonly stdoutIsTTY?: boolean;
+  readonly stderrIsTTY?: boolean;
+  readonly noColor?: boolean;
+}
+
+export interface StreamStyle {
+  readonly enabled: boolean;
+  bold(text: string): string;
+  dim(text: string): string;
+  red(text: string): string;
+  yellow(text: string): string;
+  green(text: string): string;
+  cyan(text: string): string;
+  magenta(text: string): string;
+  heading(text: string): string;
+  label(text: string): string;
+  command(text: string): string;
+  path(text: string): string;
+  note(text: string): string;
+  severity(text: string): string;
+  status(text: string): string;
+  outcome(text: string): string;
+}
+
+export interface Presentation {
+  readonly stdout: StreamStyle;
+  readonly stderr: StreamStyle;
+}
+
+const RESET = '\u001b[0m';
+const BOLD = '\u001b[1m';
+const DIM = '\u001b[2m';
+const RED = '\u001b[31m';
+const GREEN = '\u001b[32m';
+const YELLOW = '\u001b[33m';
+const MAGENTA = '\u001b[35m';
+const CYAN = '\u001b[36m';
+
+const STYLE_HEADING = [BOLD, CYAN];
+
+let activePresentation = createPresentation();
+
+function colorize(enabled: boolean, codes: readonly string[], text: string): string {
+  return enabled ? `${codes.join('')}${text}${RESET}` : text;
+}
+
+function normalizeNoColor(value: boolean | undefined): boolean {
+  if (value !== undefined) return value;
+  return process.env.NO_COLOR !== undefined;
+}
+
+function colorEnabled(mode: ColorMode, isTTY: boolean, noColor: boolean): boolean {
+  if (mode === 'never') return false;
+  if (mode === 'always') return true;
+  return isTTY && !noColor;
+}
+
+function createStreamStyle(enabled: boolean): StreamStyle {
+  return {
+    enabled,
+    bold: (text: string) => colorize(enabled, [BOLD], text),
+    dim: (text: string) => colorize(enabled, [DIM], text),
+    red: (text: string) => colorize(enabled, [RED], text),
+    yellow: (text: string) => colorize(enabled, [YELLOW], text),
+    green: (text: string) => colorize(enabled, [GREEN], text),
+    cyan: (text: string) => colorize(enabled, [CYAN], text),
+    magenta: (text: string) => colorize(enabled, [MAGENTA], text),
+    heading: (text: string) => colorize(enabled, STYLE_HEADING, text),
+    label: (text: string) => colorize(enabled, [BOLD], text),
+    command: (text: string) => colorize(enabled, [BOLD], text),
+    path: (text: string) => colorize(enabled, [CYAN], text),
+    note: (text: string) => colorize(enabled, [DIM], text),
+    severity: (text: string) => {
+      switch (text) {
+        case 'error':
+          return colorize(enabled, [RED, BOLD], text);
+        case 'warn':
+          return colorize(enabled, [YELLOW, BOLD], text);
+        case 'info':
+          return colorize(enabled, [CYAN], text);
+        default:
+          return colorize(enabled, [BOLD], text);
+      }
+    },
+    status: (text: string) => {
+      switch (text) {
+        case 'accepted':
+        case 'decided':
+        case 'within-sla':
+        case 'migrated':
+          return colorize(enabled, [GREEN, BOLD], text);
+        case 'proposed':
+        case 'due':
+        case 'missing-sla':
+        case 'updated':
+          return colorize(enabled, [YELLOW, BOLD], text);
+        case 'draft':
+        case 'not-queued':
+        case 'unchanged':
+          return colorize(enabled, [DIM], text);
+        case 'rejected':
+        case 'superseded':
+        case 'overdue':
+        case 'diverged':
+          return colorize(enabled, [RED, BOLD], text);
+        case 'deprecated':
+        case 'skipped':
+          return colorize(enabled, [MAGENTA, BOLD], text);
+        case 'escalated':
+          return colorize(enabled, [MAGENTA, BOLD], text);
+        default:
+          return colorize(enabled, [BOLD], text);
+      }
+    },
+    outcome: (text: string) => {
+      switch (text) {
+        case 'migrated':
+          return colorize(enabled, [GREEN, BOLD], text);
+        case 'updated':
+          return colorize(enabled, [CYAN, BOLD], text);
+        case 'unchanged':
+          return colorize(enabled, [DIM], text);
+        case 'diverged':
+          return colorize(enabled, [RED, BOLD], text);
+        case 'skipped':
+          return colorize(enabled, [YELLOW, BOLD], text);
+        default:
+          return colorize(enabled, [BOLD], text);
+      }
+    },
+  };
+}
+
+export function createPresentation(options: PresentationOptions = {}): Presentation {
+  const noColor = normalizeNoColor(options.noColor);
+  const mode = options.colorMode ?? 'auto';
+  const stdoutIsTTY = options.stdoutIsTTY ?? process.stdout.isTTY === true;
+  const stderrIsTTY = options.stderrIsTTY ?? process.stderr.isTTY === true;
+
+  return {
+    stdout: createStreamStyle(colorEnabled(mode, stdoutIsTTY, noColor)),
+    stderr: createStreamStyle(colorEnabled(mode, stderrIsTTY, noColor)),
+  };
+}
+
+export function setPresentation(options: PresentationOptions = {}): Presentation {
+  activePresentation = createPresentation(options);
+  return activePresentation;
+}
+
+export function getPresentation(): Presentation {
+  return activePresentation;
+}
+
+export function stripAnsi(text: string): string {
+  return text.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+export function styleUsageBlock(text: string, style: StreamStyle): string {
+  const lines = text.split('\n');
+  return lines
+    .map((line) => {
+      if (line.startsWith('Usage:')) return style.heading(line);
+      if (/^(Commands|Options|Arguments|Examples|Exit codes):$/.test(line)) return style.heading(line);
+      if (line.startsWith('  -h, --help')) return `${style.label('  -h, --help')}${line.slice('  -h, --help'.length)}`;
+      if (line.startsWith('  -V, --version')) return `${style.label('  -V, --version')}${line.slice('  -V, --version'.length)}`;
+      return line;
+    })
+    .join('\n');
+}
+
+export function styleMarkdownReport(text: string, style: StreamStyle): string {
+  return text
+    .split('\n')
+    .map((line) => {
+      if (line.startsWith('# ')) return style.heading(line);
+      if (line.startsWith('## ')) return style.heading(line);
+      if (line.startsWith('### ')) return style.heading(line);
+      if (line.startsWith('#### ')) return style.heading(line);
+      if (line.startsWith('Corpus fingerprint: ')) {
+        return `${style.label('Corpus fingerprint: ')}${line.slice('Corpus fingerprint: '.length)}`;
+      }
+      if (line.startsWith('*No proposed records found.*')) return style.note(line);
+      return line;
+    })
+    .join('\n');
+}

--- a/packages/cli/src/queue.ts
+++ b/packages/cli/src/queue.ts
@@ -5,9 +5,10 @@ import {
   lintCorpus,
   resolveAsOf,
 } from '@adrkit/core';
-import { commandOptions, requiredCommandValueChoices } from './command-registry.ts';
+import { commandOptions, renderGlobalColorUsageLine, requiredCommandValueChoices, withGlobalColorOption } from './command-registry.ts';
 import { corpusDirectoryErrorKind, corpusDirectoryErrorMessage, formatUsageError } from './errors.ts';
 import { closestCandidate } from './recovery.ts';
+import { getPresentation, styleUsageBlock } from './presentation.ts';
 
 const USAGE = `Usage: adr queue [options]
 
@@ -19,6 +20,7 @@ Options:
                             Accepts YYYY-MM-DD or an ISO datetime with an explicit
                             timezone (e.g. 2026-01-08 or 2026-01-08T00:00:00Z).
   --format markdown|json    Output format (default: markdown)
+${renderGlobalColorUsageLine()}
   -h, --help                Show this help and exit
 
 Examples:
@@ -34,7 +36,7 @@ Exit codes: 0 = report, no error findings; 1 = report with corpus error findings
 export const QUEUE_USAGE = USAGE;
 
 function usageError(message: string): number {
-  process.stderr.write(formatUsageError(message, USAGE, 'queue'));
+  process.stderr.write(formatUsageError(message, USAGE, 'queue', getPresentation().stderr));
   return 2;
 }
 
@@ -45,7 +47,7 @@ interface ParsedFlags {
   help: boolean;
 }
 
-const QUEUE_OPTIONS = commandOptions('queue');
+const QUEUE_OPTIONS = withGlobalColorOption(commandOptions('queue'));
 const QUEUE_FORMAT_CHOICES = requiredCommandValueChoices('queue', '--format');
 
 function formatChoiceList(values: readonly string[]): string {
@@ -130,7 +132,7 @@ export async function runQueue(args: string[]): Promise<number> {
 
   const { flags } = parsed;
   if (flags.help) {
-    process.stdout.write(USAGE);
+    process.stdout.write(styleUsageBlock(USAGE, getPresentation().stdout));
     return 0;
   }
 

--- a/packages/cli/test/color.test.ts
+++ b/packages/cli/test/color.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { join, resolve } from 'node:path';
+import { cleanupTestDir, recordMarkdown, resetTestDir, writeText } from '../../core/test/helpers.ts';
+import { stripAnsi } from '../src/presentation.ts';
+
+const CLI_PATH = resolve(process.cwd(), 'packages/cli/src/index.ts');
+const DIR_NAME = 'cli-color';
+const QUEUE_FIX = 'packages/core/test/fixtures/queue';
+
+async function runAdr(args: string[], cwd = process.cwd(), env: Record<string, string> = {}) {
+  const proc = Bun.spawn([process.execPath, CLI_PATH, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+afterEach(async () => {
+  await cleanupTestDir(DIR_NAME);
+});
+
+describe('CLI color presentation', () => {
+  test('explicit color turns on ANSI in human help output', async () => {
+    const result = await runAdr(['--color', 'always', '--help']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('\u001b[');
+    expect(result.stdout).toContain('adrkit 0.9.0');
+  });
+
+  test('forced color keeps lint stdout and stderr separated', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const dir = join(root, 'docs/adr');
+    await writeText(join(dir, '0001-bad.md'), recordMarkdown('0001', 'Bad').replace('status: draft', 'status: superseded'));
+
+    const result = await runAdr(['--color', 'always', 'lint'], root);
+
+    expect(result.exitCode).toBe(1);
+    expect(stripAnsi(result.stdout)).toContain('checked 1 records');
+    expect(result.stdout).toContain('\u001b[');
+    expect(result.stdout).not.toContain('superseded-requires-supersededBy');
+    expect(result.stderr).toContain('superseded-requires-supersededBy');
+    expect(result.stderr).toContain('\u001b[');
+    expect(result.stderr).not.toContain('checked 1 records');
+  });
+
+  test('JSON output stays ANSI-free even when color is forced', async () => {
+    const result = await runAdr(
+      ['--color', 'always', 'queue', '--dir', `${QUEUE_FIX}/within-sla-corpus`, '--as-of', '2026-01-08', '--format', 'json'],
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).not.toContain('\u001b[');
+    expect(JSON.parse(result.stdout).version).toBe('1');
+  });
+
+  test('queue markdown stays canonical and ANSI-free even when color is forced', async () => {
+    const result = await runAdr(
+      ['--color', 'always', 'queue', '--dir', `${QUEUE_FIX}/within-sla-corpus`, '--as-of', '2026-01-08', '--format', 'markdown'],
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).not.toContain('\u001b[');
+    expect(result.stdout).toBe(stripAnsi(result.stdout));
+  });
+
+  test('completion scripts stay ANSI-free even when color is forced', async () => {
+    const result = await runAdr(['--color', 'always', 'completion', 'bash']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).not.toContain('\u001b[');
+    expect(result.stdout).toContain('complete -F _adr_completion adr adrkit');
+  });
+
+  test('global color parsing stops at -- and leaves the literal positional untouched', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    await writeText(join(root, '--color'), recordMarkdown('0001', 'Color').replace('status: draft', 'status: proposed'));
+
+    const result = await runAdr(['--color', 'always', 'lint', '--', '--color'], root);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(stripAnsi(result.stdout)).toContain('checked 1 records');
+    expect(result.stderr).not.toContain('Invalid --color value');
+  });
+});

--- a/packages/cli/test/completion.test.ts
+++ b/packages/cli/test/completion.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'bun:test';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { COMMAND_VALUE_CHOICES } from '../src/command-registry.ts';
 
 const CLI_PATH = resolve(process.cwd(), 'packages/cli/src/index.ts');
 const SHELLS = {
@@ -106,19 +105,6 @@ describe('adr completion CLI', () => {
     expect(result.stderr).toContain('Expected "bash", "zsh", or "fish".');
   });
 
-  test('completion value metadata stays aligned with the shared registry', async () => {
-    const result = await runAdr(['completion', 'bash']);
-
-    expect(result.exitCode).toBe(0);
-    for (const choices of Object.values(COMMAND_VALUE_CHOICES)) {
-      for (const valueChoices of Object.values(choices)) {
-        for (const choice of valueChoices) {
-          expect(result.stdout).toContain(choice);
-        }
-      }
-    }
-  });
-
   test('requires a shell argument', async () => {
     const result = await runAdr(['completion']);
 
@@ -178,7 +164,7 @@ describe('adr completion CLI', () => {
           'printf "%s\\n" "${COMPREPLY[@]}"',
         ].join('; '),
       ]);
-      expect(lines(secondSlot.stdout)).toEqual([]);
+      expect(lines(secondSlot.stdout)).toEqual(expect.arrayContaining(['-h', '--help', '--color']));
 
       const statusValues = await runShell([
         SHELLS.bash!,
@@ -224,6 +210,171 @@ describe('adr completion CLI', () => {
         ].join('; '),
       ]);
       expect(lines(emptyTokenOptions.stdout)).toEqual(expect.arrayContaining(['--from', '--dir', '--dry-run']));
+
+      const colorValues = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr --color "")',
+          'COMP_CWORD=2',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(colorValues.stdout)).toEqual(expect.arrayContaining(['auto', 'always', 'never']));
+
+      const colorPrefixedValues = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr --color=)',
+          'COMP_CWORD=1',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(colorPrefixedValues.stdout)).toEqual(expect.arrayContaining(['--color=auto', '--color=always', '--color=never']));
+
+      const commandColorOption = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr lint --co)',
+          'COMP_CWORD=2',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(commandColorOption.stdout)).toEqual(expect.arrayContaining(['--color']));
+
+      const helpColorOption = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr help --co)',
+          'COMP_CWORD=2',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(helpColorOption.stdout)).toEqual(expect.arrayContaining(['--color']));
+
+      const completionLateOptions = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr completion bash "")',
+          'COMP_CWORD=3',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(completionLateOptions.stdout)).toEqual(expect.arrayContaining(['-h', '--help', '--color']));
+
+      const helpLateOptions = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr help check "")',
+          'COMP_CWORD=3',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(helpLateOptions.stdout)).toEqual(expect.arrayContaining(['-h', '--help', '--color']));
+
+      const commandAfterGlobalColor = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr --color auto "")',
+          'COMP_CWORD=3',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(commandAfterGlobalColor.stdout)).toEqual(expect.arrayContaining(['lint', 'completion', 'help']));
+
+      const commandAfterEqualsColor = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr --color=auto "")',
+          'COMP_CWORD=2',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(commandAfterEqualsColor.stdout)).toEqual(expect.arrayContaining(['lint', 'completion', 'help']));
+
+      const exactTerminator = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr lint --)',
+          'COMP_CWORD=2',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(exactTerminator.stdout)).toEqual([]);
+
+      const priorTerminator = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr lint -- "")',
+          'COMP_CWORD=3',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(priorTerminator.stdout)).toEqual([]);
+
+      const afterTerminator = await runShell([
+        SHELLS.bash!,
+        '--noprofile',
+        '--norc',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'COMP_WORDS=(adr lint -- --color)',
+          'COMP_CWORD=3',
+          '_adr_completion',
+          'printf "%s\\n" "${COMPREPLY[@]}"',
+        ].join('; '),
+      ]);
+      expect(lines(afterTerminator.stdout)).toEqual([]);
     });
   });
 
@@ -261,7 +412,7 @@ describe('adr completion CLI', () => {
           '_adr_completion',
         ].join('; '),
       ]);
-      expect(lines(noSecondSlot.stdout)).toEqual([]);
+      expect(lines(noSecondSlot.stdout)).toEqual(expect.arrayContaining(['-h', '--help', '--color']));
 
       const statusValues = await runShell([
         SHELLS.zsh!,
@@ -290,6 +441,174 @@ describe('adr completion CLI', () => {
         ].join('; '),
       ]);
       expect(lines(emptyTokenOptions.stdout)).toEqual(expect.arrayContaining(['--from', '--dir', '--dry-run']));
+
+      const formatValues = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr queue --format "")',
+          'CURRENT=4',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(formatValues.stdout)).toEqual(expect.arrayContaining(['markdown', 'json']));
+
+      const colorValues = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr --color "")',
+          'CURRENT=3',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(colorValues.stdout)).toEqual(expect.arrayContaining(['auto', 'always', 'never']));
+
+      const colorPrefixedValues = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr --color=)',
+          'CURRENT=2',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(colorPrefixedValues.stdout)).toEqual(expect.arrayContaining(['--color=auto', '--color=always', '--color=never']));
+
+      const commandColorOption = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr lint --co)',
+          'CURRENT=3',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(commandColorOption.stdout)).toEqual(expect.arrayContaining(['--color']));
+
+      const helpColorOption = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr help --co)',
+          'CURRENT=3',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(helpColorOption.stdout)).toEqual(expect.arrayContaining(['--color']));
+
+      const completionLateOptions = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr completion bash "")',
+          'CURRENT=4',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(completionLateOptions.stdout)).toEqual(expect.arrayContaining(['-h', '--help', '--color']));
+
+      const helpLateOptions = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr help check "")',
+          'CURRENT=4',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(helpLateOptions.stdout)).toEqual(expect.arrayContaining(['-h', '--help', '--color']));
+
+      const commandAfterGlobalColor = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr --color auto "")',
+          'CURRENT=4',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(commandAfterGlobalColor.stdout)).toEqual(expect.arrayContaining(['lint', 'completion', 'help']));
+
+      const commandAfterEqualsColor = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr --color=auto "")',
+          'CURRENT=3',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(commandAfterEqualsColor.stdout)).toEqual(expect.arrayContaining(['lint', 'completion', 'help']));
+
+      const exactTerminator = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr lint --)',
+          'CURRENT=3',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(exactTerminator.stdout)).toEqual([]);
+
+      const priorTerminator = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr lint -- "")',
+          'CURRENT=4',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(priorTerminator.stdout)).toEqual([]);
+
+      const afterTerminator = await runShell([
+        SHELLS.zsh!,
+        '-f',
+        '-c',
+        [
+          `source ${JSON.stringify(scriptPath)}`,
+          'function compadd() { shift 2; print -rl -- "$@"; }',
+          'words=(adr lint -- --color)',
+          'CURRENT=4',
+          '_adr_completion',
+        ].join('; '),
+      ]);
+      expect(lines(afterTerminator.stdout)).toEqual([]);
     });
   });
 
@@ -364,6 +683,114 @@ describe('adr completion CLI', () => {
         `source ${JSON.stringify(scriptPath)}; complete -C "adr help -"`,
       ]);
       expect(lines(leadingDashSuppression.stdout)).not.toEqual(expect.arrayContaining(['new', 'lint', 'completion']));
+
+      const commandColorOption = await runShell([
+        SHELLS.fish!,
+        '-c',
+        `source ${JSON.stringify(scriptPath)}; complete -C ${JSON.stringify('adr lint --co')}`,
+      ]);
+      expect(lines(commandColorOption.stdout).some((line) => line.startsWith('--color'))).toBe(true);
+
+      const helpColorOption = await runShell([
+        SHELLS.fish!,
+        '-c',
+        `source ${JSON.stringify(scriptPath)}; complete -C ${JSON.stringify('adr help --co')}`,
+      ]);
+      expect(lines(helpColorOption.stdout).some((line) => line.startsWith('--color'))).toBe(true);
+
+      const completionLateOptions = await runShell([
+        SHELLS.fish!,
+        '-c',
+        `source ${JSON.stringify(scriptPath)}; complete -C ${JSON.stringify('adr completion bash ')}`,
+      ]);
+      expect(lines(completionLateOptions.stdout).some((line) => line.startsWith('--help'))).toBe(true);
+      expect(lines(completionLateOptions.stdout).some((line) => line.startsWith('--color'))).toBe(true);
+
+      const helpLateOptions = await runShell([
+        SHELLS.fish!,
+        '-c',
+        `source ${JSON.stringify(scriptPath)}; complete -C ${JSON.stringify('adr help check ')}`,
+      ]);
+      expect(lines(helpLateOptions.stdout).some((line) => line.startsWith('--help'))).toBe(true);
+      expect(lines(helpLateOptions.stdout).some((line) => line.startsWith('--color'))).toBe(true);
+
+      const exactTerminator = await runShell([
+        SHELLS.fish!,
+        '-c',
+        `source ${JSON.stringify(scriptPath)}; complete -C ${JSON.stringify('adr lint --')}`,
+      ]);
+      expect(lines(exactTerminator.stdout)).toEqual([]);
+
+      const priorTerminator = await runShell([
+        SHELLS.fish!,
+        '-c',
+        `source ${JSON.stringify(scriptPath)}; complete -C ${JSON.stringify('adr lint -- ')}`,
+      ]);
+      expect(lines(priorTerminator.stdout)).toEqual([]);
+
+      const colorValue = await runShell([
+        SHELLS.fish!,
+        '-c',
+        fishScript(scriptPath, ['adr', '--color'], [
+          'if __adr_color_value',
+          '    echo value',
+          'end',
+        ]),
+      ]);
+      expect(lines(colorValue.stdout)).toEqual(['value']);
+
+      const colorPrefixedValue = await runShell([
+        SHELLS.fish!,
+        '-c',
+        fishScript(scriptPath, ['adr', '--color=auto'], [
+          'if __adr_color_value',
+          '    echo value',
+          'end',
+        ]),
+      ]);
+      expect(lines(colorPrefixedValue.stdout)).toEqual(['value']);
+
+      const commandAfterGlobalColor = await runShell([
+        SHELLS.fish!,
+        '-c',
+        fishScript(scriptPath, ['adr', '--color', 'auto', 'lint'], [
+          'if __adr_root_position',
+          '    echo root',
+          'end',
+          'if __adr_subcommand_is lint',
+          '    echo command',
+          'end',
+        ]),
+      ]);
+      expect(lines(commandAfterGlobalColor.stdout)).toEqual(['command']);
+
+      const commandAfterEqualsColor = await runShell([
+        SHELLS.fish!,
+        '-c',
+        fishScript(scriptPath, ['adr', '--color=auto', 'lint'], [
+          'if __adr_root_position',
+          '    echo root',
+          'end',
+          'if __adr_subcommand_is lint',
+          '    echo command',
+          'end',
+        ]),
+      ]);
+      expect(lines(commandAfterEqualsColor.stdout)).toEqual(['command']);
+
+      const afterTerminator = await runShell([
+        SHELLS.fish!,
+        '-c',
+        fishScript(scriptPath, ['adr', 'lint', '--', '--color'], [
+          'if __adr_after_terminator',
+          '    echo after',
+          'end',
+          'if __adr_subcommand_is lint',
+          '    echo command',
+          'end',
+        ]),
+      ]);
+      expect(lines(afterTerminator.stdout)).toEqual(['after', 'command']);
     });
   });
 });

--- a/packages/cli/test/help-version.test.ts
+++ b/packages/cli/test/help-version.test.ts
@@ -5,7 +5,8 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { COMMAND_ORDER } from '../src/command-registry.ts';
 import { CLI_VERSION } from '../src/index.ts';
@@ -83,6 +84,7 @@ describe('adr help (#42)', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('Usage: adr migrate --from madr');
     expect(result.stdout).toContain('--rename');
+    expect(result.stdout).toContain('--color <auto|always|never>');
   });
 
   test('adr help help documents the help command without suggesting itself', async () => {
@@ -109,6 +111,25 @@ describe('adr help (#42)', () => {
     expect(result.stdout).toContain('proposals/0042-adopt-postgresql.md --dir docs/adr');
   });
 
+  test('command help stays literal after -- and still parses command options before it', async () => {
+    const dir = await mkdtemp(`${tmpdir()}/adr-help-literal-`);
+    try {
+      const dashDash = await runAdr(['new', '--dir', dir, '--', '--help']);
+      const dash = await runAdr(['new', '--dir', dir, '--', '-h']);
+
+      expect(dashDash.exitCode).toBe(0);
+      expect(dashDash.stderr).toBe('');
+      expect(dashDash.stdout).not.toContain('Usage: adr new');
+      expect(dashDash.stdout).toContain(dir);
+
+      expect(dash.exitCode).toBe(2);
+      expect(dash.stdout).toBe('');
+      expect(dash.stderr).toContain('Title must be between 3 and 120 characters');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test('adr new reports supported statuses and focused help for an invalid value', async () => {
     const help = await runAdr(['help', 'new']);
     const invalid = await runAdr(['new', 'Adopt PostgreSQL', '--status', 'active']);
@@ -117,6 +138,14 @@ describe('adr help (#42)', () => {
     expect(invalid.exitCode).toBe(2);
     expect(invalid.stderr).toContain('Error: Invalid status "active"');
     expect(invalid.stderr).toContain("Run 'adr help new' for more information.");
+  });
+
+  test('command-scoped typo recovery suggests the global color option', async () => {
+    const result = await runAdr(['lint', '--colr', 'always']);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Unknown option "--colr". Did you mean "--color"?');
   });
 
   test('adr help explain states the scan bound as a bound, not as the extent', async () => {
@@ -147,6 +176,7 @@ describe('adr help (#42)', () => {
         continue;
       }
 
+      expect(viaFlag.stdout).toContain('--color <auto|always|never>');
       expect(viaFlag.stdout).toBe(viaHelp.stdout);
     }
   });

--- a/packages/cli/test/presentation.test.ts
+++ b/packages/cli/test/presentation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { createPresentation, stripAnsi } from '../src/presentation.ts';
+
+describe('presentation styling', () => {
+  test('auto colors only terminal-facing streams', () => {
+    const presentation = createPresentation({ colorMode: 'auto', stdoutIsTTY: true, stderrIsTTY: false, noColor: false });
+
+    expect(presentation.stdout.enabled).toBe(true);
+    expect(presentation.stderr.enabled).toBe(false);
+    expect(presentation.stdout.heading('Heading')).not.toBe('Heading');
+    expect(stripAnsi(presentation.stdout.heading('Heading'))).toBe('Heading');
+    expect(presentation.stderr.heading('Heading')).toBe('Heading');
+  });
+
+  test('NO_COLOR disables auto even when a stream is a tty', () => {
+    const presentation = createPresentation({ colorMode: 'auto', stdoutIsTTY: true, stderrIsTTY: true, noColor: true });
+
+    expect(presentation.stdout.enabled).toBe(false);
+    expect(presentation.stderr.enabled).toBe(false);
+    expect(presentation.stdout.status('accepted')).toBe('accepted');
+    expect(presentation.stderr.status('warn')).toBe('warn');
+  });
+
+  test('explicit color always and never override terminal detection', () => {
+    const always = createPresentation({ colorMode: 'always', stdoutIsTTY: false, stderrIsTTY: false, noColor: true });
+    const never = createPresentation({ colorMode: 'never', stdoutIsTTY: true, stderrIsTTY: true, noColor: false });
+
+    expect(always.stdout.enabled).toBe(true);
+    expect(always.stderr.enabled).toBe(true);
+    expect(always.stdout.label('checked:')).toContain('\u001b[');
+    expect(stripAnsi(always.stdout.label('checked:'))).toBe('checked:');
+
+    expect(never.stdout.enabled).toBe(false);
+    expect(never.stderr.enabled).toBe(false);
+    expect(never.stderr.label('checked:')).toBe('checked:');
+  });
+});


### PR DESCRIPTION
Adds centralized TTY-aware styling for human-facing CLI output while keeping JSON, completion scripts, and other machine-readable output ANSI-free and stable. Honors NO_COLOR, supports explicit auto/always/never control, and adds focused tests for color behavior and stream separation.\n\nValidation: bun run typecheck; bun run --filter='@adrkit/core' build && bun run --filter='@adrkit/evaluator' build && bun run --filter='@adrkit/cli' build; bun run check:changelog