### PR TITLE
Release v0.10.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: adrkit version
       description: Output of `adr --version` (or the package version you installed).
-      placeholder: '0.9.0'
+      placeholder: '0.10.0'
     validations:
       required: true
   - type: dropdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Decision memory for human- and agent-authored plans — machine-readable ADRs
 that are enforceable in CI and legible to agents, without leaving git.
-Status: early — phases 0–6 landed and v0.9.0 is public. `@adrkit/core`,
+Status: early — phases 0–6 landed and v0.10.0 is public. `@adrkit/core`,
 `@adrkit/evaluator`, `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
 `check`, `queue`, `migrate --from madr`, `evaluate`) are published on npm, as is
 the independently versioned `@adrkit/spec-kit` Spec Kit extension (0.1.2); the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-26
+
 ### Changed
 
 - **The CLI help is now task-oriented and suitable for discovery.** Top-level
@@ -1094,7 +1096,8 @@ against live Spec Kit, rather than reasoning about it:
 - Node-targeted published distribution of all packages, smoke-tested under Node
   22 and 24.
 
-[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/mbeacom/adrkit/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/mbeacom/adrkit/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mbeacom/adrkit/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mbeacom/adrkit/compare/v0.6.0...v0.7.0

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -67,7 +67,11 @@ adrkit/
         ├── 0024  report the measured scan extent            accepted
         ├── 0025  badges as recipes over existing output     accepted
         ├── 0026  identify the CI comment by token evidence  accepted
-        └── 0027  ratify the deterministic evaluator         accepted
+        ├── 0027  ratify the deterministic evaluator         accepted
+        ├── 0028  ship decision memory as an agent plugin    accepted
+        ├── 0029  scope Backstage as a downstream consumer   accepted
+        ├── 0030  keep dependency-bearing extensions external accepted
+        └── 0031  publish a narrow consumer SDK contract     accepted
 ```
 
 ## Known-open, deliberately
@@ -102,8 +106,8 @@ independent of the GitHub namespace and unaffected either way.
 
 ## Verification
 
-28 files under `docs/adr/` — the template plus 27 records, ids 0001–0027, no
-gaps. All at schema 0.1.0: 25 accepted, 0 proposed, 2 superseded, and the
+32 files under `docs/adr/` — the template plus 31 records, ids 0001–0031, no
+gaps. All at schema 0.1.0: 29 accepted, 0 proposed, 2 superseded, and the
 template at `draft`.
 No dangling `relatesTo`. No one-way door on the auto tier. No accepted record
 without a decider or an import provenance. JSON Schema and Zod agree on property

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ different artifact from a heading convention. That is the whole thesis.
 
 Early, under active development, and deliberately honest about what is proven.
 
