### PR TITLE
Release v0.11.0 and spec-kit v0.1.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: adrkit version
       description: Output of `adr --version` (or the package version you installed).
-      placeholder: '0.10.0'
+      placeholder: '0.11.0'
     validations:
       required: true
   - type: dropdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,10 @@
 
 Decision memory for human- and agent-authored plans — machine-readable ADRs
 that are enforceable in CI and legible to agents, without leaving git.
-Status: early — phases 0–6 landed and v0.10.0 is public. `@adrkit/core`,
+Status: early — phases 0–6 landed and v0.11.0 is public. `@adrkit/core`,
 `@adrkit/evaluator`, `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
 `check`, `queue`, `migrate --from madr`, `evaluate`) are published on npm, as is
-the independently versioned `@adrkit/spec-kit` Spec Kit extension (0.1.2); the
+the independently versioned `@adrkit/spec-kit` Spec Kit extension (0.1.3); the
 repository-backed CI Action is available at `mbeacom/adrkit/packages/ci@v0`.
 The published `@adrkit/mcp` server has exactly four local stdio tools and serves
 **both** MCP protocol eras over one stdio connection — `2026-07-28` (stateless;
@@ -119,7 +119,7 @@ Things that are load-bearing and easy to break:
   [ADR-0007](./docs/adr/0007-adapter-isolation-and-public-surface-build.md) — its
   semver contract is with Spec Kit, not with `@adrkit/core`. It releases on its
   own `spec-kit-v<semver>` tag (see [`docs/RELEASING.md`](./docs/RELEASING.md)),
-  currently **0.1.2**, and does **not** move with the repository version.
+  currently **0.1.3**, and does **not** move with the repository version.
 - **Two version fields must agree**: `package.json` (npm) and `extension.yml`
   (Spec Kit). A test asserts they match — 0.1.1 shipped with them diverged and
   told every user the wrong version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-26
+
 ### Added
 
 - **A source-built OCI image for the CLI, MCP server, and both CI entry
@@ -75,6 +77,22 @@ Until `1.0.0`, minor releases may include breaking changes
   JSON, Mermaid, explicit terminal output, and the new core exports. The release
   runbook now includes bad-version deprecation, temporary dist-tag rollback, and
   forward-only lockstep hotfix steps.
+
+### Fixed
+
+- **Release publication dry-runs now verify registry integrity before deciding
+  what to publish.** An unchanged independently versioned adapter riding along
+  with a lockstep release is skipped when its packed bytes match npm, just as it
+  is during real publication, instead of `npm publish --dry-run` rejecting the
+  already-published version.
+
+## [spec-kit-0.1.3] - 2026-08-26
+
+### Changed
+
+- Refreshed the Spec Kit extension README with the community-catalog install
+  path, project-local CLI resolution, a concise plan-loop workflow, and clearer
+  runtime guarantees and support guidance.
 
 ## [0.10.0] - 2026-08-26
 
@@ -1163,7 +1181,8 @@ against live Spec Kit, rather than reasoning about it:
 - Node-targeted published distribution of all packages, smoke-tested under Node
   22 and 24.
 
-[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/mbeacom/adrkit/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/mbeacom/adrkit/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/mbeacom/adrkit/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mbeacom/adrkit/compare/v0.7.0...v0.8.0
@@ -1171,6 +1190,7 @@ against live Spec Kit, rather than reasoning about it:
 [0.6.0]: https://github.com/mbeacom/adrkit/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mbeacom/adrkit/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/mbeacom/adrkit/compare/v0.3.0...v0.4.0
+[spec-kit-0.1.3]: https://github.com/mbeacom/adrkit/compare/spec-kit-v0.1.2...spec-kit-v0.1.3
 [spec-kit-0.1.2]: https://github.com/mbeacom/adrkit/compare/spec-kit-v0.1.1...spec-kit-v0.1.2
 [spec-kit-0.1.1]: https://github.com/mbeacom/adrkit/compare/spec-kit-v0.1.0...spec-kit-v0.1.1
 [spec-kit-0.1.0]: https://github.com/mbeacom/adrkit/releases/tag/spec-kit-v0.1.0

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -56,7 +56,7 @@ adrkit/
 
 - The ADR corpus lives in [docs/adr/](docs/adr/), with `0000-template.md` plus
   numbered records.
-- There are 34 files: the template plus 33 records, ids `0001`-`0033`, with 31
+- There are 35 files: the template plus 34 records, ids `0001`-`0034`, with 32
   accepted and 2 superseded records.
 - The schema source of truth lives in
   `packages/core/src/schema/adr.schema.ts`.

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/adapters/spec-kit": {
       "name": "@adrkit/spec-kit",
-      "version": "0.1.2",
+      "version": "0.1.3",
     },
     "packages/catalog-envelope": {
       "name": "@adrkit/catalog-envelope",
@@ -55,7 +55,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "bin": {
         "adr": "./dist/index.js",
         "adrkit": "./dist/index.js",
@@ -70,7 +70,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -85,7 +85,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -96,7 +96,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,13 +9,13 @@ Action, and one lockstep OCI image:
 | `@adrkit/evaluator` | npm |
 | `@adrkit/cli` (`adr`, `adrkit`) | npm |
 | `@adrkit/mcp` (`adrkit-mcp`) | npm |
-| `packages/ci/action.yml` | Git tag (latest immutable release `v0.10.0`, moving `v0`) |
+| `packages/ci/action.yml` | Git tag (latest immutable release `v0.11.0`, moving `v0`) |
 | `ghcr.io/mbeacom/adrkit` | GitHub Container Registry (`vX.Y.Z`, moving `vX`, `latest`; begins with the first release containing ADR-0032) |
 
 `@adrkit/ci` stays private because GitHub executes the committed Action bundle
 directly from the referenced repository ref.
 
-The coordinated lockstep surface is published; the current release is `v0.10.0`. `@adrkit/core`,
+The coordinated lockstep surface is published; the current release is `v0.11.0`. `@adrkit/core`,
 `@adrkit/evaluator`, and `@adrkit/cli` use GitHub Actions Trusted Publishing.
 `@adrkit/mcp` was created with the isolated one-time bootstrap path below; its
 Trusted Publisher and token-restriction cleanup must be completed before the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Decision memory for human and agent-authored plans \u2014 machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/packages/adapters/spec-kit/extension.yml
+++ b/packages/adapters/spec-kit/extension.yml
@@ -12,7 +12,7 @@ schema_version: "1.0"
 extension:
   id: "adrkit"
   name: "adrkit — decision memory for spec-driven development"
-  version: "0.1.2"
+  version: "0.1.3"
   description: "Pulls the decisions governing this work into agent context, checks produced plans against them, and drafts an ADR from a plan artifact."
   author: "Mark Beacom (@mbeacom)"
   repository: "https://github.com/mbeacom/adrkit"

--- a/packages/adapters/spec-kit/package.json
+++ b/packages/adapters/spec-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/spec-kit",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Spec Kit extension that injects adrkit's governing decisions into the spec-driven plan loop.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -62,7 +62,7 @@ import { getPresentation, setPresentation, styleUsageBlock, type ColorMode, type
  * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
  * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
  */
-export const CLI_VERSION = '0.10.0';
+export const CLI_VERSION = '0.11.0';
 
 function topLevelUsage(style?: StreamStyle): string {
   return renderTopLevelUsage(CLI_VERSION, style);

--- a/packages/cli/test/color.test.ts
+++ b/packages/cli/test/color.test.ts
@@ -33,7 +33,7 @@ describe('CLI color presentation', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe('');
     expect(result.stdout).toContain('\u001b[');
-    expect(result.stdout).toContain('adrkit 0.10.0');
+    expect(result.stdout).toContain('adrkit 0.11.0');
   });
 
   test('forced color keeps lint stdout and stderr separated', async () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adrkit/mcp",
   "mcpName": "dev.adrkit/mcp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetDecisionContext } from './tools/get-decision-context.ts';
 import { registerListSuperseded } from './tools/list-superseded.ts';
 import type { ToolConfig } from './tools/shared.ts';
 
-export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.10.0' } as const;
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.11.0' } as const;
 
 /**
  * The MCP protocol revision this server serves through `serveStdio`'s modern era.

--- a/scripts/release-publish.test.ts
+++ b/scripts/release-publish.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   assertPublishTag,
   existingIntegrity,
+  publishArtifacts,
   publishEnvironment,
   shouldPublishArtifact,
 } from './release-publish.ts';
@@ -54,6 +55,28 @@ describe('release registry safety', () => {
     expect(() => shouldPublishArtifact(artifact, 'sha512-other')).toThrow(
       'already exists with different integrity',
     );
+  });
+
+  test('dry runs skip matching artifacts and publish absent ones', async () => {
+    const existing = { ...artifact, name: '@adrkit/spec-kit', version: '0.1.2' };
+    const next = { ...artifact, version: '0.11.0' };
+    const lookups: string[] = [];
+    const published: Array<{ name: string; dryRun: boolean }> = [];
+
+    await publishArtifacts(
+      [existing, next],
+      true,
+      async (candidate) => {
+        lookups.push(candidate.name);
+        return candidate === existing ? candidate.integrity : undefined;
+      },
+      async (candidate, dryRun) => {
+        published.push({ name: candidate.name, dryRun });
+      },
+    );
+
+    expect(lookups).toEqual(['@adrkit/spec-kit', '@adrkit/core']);
+    expect(published).toEqual([{ name: '@adrkit/core', dryRun: true }]);
   });
 
   test('requires the exact tag the manifest names, not one rebuilt from the version', () => {

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -109,6 +109,25 @@ async function npmPublish(artifact: ReleaseArtifact, dryRun: boolean): Promise<v
   assert(exitCode === 0, `Publishing ${artifact.name}@${artifact.version} failed with exit ${exitCode}`);
 }
 
+type IntegrityLookup = (artifact: ReleaseArtifact) => Promise<string | undefined>;
+type ArtifactPublisher = (artifact: ReleaseArtifact, dryRun: boolean) => Promise<void>;
+
+export async function publishArtifacts(
+  artifacts: readonly ReleaseArtifact[],
+  dryRun: boolean,
+  lookupIntegrity: IntegrityLookup = existingIntegrity,
+  publishArtifact: ArtifactPublisher = npmPublish,
+): Promise<void> {
+  for (const artifact of artifacts) {
+    const integrity = await lookupIntegrity(artifact);
+    if (!shouldPublishArtifact(artifact, integrity)) {
+      console.log(`release-publish: ${artifact.name}@${artifact.version} already matches; skipping`);
+      continue;
+    }
+    await publishArtifact(artifact, dryRun);
+  }
+}
+
 export async function publishRelease(args = Bun.argv.slice(2)): Promise<void> {
   const unknownArgs = args.filter((argument) => argument !== '--dry-run');
   assert(unknownArgs.length === 0, `Unknown release-publish arguments: ${unknownArgs.join(', ')}`);
@@ -124,16 +143,7 @@ export async function publishRelease(args = Bun.argv.slice(2)): Promise<void> {
     assertPublishTag(manifest, Bun.env.GITHUB_REF_NAME);
   }
 
-  for (const artifact of manifest.artifacts) {
-    if (!dryRun) {
-      const integrity = await existingIntegrity(artifact);
-      if (!shouldPublishArtifact(artifact, integrity)) {
-        console.log(`release-publish: ${artifact.name}@${artifact.version} already matches; skipping`);
-        continue;
-      }
-    }
-    await npmPublish(artifact, dryRun);
-  }
+  await publishArtifacts(manifest.artifacts, dryRun);
 }
 
 if (import.meta.main) {

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -14,7 +14,7 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
 				</svg>
 				CLI works today
 			</span>
-			<span>v0.10.0 on npm · decision memory in git</span>
+			<span>v0.11.0 on npm · decision memory in git</span>
 		</div>
 
 		<h1 id="_top" data-page-title set:html={title} />

--- a/site/src/content/docs/badges.mdx
+++ b/site/src/content/docs/badges.mdx
@@ -100,8 +100,8 @@ jobs:
       # current release.
       - run: |
           mkdir -p .adrkit
-          npx @adrkit/cli@0.10.0 queue --format json > .adrkit/queue.json.tmp
-          npx @adrkit/cli@0.10.0 lint --json  > .adrkit/lint.json.tmp
+          npx @adrkit/cli@0.11.0 queue --format json > .adrkit/queue.json.tmp
+          npx @adrkit/cli@0.11.0 lint --json  > .adrkit/lint.json.tmp
 
       # A truncated or malformed write renders as `no result` on the badge, which
       # reads as a bug in your tooling. Fail here instead of committing it.

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -43,8 +43,8 @@ The Action updates its existing comment on later pushes, so each pull request
 keeps one current governing-decisions comment. No additional token environment
 variable is required when using the default `GITHUB_TOKEN`.
 
-`v0` is a moving major tag, and it now resolves to a `v0.10.0` build. Pin the
-immutable `v0.10.0` tag or a commit SHA for maximum reproducibility.
+`v0` is a moving major tag, and it now resolves to a `v0.11.0` build. Pin the
+immutable `v0.11.0` tag or a commit SHA for maximum reproducibility.
 
 <Aside type="note" title="Comments from before the upgrade">
 	The Action is comment-only and deletes nothing, so duplicate comments a pull request
@@ -53,14 +53,14 @@ immutable `v0.10.0` tag or a commit SHA for maximum reproducibility.
 </Aside>
 
 <Aside type="caution" title="Pinning a release tag by SHA">
-	The `v*` release tags are **annotated**, so `refs/tags/v0.10.0` resolves to a tag
+	The `v*` release tags are **annotated**, so `refs/tags/v0.11.0` resolves to a tag
 	object rather than a commit, and `uses:` rejects that SHA. Pin the commit the tag
 	points *at*:
 
 	```sh
