### PR TITLE
docs: Improve user-facing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,211 +2,178 @@
 
 ## Toolchain
 
-Bun 1.3.14 (see [ADR-0010](docs/adr/0010-bun-toolchain.md)). Install it, then
-run `bun install --frozen-lockfile`. Bun is a **development** dependency only —
-nothing published by this project requires it, and every published artifact is
-smoke-tested under Node.
+Install Bun 1.3.14, then run:
 
-`bunfig.toml` sets `linker = "isolated"`. Do not change it: the hoisted linker
-permits phantom dependencies, which would let the core import an adapter while
-CI's dependency check still passed.
+```bash
+bun install --frozen-lockfile
+```
 
-## Your first PR
+Bun is a **development** dependency only. Published artifacts are smoke-tested
+under Node and do not require Bun at runtime.
 
-Welcome. The rest of this document is the full rigor — but you do not have to
-start at the hardest surface. Two areas have the steepest on-ramp and are worth
-avoiding for a first contribution:
+`bunfig.toml` sets `linker = "isolated"`. Do not change it. The hoisted linker
+permits phantom dependencies, which would let core surfaces import adapters
+without the dependency boundary catching it.
+
+## Good first contributions
+
+You do not need to start with the hardest surface.
+
+Two areas have the steepest on-ramp:
 
 - **The CI Action bundle** (`packages/ci/dist`) must be rebuilt under
-  linux/amd64, or the byte-for-byte diff gate fails on a Mac-built bundle (see
-  "Changing the CI Action" below).
-- **The schema emit-parity gate** requires the Zod source
-  (`packages/core/src/schema/adr.schema.ts` — the single source of truth) and the
-  generated `schema/adr.schema.json` to stay in lockstep. The root
-  `schema/adr.schema.ts` is only a one-line compatibility re-export and is not
-  where you make the change (see "Changing the schema").
+  `linux/amd64`, or the byte-for-byte diff gate fails on a Mac-built bundle.
+- **The schema parity gate** requires the Zod source
+  (`packages/core/src/schema/adr.schema.ts`) and the generated
+  `schema/adr.schema.json` to stay in lockstep.
 
-Good first PRs steer clear of both and still matter a great deal:
+Good first PRs usually start here instead:
 
-- **Docs** — fix or extend anything under `site/` or the package READMEs. If a
-  documented command behaves differently than described, that is a real bug.
-- **Fixtures** — add a corpus fixture that exercises a case the current tests
-  miss (a supersession cycle, an odd MADR variant, an `affects` edge case).
-- **Tests** — cover an untested branch. Per
-  [ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md),
-  watch each new test **fail first** against unfixed code, then pass — a check
-  that never failed is not coverage.
+- **Docs** - package READMEs, root docs, and site content.
+- **Fixtures** - add corpus fixtures for edge cases the current tests miss.
+- **Tests** - cover an untested branch and prove the new check really fires.
 