-- **Published — v0.9.0 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
+- **Published — v0.10.0 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
   the deterministic Pass 0 `@adrkit/evaluator`, and the read-only `@adrkit/mcp`
   server are all implemented and released. The MCP server speaks both protocol
   eras and passed real-session dogfood against the published artifact on each,

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "bin": {
         "adr": "./dist/index.js",
         "adrkit": "./dist/index.js",
@@ -70,7 +70,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -85,7 +85,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -96,7 +96,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,12 +9,12 @@ Action:
 | `@adrkit/evaluator` | npm |
 | `@adrkit/cli` (`adr`, `adrkit`) | npm |
 | `@adrkit/mcp` (`adrkit-mcp`) | npm |
-| `packages/ci/action.yml` | Git tag (latest immutable release `v0.9.0`, moving `v0`) |
+| `packages/ci/action.yml` | Git tag (latest immutable release `v0.10.0`, moving `v0`) |
 
 `@adrkit/ci` stays private because GitHub executes the committed Action bundle
 directly from the referenced repository ref.
 
-The coordinated lockstep surface is published; the current release is `v0.9.0`. `@adrkit/core`,
+The coordinated lockstep surface is published; the current release is `v0.10.0`. `@adrkit/core`,
 `@adrkit/evaluator`, and `@adrkit/cli` use GitHub Actions Trusted Publishing.
 `@adrkit/mcp` was created with the isolated one-time bootstrap path below; its
 Trusted Publisher and token-restriction cleanup must be completed before the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Decision memory for human and agent-authored plans \u2014 machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -56,7 +56,7 @@ import { getPresentation, setPresentation, styleUsageBlock, type ColorMode, type
  * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
  * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
  */
-export const CLI_VERSION = '0.9.0';
+export const CLI_VERSION = '0.10.0';
 
 function topLevelUsage(style?: StreamStyle): string {
   return renderTopLevelUsage(CLI_VERSION, style);

--- a/packages/cli/test/color.test.ts
+++ b/packages/cli/test/color.test.ts
@@ -33,7 +33,7 @@ describe('CLI color presentation', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe('');
     expect(result.stdout).toContain('\u001b[');
-    expect(result.stdout).toContain('adrkit 0.9.0');
+    expect(result.stdout).toContain('adrkit 0.10.0');
   });
 
   test('forced color keeps lint stdout and stderr separated', async () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adrkit/mcp",
   "mcpName": "dev.adrkit/mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetDecisionContext } from './tools/get-decision-context.ts';
 import { registerListSuperseded } from './tools/list-superseded.ts';
 import type { ToolConfig } from './tools/shared.ts';
 
-export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.9.0' } as const;
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.10.0' } as const;
 
 /**
  * The MCP protocol revision this server serves through `serveStdio`'s modern era.

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -14,7 +14,7 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
 				</svg>
 				CLI works today
 			</span>
-			<span>v0.9.0 on npm · decision memory in git</span>
+			<span>v0.10.0 on npm · decision memory in git</span>
 		</div>
 
 		<h1 id="_top" data-page-title set:html={title} />

--- a/site/src/content/docs/badges.mdx
+++ b/site/src/content/docs/badges.mdx
@@ -92,8 +92,8 @@ jobs:
       # current release.
       - run: |
           mkdir -p .adrkit
-          npx @adrkit/cli@0.9.0 queue --format json > .adrkit/queue.json.tmp
-          npx @adrkit/cli@0.9.0 lint --json  > .adrkit/lint.json.tmp
+          npx @adrkit/cli@0.10.0 queue --format json > .adrkit/queue.json.tmp
+          npx @adrkit/cli@0.10.0 lint --json  > .adrkit/lint.json.tmp
 
       # A truncated or malformed write renders as `no result` on the badge, which
       # reads as a bug in your tooling. Fail here instead of committing it.

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -43,7 +43,7 @@ The Action finds the comment it posted on an earlier push and edits it in place,
 pull request carries one governing-decisions comment however many times you push
 ([ADR-0026](/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows/)). Releases **through `v0.6.0` could not do this on their own** and
 needed an `env: GITHUB_TOKEN: ${{ github.token }}` block
-([#107](https://github.com/mbeacom/adrkit/issues/107)). `@v0` now resolves to `v0.9.0`,
+([#107](https://github.com/mbeacom/adrkit/issues/107)). `@v0` now resolves to `v0.10.0`,
 so that block is no longer required — and costs nothing if you still have it, because
 the Action never reads the variable to identify its token.
 
@@ -55,8 +55,8 @@ updated in place. The runner log confirms the variable was genuinely absent rath
 merely deleted from a file. The observation covers the **default `GITHUB_TOKEN`**; a
 custom GitHub App token takes the same code path but has not been observed separately.
 
-`v0` is a moving major tag, and it now resolves to a `v0.9.0` build. Pin the
-immutable `v0.9.0` tag or a commit SHA for maximum reproducibility.
+`v0` is a moving major tag, and it now resolves to a `v0.10.0` build. Pin the
+immutable `v0.10.0` tag or a commit SHA for maximum reproducibility.
 
 Every same-repository, non-Dependabot pull request in the adrkit repository runs this
 Action against itself and asserts the result. Fork and Dependabot pull requests are
@@ -73,14 +73,14 @@ open for both.
 </Aside>
 
 <Aside type="caution" title="Pinning a release tag by SHA">
-	The `v*` release tags are **annotated**, so `refs/tags/v0.9.0` resolves to a tag
+	The `v*` release tags are **annotated**, so `refs/tags/v0.10.0` resolves to a tag
 	object rather than a commit, and `uses:` rejects that SHA. Pin the commit the tag
 	points *at*:
 
 	```sh
-	git rev-parse v0.9.0^{commit}
+	git rev-parse v0.10.0^{commit}
 	# or, over the API — this endpoint peels the tag for you:
-	gh api repos/mbeacom/adrkit/commits/v0.9.0 --jq .sha
+	gh api repos/mbeacom/adrkit/commits/v0.10.0 --jq .sha
 	```
 
 	Note that `GET /git/ref/tags/{tag}` does **not** peel: its `object.sha` is the tag

--- a/site/src/content/docs/commands.mdx
+++ b/site/src/content/docs/commands.mdx
@@ -6,8 +6,10 @@ description: Every adrkit CLI command, its options, and its documented exit code
 import { Aside } from '@astrojs/starlight/components';
 
 The `adr` binary (published as `@adrkit/cli`) is a small set of deterministic
-commands. Run any of them with `--help`, or `adr help <command>`, to print the
-same text shown here. Global synopsis:
+commands. Run `adr` with no arguments or `adr --help` for task-oriented command
+discovery and common workflows. Run any command with `--help`, or
+`adr help <command>`, for its arguments, options, examples, and exit codes.
+Compact synopsis:
 
 ```text
 adr lint [paths...] [--json] [--dir docs/adr]
@@ -18,9 +20,11 @@ adr explain <path> [--dir docs/adr] [--json]
 adr check <files...> [--dir docs/adr] [--json]
 adr evaluate <proposal-path> --snapshot <bundle.json> --date YYYY-MM-DD [--json] [--dir docs/adr]
 adr queue [--dir docs/adr] [--as-of YYYY-MM-DD] [--format markdown|json]
+adr completion <bash|zsh|fish>
 
 adr help [command]        Show help, or help for one command
 adr --version             Print the @adrkit/cli version
+adr --color <mode> <command> [options]  Colorize human-readable output
 ```
 
 <Aside type="caution" title="Invoking these commands">
@@ -34,6 +38,54 @@ adr --version             Print the @adrkit/cli version
 	binary is not linked locally, and runs that other tool rather than failing.
 	See the [quickstart](/quickstart/#install).
 </Aside>
+
+## Find commands and recover from mistakes
+
+Running `adr` with no arguments prints the top-level help to stdout and exits
+`0`. The help groups commands by the task they perform, includes common
+workflows, and points to this reference. `adr help <command>` and
+`adr <command> --help` print the same focused command help.
+
+Usage errors stay on stderr and exit `2`. Instead of appending the full global
+help, a command error prints that command's usage and points to
+`adr help <command>`. Near-miss command names and long options suggest the
+closest documented spelling. The closed value sets for `new --status`,
+`graph --format`, `migrate --from`, `queue --format`, and
+`completion <shell>` do the same:
+
+```text
+Error: Unknown option "--jsn". Did you mean "--json"?
+
+Usage: adr lint [paths...] [options]
+Run 'adr help lint' for more information.
+```
+
+Suggestions are conservative: an unrelated command, option, or value is
+rejected without guessing.
+
+## Global color and stable machine output
+
+`--color auto|always|never` is a global option. Put it before the command for
+the clearest invocation:
+
+```sh
+adr --color always lint
+```
+
+Both `--color always` and `--color=always` are recognized anywhere before the
+`--` argument terminator. After `--`, `--color` is an ordinary positional value.
+
+| Mode | Meaning |
+|---|---|
+| `auto` | Default. Color each human-readable output stream only when that stream is a TTY and `NO_COLOR` is unset. |
+| `always` | Force color for human-readable output, including redirects and pipes; this explicit choice overrides `NO_COLOR`. |
+| `never` | Disable color. |
+
+Stdout and stderr are detected independently, so redirecting one does not
+change the other. Color changes presentation only: exit codes and the
+stdout/stderr split are unchanged. Machine-oriented output remains ANSI-free
+even under `--color always`, including JSON, generated completion scripts, and
+the canonical queue Markdown format.
 
 ## adr lint
 
@@ -281,6 +333,77 @@ managed-issue Action.
 **Exit codes:** `0` report, no error findings · `1` report emitted with
 error-severity corpus findings · `2` usage error (invalid flag/value or
 unreachable corpus directory).
+
+## adr completion
+
+Write a deterministic completion script for Bash, Zsh, or Fish to stdout:
+
+```sh
+adr completion <bash|zsh|fish>
+```
+
+The generated definitions cover top-level commands, each command's documented
+options, and closed value sets such as `--format` and `--status`. They register
+both `adr` and the `adrkit` binary alias where the shell format permits.
+
+| Argument or option | Meaning |
+|---|---|
+| `<shell>` | Required; one of `bash`, `zsh`, or `fish` |
+| `--help` | Show help and exit |
+
+**Exit codes:** `0` script emitted · `2` usage error (missing or unsupported
+shell).
+
+Shells commonly lazy-load completion definitions by filename. Install the same
+generated script under both the `adr` and `adrkit` names so completion works
+regardless of which binary you type first.
+
+### Bash
+
+```sh
+mkdir -p ~/.local/share/bash-completion/completions
+adr completion bash > ~/.local/share/bash-completion/completions/adr
+cp ~/.local/share/bash-completion/completions/adr \
+  ~/.local/share/bash-completion/completions/adrkit
+```
+
+This location is loaded by
+[bash-completion](https://github.com/scop/bash-completion). Reload the shell
+after installing the files. For only the current shell, source the generated
+script directly:
+
+```sh
+source <(adr completion bash)
+```
+
+### Zsh
+
+```sh
+mkdir -p ~/.zsh/completions
+adr completion zsh > ~/.zsh/completions/_adr
+cp ~/.zsh/completions/_adr ~/.zsh/completions/_adrkit
+```
+
+Add the directory to `fpath` before your existing `compinit` setup, then reload
+the shell:
+
+```sh
+fpath=(~/.zsh/completions $fpath)
+autoload -Uz compinit
+compinit
+```
+
+### Fish
+
+```sh
+mkdir -p ~/.config/fish/completions
+adr completion fish > ~/.config/fish/completions/adr.fish
+ln -sf ~/.config/fish/completions/adr.fish \
+  ~/.config/fish/completions/adrkit.fish
+```
+
+Copying `adr.fish` to `adrkit.fish` works too. Fish discovers either file
+automatically; no shell restart is required.
 
 ## adr help · adr --version
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
 <div class="adr-home">
 	<section class="adr-status-band" aria-label="Project status">
 		<div class="adr-status-band__item">
-			<span class="adr-status adr-status--current">Published · v0.9.0</span>
+			<span class="adr-status adr-status--current">Published · v0.10.0</span>
 			<p><code>@adrkit/core</code>, <code>@adrkit/cli</code>, <code>@adrkit/evaluator</code>, and <code>@adrkit/mcp</code> are on npm, plus the independently versioned <code>@adrkit/spec-kit</code> extension; the CI Action ships at <code>mbeacom/adrkit/packages/ci@v0</code>.</p>
 		</div>
 		<div class="adr-status-band__item">

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -262,6 +262,7 @@ adr migrate --from madr --dir docs/adr --rename
 
 - Enforce decisions on every PR — see [Use in CI](/ci/).
 - Give agents the decision graveyard — see [MCP setup](/mcp/).
-- Every flag and exit code — see the [Command reference](/commands/).
+- Discover commands, enable shell completion, configure color, and check every
+  exit code — see the [Command reference](/commands/).
 - Reference the schema from your editor and CI — see the [JSON Schema](/schema/).
 - Read how adrkit governs itself in the [decision records](/adr/).

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -10,7 +10,7 @@ decisions govern a file, renders the decision graph, migrates an existing MADR
 corpus in place, emits the ARB operations queue, and runs the deterministic
 evaluator.
 
-<Aside type="tip" title="Published on npm (v0.9.0)">
+<Aside type="tip" title="Published on npm (v0.10.0)">
 	`@adrkit/cli` is live. Consumers install it with your Node package manager and
 	run the `adr` binary — no clone required. Published artifacts are Node-targeted
 	([ADR-0010](/adr/0010-bun-toolchain/)); Bun is used for developing adrkit


### PR DESCRIPTION
## Summary

- bump the four lockstep npm packages, root release coordinator, CLI/MCP runtime metadata, MCP registry descriptor, and exactly four `bun.lock` workspace versions to `0.10.0`
- finalize the 2026-08-26 changelog for task-oriented help, mistake recovery, Bash/Zsh/Fish completions, and TTY-aware presentation while preserving machine-output behavior
- advance current-release documentation, executable CLI pins, issue metadata, and the ADR manifest inventory through ADR-0031
- leave `@adrkit/spec-kit`, the agent plugin, and other independently versioned/private surfaces unchanged

## Validation

- Bun 1.3.14 frozen installs for the repository and site
- version consistency tests, changelog guard, published-doc pin guard, and `release:pack -- --tag v0.10.0`
- release manifest: four lockstep packages at `0.10.0`; `@adrkit/spec-kit` unchanged at `0.1.2`
- repository typecheck, build, lint, dependency-boundary check, freeze-hash check, site grammar check, and ADR lint
- full test suite: 2,612 passed, 1 platform-specific skip, 0 failed
- documentation site build: 42 pages
- no validation-only lockfile or generated CI bundle drift
- DCO check passed for the release commit

## After merge

1. Create and push the annotated `v0.10.0` tag from the merged release commit.
2. Approve the protected `npm` environment deployment and verify all four lockstep packages publish, the immutable GitHub release is created, and the moving `v0` Action tag advances.
3. After npm publication is verified, manually publish the MCP registry entry from `packages/mcp` with `mcp-publisher publish`; no workflow performs this step.