-	git rev-parse v0.10.0^{commit}
+	git rev-parse v0.11.0^{commit}
 	# or, over the API — this endpoint peels the tag for you:
-	gh api repos/mbeacom/adrkit/commits/v0.10.0 --jq .sha
+	gh api repos/mbeacom/adrkit/commits/v0.11.0 --jq .sha
 	```
 
 	Note that `GET /git/ref/tags/{tag}` does **not** peel: its `object.sha` is the tag

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
 <div class="adr-home">
 	<section class="adr-status-band" aria-label="Project status">
 		<div class="adr-status-band__item">
-			<span class="adr-status adr-status--current">Published · v0.10.0</span>
+			<span class="adr-status adr-status--current">Published · v0.11.0</span>
 			<p><code>@adrkit/core</code>, <code>@adrkit/cli</code>, <code>@adrkit/evaluator</code>, and <code>@adrkit/mcp</code> are on npm, plus the independently versioned <code>@adrkit/spec-kit</code> extension; the CI Action ships at <code>mbeacom/adrkit/packages/ci@v0</code>.</p>
 		</div>
 		<div class="adr-status-band__item">

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -10,7 +10,7 @@ decisions govern a file, renders the decision graph, migrates an existing MADR
 corpus in place, emits the ARB operations queue, and runs the deterministic
 evaluator.
 
-<Aside type="tip" title="Published on npm (v0.10.0)">
+<Aside type="tip" title="Published on npm (v0.11.0)">
 	`@adrkit/cli` is live. Consumers install it with your Node package manager and
 	run the `adr` binary — no clone required.
 </Aside>


### PR DESCRIPTION
Prepare the next lockstep and Spec Kit releases.

- cut the unreleased changes as v0.11.0
- bump the independently versioned Spec Kit extension to v0.1.3
- align package, runtime, lockfile, MCP registry, documentation, and issue-template version surfaces
- refresh the ADR corpus inventory
- make release publication dry-runs verify and skip registry-identical artifacts

Release order after merge: publish `spec-kit-v0.1.3`, wait for success, then publish `v0.11.0`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>