-Everything runs from a clean clone with `bun install --frozen-lockfile` and no
-credentials ([ADR-0007](docs/adr/0007-adapter-isolation-and-public-surface-build.md)).
 Open an [issue](https://github.com/mbeacom/adrkit/issues/new/choose) or a
-[Discussion](https://github.com/mbeacom/adrkit/discussions) if you would like a
-pointer to a good starting spot.
+[Discussion](https://github.com/mbeacom/adrkit/discussions) if you want help
+finding a starting point.
 
 ## Sign-off is required
 
-All commits require a [DCO](https://developercertificate.org/) sign-off. There is
-no CLA — see [ADR-0006](docs/adr/0006-license-apache-2-and-single-monorepo.md) for
-why.
+All commits require a [DCO](https://developercertificate.org/) sign-off. There
+is no CLA.
 
-```
+```bash
 git commit -s -m "your message"
 ```
 
-**This is enforced.** The `dco` job checks every commit your pull request adds and
-is a required status check, so an unsigned commit cannot merge. If you forgot, sign
-the whole branch at once and force-push:
+The `dco` job checks every commit in the pull request. If you forgot to sign
+off earlier commits, re-sign the branch and force-push:
 
-```
+```bash
 git rebase --signoff origin/main
 git push --force-with-lease
 ```
 
-The trailer must name you: `Signed-off-by: Your Name <your@email>`, matching the
-commit's author or committer exactly. Merge commits are exempt — the commits they
-merge carry the certification. Bot accounts are exempt from the address half only,
-because they sign from a service address; their trailer must still name them.
+The trailer must name you exactly:
+`Signed-off-by: Your Name <your@email>`.
 
-**Editing in the browser?** A commit made through the GitHub web editor carries no
-sign-off, and you cannot add one from the browser. Clone the branch, run the rebase
-above, and force-push — or make the change locally with `git commit -s` to begin
-with. This catches docs-only contributions in particular, so it is worth knowing
-before you start rather than after the check goes red.
+GitHub's web editor does not add a sign-off. For browser edits, clone the
+branch locally, run the rebase above, and force-push.
 
-## Two hard rules
+## Quality bar
 
-These are enforced in CI. A PR that violates either will fail, and the fix is to
-change the code, not the check.
+These rules are enforced in CI. If a pull request violates them, fix the code,
+not the check.
 
-**1. A clean clone has one narrow network exception for dependency install.**
+### 1. A clean clone gets one narrow network exception
 
-```
+```bash
 git clone <repo> && cd adrkit
 bun install --frozen-lockfile
 bun run typecheck && bun run build && bun test && bun run lint
 ```
 
-The frozen install is the only step that may use the network, and it may contact
-only the unauthenticated public package registry. It must use Bun 1.3.14, the
-committed `bun.lock`, and the repository's `bunfig.toml` settings, including the
-isolated linker and `minimumReleaseAge`.
+The frozen install is the only step that may use the network, and it may
+contact only the unauthenticated public package registry. It must use the
+committed `bun.lock` and repository `bunfig.toml`, including the isolated
+linker and `minimumReleaseAge`.
 
 After installation, build, typecheck, test, lint, packaging, smoke tests, and
 runtime behavior must require no credentials, no services, and no network
-access. Contributions may not use private or authenticated registries, registry
-tokens or other credentials, authenticated APIs, non-public dependency surfaces,
-network-dependent tests or runtime behavior, or anything requiring a managed
-device. See
-[ADR-0007](docs/adr/0007-adapter-isolation-and-public-surface-build.md).
+access. Do not add private registries, authenticated APIs, network-dependent
+tests, or anything that requires a managed device.
 
-**2. The core depends on no adapter.**
+### 2. Core surfaces do not depend on adapters
 
-`packages/core`, `packages/cli`, and `schema/` import nothing from
-`packages/adapters/*`. Integrations are optional, separately versioned, and
-allowed to break on upstream churn. The core is not.
+`packages/core`, `packages/cli`, and `schema/` must not import from
+`packages/adapters/*`.
 
-**3. A check does not count as coverage until you have watched it fail.**
+Integrations are optional and separately versioned. The core and CLI are not.
 
-When you add or tighten an assertion, lint rule, or CI gate, build an input it is
-supposed to reject and confirm it actually fails on that input. "The suite still
-passes" only establishes that your assertion does not crash. Keep the failing
-input as a permanent negative case — the artifact that proves a check works is
-the case that makes it fail.
+### 3. A new check should fail before you trust it
 
-Prefer asserting a specific observed value over a count or an absence. `0`, `[]`,
-and "no X found" render identically whether the tool looked and found nothing or
-could not look at all, which is why a green check can mean "I am blind" and be
-trusted anyway. Where a count or absence really is the right assertion, the
-negative case is mandatory rather than advisory.
+When you add or tighten an assertion, lint rule, or CI gate, build an input it
+is supposed to reject and confirm it actually fails on that input. "The suite
+still passes" only proves the check does not crash.
 
-This extends past assertions to any claim of the form "X is not there." One
-negative observation of a default configuration is not evidence a capability is
-missing — check whether you looked in the only place it could be.
+Keep the failing input as a permanent negative case. That is the artifact that
+shows the check works.
 
-If you defer the work, hand over the failing case, not the instruction. "Please
-verify this fires" transfers the whole cost of constructing the input and leaves
-the recipient unable to tell whether you ever built one.
+Prefer asserting a specific observed value over a count or an absence. `0`,
+`[]`, and "no X found" can mean either "looked and found nothing" or "never
+looked at all." Where a count or absence really is the right assertion, the
+negative case is mandatory.
 
-Aimed at checks guarding a corpus or an input the tool must not silently skip;
-applying it to every trivial equality assertion is cargo cult. See
-[ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md).
+This applies beyond tests. If you are claiming "X is not there," make sure you
+checked the only place it could be.
 
-## The `action-dogfood` check
+## What to expect from CI on your PR
 
-This repository runs its own governing-decisions Action against its own pull requests.
-The `action-dogfood` job dispatches it twice and asserts that the pull request ends up
-carrying exactly one `<!-- adrkit:ci -->` comment, and that the second dispatch updated
-it rather than posting another. That gap is how
-[#107](https://github.com/mbeacom/adrkit/issues/107) shipped duplicate comments to every
-adopter for two releases while every test stayed green.
+This repository runs its own governing-decisions Action against pull requests.
 
-Two things you will notice:
+- **Your pull request gets a bot comment** listing the decisions that govern the
+  changed files. It is updated in place on each push; it should not re-post as a
+  second comment.
+- **Fork pull requests skip that job.** A fork's `GITHUB_TOKEN` is read-only, so
+  the Action correctly declines to comment. Dependabot pull requests skip it for
+  the same reason.
 
-- **Your pull request gets a bot comment** listing the decisions that govern your
-  changed files. That is the product working; it is updated in place on every push, not
-  re-posted.
-- **On a fork pull request the job is skipped.** A fork's `GITHUB_TOKEN` is read-only
-  whatever the workflow asks for, so the Action correctly declines to comment and there
-  is nothing to assert. A skipped job reports success and will not block your merge.
-  Dependabot pull requests skip it for the same reason.
-
-If it goes red and you did not touch `packages/ci`, `scripts/check-ci-comment.ts`, or
-`.github/workflows/ci.yml`, it is almost certainly not your branch — say so on the pull
-request rather than changing your code. The one failure a contributor cannot clear
-alone is a **duplicate** comment: the Action never deletes, so a surplus comment
-outlives whatever created it and a maintainer has to delete it (hiding it as off-topic
-does not work — the API still returns it).
+If `action-dogfood` fails and you did not touch `packages/ci`,
+`scripts/check-ci-comment.ts`, or `.github/workflows/ci.yml`, call that out on
+the pull request instead of changing unrelated code.
 
 ## Changing a decision
 
 This project governs itself. If your change contradicts an accepted record in
-`docs/adr/`, the PR must include a record that supersedes it — with the argument,
-not just the status flip. Silently contradicting an accepted decision is the one
-review comment guaranteed to block a merge.
+`docs/adr/`, the PR should include a superseding ADR with the argument, not
+just a status flip.
 
-Adding a decision:
+To add a new decision:
 
-```
+```bash
 adr new "Use X for Y"
 ```
 
-**First check whether it should be a new record at all.** Run `adr explain` on the
-paths you would put in `affects`. If an accepted record already governs them, a
-completed action item on *that* record is usually the right artifact — that is how
-the DCO gate landed (a new CI job and a new `scripts/check-dco.ts`, recorded as
-action item 2 on [ADR-0006](docs/adr/0006-license-apache-2-and-single-monorepo.md),
-adding no record). A new record earns its place when it makes a commitment no
-existing record made. The rubric scores how good a record is, never whether it
-needed to exist, so nothing downstream will catch this for you.
+Before you create a new record, run `adr explain` on the paths you would place
+in `affects`. If an accepted record already governs them, extending that record
+or completing work it already called for may be the better fit.
 
-Fill in the alternatives honestly. An alternative no competent engineer would
-choose is a straw man and scores zero — see
-[the rubric](docs/EVALUATOR_RUBRIC.md).
+When you do write a new record, describe the alternatives honestly. See
+[docs/EVALUATOR_RUBRIC.md](docs/EVALUATOR_RUBRIC.md) for the scoring rubric the
+project uses when reviewing proposals.
 
 ## Changing the schema
 
-`schema/adr.schema.ts` is the source of truth; `schema/adr.schema.json` is
-generated. Run `bun run schema:emit` and commit both. CI fails if they diverge.
+The Zod source of truth lives at `packages/core/src/schema/adr.schema.ts`.
+`schema/adr.schema.ts` is a compatibility re-export, and
+`schema/adr.schema.json` is generated.
 
-Breaking schema changes require a major version and a migration. Additive
-changes are minor. See
-[ADR-0002](docs/adr/0002-typed-frontmatter-as-madr-superset.md).
+Run:
+
+```bash
+bun run schema:emit
+```
+
+Then commit the source change and the generated JSON. CI fails if they diverge.
+
+Breaking schema changes require a major version and a migration path. Additive
+changes are minor.
 
 ## Changing the evaluator rubric
 
-Rubric changes are decisions, not tweaks. They ship as an ADR with calibration
-deltas attached — see [ADR-0005](docs/adr/0005-deterministic-first-evaluator-with-declarative-escalation.md).
+Rubric changes are decisions, not casual wording tweaks. Update the rubric with
+the same care as an ADR, and keep its stated shipped-vs-design-target boundary
+accurate.
 
 ## Changing the CI Action (`packages/ci`)
 
 The `@adrkit/ci` Action ships a committed, self-contained bundle at
-`packages/ci/dist/index.js`, and CI enforces it matches source with a
-`git diff --exit-code packages/ci/dist` gate (mirroring `schema-emit-matches`).
+`packages/ci/dist/index.js`, and CI enforces that it matches source with a
+`git diff --exit-code packages/ci/dist` gate.
 
-**Rebuild the bundle under `linux/amd64` bun 1.3.14** (the CI toolchain) — not on a
-Mac. bun's CJS-interop codegen differs between the macOS-arm64 and linux-x64 builds
-of the same bun version, so a Mac-built bundle drifts and fails the gate. Use the
-pinned container:
+**Rebuild the bundle under `linux/amd64` Bun 1.3.14**, not on a Mac. Bun's
+CommonJS interop output differs across host targets, so a Mac-built bundle
+drifts and fails the gate. Use the pinned container:
 
 ```bash
 docker run --rm --platform linux/amd64 -v "$PWD":/work -w /work oven/bun:1.3.14 \
@@ -214,5 +181,12 @@ docker run --rm --platform linux/amd64 -v "$PWD":/work -w /work oven/bun:1.3.14 
 bun install --frozen-lockfile   # restore your local (host) install afterward
 ```
 
-Then commit `packages/ci/dist`. Any change to `packages/ci/src` **or** `@adrkit/core`
-(which is bundled in) requires regenerating it.
+Then commit `packages/ci/dist`. Any change to `packages/ci/src` **or**
+`@adrkit/core` (which is bundled in) requires regenerating it.
+
+## Architecture and governance links
+
+- [README.md](README.md) - product overview and installation paths
+- [docs/adr/](docs/adr/) - governing decisions
+- [docs/EVALUATOR_RUBRIC.md](docs/EVALUATOR_RUBRIC.md) - proposal review rubric
+- [docs/RELEASING.md](docs/RELEASING.md) - release procedures

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ the pull request instead of changing unrelated code.
 ## Changing a decision
 
 This project governs itself. If your change contradicts an accepted record in
-`docs/adr/`, the PR should include a superseding ADR with the argument, not
+`docs/adr/`, the PR must include a superseding ADR with the argument, not
 just a status flip.
 
 To add a new decision:
@@ -161,9 +161,9 @@ changes are minor.
 
 ## Changing the evaluator rubric
 
-Rubric changes are decisions, not casual wording tweaks. Update the rubric with
-the same care as an ADR, and keep its stated shipped-vs-design-target boundary
-accurate.
+Rubric changes are ADRs, not casual wording tweaks. Include the decision record
+with the change and, once calibration metrics exist, attach the calibration
+deltas. Keep the stated shipped-vs-design-target boundary accurate.
 
 ## Changing the CI Action (`packages/ci`)
 

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,114 +1,61 @@
-# adrkit — repository manifest
+# adrkit - repository manifest
 
-A map of the tracked surfaces and the decision corpus that governs them. This
-file started as the seed-bundle manifest for the first commit; it is now the
-inventory, refreshed as the corpus and the package layout move.
+A quick map of the repository's public surfaces, supporting packages, and
+decision corpus.
 
 ```
 adrkit/
-├── README.md                      positioning, quickstart, license carve-out
-├── CONTRIBUTING.md                DCO + the two hard rules from ADR-0007
-├── CHANGELOG.md                   Keep a Changelog; SemVer per ADR-0002
-├── CODEOWNERS                     governance surfaces gated
+├── README.md                      product overview, install paths, status
+├── CONTRIBUTING.md                contributor workflow, quality bar, DCO
+├── CHANGELOG.md                   released changes
+├── CODEOWNERS                     review ownership for governed surfaces
 ├── NOTICE                         Apache attribution + CC0 carve-out notice
-├── plan.md                        orchestrator handoff: phases, exit criteria, tasks
+├── plan.md                        active planning and open questions
 ├── MANIFEST.md                    this file
 ├── DESIGN.md  PRODUCT.md          design and product framing
 ├── .gitignore  .editorconfig
-├── bunfig.toml  .bun-version    linker = "isolated" is load-bearing (ADR-0010)
-├── .github/workflows/             CI enforces ADR-0002 and ADR-0007 commitments
+├── bunfig.toml  .bun-version      Bun development toolchain; isolated linker
+├── .github/workflows/             CI workflows
 ├── schema/
-│   ├── adr.schema.ts              re-export of the Zod source of truth
-│   ├── adr.schema.json            GENERATED. Do not hand-edit. $id at v0.1.0
+│   ├── adr.schema.ts              compatibility re-export
+│   ├── adr.schema.json            generated JSON Schema; do not hand-edit
 │   └── LICENSE                    CC0, schema only
 ├── packages/
-│   ├── core/                      @adrkit/core — schema (SOURCE OF TRUTH:
-│   │                              src/schema/adr.schema.ts), resolver, queue kernel
-│   ├── cli/                       @adrkit/cli — the `adr` and `adrkit` binaries
-│   ├── evaluator/                 @adrkit/evaluator — deterministic Pass 0
-│   ├── mcp/                       @adrkit/mcp — read-only stdio MCP server
-│   ├── ci/                        private — the two GitHub Actions + bundled dist
+│   ├── core/                      @adrkit/core - parsing, validation, resolution
+│   ├── cli/                       @adrkit/cli - `adr` / `adrkit` binaries
+│   ├── evaluator/                 @adrkit/evaluator - deterministic Pass 0
+│   ├── mcp/                       @adrkit/mcp - read-only stdio MCP server
+│   ├── ci/                        private GitHub Actions + bundled dist
+│   ├── catalog-envelope/          experimental envelope reader/validator
 │   └── adapters/
-│       └── spec-kit/              @adrkit/spec-kit — independently versioned
-│                                  (ADR-0007); ships no dist, no dependencies
-├── scripts/                       release pack/publish, dep boundary + audit + DCO gates
+│       ├── spec-kit/              @adrkit/spec-kit - published Spec Kit extension
+│       ├── agent-plugin/          portable plugin for Copilot/Claude/APM/opencode
+│       └── catalog-backstage/     experimental Backstage generator package
+├── scripts/                       release, audit, dependency-boundary, and DCO checks
 ├── site/                          Astro Starlight docs site; hosts the schema at its $id
-├── specs/                         001–009, one spec-kit feature per phase/spike
+├── specs/                         feature work and contracts
 └── docs/
-    ├── EVALUATOR_RUBRIC.md        4 passes, 8 dimensions, escalation triggers
-    ├── RELEASING.md               lockstep and adapter release procedures
-    ├── DISTRIBUTION.md            registry/directory playbook
-    ├── reference-verification-spec-kit-extension.md   ADR-0014 rung-2 evidence index
-    └── adr/
-        ├── 0000-template.md                              draft (template)
-        ├── 0001  git-native markdown records            accepted
-        ├── 0002  MADR-superset typed frontmatter        accepted
-        ├── 0003  Spec Kit extension + standalone CLI    accepted
-        ├── 0004  git truth, DB as derived index         accepted
-        ├── 0005  deterministic-first evaluator          superseded
-        ├── 0006  Apache-2.0, DCO, monorepo              accepted
-        ├── 0007  adapter isolation, public-surface build accepted
-        ├── 0008  MADR migration + one-way import         accepted
-        ├── 0009  affects resolution + catalog binding    accepted
-        ├── 0010  Bun toolchain, Node-targeted output      accepted
-        ├── 0011  host schema at its $id (adrkit.dev)      accepted
-        ├── 0012  explicit catalog owned-paths binding     accepted
-        ├── 0013  reconcile 0007/0009 with offline gen     accepted
-        ├── 0014  three-rung phase-landing evidence ladder accepted
-        ├── 0015  validate descriptors before canonicalizing accepted
-        ├── 0016  observed-failing as the coverage bar      accepted
-        ├── 0017  explicit, release-scoped dependency audit accepted
-        ├── 0018  MCP SDK v2, dual-era protocol revisions   accepted
-        ├── 0019  ship the Spec Kit extension (spike no-go) accepted
-        ├── 0020  rescope SC-010, authorize catalog adapter accepted
-        ├── 0021  inbound markers without a schema change   superseded
-        ├── 0022  scan markers in check and CI, no authority accepted
-        ├── 0023  read a marker only where the format hides it accepted
-        ├── 0024  report the measured scan extent            accepted
-        ├── 0025  badges as recipes over existing output     accepted
-        ├── 0026  identify the CI comment by token evidence  accepted
-        ├── 0027  ratify the deterministic evaluator         accepted
-        ├── 0028  ship decision memory as an agent plugin    accepted
-        ├── 0029  scope Backstage as a downstream consumer   accepted
-        ├── 0030  keep dependency-bearing extensions external accepted
-        └── 0031  publish a narrow consumer SDK contract     accepted
+    ├── EVALUATOR_RUBRIC.md        evaluator rubric and status boundary
+    ├── RELEASING.md               release procedures
+    ├── DISTRIBUTION.md            distribution channels and registry notes
+    ├── reference-verification-spec-kit-extension.md
+    ├── reference-verification-agent-plugin.md
+    └── adr/                       numbered decision records plus the draft template
 ```
 
-## Known-open, deliberately
+## Current planning sources
 
-- Schema `$id` is `https://adrkit.dev/...` — recorded and hosted per ADR-0011:
-  the docs site serves the schema byte-for-byte at its `$id` on the apex domain
-  via GitHub Pages, and the hostname is fixed for the life of the major version.
-  Not `mbeacom.github.io` — ADR-0006 publishes under a personal namespace that
-  may later transfer to an org, and a namespace-encoded `$id` breaks every
-  pinned reference on transfer.
-- No record remains `proposed`. 0005 was superseded by 0027 on 2026-08-12, which
-  ratified the deterministic evaluator and re-timed its calibration obligation;
-  `adr queue` is consequently empty. Records 0003 and 0006–0009 were ratified on
-  2026-08-12, closing a gap in which accepted records rested on a proposed
-  foundation.
-- ADR-0014 rung-3 external/community validation is open for both the Phase 6 ARB
-  queue and the Spec Kit extension. Tracked honestly as absent, never as met.
-- Catalog binding is not built. `packages/adapters/catalog-backstage` exists as
-  placement and dependency boundary only and generates nothing; no snapshot
-  envelope exists. The viability spike `specs/009-catalog-binding-viability/`
-  recorded `blocked`, and ADR-0020 authorizes the work without asserting it has
-  landed. ADR-0009's catalog-port action item is open for the same reason.
-- Three open questions at the foot of `plan.md`. Do not let an implementer
-  resolve them silently.
+- [README.md](README.md) - reader-facing overview and install paths
+- [CHANGELOG.md](CHANGELOG.md) - what has shipped
+- [plan.md](plan.md) - active planning and open questions
+- [docs/adr/](docs/adr/) - governing decisions
+- [docs/RELEASING.md](docs/RELEASING.md) - release procedures
 
-## Repo target
+## Decision corpus
 
-`github.com/mbeacom/adrkit` — personal namespace per ADR-0006, not a new org.
-Transfer to an organization remains available later; GitHub preserves redirects.
-`CODEOWNERS` is already scoped to `@mbeacom`. The npm scope `@adrkit` is
-independent of the GitHub namespace and unaffected either way.
-
-## Verification
-
-32 files under `docs/adr/` — the template plus 31 records, ids 0001–0031, no
-gaps. All at schema 0.1.0: 29 accepted, 0 proposed, 2 superseded, and the
-template at `draft`.
-No dangling `relatesTo`. No one-way door on the auto tier. No accepted record
-without a decider or an import provenance. JSON Schema and Zod agree on property
-casing. No `@adr/` references remain — the scope is `@adrkit/*` throughout.
+- The ADR corpus lives in [docs/adr/](docs/adr/), with `0000-template.md` plus
+  numbered records.
+- The schema source of truth lives in
+  `packages/core/src/schema/adr.schema.ts`.
+- `schema/adr.schema.json` is generated from that source and hosted at the
+  schema `$id` through the docs site.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ answer where the next decision is being made.
 ## Quickstart
 
 The CLI is published as [`@adrkit/cli`](https://www.npmjs.com/package/@adrkit/cli)
-and exposes the `adr` binary. Published artifacts target **Node 22+**
-([ADR-0010](docs/adr/0010-bun-toolchain.md)):
+and exposes the `adr` binary. Published artifacts target **Node 22+**:
 
 ```sh
 npx @adrkit/cli lint                 # validate the corpus in docs/adr
@@ -38,6 +37,18 @@ The pure library surfaces install independently:
 
 See the [Quickstart guide](https://adrkit.dev/quickstart/) and the full
 [command reference](https://adrkit.dev/commands/).
+
+## Choose a starting point
+
+| If you want to... | Start here | Notes |
+|---|---|---|
+| Validate or inspect an ADR corpus | [`@adrkit/cli`](packages/cli/README.md) | `npx @adrkit/cli ...` on Node 22+ |
+| Build your own tooling | [`@adrkit/core`](packages/core/README.md) | Pure parser, validator, matcher, and queue APIs |
+| Run the deterministic proposal checks | [`@adrkit/evaluator`](packages/evaluator/README.md) | Pass 0 is the shipped evaluator surface today |
+| Feed prior decisions to coding agents | [`@adrkit/mcp`](packages/mcp/README.md) | Local, read-only stdio MCP server |
+| Comment governing decisions on pull requests | [Use in CI](https://adrkit.dev/ci/) | GitHub Action from this repository |
+| Add decision memory to Spec Kit | [`@adrkit/spec-kit`](packages/adapters/spec-kit/README.md) | Published separately for Spec Kit `>=0.13.0,<0.16.0` |
+| Add decision memory to Copilot, Claude Code, or opencode | [`adrkit` agent plugin](packages/adapters/agent-plugin/README.md) | Install from this repository or marketplace |
 
 ## What it looks like
 
@@ -112,13 +123,9 @@ construction, and hooks can only reach commands that do not write — `draft` is
 deliberately unreachable from any hook, because a plan-phase hook creating
 records unprompted would manufacture decision memory rather than record it.
 
-Pinned to Spec Kit `>=0.13.0,<0.16.0`, continuously re-verified against 0.13.0,
-0.14.4, and 0.15.1 in an isolated reference repository. **Landed /
-reference-verified** on
-[ADR-0014](docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md)
-rungs 1–2 — see the
-[evidence index](docs/reference-verification-spec-kit-extension.md). Not
-externally validated (rung 3 open).
+Pinned to Spec Kit `>=0.13.0,<0.16.0` and tested against 0.13.0, 0.14.4, and
+0.15.1. It is available from the Spec Kit community catalog; see the package
+README for setup.
 
 ## For any coding agent: the plugin
 
@@ -155,11 +162,11 @@ It deliberately ships **no MCP configuration**: Copilot CLI spawns a plugin's
 MCP servers outside the workspace, and outside any Git repository, so the adrkit
 server exits during `initialize`. MCP is wired per project instead — see the
 [plugin README](packages/adapters/agent-plugin/README.md#mcp-is-configured-per-project-not-shipped-here)
-and [ADR-0028](docs/adr/0028-ship-decision-memory-as-a-portable-agent-plugin-and-omit-the-mcp-wiring-hosts-cannot-honor.md).
+for the host-specific setup.
 
-Independently versioned per ADR-0007. At **rung 1** of ADR-0014 — unit and
-contract coverage plus maintainer verification against the installed hosts. No
-reference-repository run, no external validation.
+Status: installable today from this repository and versioned independently from
+the npm packages. It is the smallest surface that makes the context -> check ->
+draft loop available inside current coding-agent hosts.
 
 ## The problem
 
@@ -266,48 +273,18 @@ different artifact from a heading convention. That is the whole thesis.
 
 ## Project status
 
-Early, under active development, and deliberately honest about what is proven.
+adrkit is still pre-1.0, but several surfaces are ready to use today. This
+table is the short version:
 
-- **Published — v0.10.0 on npm.** The schema, `@adrkit/core`, `@adrkit/cli`,
-  the deterministic Pass 0 `@adrkit/evaluator`, and the read-only `@adrkit/mcp`
-  server are all implemented and released. The MCP server speaks both protocol
-  eras and passed real-session dogfood against the published artifact on each,
-  driven through the official MCP Inspector
-  ([ADR-0018](docs/adr/0018-adopt-mcp-sdk-v2-and-serve-protocol-revision-2026-07-28-dual-era.md)).
-- **Expanded in v0.5.0, and at rung 1 only.** A file can declare the decision it
-  lives under with an `@adr <id>` marker on a dedicated comment line. v0.4.0
-  resolved that inbound edge in `adr explain`
-  ([ADR-0021](docs/adr/0021-resolve-inbound-source-annotations-without-changing-the-schema.md));
-  v0.5.0 extended it to `adr check` and the governing-decisions Action, so a
-  marker-declared record appears alongside the `affects` patterns that already
-  matched the path
-  ([ADR-0022](docs/adr/0022-scan-inbound-markers-in-check-and-ci-without-giving-them-exit-code-authority.md),
-  superseding ADR-0021).
-  A marker is read only where the file's own format hides it — never inside a
-  fenced block, and in markdown only from `<!--` or `{/*`
-  ([ADR-0023](docs/adr/0023-read-a-marker-only-where-the-format-hides-it-fences-and-markdown-prose.md)).
-  Markers add governance context and findings, but never exit-code authority: no
-  marker a pull request writes can fail a check. A changed ADR record that fails
-  validation still does — that is what the check is for.
-  Evidence is unit, contract, and purity coverage plus maintainer verification —
-  **rung 1** of the ADR-0014 ladder, not the rungs 1–2 the surfaces below carry.
-  Contributed by [@aballiet](https://github.com/aballiet) in
-  [#97](https://github.com/mbeacom/adrkit/pull/97) — the first community feature
-  this project has shipped — and
-  [#106](https://github.com/mbeacom/adrkit/pull/106), and by
-  [@davesheffer](https://github.com/davesheffer) in
-  [#109](https://github.com/mbeacom/adrkit/pull/109).
-- **Landed, maintainer reference-verified — not yet externally validated.** The
-  Phase 6 ARB queue (`adr queue` plus the managed-issue Action) is verified on
-  rungs 1–2 of the
-  [ADR-0014](docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md)
-  evidence ladder via a maintainer-owned isolated reference repository. The rung-3
-  external/community signal is tracked honestly as **open**.
-- **Not built yet.** The later probabilistic evaluator passes (Passes 1–3) and
-  pluggable catalog binding. See [`plan.md`](./plan.md) and
-  [CHANGELOG.md](./CHANGELOG.md).
-
-No release is cut by governance or docs changes alone.
+| State | Surface | What that means |
+|---|---|---|
+| Available now | `@adrkit/core`, `@adrkit/cli`, `@adrkit/evaluator`, `@adrkit/mcp` | Published on npm for Node 22+ |
+| Available now | `@adrkit/spec-kit` | Published separately for current Spec Kit releases |
+| Available now | `adr queue` and the governing-decisions GitHub Action | Queue reporting and PR comments are part of the shipped workflow |
+| Available now | `adrkit` agent plugin | Install from this repository or marketplace; shells out to `adr` |
+| In development | Later evaluator passes | Passes 1–3 and calibration remain design targets; Pass 0 is the implemented evaluator surface |
+| In development | Catalog packages | `@adrkit/catalog-envelope` and `@adrkit/catalog-backstage` exist in the workspace at `0.0.0` and are not released |
+| Planned | Additional downstream integrations | Future integrations will build on the current typed corpus and read-only retrieval model |
 
 ## Design commitments
 
@@ -328,12 +305,9 @@ These are enforced, not aspirational. Each links to the record that decided it.
 
 Every decision in this project is governed by this project. The repository's
 first commit is its own decision corpus — see [`docs/adr/`](docs/adr/). The
-evaluator rubric is itself an ADR, and changes to it ship as ADRs. No
-probabilistic evaluator pass has shipped, so no escalation precision/recall
-figures exist yet; per
-[ADR-0027](docs/adr/0027-ratify-the-deterministic-evaluator-and-bind-calibration-reporting-to-the-first-probabilistic-pass.md)
-that absence is stated rather than assumed, and the first such pass may not ship
-without a holdout frozen before it produced a score.
+evaluator rubric is itself versioned here too. The published evaluator currently
+implements the deterministic Pass 0 only; later passes remain documented design
+targets rather than released behavior.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,20 @@
 # Security Policy
 
-adrkit is early software, but security reports are taken seriously. Thank you for
-helping keep the project and its users safe.
+adrkit is early software, but security reports are taken seriously. Thank you
+for helping keep the project and its users safe.
 
 ## Supported versions
 
-Security fixes are released against the latest published minor. Older versions
-are not patched in place; upgrade to the latest `0.x` release to receive fixes.
+Security fixes ship against the latest published minor. Older versions are not
+patched in place; upgrade to the newest `0.x` release to receive fixes.
 
 | Version | Supported |
 |---------|-----------|
-| 0.2.x   | ✅        |
-| < 0.2   | ❌        |
+| 0.10.x  | ✅        |
+| < 0.10  | ❌        |
 
-Until adrkit reaches `1.0.0`, minor releases may include breaking changes
-([ADR-0002](docs/adr/0002-typed-frontmatter-as-madr-superset.md)); prefer the
-newest release.
+Until adrkit reaches `1.0.0`, minor releases may include breaking changes, so
+prefer the newest release line.
 
 ## Reporting a vulnerability
 
@@ -27,8 +26,8 @@ Report privately through GitHub Security Advisories:
    of the repository.
 2. Click **Report a vulnerability** to open a private advisory.
 
-This routes the report privately to the maintainer. If private reporting is
-unavailable to you, email [m@beacom.dev](mailto:m@beacom.dev) instead.
+This routes the report privately to the maintainer. If private reporting is not
+available to you, email [m@beacom.dev](mailto:m@beacom.dev) instead.
 
 Please include:
 
@@ -44,19 +43,18 @@ Please include:
 
 ## Scope
 
-adrkit is deliberately narrow: match resolution is a pure function, and the MCP
-server and CLI make no network or model calls. Nothing requires credentials to
-**build**, and the local tools (`adr`, `@adrkit/mcp`, `@adrkit/core`,
-`@adrkit/evaluator`) require none to **run**
-([ADR-0007](docs/adr/0007-adapter-isolation-and-public-surface-build.md)).
+adrkit is deliberately narrow. Match resolution is a pure function, and the
+local CLI and MCP surfaces make no network or model calls. Nothing requires
+credentials to **build**, and the local tools (`adr`, `@adrkit/mcp`,
+`@adrkit/core`, `@adrkit/evaluator`) require none to **run**.
 
-The two shipped GitHub Actions are the deliberate exception, because their whole
-job is to write back to GitHub: the governing-decisions Action fails without a
-token (`packages/ci/src/index.ts`) and needs `pull-requests: write` to comment,
-and the queue Action needs `issues: write` to maintain its managed issue. Both
-accept the workflow's default `GITHUB_TOKEN`; neither asks for a personal token.
+The shipped GitHub Actions are the exception because their job is to write back
+to GitHub. The governing-decisions Action needs `pull-requests: write` to
+comment, and the queue Action needs `issues: write` to maintain its managed
+issue. Both accept the workflow's default `GITHUB_TOKEN`; neither requires a
+personal token.
 
-Reports that concern this trust boundary — for example, a path-containment escape
-in the MCP server, the CLI reading outside its corpus directory, or an Action
-using its token beyond the scope documented in its `action.yml` — are especially
-valuable.
+Reports about this trust boundary are especially helpful. Examples include a
+path-containment escape in the MCP server, the CLI reading outside its corpus
+directory, or an Action using its token beyond the scope documented in its
+`action.yml`.

--- a/docs/EVALUATOR_RUBRIC.md
+++ b/docs/EVALUATOR_RUBRIC.md
@@ -4,9 +4,10 @@ The evaluator scores a **proposal** — a `draft` or `proposed` ADR, or an agent
 plan being converted into one. It never approves anything. Its only outputs are
 a scored report and a routing recommendation.
 
-> **Status:** `@adrkit/evaluator` currently implements **Pass 0** only. Passes
-> 1–3, escalation routing, and calibration guidance below describe the intended
-> rubric contract and design targets; they are not shipped behavior yet.
+> **Status:** `@adrkit/evaluator` implements **Pass 0**, including its eight
+> deterministic escalation triggers and named-human routing. Passes 1–3, the
+> three escalation triggers that depend on those passes, and the calibration
+> guidance below are design targets; they are not shipped behavior yet.
 
 Design constraints, in priority order:
 

--- a/docs/EVALUATOR_RUBRIC.md
+++ b/docs/EVALUATOR_RUBRIC.md
@@ -4,12 +4,16 @@ The evaluator scores a **proposal** — a `draft` or `proposed` ADR, or an agent
 plan being converted into one. It never approves anything. Its only outputs are
 a scored report and a routing recommendation.
 
+> **Status:** `@adrkit/evaluator` currently implements **Pass 0** only. Passes
+> 1–3, escalation routing, and calibration guidance below describe the intended
+> rubric contract and design targets; they are not shipped behavior yet.
+
 Design constraints, in priority order:
 
 1. **Deterministic before probabilistic.** Anything checkable without a model is
    checked without a model, first, and reported separately.
 2. **Per-dimension scores with citations.** No gestalt verdict. A single number
-   is unfalsifiable and gets ignored within two sprints.
+   is too coarse to audit on its own.
 3. **Separation of grading and attacking.** The adversarial pass is a distinct
    call with a distinct context. A model asked to both defend and critique does
    neither well.
@@ -39,9 +43,9 @@ without spending tokens on the later passes.
 | `decider-resolvable` | warn | Identities resolve in the org directory |
 | `expiry-sane` | info | `reviewBy` is in the future |
 
-Deterministic findings land in `evaluation.deterministicFindings`. In practice
-this pass catches a large share of what a reviewer would have caught, at
-effectively zero cost — build it fully before writing a single prompt.
+Deterministic findings land in `evaluation.deterministicFindings`. This pass is
+designed to catch routine structural and policy issues before later passes spend
+tokens.
 
 ---
 
@@ -56,8 +60,8 @@ Assemble the context the later passes reason over. Not scored.
 - Any ADR at broader `scope` in the same `domain`.
 - The diff or spec artifact the proposal derives from, if present.
 
-Retrieval quality dominates evaluation quality. Instrument recall here before
-tuning anything downstream.
+Retrieval quality constrains evaluation quality. Measure recall here before
+tuning downstream passes.
 
 ---
 
@@ -77,21 +81,20 @@ why this came up *now*? Distinguishes a real constraint from a preference.
 *Score 2 cap if the problem statement is a restatement of the chosen solution.*
 
 ### D2 — Alternatives considered
-Are there ≥2 genuine alternatives, including "do nothing"? Straw men are the
-dominant failure mode: an alternative that no competent engineer would pick is
-worth 0, not 2.
+Are there ≥2 genuine alternatives, including "do nothing"? Weak alternatives do
+not carry review value: an option that no competent engineer would pick is worth
+0, not 2.
 *Score 1 cap if every alternative shares the chosen option's core assumption.*
 
 ### D3 — Trade-off honesty
 Are the **costs** of the chosen option stated as plainly as its benefits? A
-proposal whose chosen option has no listed downsides is not a decision, it's an
-advertisement.
+proposal whose chosen option has no listed downsides is incomplete.
 *Score 0 if the consequences section contains no negative consequence.*
 
 ### D4 — Reversibility & blast radius accuracy
 Does the stated `reversibility` / `blastRadius` match the substance? Systematic
-under-declaration is the failure that makes the fast path dangerous — this
-dimension is the fast path's safety interlock.
+under-declaration makes the fast path unsafe, so this dimension is its safety
+interlock.
 *Any downward correction here forces re-routing.*
 
 ### D5 — Prior-decision coherence
@@ -102,13 +105,13 @@ scores 4.
 
 ### D6 — Falsifiability
 How would we know this was wrong? Names a metric, a threshold, a review date,
-or an exit condition. This is the dimension that most separates ADRs that stay
-alive from ADRs that rot.
+or an exit condition. This is the dimension that most clearly separates durable
+ADRs from ones that cannot later be checked.
 
 ### D7 — Operational consequences
 Who carries this after merge? Runbook impact, on-call surface, migration path,
-rollback, cost trajectory. Chronically weakest dimension in practice; weight it
-accordingly for infra decisions.
+rollback, cost trajectory. This is often the thinnest dimension in
+infrastructure proposals, so larger-scope changes may weight it more heavily.
 
 ### D8 — Enforcement specificity
 Are `affects` and (where appropriate) `assertions` populated well enough that
@@ -157,8 +160,8 @@ model-discretionary.
 | `human-requested` | Anyone asks. Always available, never overridden. |
 
 Escalation routes to a **named human**, resolved from `deciders`, CODEOWNERS of
-the affected paths, or the IDP catalog owner — in that order. "Escalated to the
-ARB" with no name attached is how proposals die quietly.
+the affected paths, or the IDP catalog owner — in that order. A routed review
+needs an explicit owner, not an anonymous destination.
 
 ### What escalation does *not* mean
 
@@ -170,8 +173,8 @@ does not empty it.
 
 ## Calibration
 
-The rubric is worthless uncalibrated, and calibration is what makes this
-defensible in a regulated environment.
+The rubric needs calibration to remain trustworthy, especially in regulated
+environments.
 
 - Maintain a labeled set of historical proposals with known outcomes (shipped
   clean / shipped and reverted / caused an incident / rejected in review).
@@ -187,5 +190,5 @@ defensible in a regulated environment.
   recommendation, by tier and by dimension. Persistent overrides in one
   direction mean the rubric is miscalibrated, not that the humans are wrong.
 
-Publishing the false-negative rate is uncomfortable and is exactly what stops
-this from becoming evaluator theater.
+Publishing the false-negative rate keeps the system auditable and makes missed
+escalations visible.

--- a/docs/adr/0019-ship-the-spec-kit-extension-treating-the-spike-no-go-as-a-measurement-artifact.md
+++ b/docs/adr/0019-ship-the-spec-kit-extension-treating-the-spike-no-go-as-a-measurement-artifact.md
@@ -242,7 +242,7 @@ until it does not.
 2. [x] Enforce the read-only hook boundary with a test observed failing first
 3. [x] Re-verify the `speckit_version` pin against the next Spec Kit minor before widening it — done 2026-08-01, see the addendum above; widened to `<0.16.0`, verified at 0.13.0, 0.14.4, 0.15.1
 4. [x] Decide whether to publish `@adrkit/spec-kit` to npm, or install it from the repository — **both channels**, see the addendum below
-5. [ ] Submit the catalog entry to `github/spec-kit` once a release asset exists — via the Extension Submission **issue template**; the publishing guide forbids editing `catalog.community.json` by PR
+5. [x] Submit the catalog entry to `github/spec-kit` once a release asset exists — landed 2026-08-25 via [github/spec-kit#3947](https://github.com/github/spec-kit/pull/3947); adrkit is listed in the community catalog
 6. [x] Remove `@adrkit/spec-kit` from `BOOTSTRAP_PACKAGES` after its first publish, once Trusted Publishing is configured for the name — done 2026-08-03; the set is now empty, which is its correct steady state. The `NPM_BOOTSTRAP_TOKEN` secret can be deleted.
 
 ### Addendum, 2026-08-02: distribution channels (action item 4)

--- a/packages/adapters/agent-plugin/README.md
+++ b/packages/adapters/agent-plugin/README.md
@@ -1,16 +1,18 @@
-# adrkit — agent plugin
+# adrkit - agent plugin
 
 Decision memory for the agent that is about to change your code.
 
-This is adrkit's fourth distribution surface, after the npm packages, the CI Action, and the
-[Spec Kit extension](../spec-kit/README.md). It packages adrkit's workflow as
-portable agent components — one skill, one read-only subagent, and four slash
-commands — so an agent loads the decisions that already govern a change *before*
-planning it, reconciles the plan against them, and records a new decision when
-the work actually makes one.
+This package turns adrkit's workflow into portable agent components: one skill,
+one read-only subagent, and four slash commands. An agent can load the
+decisions that already govern a change before planning it, check the plan
+against them, and draft a new record when the work actually makes one.
 
 Everything here drives the [`adr`](../../cli/README.md) CLI. Nothing in this
 plugin reaches the network, and only `/adr-draft` writes anything.
+
+> **Status:** installable today from this repository and its marketplace
+> metadata. The surface is intentionally small, host-specific, and versioned
+> independently from the npm packages. It is not published to npm.
 
 ## Install
 
@@ -25,31 +27,37 @@ copilot plugin install adrkit@adrkit
 /plugin marketplace add mbeacom/adrkit
 /plugin install adrkit@adrkit
 
-# Agent Package Manager — deploys the same components into whichever
-# harness you name (claude, copilot, opencode, and others `apm targets` lists)
+# Agent Package Manager
 apm install mbeacom/adrkit/packages/adapters/agent-plugin --target copilot
 ```
 
-You also need the CLI itself, which the components shell out to:
+You also need the CLI itself, because the components shell out to it:
 
 ```bash
-npm install -g @adrkit/cli     # or add @adrkit/cli to the project
+npm install -g @adrkit/cli
+# or add @adrkit/cli to the project instead
 ```
 
-Components resolve it from `$ADRKIT_CLI`, then `./node_modules/.bin/adr`, then
-`PATH`. The corpus defaults to `docs/adr` and is overridable with `ADRKIT_DIR`.
+Components resolve the CLI from `$ADRKIT_CLI`, then `./node_modules/.bin/adr`,
+then `PATH`. The corpus defaults to `docs/adr` and is overridable with
+`ADRKIT_DIR`.
 
 ### opencode
 
-opencode has no plugin-manifest concept, so either let APM place the components
-(`apm install ... --target opencode`, measured writing `.opencode/agents/`,
-`.opencode/commands/`, and the skill to `.agents/skills/`), or copy `agents/`,
-`commands/`, **and `skills/`** into place yourself. Do not omit `skills/`: the
-skill is the part that works without being asked for, and an install without it
-silently degrades to commands-only — you get decision memory when you remember
-to ask for it, which is the failure this plugin exists to prevent.
-`opencode/opencode.json` in this directory is the MCP fragment to merge into your
-project config — see [MCP](#mcp-is-configured-per-project-not-shipped-here).
+opencode has no plugin-manifest concept, so either let APM place the
+components:
+
+```bash
+apm install mbeacom/adrkit/packages/adapters/agent-plugin --target opencode
+```
+
+or copy `agents/`, `commands/`, **and `skills/`** into place yourself. Do not
+omit `skills/`: that is the part that works without being asked for, and an
+install without it silently degrades to commands-only.
+
+`opencode/opencode.json` in this directory is the MCP fragment to merge into
+your project config - see
+[MCP](#mcp-is-configured-per-project-not-shipped-here).
 
 ## What it ships
 
@@ -63,120 +71,55 @@ project config — see [MCP](#mcp-is-configured-per-project-not-shipped-here).
 | Command | `/adr-queue [--as-of ...]` | no |
 
 The skill is the part that works without being asked for: it teaches the
-context → check → draft loop, the exit-code contract, and the rules that keep
-the record honest — a new record is `proposed` rather than `accepted`, a
-superseded decision stays in place, and a record with no `affects` matcher
-governs nothing.
+context -> check -> draft loop, the exit-code contract, and the rules that keep
+the record honest.
 
-## Things that are load-bearing and easy to break
+## Host compatibility notes
 
-Each of these was measured against the real hosts, not inferred from their docs.
-
-- **`.claude-plugin/plugin.json` is the one manifest both hosts read.** Copilot
-  CLI checks `.plugin/`, the root, `.github/plugin/`, then `.claude-plugin/`;
-  Claude Code reads only `.claude-plugin/`. The same logic puts the marketplace
-  catalog at the repository root's `.claude-plugin/marketplace.json`.
-
-- **The manifest declares no component paths.** `agents`, `skills`, and
-  `commands` are documented Copilot fields that take a string or an array, but
-  Claude Code's validator rejects the string form outright
-  (`commands: Invalid input`). Both hosts discover `agents/`, `skills/`, and
-  `commands/` by convention, so omitting the fields is the only shape that
-  loads everywhere. `category` is likewise a marketplace-entry field, not a
-  plugin field, and lives in `marketplace.json`.
-
-- **The subagent declares no `tools` list.** The three hosts disagree on both
-  the type and the vocabulary: Claude Code takes a comma-separated string of
-  capitalized names, Copilot CLI an array of lowercase ones, and opencode
-  requires a name-to-boolean mapping and **rejects the agent at load time** when
-  handed a list. There is no portable value, so the read-only contract is
-  stated in the agent body instead. `apm install --target opencode` reports this
-  class of error, which is how it was found.
-
+- **`.claude-plugin/plugin.json` is the shared manifest.** GitHub Copilot CLI
+  searches several conventional locations; Claude Code reads
+  `.claude-plugin/` only. The marketplace catalog lives at the repository root's
+  `.claude-plugin/marketplace.json`.
+- **The manifest declares no component paths.** Copilot CLI and Claude Code do
+  not accept the same manifest shape for `agents`, `skills`, and `commands`, so
+  the portable form is to rely on conventional directories instead.
+- **The subagent declares no `tools` list.** Claude Code, Copilot CLI, and
+  opencode disagree on both the data type and the vocabulary for that field. The
+  read-only contract therefore lives in the agent body, not in host-specific
+  metadata.
 - **`copilot plugin install` prints only a skill count.** "Installed 1 skill"
-  does not mean the agent and commands were dropped; they are loaded at session
-  start. Verify with a fresh session, not with the install output.
+  does not mean the agent and commands were dropped; start a fresh session to
+  verify the full install.
+- **Version fields must agree.** `.claude-plugin/plugin.json`, `apm.yml`, and
+  `package.json` must stay in sync because host caches key off that version.
 
-- **Every version field must agree** — `.claude-plugin/plugin.json`, `apm.yml`,
-  and `package.json`. Claude Code keys its plugin cache on `version`, so a
-  shipped change carrying a stale one is a change users never receive. The
-  sibling Spec Kit adapter shipped 0.1.1 with two of these diverged and told
-  every user the wrong number; `test/manifest.test.ts` asserts all three.
-
-### MCP is configured per project, not shipped here
+## MCP is configured per project, not shipped here
 
 This plugin deliberately ships **no `.mcp.json`**, even though
 [`@adrkit/mcp`](../../mcp/README.md) exists and the skill uses its tools when
 they are present.
 
-GitHub Copilot CLI spawns a plugin's MCP servers with a working directory that
-is not the workspace and not a Git repository at all — measured directly, by
-having the configured command record its own `pwd` and environment. The spawn
-environment carries `PLUGIN_ROOT` and `COPILOT_PLUGIN_ROOT` but nothing naming
-the repository. The adrkit MCP server requires its root to be a Git worktree, so
-it exits during `initialize`, and the only user-visible result is a
-`Failed to start MCP client for adrkit` line in the session log, every session.
+GitHub Copilot CLI launches a plugin's MCP servers outside the workspace, so
+`@adrkit/mcp` cannot reliably discover the repository root from plugin metadata
+alone. A server that cannot start is worse than one that was never configured,
+so MCP wiring belongs in your project config instead.
 
-A server that cannot start is worse than one that was never configured, so the
-wiring lives where the working directory can be configured correctly — your own
-project config. See the [MCP setup guide](https://adrkit.dev/mcp/), and
-`opencode/opencode.json` here for the project-level opencode form. APM validated
-that fragment's placement, but the MCP process was not driven end to end under
-opencode; its workspace working directory remains an expectation to verify, not
-measured host behavior.
-
-Two smaller findings from the same measurements, worth keeping if that wiring is
-ever revisited:
-
-- `npx -y @adrkit/mcp@^0.8.0` resolves and starts correctly in an ordinary
-  consumer repository. It fails **inside this monorepo**, with
-  `sh: adrkit-mcp: command not found`, and so does the
-  `npx -y -p @adrkit/mcp@<range> adrkit-mcp` form — both were measured failing
-  here. The cause is not the invocation: npx resolves `@adrkit/mcp` to the local
-  workspace package, whose bin is named `adrkit-mcp`, and Bun's isolated linker
-  does not create `node_modules/.bin/adrkit-mcp` for a workspace member. There is
-  no npx spelling that works around that. Inside this repository, run the built
-  entry point directly — `bun run build`, then
-  `node packages/mcp/dist/bin.js` — which was measured completing an
-  `initialize` handshake.
-- JSON has no comments. `"//"` keys survive Copilot's loader but Claude Code's
-  validator reports them as unknown fields, so the reasoning belongs in prose
-  like this rather than in the manifests.
+See the [MCP setup guide](https://adrkit.dev/mcp/) and the package
+[README](../../mcp/README.md). For opencode, this directory includes the
+project-level `opencode/opencode.json` fragment to merge into your config.
 
 ## Versioning
 
-Independently versioned, per
-[ADR-0007](../../../docs/adr/0007-adapter-isolation-and-public-surface-build.md):
-an adapter's semver contract is with its hosts, not with `@adrkit/core`, so this
-does not move with the repository release tag.
+This plugin is versioned independently from `@adrkit/core` and the other npm
+packages because its compatibility contract is with the host tools, not with the
+runtime libraries.
 
-Not published to npm. Every host installs it from git, so an npm copy would only
-add a second, staler path to the same bytes.
+It is installed from git or marketplace metadata, not from npm.
 
-## Status
-
-Landed at **rung 1** of the
-[ADR-0014](../../../docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md)
-evidence ladder — unit and contract coverage, each guard observed failing
-against a deliberate violation, plus direct maintainer verification against the
-installed hosts. The components were not merely confirmed to load: in an
-ephemeral consumer repository with a four-record corpus, `/adr-context`
-resolved the governing decision and its inbound marker, `/adr-check` returned
-`re-proposes-rejected` against a rejected record and stopped without writing,
-`/adr-draft` wrote exactly one `proposed` record that then lints and appears in
-the queue, and the `decision-checker` agent produced per-decision verdicts from
-the CLI. Five defects were found and fixed along the way.
-
-It has had **no** persistent reference-repository run (rung 2) — the consumer
-repository was ephemeral, there is no CI attached to it, and the public
-marketplace source is unverified until this branch merges — and **no** external
-validation (rung 3). The full scope, including what these runs do *not*
-establish, is in the
-[evidence index](../../../docs/reference-verification-agent-plugin.md).
-
-Authorized by
-[ADR-0028](../../../docs/adr/0028-ship-decision-memory-as-a-portable-agent-plugin-and-omit-the-mcp-wiring-hosts-cannot-honor.md).
+For deeper maintainer test notes and current limitations, see
+[docs/reference-verification-agent-plugin.md](../../../docs/reference-verification-agent-plugin.md).
 
 ## License
 
-Apache-2.0. See [LICENSE](./LICENSE) and [NOTICE](./NOTICE).
+Apache-2.0. See the repository [LICENSE](../../../LICENSE) and
+[NOTICE](../../../NOTICE).

--- a/packages/adapters/agent-plugin/README.md
+++ b/packages/adapters/agent-plugin/README.md
@@ -117,9 +117,8 @@ runtime libraries.
 It is installed from git or marketplace metadata, not from npm.
 
 For deeper maintainer test notes and current limitations, see
-[docs/reference-verification-agent-plugin.md](../../../docs/reference-verification-agent-plugin.md).
+[the verification notes](https://github.com/mbeacom/adrkit/blob/main/docs/reference-verification-agent-plugin.md).
 
 ## License
 
-Apache-2.0. See the repository [LICENSE](../../../LICENSE) and
-[NOTICE](../../../NOTICE).
+Apache-2.0. See the packaged [LICENSE](./LICENSE) and [NOTICE](./NOTICE).

--- a/packages/adapters/catalog-backstage/README.md
+++ b/packages/adapters/catalog-backstage/README.md
@@ -1,135 +1,63 @@
 # @adrkit/catalog-backstage
 
-A standalone, offline generator that reads Backstage catalog descriptor files —
-named explicitly by one local input manifest — and writes one versioned snapshot
-envelope.
+Offline generator package for turning Backstage catalog descriptors into an
+adrkit snapshot envelope.
 
-It is invoked directly, by name. There is no dynamic runtime adapter or plugin
-loader of any kind, and no composition host that discovers, resolves, or
-dynamically imports a catalog adapter at runtime — not even one restricted to a
-single statically-known package name
-([ADR-0013](../../../docs/adr/0013-reconcile-adapter-isolation-and-catalog-binding-with-the-offline-snapshot-genera.md)).
+> **Status:** in development. This workspace package is version `0.0.0` and is
+> not released. Today it exists to hold the package boundary, entry point, and
+> tests for future work. It does **not** yet read input manifests, parse
+> descriptors, derive ownership, or write snapshot envelopes.
 
----
+## What exists today
 
-## Status: this package generates nothing yet
+- the package manifest and workspace placement
+- the package entry point
+- the dependency boundary around the future adapter
 
-Feature `010-catalog-backstage` is partially built. What exists in this package
-today is its **placement** and its **dependency boundary** — the package
-manifest, the entry point, and the tests that hold the boundary in place. That
-is all.
+If you are looking for a generator you can run today, this is not it yet.
 
-Not implemented here, and therefore not to be inferred from this package's
-existence: the input-manifest reader, descriptor admissibility, canonical
-identity, ownership derivation, the glob dialect, the atomic fail-closed
-pipeline, and the snapshot envelope itself. Those are requirements on later
-phases of the feature, recorded in
-[`specs/010-catalog-backstage/`](../../../specs/010-catalog-backstage/). They are
-not behaviour this package has.
+## Intended contract when output ships
 
-**No generator has run. No envelope exists.**
+This package is meant to validate descriptor content and produce one offline
+snapshot envelope. Even when that generator exists, a consumer should conclude
+only that the adapter's rules returned a particular result for particular
+descriptor bytes.
 
-### Where this sits on the evidence ladder
+A consumer should **not** infer any of the following from the adapter's output:
 
-Per [ADR-0014](../../../docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md),
-and stated in that record's own vocabulary rather than a synonym for it:
-
-| Rung | State | This package |
-|---|---|---|
-| 1 | unit / contract / conformance evidence | partial — covers only what exists, which is placement and boundary |
-| 2 | **reference-verified** | **not reached, and not claimed** |
-| 3 | **externally validated** | **not reached, and not claimed** |
-
-[ADR-0020](../../../docs/adr/0020-rescope-sc-010-and-authorize-work-toward-the-backstage-catalog-adapter.md)
-authorizes this work toward **rung 1 only**. It authorizes the work; it does not
-authorize a release, and the decision to release at all is deferred to a later
-record (clause 9). Nothing in this package is `reference-verified`, `externally
-validated`, `adopted`, or in `sustained adoption`.
-
-Any verification performed here is performed by the maintainer. Maintainer-owned
-verification is not external, third-party, or community adoption, and this
-package will not describe it as any of those. Where a corpus of upstream-authored
-descriptors is used as *input*, only that corpus **data** is third-party — never
-the validation applied to it.
-
----
-
-## What a consumer may and may not conclude from this adapter's output
-
-This section is a requirement on this document
-(`spec.md` FR-062, FR-063), not a disclaimer appended to it.
-
-**A consumer may conclude**, once the adapter produces output at all, exactly
-this much: that a set of pure validator predicates returned a particular result
-when invoked against particular descriptor content. That is the whole warrant.
-
-**A consumer may not conclude:**
-
-- **Anything about Backstage as a running system.** This package makes no claim
-  about how a Backstage instance resolves, interprets, or acts on a descriptor.
-  It evaluates descriptor *content* against a pinned model of the descriptor
-  format. A predicate's return value and a running system's behaviour are
-  different facts, and only the first is available here.
-- **That a valid envelope is a correct envelope.** A populated, digest-verified
-  envelope proves **integrity**, not **correctness**: a semantically wrong
-  envelope can carry a perfectly valid self-digest (ADR-0020 clause 5). The
-  digest tells a reader the envelope is intact and unmodified. It says nothing
-  about whether the ownership it records is right.
-- **That ownership was inferred.** Ownership comes from an explicit
-  `adrkit.io/owned-paths` annotation and from nowhere else. No descriptor-parent,
-  repository-root, or identity-only normalization heuristic is present in this
-  package as inferred, authoritative, default, or opt-in behaviour. Those were
-  measurement instruments in an earlier spike, labelled non-authoritative by
-  their own contract, and they do not carry into this adapter (`spec.md` FR-061).
-- **That the `adrkit.io/owned-paths` annotation is an established convention.**
-  **Adoption of `adrkit.io/owned-paths` by anyone other than the maintainer is
-  neither established nor gated by this feature.** No descriptor in any upstream
-  corpus consulted by this work carries the annotation. Where an annotation
-  appears over real upstream descriptors, it is a maintainer-authored overlay
-  applied to descriptors that are otherwise unmodified — and the fact that the
-  overlay is maintainer-authored travels with any claim made from it.
-- **That absence of ownership means anything about the entity.** An entity with
-  no annotation, an entity with an empty annotation, and an entity whose
-  annotation matched no path are three distinct states, and none of them is
-  evidence that the entity owns nothing.
-
----
+- **How a running Backstage instance behaves.** This package will evaluate
+  descriptor content, not a live Backstage deployment.
+- **That integrity implies correctness.** A valid envelope can still record the
+  wrong ownership.
+- **That ownership was inferred.** Ownership comes only from an explicit
+  `adrkit.io/owned-paths` annotation.
+- **That missing ownership means "owns nothing."** Annotation-absent,
+  explicit-empty, and matched-nothing remain distinct states.
 
 ## Boundary
 
 - **Nothing outside `packages/adapters/**` may depend on this package.**
-  `packages/core`, `packages/cli`, and `schema/` import nothing from it and must
-  not otherwise learn it exists
-  ([ADR-0007](../../../docs/adr/0007-adapter-isolation-and-public-surface-build.md);
-  Constitution Principle III). Enforced by `bun run check:deps`, whose guard was
-  observed rejecting exactly that edge before it was relied on
-  ([ADR-0016](../../../docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).
+  `packages/core`, `packages/cli`, and `schema/` must not import from it. Check
+  this with `bun run check:deps`.
 - **This package does not depend on `@adrkit/catalog-envelope`, and that package
-  does not depend on this one.** The envelope file on disk is the entire
-  interface between them. Each declares the envelope's shape independently, which
-  is what makes the consumer's validation a check rather than a comparison of the
-  generator against itself.
-- **The `@adrkit/core` dependency is for canonicalization primitives only** —
-  `canonicalStringify` and `compareCodeUnits`. It does **not** couple this
-  package's version to core's API. This adapter is versioned independently per
-  ADR-0007: its semver contract is with Backstage, not with `@adrkit/core`.
-- **This package writes nothing to `schema/`** and adds nothing to
-  `schema/adr.schema.json`. The snapshot envelope is a separate artifact and
-  stays one.
-
----
+  does not depend on this one.** The envelope file on disk is the whole
+  interface between them.
+- **The `@adrkit/core` dependency is for canonicalization helpers only.** It
+  does not couple this package's versioning to core's API.
+- **This package writes nothing to `schema/`.** The snapshot envelope stays a
+  separate artifact.
 
 ## Toolchain
 
-Bun for development; any published artifact targets Node
-([ADR-0010](../../../docs/adr/0010-bun-toolchain.md)).
+Development uses Bun; any future published artifact will target Node `>=22`.
 
 ```bash
-bun test                     # from the repository root
+bun test
 bun run --filter='@adrkit/catalog-backstage' typecheck
-bun run check:deps           # the dependency boundary above
+bun run check:deps
 ```
 
 ## License
 
-Apache-2.0. See [LICENSE](./LICENSE) and [NOTICE](./NOTICE).
+Apache-2.0. See the repository [LICENSE](../../../LICENSE) and
+[NOTICE](../../../NOTICE).

--- a/packages/adapters/spec-kit/README.md
+++ b/packages/adapters/spec-kit/README.md
@@ -94,8 +94,8 @@ network — a missing CLI is reported, never fetched.
 
 ## Compatibility and support
 
-The extension is continuously tested against every supported Spec Kit release.
-Report compatibility issues in the
+The extension is tested against Spec Kit 0.13.0, 0.14.4, and 0.15.1. Report
+compatibility issues in the
 [adrkit issue tracker](https://github.com/mbeacom/adrkit/issues). Maintainers can
 find the detailed verification record in
 [`docs/reference-verification-spec-kit-extension.md`](../../../docs/reference-verification-spec-kit-extension.md).

--- a/packages/adapters/spec-kit/README.md
+++ b/packages/adapters/spec-kit/README.md
@@ -23,17 +23,16 @@ Plus one hook: `after_plan` offers to run `/speckit.adrkit.check`. It is
 
 ## Requirements
 
-- Spec Kit `>=0.13.0,<0.16.0`. Verified by installing and rendering against
-  0.13.0, 0.14.4, and 0.15.1; widening past 0.16 means re-verifying first, not
-  bumping. See
-  [ADR-0019](../../../docs/adr/0019-ship-the-spec-kit-extension-treating-the-spike-no-go-as-a-measurement-artifact.md).
-- The `adr` CLI (`npm install -g @adrkit/cli`), or `ADRKIT_CLI` pointing at its
-  entry point.
+- Spec Kit `>=0.13.0,<0.16.0`. Compatibility is tested against 0.13.0, 0.14.4,
+  and 0.15.1.
+- The `adr` CLI (`npm install -g @adrkit/cli`), a project-local installation,
+  or `ADRKIT_CLI` pointing at its entry point.
 - An ADR corpus. Defaults to `docs/adr`.
 
 ## Install
 
-From the Spec Kit catalog, once the entry lands:
+From the
+[Spec Kit community catalog](https://github.com/github/spec-kit/blob/main/extensions/catalog.community.json):
 
 ```sh
 specify extension add adrkit
@@ -48,14 +47,21 @@ specify extension add --dev path/to/packages/adapters/spec-kit
 Then `/speckit.adrkit.context` is available in your agent, and `/speckit.plan`
 will offer the `after_plan` hook.
 
-The package is also published on npm as `@adrkit/spec-kit`, versioned
-independently of the rest of the scope: its semver contract is with Spec Kit,
-not with `@adrkit/core` (ADR-0007).
+The package is also published on npm as `@adrkit/spec-kit` for programmatic or
+pinned installs.
+
+## Use it in the plan loop
+
+1. Run `/speckit.adrkit.context` before planning.
+2. Run `/speckit.plan`, then accept the optional check or run
+   `/speckit.adrkit.check` directly.
+3. Run `/speckit.adrkit.draft` when the plan introduces a decision worth
+   recording.
 
 ## Configuration
 
-Every knob is an environment variable, because an extension that needs its own
-config file is an extension nobody installs.
+The extension works without additional configuration. Override its defaults
+with environment variables when needed.
 
 | Variable | Default | Meaning |
 |---|---|---|
@@ -69,11 +75,7 @@ The CLI is resolved in a fixed order: `ADRKIT_CLI`, then
 `./node_modules/.bin/adr`, then `adr` on `PATH`. No branch of that reaches the
 network — a missing CLI is reported, never fetched.
 
-## Design constraints
-
-These are enforced by tests, not by convention, and each was observed failing
-under a deliberately introduced defect before it was trusted
-([ADR-0016](../../../docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).
+## Runtime guarantees
 
 - **Hooks never write.** `draft` is the only command that writes, and it is
   unreachable from any hook. A plan-phase hook creating records unprompted would
@@ -83,35 +85,20 @@ under a deliberately introduced defect before it was trusted
 - **Failures name what is missing.** No command exits 0 having found nothing
   because it was looking in the wrong place. "0 decisions govern this" and "I
   could not see the corpus" must never render as the same string.
-- **`check` mutates nothing**, verified by byte-comparing the whole project tree
-  before and after.
+- **`check` mutates nothing.**
 - **Nothing development-only reaches your repo.** `specify extension add --dev`
   copies this directory verbatim, so `.extensionignore` keeps the test suite,
   `tsconfig.json`, and `package.json` out of your `.specify/extensions/`. The
   package declares no dependencies at all, so there is never a `node_modules/`
   to copy — a workspace symlink in one aborts the install partway through.
 
-## Provenance
+## Compatibility and support
 
-The hook mechanism was verified end-to-end against live Spec Kit v0.13.0 by
-[spike 008](../../../specs/008-spec-kit-hook-viability/), under a
-kernel-enforced network namespace, with an independent evidence audit. That
-spike's recorded verdict is `no-go`, driven by a measurement artifact it
-disclosed itself; [ADR-0019](../../../docs/adr/0019-ship-the-spec-kit-extension-treating-the-spike-no-go-as-a-measurement-artifact.md)
-records why that verdict does not block this package, and what still binds.
-
-Per [ADR-0014](../../../docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md)
-this package is **landed / reference-verified** on rungs 1–2. Rung 2 is a
-maintainer-owned isolated reference repository,
-[`adrkit-t018-dogfood`](https://github.com/mbeacom/adrkit-t018-dogfood), which
-re-installs this extension from a pinned adrkit commit into a real Spec Kit
-project on every push and weekly, across all three declared upstream versions —
-41 self-verifying, fail-closed assertions each. The gate was observed failing on
-a deliberate divergence before being trusted. Evidence index:
+The extension is continuously tested against every supported Spec Kit release.
+Report compatibility issues in the
+[adrkit issue tracker](https://github.com/mbeacom/adrkit/issues). Maintainers can
+find the detailed verification record in
 [`docs/reference-verification-spec-kit-extension.md`](../../../docs/reference-verification-spec-kit-extension.md).
-
-It is **not** externally validated (rung 3): nobody but the maintainer has run
-this in their own repository yet.
 
 ## License
 

--- a/packages/catalog-envelope/README.md
+++ b/packages/catalog-envelope/README.md
@@ -1,58 +1,47 @@
 # @adrkit/catalog-envelope
 
-Reads a catalog snapshot envelope, validates its **integrity**, and — only after
-every check passes — derives a `CatalogSnapshot`-shaped artifact from it.
+Reads a catalog snapshot envelope, validates its **integrity**, and - only after
+every check passes - derives a `CatalogSnapshot`-shaped artifact from it.
 
 This package reads envelopes. It never generates them.
 
----
+> **Status:** experimental workspace package, version `0.0.0`, not released.
+> The implemented surface is admission plus derivation for snapshot envelopes.
+> It is not wired into the CLI or other public adrkit packages.
 
 ## An integrity validator, not a correctness oracle
 
-This distinction is the reason this package exists as a separate thing, so it is
-stated before anything else.
-
 Everything this package can establish is that an envelope is **intact,
-well-formed, self-consistent, current, and about the repository that is asking.**
-None of that establishes that the envelope's contents are **right**.
+well-formed, self-consistent, current, and about the repository that is
+asking.** None of that establishes that the envelope's contents are **right**.
 
-A populated, digest-verified envelope proves integrity, not correctness: a
-semantically wrong envelope can carry a perfectly valid self-digest
-([ADR-0020](../../docs/adr/0020-rescope-sc-010-and-authorize-work-toward-the-backstage-catalog-adapter.md)
-clause 5). A green result from this package means "nothing was corrupted, dropped,
-or stale." It does not mean "the ownership recorded here is the ownership that
-should have been recorded." Nothing in this package is able to determine the
-latter, and no output of it may be read as having done so.
+A green result means "nothing was corrupted, dropped, or stale." It does not
+mean "the recorded ownership is correct."
 
-Two consequences worth naming, because they are easy to invert:
+Two consequences are easy to invert:
 
-- **A rejection is a statement about the envelope, not about the repository.** An
-  envelope that fails validation tells you the artifact is unusable, not that the
-  catalog it describes is wrong.
-- **Isolation is a property of the query, not a rejection.** A *valid* envelope
-  describing a different repository is accepted as valid; the repository boundary
-  shows up as the query returning no matches, not as an error.
+- **A rejection is about the envelope, not the repository.** A failed admission
+  means the artifact is unusable, not that the catalog it describes is wrong.
+- **Isolation is a query result, not a rejection.** A valid envelope for a
+  different repository can still be admitted; the repository mismatch shows up as
+  an empty query, not a structural error.
 
----
+## What it does, in order
 
-## What it does, in the order it does it
-
-The order is the contract, not an implementation detail
-([`snapshot-envelope.md`](../../specs/009-catalog-binding-viability/contracts/snapshot-envelope.md)
-§2; `spec.md` FR-045, FR-046). Each stage runs only after every stage above it
-has passed, and each rejects with its own named reason.
+The order below is the contract. Each stage runs only after the stage above it
+has passed, and each failure has its own named reason.
 
 | # | Stage | Rejects as |
 |---|---|---|
 | 1 | Parses as JSON at all | `invalid-json` |
-| 2 | The complete envelope shape, every field the correct JSON type, **at every nesting level** | `missing-or-wrong-required-field` |
-| 3 | The frozen matcher contract by **exact value** — `schemaVersion`, the whole `globDialect` object, the exact `capabilities` tuple | `unrecognized-schema-or-dialect-or-capability` |
-| 4 | Every `sources[]` digest present, correctly typed, and matching its file's actual bytes | `missing-source-digest` |
+| 2 | Complete envelope shape, with correct JSON types at every nesting level | `missing-or-wrong-required-field` |
+| 3 | Frozen matcher contract by exact value: `schemaVersion`, the full `globDialect`, and the exact `capabilities` tuple | `unrecognized-schema-or-dialect-or-capability` |
+| 4 | Every `sources[]` digest present, correctly typed, and matching the source bytes | `missing-source-digest` |
 | 5 | `completeness.identityOnly === false` | `identity-only-true` |
-| — | **Then** independent digest recomputation | `digest-mismatch` |
-| — | **Then** staleness, as exact revision inequality | `stale-revision` |
-| — | **Then** repository identity | `repository-identity-mismatch` |
-| — | **Only then** `CatalogSnapshot`-shaped derivation | refused outright without an admission token |
+| - | Independent digest recomputation | `digest-mismatch` |
+| - | Staleness as exact revision inequality | `stale-revision` |
+| - | Repository identity | `repository-identity-mismatch` |
+| - | `CatalogSnapshot`-shaped derivation | refused outright without an admission token |
 
 ```ts
 import { admitEnvelope, deriveCatalogSnapshot } from '@adrkit/catalog-envelope';
@@ -64,120 +53,58 @@ const admission = admitEnvelope(envelopeText, {
 });
 
 if (admission.outcome === 'refused') {
-  // `refusedAt` names the stage, `reason` the category, `detail` the specifics.
-  throw new Error(`${admission.refusedAt}: ${admission.reason} — ${admission.detail}`);
+  throw new Error(`${admission.refusedAt}: ${admission.reason} - ${admission.detail}`);
 }
 
 const { snapshot, derivedFrom } = deriveCatalogSnapshot(admission.admitted);
 ```
 
 `deriveCatalogSnapshot` accepts `unknown` and **throws** on anything without an
-admission token. That is deliberate: a returned rejection can be ignored and the
-caller can go on to read `derivedPaths` anyway, and FR-046 does not permit that.
+admission token. That keeps callers from ignoring a refusal and deriving anyway.
 
-### Three things that are easy to get backwards
+## Contract details that matter in practice
 
-- **Staleness is exact inequality, never an ordering.** A commit SHA is an opaque
-  identifier with no ordering available without git-ancestry data, which is out
-  of scope. Any revision other than the configured expected-current one is stale
-  — never "older than". There is no `<` anywhere in that module. The expectation
-  is also keyed to a repository: repository A's expected revision says nothing
-  about an envelope describing repository B.
-- **Step 5 reads one boolean.** Whether an envelope is partial/identity-only is
-  determined **solely** from `completeness.identityOnly`, never by scanning the
-  entity list. An envelope whose entities are *all* `annotation-absent` with
-  `identityOnly: false` is accepted — absent annotations are a valid, expected
-  state.
-- **The lossy mapping is not repaired.** `CatalogSnapshotEntity` has no
+- **Staleness is exact inequality, never ordering.** A commit SHA is treated as
+  an opaque identifier. Any revision other than the configured expected revision
+  is stale.
+- **Step 5 reads one boolean.** Whether an envelope is partial is determined
+  solely from `completeness.identityOnly`, never by scanning the entity list.
+- **The lossy mapping is intentional.** `CatalogSnapshotEntity` has no
   `ownershipState`, so `explicit-empty` and `annotation-absent` both derive an
-  empty `paths`. The distinction stays on the envelope; it is not smuggled into
-  the core type, and changing `CatalogSnapshot` to carry it is out of scope.
+  empty `paths` array. The distinction stays on the envelope.
 
 ## What the digest does and does not establish
 
-Both statements travel with every mention of the digest check, in code, in tests,
-and in evidence. That is a requirement (`spec.md` FR-041), not editorial caution.
+- **Accidental-corruption and naive-mutation detection only.** It does not
+  protect against an actor who changes content and recomputes the same digest.
+- **Integrity, not correctness.** A semantically wrong envelope can still carry
+  a valid self-digest.
 
-- **Accidental-corruption and naive-mutation detection only.** It does not resist
-  an adversary who mutates content and also recomputes the same digest with the
-  same algorithm. A cryptographically-signed tamper-evidence mechanism — with its
-  own key-management, trust-anchor, and deterministic-output questions — is an
-  explicitly open question this feature does not attempt.
-- **Integrity, not correctness.** A semantically wrong envelope can carry a
-  perfectly valid self-digest.
-
-The canonicalization primitive is `canonicalStringify` from `@adrkit/core`, not a
-second implementation written here — a second definition of "canonical" could
-drift silently from the generator's, which is the failure the digest exists to
-detect. For the envelope's closed scalar domain its bytes are *equivalent to*
-RFC 8785/JCS output; that equivalence is scoped to the domain and is not a claim
-that `canonicalStringify` is a general-purpose RFC 8785 implementation.
-
-## Status
-
-Phase C of feature `010-catalog-backstage` is implemented: the five ordered
-validation steps, digest recomputation, staleness, repository identity and
-isolation, and gated derivation. Phases B, D, E, F and G are recorded in
-[`specs/010-catalog-backstage/`](../../specs/010-catalog-backstage/) and are not
-behaviour this package has.
-
-Every check here was **observed failing before it was relied on**
-([ADR-0016](../../docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)):
-each of the five steps was deleted in turn, the digest was replaced with the
-declared value, staleness was rewritten as an ordering comparison, and both
-repository outcomes were conflated in each direction — with the failures captured
-verbatim under
-[`evidence/negative-cases/`](../../specs/010-catalog-backstage/evidence/negative-cases/).
-One of those observations found a real defect in a test that had been passing.
-
-Per [ADR-0014](../../docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md),
-stated in that record's own vocabulary: this is rung-1 evidence. This package is
-**not** `reference-verified` (rung 2) and **not** `externally validated` (rung 3),
-and claims neither. Every fixture is synthetic and hand-authored, with no external
-adopter involved; every observation is maintainer-owned, which is not external,
-third-party, or community adoption and will not be described as such.
-
-No release is authorized or prepared; ADR-0020 clause 9 defers that decision to a
-later record.
-
----
+The package uses `canonicalStringify` from `@adrkit/core` for digest input, so
+the validator and generator do not drift into competing definitions of
+"canonical." For the envelope's closed scalar domain, the resulting bytes are
+equivalent to RFC 8785/JCS output; that is not a claim of general-purpose RFC
+8785 coverage.
 
 ## Boundary
 
-- **This package is deliberately not under `packages/adapters/`.** `spec.md`
-  FR-044 requires the envelope validator and `CatalogSnapshot` deriver to live in
-  a workspace package outside `packages/adapters/**`. The dependency check
-  classifies adapters by path prefix alone, so this package is a non-adapter as a
-  matter of its *location* rather than by an allowlisted exception. Moving it
-  would silently invert that classification.
-- **There is no dependency edge to or from `@adrkit/catalog-backstage`, in either
-  direction, and there must never be one.** The envelope file on disk is the
-  entire interface. Both sides declare the envelope's shape independently — the
-  single deliberate duplication in this design. A shared type module would be an
-  import edge, and if both sides derived their view of the envelope from one
-  declaration, a generator that changed the shape would change it on both sides
-  at once and this package's validation would be a tautology. The cost is real
-  and accepted: the two declarations can diverge, and nothing but this package's
-  validation failing will say so. **That failure is the intended signal.**
+- **This package is deliberately outside `packages/adapters/`.** Its placement is
+  part of the dependency boundary.
+- **There must never be a dependency edge to or from
+  `@adrkit/catalog-backstage`.** The envelope file on disk is the whole
+  interface between them.
 - **This package writes nothing to `schema/`.** The envelope is not added to
-  `schema/adr.schema.json` and does not become a field on `CatalogSnapshot` or
-  `CatalogSnapshotEntity`.
-- **It is not wired into `@adrkit/cli` or `@adrkit/core`**, and wiring it in is
-  explicitly out of scope for this feature.
-
-Both directions of the boundary above are enforced by `bun run check:deps`, and
-each guard was observed rejecting the edge it forbids before it was relied on
-([ADR-0016](../../docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).
-
----
+  `schema/adr.schema.json` and does not become a field on
+  `CatalogSnapshot` or `CatalogSnapshotEntity`.
+- **It is not wired into `@adrkit/cli` or `@adrkit/core`.** Check the boundary
+  with `bun run check:deps`.
 
 ## Toolchain
 
-Bun for development; any published artifact targets Node
-([ADR-0010](../../docs/adr/0010-bun-toolchain.md)).
+Development uses Bun; any future published artifact will target Node `>=22`.
 
 ```bash
-bun test                     # from the repository root
+bun test
 bun run --filter='@adrkit/catalog-envelope' typecheck
 bun run check:deps
 ```

--- a/packages/catalog-envelope/README.md
+++ b/packages/catalog-envelope/README.md
@@ -11,12 +11,10 @@ This package reads envelopes. It never generates them.
 
 ## An integrity validator, not a correctness oracle
 
-Everything this package can establish is that an envelope is **intact,
-well-formed, self-consistent, current, and about the repository that is
-asking.** None of that establishes that the envelope's contents are **right**.
-
-A green result means "nothing was corrupted, dropped, or stale." It does not
-mean "the recorded ownership is correct."
+Admission establishes that an envelope is **intact, well-formed,
+self-consistent, current, and about the repository that is asking.** A
+populated, digest-verified envelope proves integrity, not correctness; a
+semantically wrong envelope can carry a perfectly valid self-digest.
 
 Two consequences are easy to invert:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,18 +2,16 @@
 
 Git-native architecture decision record tooling from adrkit.
 
-Zero-install with `npx`, naming the package (the published binary is `adr`, but a
-bare `npx adr` resolves an unrelated `adr` package on npm):
+## Install and run
+
+Use the package name for zero-install runs. The published binary is `adr`, but a
+bare `npx adr` resolves an unrelated npm package:
 
 ```sh
 npx @adrkit/cli lint
 ```
 
-Or add it as a dev dependency and invoke it through an npm script. A bare `adr`
-will not be on an interactive shell's PATH, and a bare `npx adr` is worse than
-missing — when the binary is not linked into `node_modules/.bin`, it silently
-downloads and runs the unrelated registry package instead of failing. A script
-resolves `node_modules/.bin` directly and stops with `command not found`:
+For project use, add it as a dev dependency and invoke it through a script:
 
 ```sh
 npm install --save-dev @adrkit/cli    # or: bun add --dev @adrkit/cli
@@ -21,7 +19,10 @@ npm pkg set scripts.adr=adr
 npm run adr -- lint
 ```
 
-Or install it globally, which does put a bare `adr` on your PATH:
+That keeps you on the installed local binary instead of whatever `npx adr` might
+download from the registry.
+
+You can also install it globally:
 
 ```sh
 npm install -g @adrkit/cli
@@ -29,24 +30,36 @@ adr lint
 ```
 
 Every install also provides `adrkit`, an identical alias for the same binary.
-Nothing else on npm claims that binary name, so prefer it wherever a silent
-wrong-tool substitution would be hard to notice — CI, `Makefile`s, and agent
-instructions:
+Prefer `adrkit` in CI, Makefiles, and agent instructions because its name is
+unambiguous:
 
 ```sh
-adrkit lint          # same binary, unambiguous name
+adrkit lint
 ```
 
-That applies to the installed binary only. Do not use `npx adrkit` / `bunx
-adrkit`: there is no unscoped `adrkit` package and there never will be — npm
-refuses that name as too similar to `pdfkit`. The form resolves against the
-registry and would run whatever anyone publishes under it — and in CI, where npm
-assumes `--yes` on a non-TTY, it would install and run it without prompting. Use
-`npx @adrkit/cli` for zero-install.
+Do **not** use `npx adrkit` or `bunx adrkit`. There is no unscoped `adrkit`
+package, so those forms would resolve against the registry rather than the
+published `@adrkit/cli` package.
 
 Human-readable CLI output is TTY-aware: it stays ANSI-free when redirected or
-piped, honors `NO_COLOR`, and can be forced with `--color auto|always|never`
-before the command, for example `adr --color always lint`.
+piped, honors `NO_COLOR`, and can be forced with `--color auto|always|never`.
+
+## Commands
+
+The binary includes:
+
+- `new`
+- `lint`
+- `graph`
+- `explain`
+- `check`
+- `queue`
+- `migrate --from madr`
+- `completion`
+- `evaluate`
+
+Run `adr --help` for the command list, `adr help <command>` for one command's
+flags, and `adr --version` to print the installed version.
 
 ## Shell completions
 
@@ -69,22 +82,15 @@ If you prefer symlinks, point both Fish entry points at the same generated file:
 ln -sf ~/.config/fish/completions/adr.fish ~/.config/fish/completions/adrkit.fish
 ```
 
-The `adr` binary includes `new`, `lint`, `graph`, `explain`, `check`, `queue`,
-`migrate --from madr`, `completion`, and the offline deterministic `evaluate`
-command.
-
-Run `adr --help` for the command list, `adr help <command>` for one command's
-flags, and `adr --version` to print the installed version.
-
 ## Inbound `@adr` markers
 
 `adr explain <path>` and `adr check <files...>` resolve decisions in both
 directions. A record declares the paths it governs with `affects`; a source
-file declares the decision it lives under with a marker in a comment:
+file can declare the decision it lives under with a comment marker:
 
 ```ts
 // @adr 0012
-export function syncOnce() { … }
+export function syncOnce() { /* ... */ }
 ```
 
 ```
@@ -96,38 +102,32 @@ Decisions governing src/services/sync/retry.ts:
     declared by src/services/sync/retry.ts:1 (@adr 0012)
 ```
 
-This lets `affects` stay narrow — the *defining* files — while the surrounding
-neighbourhood opts in one line at a time. At most the first 8192 bytes of a file
-are scanned, in any language — the scan stops at the last complete line inside that
-bound — and the marker must be the first content on a
-dedicated comment line that is not inside a ` ``` ` or `~~~` fence — so
-documenting the syntax, as this file does above, is not declaring it. In a
-markdown file (`.md`, `.mdx`, `.markdown`) the comment is `<!--` or `{/*`; `#`
-and `*` are a heading and a bullet there, and do not declare. Nothing is written
-back to the record. In
-`--json`, pattern matches carry `firedMatchers` and file declarations carry
-`declaredBy`. `explain --json` carries a single-file `markers` block, while
-`check --json` carries a `markerScan` report with scan-state counts and exact
-unavailable, truncated, and skipped paths. The `explain` block also reports
-`scannedBytes` / `fileBytes` — the prefix handed to the scanner and the file's size —
-so `fileBytes - scannedBytes` sizes the unscanned remainder of a truncated file
-instead of leaving it to be guessed from the window constant. The two are separate
-observations taken either side of the read, so clamp the difference at `0`: a file
-appended to mid-scan can report more scanned than total. Both `explain`'s human note
-and `check`'s truncation warning disclose that measured extent per path; `check --json`
-deliberately does not carry it, so its report shape is unchanged. Multi-file scans are
-capped
-at 3,000 normalized paths and 16 concurrent reads; skipped paths warn but never
-fail. The cap matches GitHub's changed-file ceiling, so only a local invocation
-can reach it.
+Marker scanning is intentionally narrow:
+
+- only the first **8192 bytes** of a file are considered
+- the scan stops at the last complete line inside that window
+- the marker must be the first content on a dedicated comment line
+- lines inside fenced code blocks are ignored
+- markdown files (`.md`, `.mdx`, `.markdown`) accept only `<!--` and `{/*`
+
+Nothing is written back to the record.
+
+In `--json`, pattern matches appear in `firedMatchers` and file declarations in
+`declaredBy`. `explain --json` includes a single-file `markers` block plus
+`scannedBytes` and `fileBytes`. `check --json` includes a `markerScan` report
+with state counts and exact unavailable, truncated, and skipped paths.
+
+Multi-file scans are capped at **3,000 normalized paths** with **16 concurrent
+reads**. Skipped paths warn but never fail, and marker claims never change the
+exit code.
+
 See [the commands reference](https://adrkit.dev/commands/#inbound-adr-markers).
 
 The published ESM CLI runs on Node.js 22 or newer; development in the adrkit
 repository uses Bun.
 
-See also [`@adrkit/mcp`](../mcp/README.md) — a local, read-only Model Context
-Protocol server that exposes this corpus (including superseded/rejected
-decisions) to coding agents.
+See also [`@adrkit/mcp`](../mcp/README.md), a local read-only Model Context
+Protocol server that exposes the same corpus to coding agents.
 
 Documentation: <https://adrkit.dev>
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 Pure, deterministic building blocks for working with adrkit architecture
 decision records: parsing, schema validation, corpus invariants, MADR migration,
-graph construction, and `affects` resolution.
+graph construction, queue projection, and `affects` resolution.
 
 ```sh
 npm install @adrkit/core      # or: bun add @adrkit/core
@@ -18,8 +18,7 @@ const findings = lintCorpus(records);
 
 `resolveAffects` is the outbound edge: a record declares patterns, and paths are
 matched against them. `resolveSourceMarkers` is the inbound edge: a source file
-declares the decision it lives under with an `@adr <id>` marker in a comment
-([ADR-0021](https://github.com/mbeacom/adrkit/blob/main/docs/adr/0021-resolve-inbound-source-annotations-without-changing-the-schema.md)).
+declares the decision it lives under with an `@adr <id>` marker in a comment.
 
 ```ts
 import {
@@ -43,58 +42,56 @@ const governedBy = mergeSourceDeclarations(
 );
 ```
 
-Each decision keeps the two apart: `firedMatchers` is what the record matched,
-`declaredBy` is what the file declared. `declaredBy` is omitted entirely when
-nothing declared the record, so consumers written against the pre-marker shape
-are unaffected.
+`firedMatchers` records what the ADR matched. `declaredBy` records what the file
+declared. Keeping them separate lets consumers distinguish "this record matched
+the path" from "this file opted into the record."
 
-`scanSourceMarkers(source, path)` is the pure half — text in, markers out, no
-filesystem — bounded to the first `MARKER_HEADER_WINDOW_BYTES` (8192) of the
-source and reporting `truncated` when it stopped short. Markers must be the first
-content on a dedicated comment line, which keeps documentation prose and string
-literals in their common inline forms from becoming declarations. A line inside a
-` ``` ` or `~~~` fence is an example rather than a declaration, and `path`
-selects the introducer set: a markdown extension (`.md`, `.mdx`, `.markdown`)
-accepts only `<!--` and `{/*`, because `#` and `*` are markdown's own heading and
-list syntax. Two files with identical bytes and different extensions can
-therefore scan differently.
-`readSourceMarkers` wraps the scanner with a bounded read and reports `state` as
-`scanned`, `absent`,
-`unreadable`, or `out-of-tree`, so "found no markers" is never confused with
-"could not look." A `scanned` result also carries `scannedBytes` and `fileBytes`.
-`scannedBytes` is the prefix handed to the scanner — not the number of bytes pulled
-from the handle, which also includes a truncation probe byte and any partial trailing
-line the cut then discards — and it is the cut actually taken rather than
-`min(fileBytes, 8192)`, because the window is cut back to its last complete line.
-`fileBytes - scannedBytes` is how much of a truncated file went unscanned, which
-`truncated` alone does not say. Both are omitted for a state that never opened the
-file, so a `0` extent means a window with no line terminator, never "not measured."
+## Marker scanning contract
 
-The two are separate observations, not one: `fileBytes` comes from an `fstat` taken
-before the read loop, so a file written concurrently can report `scannedBytes >
-fileBytes` (appended) or look partial when it was read whole (truncated). They are
-left unreconciled deliberately — agreeing them would hide a file that changed
-underneath the scan — so a consumer differencing them should clamp at `0` rather than
-assume the remainder is non-negative.
+`scanSourceMarkers(source, path)` is the pure half: text in, markers out, no
+filesystem. It scans only the first `MARKER_HEADER_WINDOW_BYTES` (**8192**) of
+the source and stops at the last complete line inside that window.
 
-Its `path` argument is repo-relative to `cwd`. Absolute paths and paths that climb
-out of the tree are `out-of-tree`. Every symlink is refused as `unreadable`
-without opening its target; non-regular files are also `unreadable`, so a FIFO
-cannot block the read.
+Markers must be the first content on a dedicated comment line. That keeps prose,
+string literals, and trailing inline comments from becoming declarations. Lines
+inside ` ``` ` or `~~~` fences are ignored. For markdown extensions
+(`.md`, `.mdx`, `.markdown`), the only accepted comment introducers are `<!--`
+and `{/*`.
 
-`readSourceMarkersBatch(paths, cwd)` is the impure boundary for `checkChanges`.
-It normalizes, deduplicates, and sorts paths; scans the first 3,000 with at most
-16 reads in flight; resolves the working-tree root once; and returns every
-skipped path. Pass that `SourceMarkerBatchScan` through `markerScans` to receive
-marker-aware decisions and a deterministic `markerScan` report without adding
-filesystem access to `checkChanges`.
+`readSourceMarkers(path)` adds a bounded filesystem read and reports `state` as
+`scanned`, `absent`, `unreadable`, or `out-of-tree`, so "found no markers" is
+never confused with "could not look." A scanned result includes `scannedBytes`
+and `fileBytes` for the observed scan extent.
+
+If a file changes while it is being read, treat those byte counts as
+observations rather than strict arithmetic.
+
+## Filesystem boundaries
+
+`readSourceMarkers` takes a repo-relative path from `cwd`.
+
+- Absolute paths are rejected as `out-of-tree`.
+- Paths that climb out of the working tree are `out-of-tree`.
+- Symlinks are refused as `unreadable` without opening their targets.
+- Non-regular files are also `unreadable`, so FIFOs and similar special files
+  cannot block the read.
+
+## Batch scans
+
+`readSourceMarkersBatch(paths, cwd)` is the impure boundary used by
+`checkChanges`. It normalizes, deduplicates, and sorts the input paths; scans
+the first **3,000** normalized paths with at most **16** reads in flight; and
+returns every skipped path.
+
+Pass that `SourceMarkerBatchScan` through `markerScans` to get marker-aware
+decisions and a deterministic `markerScan` report without adding filesystem
+access to `checkChanges`.
 
 The published ESM artifacts run on Node.js 22 or newer. Development in the
 adrkit repository uses Bun.
 
-See also [`@adrkit/mcp`](../mcp/README.md) — a local, read-only Model Context
-Protocol server that exposes this corpus (including superseded/rejected
-decisions) to coding agents.
+See also [`@adrkit/mcp`](../mcp/README.md), a local read-only Model Context
+Protocol server that exposes the same corpus to coding agents.
 
 Documentation: <https://adrkit.dev>
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -18,18 +18,15 @@ Part of [adrkit](https://adrkit.dev). The corpus lives in git as one Markdown fi
 per decision with typed YAML frontmatter (`@adrkit/core`); this server only reads
 it. Listed in the [official MCP registry](https://registry.modelcontextprotocol.io)
 as **`dev.adrkit/mcp`** (this is the Node/npm `@adrkit/mcp` package — unrelated to
-the `adr-kit` Python package on PyPI). A registry listing is distribution, not
-adoption; see Maturity below.
+the `adr-kit` Python package on PyPI).
 
-## Maturity
+## Status
 
-adrkit is **early**. Phases 0–6 are *landed / reference-verified* against
-[ADR-0014](https://github.com/mbeacom/adrkit/blob/main/docs/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder.md)
-rungs 1–2 (unit/contract/conformance plus maintainer-owned isolated
-reference-repository validation). It has **no external adopters or production users
-yet**, and rung-3 external/community validation is openly tracked as not-yet-met.
-The 4-tool surface is locked by a
-[surface test](https://github.com/mbeacom/adrkit/blob/main/packages/mcp/test/surface.test.ts).
+Published on npm for Node 22+ with a deliberately small, read-only stdio
+surface: four tools and no write path.
+
+adrkit is still pre-1.0. If you need repeatable client installs, pin an
+explicit `@adrkit/mcp` version in your MCP config instead of floating `latest`.
 
 ## Quick start
 
@@ -39,32 +36,8 @@ The published binary is **`adrkit-mcp`**. Run it with `npx` (no install):
 npx -y @adrkit/mcp --cwd /path/to/your/repo --dir docs/adr
 ```
 
-It speaks JSON-RPC over stdio, so you normally point an MCP client at it rather than
-running it by hand. Copy-pasteable client configs follow.
-
-### Protocol revisions
-
-The server speaks **both** MCP protocol eras on the same stdio connection, and the
-client picks. The opening exchange selects the era and pins it for the connection's
-lifetime:
-
-| Client opens with                                     | Server serves                                     |
-| ----------------------------------------------------- | ------------------------------------------------- |
-| `server/discover`, or any request carrying a 2026 `_meta` envelope | **`2026-07-28`** — stateless, no handshake |
-| `initialize` / `notifications/initialized`            | the 2025-era revision it negotiates               |
-
-On `2026-07-28` there is no `initialize` handshake and no session id: every request
-carries its own protocol version and client capabilities in `_meta`, and every result
-is self-describing (`resultType`, plus server identity in `_meta`). `tools/list` and
-`server/discover` are cacheable (SEP-2549) and are served with `ttlMs: 300000,
-cacheScope: "public"` — the four-tool surface is immutable for the life of the process
-and carries no corpus content, so a client may reuse it instead of re-listing. Corpus
-reads are never cacheable: every `tools/call` loads a fresh projection.
-
-Nothing else about the tools changes between eras — same names, same schemas, same
-annotations, same structured results. The server uses none of the features the
-`2026-07-28` revision deprecated (roots, sampling, logging) or removed (sessions,
-`ping`, `resources/subscribe`).
+It speaks JSON-RPC over stdio, so you normally point an MCP client at it rather
+than running it by hand. Copy-pasteable client configs follow.
 
 ### Claude Desktop
 
@@ -156,6 +129,30 @@ Flags win over environment variables, which win over the defaults. An unusable
 configuration exits non-zero with a diagnostic on **stderr** (`2` for an
 unparseable flag, `1` for an invalid root/directory) and never starts a transport.
 **stdout is reserved for JSON-RPC protocol frames only.**
+
+### Protocol revisions
+
+The server speaks **both** MCP protocol eras on the same stdio connection, and
+the client picks. The opening exchange selects the era and pins it for the
+connection's lifetime:
+
+| Client opens with | Server serves |
+| ----------------------------------------------------- | ------------------------------------------------- |
+| `server/discover`, or any request carrying a 2026 `_meta` envelope | **`2026-07-28`** — stateless, no handshake |
+| `initialize` / `notifications/initialized` | the 2025-era revision it negotiates |
+
+On `2026-07-28` there is no `initialize` handshake and no session id: every
+request carries its own protocol version and client capabilities in `_meta`,
+and every result is self-describing (`resultType`, plus server identity in
+`_meta`). `tools/list` and `server/discover` are cacheable (SEP-2549) and are
+served with `ttlMs: 300000, cacheScope: "public"` because the 4-tool surface is
+fixed for the life of the process and carries no corpus content. Corpus reads
+are never cacheable: every `tools/call` loads a fresh projection.
+
+Nothing else about the tools changes between eras — same names, same schemas,
+same annotations, same structured results. The server uses none of the features
+the `2026-07-28` revision deprecated (roots, sampling, logging) or removed
+(sessions, `ping`, `resources/subscribe`).
 
 ## The four tools
 

--- a/site/src/content/docs/badges.mdx
+++ b/site/src/content/docs/badges.mdx
@@ -28,7 +28,7 @@ recipe over JSON adrkit already emits, rendered by shields.io and served from
 How many decisions are on record. This is the adoption signal with evidence
 behind it: a reader can click through and count them.
 
-Publish `adr lint --json` (see [Publish the reports](#1-publish-the-reports)
+Publish `adr lint --json` (see [Publish the reports](#publish-the-reports)
 below — the same workflow emits both files), then:
 
 ```md
@@ -56,7 +56,15 @@ property to look for in any status badge, including the one below.
 How many decisions are awaiting review. This is the number no other tool can
 produce for you, and it comes straight from `adr queue`.
 
-### 1. Publish the reports
+The workflow below publishes the JSON read by this badge:
+
+```md
+[![ARB queue](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FOWNER%2FREPO%2Fmain%2F.adrkit%2Fqueue.json&query=%24.totalItems&label=ARB%20queue&suffix=%20pending&color=cb492d)](./docs/adr)
+```
+
+Replace `OWNER/REPO`, plus the branch and path if you changed them.
+
+### Publish the reports
 
 Add a workflow that regenerates both reports whenever the corpus changes.
 Each file is the command's verbatim JSON — adrkit defines no badge format:
@@ -180,13 +188,7 @@ jobs:
   in [this repository](https://github.com/mbeacom/adrkit) for a working example.
 </Aside>
 
-### 2. Point a badge at it
-
-```md
-[![ARB queue](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FOWNER%2FREPO%2Fmain%2F.adrkit%2Fqueue.json&query=%24.totalItems&label=ARB%20queue&suffix=%20pending&color=cb492d)](./docs/adr)
-```
-
-Replace `OWNER/REPO`, plus the branch and path if you changed them. A wrong URL
+After the workflow runs, a wrong URL
 renders `resource not found` and a wrong query renders `no result`, so a mistake
 is visible rather than silently wrong — but note that a *correct* URL renders
 `resource not found` too when the workflow has not published the file yet. Check
@@ -218,23 +220,13 @@ If you want deadline pressure surfaced, use the
 [queue Action](/ci/#publish-the-arb-operations-queue) instead — it maintains a
 GitHub issue that people actually receive notifications about.
 
-<Aside type="caution" title="A badge cannot detect its own staleness">
-  If the workflow above is deleted, disabled, or starts failing its push,
-  `.adrkit/queue.json` keeps its last value and the badge keeps rendering it.
-  Nothing written at generation time can know it has gone stale — only a reader
-  can.
-
-  The [corpus status badge](#corpus-status-badge) does **not** cover this: it
-  reports the workflow that runs `adr check`, which never touches the queue
-  report and stays green while the queue badge rots. The signal that actually
-  covers regeneration is a status badge for the badge workflow *itself*:
+<Aside type="caution" title="Monitor report freshness">
+  If report generation stops, the badge keeps showing its last published value.
+  Add a status badge for the report workflow so failures remain visible:
 
   ```md
   [![ARB queue badge](https://github.com/OWNER/REPO/actions/workflows/adr-queue-badge.yml/badge.svg?branch=main)](https://github.com/OWNER/REPO/actions/workflows/adr-queue-badge.yml)
   ```
-
-  Even that reports only runs that started — a workflow GitHub disabled for
-  inactivity reports nothing at all.
 </Aside>
 
 ## What adrkit will not do

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -100,7 +100,8 @@ jobs:
 
 <Aside type="note" title="Pinning the queue Action">
 	`@v0` is a moving major-version tag. Pin the commit SHA when you need a
-	byte-immutable reference: `git rev-parse v0^{commit}`.
+	byte-immutable reference. Resolve the current commit without an adrkit
+	checkout: `gh api repos/mbeacom/adrkit/commits/v0 --jq .sha`.
 </Aside>
 
 The managed issue's body is the same report you get locally:

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -7,7 +7,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 adrkit ships two GitHub Actions from this repository. Both run with only the
 default `GITHUB_TOKEN`, hold no database, and never approve anything — they read
-the corpus and write a comment or an issue ([ADR-0004](/adr/0004-git-is-source-of-truth-database-is-an-index/)).
+the corpus and write a comment or an issue.
 
 ## Comment governing decisions on a PR
 
@@ -39,32 +39,12 @@ jobs:
         #   token: ${{ github.token }}
 ```
 
-The Action finds the comment it posted on an earlier push and edits it in place, so a
-pull request carries one governing-decisions comment however many times you push
-([ADR-0026](/adr/0026-identify-the-ci-comment-by-the-strongest-author-evidence-the-token-allows/)). Releases **through `v0.6.0` could not do this on their own** and
-needed an `env: GITHUB_TOKEN: ${{ github.token }}` block
-([#107](https://github.com/mbeacom/adrkit/issues/107)). `@v0` now resolves to `v0.10.0`,
-so that block is no longer required — and costs nothing if you still have it, because
-the Action never reads the variable to identify its token.
-
-That was measured, not just read from the source. On a reference repository the block was
-removed entirely (at **job** level, which is where a copied snippet often puts it, and
-which takes the variable out of the Action's environment for every step), and two
-dispatches on one pull request left a single comment with the **same id** — created, then
-updated in place. The runner log confirms the variable was genuinely absent rather than
-merely deleted from a file. The observation covers the **default `GITHUB_TOKEN`**; a
-custom GitHub App token takes the same code path but has not been observed separately.
+The Action updates its existing comment on later pushes, so each pull request
+keeps one current governing-decisions comment. No additional token environment
+variable is required when using the default `GITHUB_TOKEN`.
 
 `v0` is a moving major tag, and it now resolves to a `v0.10.0` build. Pin the
 immutable `v0.10.0` tag or a commit SHA for maximum reproducibility.
-
-Every same-repository, non-Dependabot pull request in the adrkit repository runs this
-Action against itself and asserts the result. Fork and Dependabot pull requests are
-excluded, because their `GITHUB_TOKEN` is read-only whatever `permissions:` declares.
-The comment path is **landed / reference-verified** on
-[ADR-0014](/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder/)
-rungs 1–2, the same rung as the queue Action below; rung-3 external validation remains
-open for both.
 
 <Aside type="note" title="Comments from before the upgrade">
 	The Action is comment-only and deletes nothing, so duplicate comments a pull request
@@ -119,13 +99,8 @@ jobs:
 ```
 
 <Aside type="note" title="Pinning the queue Action">
-	`queue@v0` resolves because the `v0` tag points at a commit containing
-	`packages/ci/queue/action.yml` — first true of the v0.2.1 release, and the tag
-	has moved forward with each release since. `@v0` is a moving tag; pin the full
-	commit SHA instead if you need a byte-immutable reference, and read that SHA from
-	the tag rather than from this page — `git rev-parse v0^{commit}` — so it cannot go
-	stale here. Phase 6 is landed and maintainer reference-verified; external
-	validation ([ADR-0014](/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder/) rung 3) remains open.
+	`@v0` is a moving major-version tag. Pin the commit SHA when you need a
+	byte-immutable reference: `git rev-parse v0^{commit}`.
 </Aside>
 
 The managed issue's body is the same report you get locally:

--- a/site/src/content/docs/commands.mdx
+++ b/site/src/content/docs/commands.mdx
@@ -238,24 +238,10 @@ longer than the header window, so a marker below it was never seen — and
 `truncated: false` is what makes `declared: []` mean "nothing declares this path"
 rather than "we stopped reading first".
 
-`scannedBytes` and `fileBytes` say **how much** was read, which `truncated` does
-not: `fileBytes - scannedBytes` is the size of the unscanned remainder, so a policy
-for a truncated file is yours to set rather than inherited. They cannot tell you
-whether a marker sits past the window — nothing can, short of reading further — but
-they do tell you how much further that would be. `scannedBytes` is also not
-`min(fileBytes, windowBytes)`: the scan stops at the last complete line inside the
-window, which across this repository's own sources lands 1–77 bytes short of it, and
-much further short when one long line spans the boundary. Both fields are omitted
-for a state that never opened the file.
-
-Two details matter if you difference them. `scannedBytes` is the prefix handed to the
-scanner, not the byte count pulled from the handle — the reader also fetches a
-truncation probe byte, and discards any partial trailing line. And the two numbers are
-separate observations: `fileBytes` is taken by `fstat` before the read loop, so a file
-appended to mid-scan can report `scannedBytes` greater than `fileBytes`, and one
-truncated mid-scan can look partial when it was read whole. They are left unreconciled
-on purpose, because agreeing them would hide a file that changed underneath the scan —
-so clamp `fileBytes - scannedBytes` at `0` rather than assuming it is non-negative.
+`scannedBytes` and `fileBytes` report the observed scan extent. When
+`truncated` is `true`, use `Math.max(0, fileBytes - scannedBytes)` to estimate
+the unscanned remainder; the values are measured separately and may differ if
+the file changes during the scan.
 
 In `governedBy`, a pattern match carries `firedMatchers` and a file declaration
 carries `declaredBy`; `declaredBy` is omitted entirely when nothing declared the

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -26,8 +26,8 @@ hero:
 			<p>Corpus validation, path explanation, graphing, migration, the ARB queue, PR comments, the read-only MCP server, the Spec Kit extension, and the deterministic Pass 0 evaluator.</p>
 		</div>
 		<div class="adr-status-band__item">
-			<span class="adr-status adr-status--planned">Honest about what's next</span>
-			<p>Evaluator Passes 1–3 and catalog binding are not built, and ADR-0014 rung-3 external validation is still open.</p>
+			<span class="adr-status adr-status--planned">Coming next</span>
+			<p>Multi-pass evaluation and Backstage catalog integration are in development.</p>
 		</div>
 	</section>
 
@@ -139,14 +139,9 @@ hero:
 				<p>Only the deterministic Pass 0 is built. The later probabilistic passes are not.</p>
 			</li>
 			<li class="adr-roadmap__item">
-				<span class="adr-status adr-status--planned">Blocked</span>
-				<h3>Catalog binding</h3>
-				<p>The viability spike ran and returned <code>blocked</code> on a named evidence shortfall. <a href="/adr/0020-rescope-sc-010-and-authorize-work-toward-the-backstage-catalog-adapter/">ADR-0020</a> rescoped that criterion and authorized adapter work, which is in the repository and unreleased.</p>
-			</li>
-			<li class="adr-roadmap__item">
-				<span class="adr-status adr-status--planned">Open</span>
-				<h3>External validation</h3>
-				<p>The ARB queue and the Spec Kit extension are maintainer reference-verified; ADR-0014 rung-3 external/community validation is still open for both.</p>
+				<span class="adr-status adr-status--planned">In development</span>
+				<h3>Backstage catalog integration</h3>
+				<p>The repository contains the adapter boundaries and catalog-envelope work; the integration is not released yet.</p>
 			</li>
 		</ul>
 	</section>

--- a/site/src/content/docs/mcp.mdx
+++ b/site/src/content/docs/mcp.mdx
@@ -40,33 +40,6 @@ root. `--dir` (env `ADRKIT_MCP_DIR`, default `docs/adr`) is resolved and
 contained within it. Flags win over environment variables. stdout carries only
 JSON-RPC frames; all diagnostics go to stderr.
 
-## Protocol revisions
-
-The server speaks **both** MCP protocol eras on the same stdio connection, and
-the client picks. The opening exchange selects the era and pins it for the
-connection's lifetime:
-
-- A `server/discover` call — or any request carrying a `2026-07-28` `_meta`
-  envelope — gets the **`2026-07-28`** revision: no `initialize` handshake, no
-  session id, every request self-describing and every result carrying a
-  `resultType`.
-- An `initialize` handshake is served as the 2025-era revision it negotiates,
-  unchanged from 0.2.1 apart from `tools/list` now listing the four tools in
-  lexicographic order.
-
-Tool names, schemas, annotations, and structured results are identical on both.
-`tools/list` and `server/discover` carry SEP-2549 cache hints
-(`ttlMs: 300000`, `cacheScope: "public"`) on the 2026 revision — the four-tool
-surface is immutable for the life of the process and holds no corpus content, so
-a client can reuse it instead of re-listing. Corpus reads are never cacheable:
-every `tools/call` re-reads the corpus.
-
-<Aside type="note">
-adrkit uses none of the features `2026-07-28` deprecated (roots, sampling,
-logging) or removed (sessions, `ping`, `resources/subscribe`). Upgrading a client
-to the new revision changes how it talks to the server, not what it gets back.
-</Aside>
-
 ## Client configuration
 
 <Tabs>
@@ -126,6 +99,19 @@ Confirm it registered with `/mcp show`.
 
 </TabItem>
 </Tabs>
+
+## Protocol revisions
+
+The server supports both MCP protocol eras on the same stdio connection, and
+the client's opening exchange selects one for the connection:
+
+- `server/discover`, or a request with a `2026-07-28` `_meta` envelope, selects
+  the stateless `2026-07-28` revision.
+- `initialize` selects the negotiated 2025-era revision.
+
+Both eras expose the same four tools, schemas, annotations, and structured
+results. The modern discovery response may be cached for five minutes; tool
+calls always re-read the corpus.
 
 ## The four tools
 

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -12,9 +12,7 @@ evaluator.
 
 <Aside type="tip" title="Published on npm (v0.10.0)">
 	`@adrkit/cli` is live. Consumers install it with your Node package manager and
-	run the `adr` binary — no clone required. Published artifacts are Node-targeted
-	([ADR-0010](/adr/0010-bun-toolchain/)); Bun is used for developing adrkit
-	itself.
+	run the `adr` binary — no clone required.
 </Aside>
 
 ## Install
@@ -22,19 +20,9 @@ evaluator.
 Add the CLI to a project, or run it one-off. It exposes the `adr` binary.
 
 <Aside type="caution" title="Always name the package: @adrkit/cli">
-	adrkit's binary is `adr`, but the bare name `adr` on npm belongs to an
-	**unrelated package**. It has no `lint`, `explain`, `graph`, or `migrate` —
-	but does ship its own `new`, so it can look like it works before failing on
-	everything else.
-
-	**Avoid bare `npx adr …` / `bunx adr …` entirely.** It only reaches adrkit if
-	the binary happens to be linked into `node_modules/.bin`, and when it is not
-	— which is common in workspaces and monorepos — it does not fail. It
-	silently downloads and runs the other tool instead.
-
-	Name the package (`npx @adrkit/cli lint`), or install `@adrkit/cli` and drive
-	it from an npm script — a script resolves `node_modules/.bin` directly and
-	fails loudly with `command not found` rather than reaching the registry.
+	The bare npm package name `adr` belongs to an unrelated tool. For one-off use,
+	run `npx @adrkit/cli …` or `bunx @adrkit/cli …`. After installation, use the
+	`adr` or `adrkit` binary.
 </Aside>
 
 <Tabs>
@@ -77,59 +65,13 @@ adr lint
 
 <Aside type="tip" title="`adrkit` — the unambiguous installed alias">
 	Every install above also provides a second binary, `adrkit`, identical to
-	`adr`. Nothing else on npm claims that binary name, so once installed it is
-	unambiguous: `adrkit lint` works wherever `adr lint` does, without competing
-	for the `.bin` entry that `adr` shares with the unrelated package.
-
-	Prefer it in anything shared or long-lived — CI, `Makefile`s, READMEs, and
-	agent instructions — where a silent wrong-tool substitution is hardest to
-	notice.
-
-	This applies to the **installed** binary only. Do not reach for
-	`npx adrkit` / `bunx adrkit`: there is no unscoped `adrkit` *package*, and
-	there never will be — npm refuses the name as too similar to `pdfkit`. That
-	form therefore resolves against the registry and would run whatever someone
-	else publishes there. `npx --no` declines to install a missing package, but
-	it still runs one already in the npx cache, so it is not a durable guard
-	either. For zero-install, name the scoped package — `npx @adrkit/cli lint`.
-</Aside>
-
-The pure library surfaces are independently installable when you only need the
-resolver or the evaluator:
-
-```sh
-npm install @adrkit/core @adrkit/evaluator
-```
-
-<Aside type="note" title="Contributing to adrkit itself?">
-	To hack on adrkit rather than consume it, clone the repo and use Bun — the
-	project's development toolchain ([ADR-0010](/adr/0010-bun-toolchain/)):
-
-	```sh
-	git clone https://github.com/mbeacom/adrkit.git
-	cd adrkit
-	bun install
-	bun run adr lint   # run the CLI from source
-	```
+	`adr`. Prefer `adrkit` in shared scripts and agent instructions. For one-off
+	use, continue to name the package: `npx @adrkit/cli lint`.
 </Aside>
 
 The examples below are written as bare `adr …` for readability. A local install
-does **not** put `adr` on your shell `PATH` — it lands in `node_modules/.bin/`
-— so translate them to whichever way you installed:
-
-| How you installed | Run the examples as |
-|---|---|
-| Nothing installed (one-off) | `npx @adrkit/cli lint` / `bunx @adrkit/cli lint` |
-| Project dev dependency | an npm script — `npm run adr -- lint` |
-| Global (`npm i -g @adrkit/cli`) | `adr lint` — bare, as written |
-| Source checkout | `bun run adr lint` |
-
-Only the global install makes the bare form work in a normal shell. Note that
-`npx adr lint` is absent from that table deliberately: it reaches adrkit only
-when the binary is linked into `node_modules/.bin`, and otherwise silently runs
-the unrelated registry package instead of failing. An npm script has no such
-ambiguity — it resolves `node_modules/.bin` and stops with `command not found`
-if the dependency is missing.
+does not put `adr` on your shell `PATH`; run it through your package script, such
+as `npm run adr -- lint`.
 
 ## Create your first record — `adr new`
 

--- a/site/src/content/docs/schema.mdx
+++ b/site/src/content/docs/schema.mdx
@@ -53,7 +53,7 @@ understands Markdown frontmatter directly, so it is the recommended way to
 validate a corpus:
 
 ```sh
-bun run adr lint
+npx @adrkit/cli lint
 ```
 
 <Aside type="caution" title="Editor YAML extensions do not validate Markdown frontmatter">

--- a/site/src/content/docs/spec-kit.mdx
+++ b/site/src/content/docs/spec-kit.mdx
@@ -121,8 +121,8 @@ network** — a missing CLI is reported, never fetched.
 ## Compatibility and support
 
 `@adrkit/spec-kit` is available from the Spec Kit community catalog and
-continuously tested against every supported Spec Kit release. If you find a
-compatibility issue, [open an issue](https://github.com/mbeacom/adrkit/issues).
+tested against Spec Kit 0.13.0, 0.14.4, and 0.15.1. If you find a compatibility
+issue, [open an issue](https://github.com/mbeacom/adrkit/issues).
 
 For implementation details, see the
 [`@adrkit/spec-kit` README](https://github.com/mbeacom/adrkit/blob/main/packages/adapters/spec-kit/README.md).

--- a/site/src/content/docs/spec-kit.mdx
+++ b/site/src/content/docs/spec-kit.mdx
@@ -21,23 +21,19 @@ re-litigates settled questions.
 | `/speckit.adrkit.check` | Checks a produced plan against the decisions that govern it, routing through the deterministic [Pass 0 evaluator](/commands/#adr-evaluate) when a snapshot bundle is configured | no |
 | `/speckit.adrkit.draft` | Scaffolds a draft ADR from the current plan artifact for you to fill in | one new record |
 
-Plus exactly one hook: `after_plan` **offers** to run
-`/speckit.adrkit.check`. It asks; it does not seize the plan loop.
+The optional `after_plan` hook offers to run `/speckit.adrkit.check` after
+`/speckit.plan`.
 
 <Aside type="caution" title="Hooks never write">
-	`draft` is the only command that writes, and it is unreachable from any hook.
-	A plan-phase hook creating records unprompted would manufacture decision
-	memory rather than record it. The boundary is enforced by a test that fails if
-	a hook is ever pointed at a writing command.
+	`draft` is the only writing command, and hooks cannot invoke it.
 </Aside>
 
 ## Requirements
 
-- **Spec Kit `>=0.13.0,<0.16.0`.** The upper bound is a verification boundary,
-  not a guess — the extension is installed and rendered against 0.13.0, 0.14.4,
-  and 0.15.1. Widening past 0.16 means re-verifying, not bumping a number
-  ([ADR-0007](/adr/0007-adapter-isolation-and-public-surface-build/)).
-- **The `adr` CLI** (`@adrkit/cli`), or `ADRKIT_CLI` pointing at its entry point.
+- **Spec Kit `>=0.13.0,<0.16.0`.** Compatibility is tested against 0.13.0,
+  0.14.4, and 0.15.1.
+- **The `adr` CLI.** Install `@adrkit/cli` globally or in the project, or set
+  `ADRKIT_CLI` to its entry point.
 - **An ADR corpus.** Defaults to `docs/adr`.
 
 ## Install
@@ -47,20 +43,23 @@ Spec Kit discovers extensions under `.specify/extensions/`, and only
 not through your package manager.
 
 <Tabs>
-<TabItem label="From a checkout">
-
-```sh
-specify extension add --dev path/to/packages/adapters/spec-kit
-```
-
-</TabItem>
 <TabItem label="Spec Kit catalog">
 
-The catalog entry has not landed yet — [ADR-0019](/adr/0019-ship-the-spec-kit-extension-treating-the-spike-no-go-as-a-measurement-artifact/)
-action item 5 is still open. Once it does, this is the idiomatic channel:
+adrkit is listed in the
+[Spec Kit community catalog](https://github.com/github/spec-kit/blob/main/extensions/catalog.community.json),
+so this is the idiomatic installation channel:
 
 ```sh
 specify extension add adrkit
+```
+
+</TabItem>
+<TabItem label="From a checkout">
+
+For local extension development:
+
+```sh
+specify extension add --dev path/to/packages/adapters/spec-kit
 ```
 
 </TabItem>
@@ -77,16 +76,22 @@ offers the `after_plan` hook.
 </Aside>
 
 The package is also published on npm as
-[`@adrkit/spec-kit`](https://www.npmjs.com/package/@adrkit/spec-kit), versioned
-**independently** of the rest of the scope: an adapter's semver contract is with
-its upstream, not with `@adrkit/core`
-([ADR-0007](/adr/0007-adapter-isolation-and-public-surface-build/)). It does not
-move with the repository's release tag.
+[`@adrkit/spec-kit`](https://www.npmjs.com/package/@adrkit/spec-kit) for
+programmatic or pinned installs.
+
+## Use it in the plan loop
+
+1. Run `/speckit.adrkit.context` before planning to load the decisions governing
+   the affected paths.
+2. Run `/speckit.plan`. The optional `after_plan` hook offers to check the plan;
+   you can also run `/speckit.adrkit.check` directly.
+3. Run `/speckit.adrkit.draft` when the plan introduces a decision worth
+   recording.
 
 ## Configuration
 
-Every knob is an environment variable, because an extension that needs its own
-config file is an extension nobody installs.
+The extension works without additional configuration. Override its defaults
+with environment variables when needed.
 
 | Variable | Default | Meaning |
 |---|---|---|
@@ -102,45 +107,22 @@ network** — a missing CLI is reported, never fetched.
 
 ## What is guaranteed
 
-These are enforced by tests, and each was observed failing under a deliberately
-introduced defect before it was trusted
-([ADR-0016](/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage/)).
-
 - **The hook is never mandatory.** A mandatory hook fires without consent; this
   one renders as an optional prompt.
 - **Failures name what is missing.** "0 decisions govern this" and "I could not
   see the corpus" never render as the same string, so no command exits 0 having
   found nothing because it was looking in the wrong place.
-- **`check` mutates nothing** — verified by byte-comparing the whole project
-  tree before and after.
+- **`check` mutates nothing.**
 - **Nothing development-only reaches your repo.** `specify extension add --dev`
   copies the directory verbatim, so `.extensionignore` keeps the test suite and
   build config out of your `.specify/extensions/`. The package declares no
   dependencies at all, so there is never a `node_modules/` to copy.
 
-## Status
+## Compatibility and support
 
-Authorized by
-[ADR-0019](/adr/0019-ship-the-spec-kit-extension-treating-the-spike-no-go-as-a-measurement-artifact/),
-which records the `no-go` verdict from the hook-viability spike as a measurement
-artifact of that spike's own verdict procedure — a byte-identical `git status`
-bar applied to `install` and `remove`, lifecycle actions whose entire purpose is
-to write files — rather than a finding against the mechanism, which the spike
-verified working in every respect.
+`@adrkit/spec-kit` is available from the Spec Kit community catalog and
+continuously tested against every supported Spec Kit release. If you find a
+compatibility issue, [open an issue](https://github.com/mbeacom/adrkit/issues).
 
-<Aside type="note" title="Landed and reference-verified — not externally validated">
-	Per [ADR-0014](/adr/0014-stage-phase-landing-evidence-across-a-three-rung-validation-ladder/)
-	this package sits on rungs 1–2. Rung 2 is a maintainer-owned isolated
-	reference repository that reinstalls the extension from a pinned adrkit commit
-	into a real Spec Kit project on every push and weekly, across all three
-	declared upstream versions — 41 self-verifying, fail-closed assertions each.
-	The gate was observed failing on a deliberate divergence before being trusted.
-
-	Rung 3 is **open**: nobody but the maintainer has run this in their own
-	repository yet.
-</Aside>
-
-Full detail lives in
-[`packages/adapters/spec-kit/README.md`](https://github.com/mbeacom/adrkit/blob/main/packages/adapters/spec-kit/README.md)
-and the
-[evidence index](https://github.com/mbeacom/adrkit/blob/main/docs/reference-verification-spec-kit-extension.md).
+For implementation details, see the
+[`@adrkit/spec-kit` README](https://github.com/mbeacom/adrkit/blob/main/packages/adapters/spec-kit/README.md).


### PR DESCRIPTION
## Summary
- reorganize public docs around installation, usage, compatibility, and next steps
- replace internal validation and release-history narration with concise product status language
- update Spec Kit catalog guidance, security support, and shipped-versus-planned feature framing

## Validation
- `bun run check:doc-pins`
- `bun run check:site-grammar`
- `bun --cwd site run build`
- `git diff --check`