### PR TITLE
Verify AMD64 and ARM64 container support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,52 @@ jobs:
           test "$status" -ne 0
           grep -F "could not load the ADR corpus at 'missing'" <<<"$output"
 
+  container-architecture-smoke:
+    name: Container architecture smoke (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            architecture: amd64
+            image: adrkit:ci-amd64
+          - platform: linux/arm64
+            architecture: arm64
+            image: adrkit:ci-arm64
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
+      - name: Build the architecture-specific all-in-one image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          cache-from: type=gha,scope=adrkit-container-${{ matrix.architecture }}
+          cache-to: type=gha,mode=max,scope=adrkit-container-${{ matrix.architecture }}
+          context: .
+          file: ./Containerfile
+          load: true
+          platforms: ${{ matrix.platform }}
+          tags: ${{ matrix.image }}
+          target: adrkit
+      - name: Smoke test the architecture-specific CLI and MCP runtimes
+        env:
+          ARCHITECTURE: ${{ matrix.architecture }}
+          CONTAINER_PLATFORM: ${{ matrix.platform }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          test "$(docker image inspect --format '{{.Architecture}}' "$IMAGE")" = "$ARCHITECTURE"
+          test "$(docker run --rm --platform "$CONTAINER_PLATFORM" --read-only --network none \
+            "$IMAGE" cli --version)" = "$(jq -r .version package.json)"
+          node scripts/smoke-container.mjs "$IMAGE" mcp
+
   audit:
     # Fail the build on high/critical advisories in this checkout's resolved
     # workspace dependency tree as installed by `bun install --frozen-lockfile`.

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -18,6 +18,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/mbeacom/adrkit
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   publish:
@@ -126,10 +127,30 @@ jobs:
             org.opencontainers.image.revision=${{ steps.source.outputs.revision }}
             org.opencontainers.image.version=${{ steps.release.outputs.version }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           provenance: false
           tags: ${{ env.IMAGE_NAME }}
           target: adrkit
+
+      - name: Verify the published architecture manifest
+        env:
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          manifest=$(docker buildx imagetools inspect \
+            "$IMAGE_NAME@$DIGEST" \
+            --format '{{json .Manifest}}')
+          actual=$(jq -r \
+            '[.manifests[].platform
+              | select(.os != null and .architecture != null)
+              | "\(.os)/\(.architecture)"]
+             | unique | sort | join(",")' \
+            <<<"$manifest")
+          expected=$(tr ',' '\n' <<<"$PLATFORMS" | sort | paste -sd, -)
+          if [ "$actual" != "$expected" ]; then
+            echo "Expected container platforms '$expected', found '$actual'." >&2
+            exit 1
+          fi
 
       - name: Attest the content-addressed image
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6  # v4.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ### Added
 
+- **End-to-end AMD64 and ARM64 container verification.** CI now builds and
+  executes the all-in-one image for both `linux/amd64` and `linux/arm64`, and
+  container publication verifies that the pushed digest contains exactly those
+  two platform manifests before attestation and tag promotion. Consumer
+  documentation now names the supported platforms and the cross-architecture
+  `--platform` override.
+
 - **`MANIFEST.md`'s decision-corpus inventory is generated, not hand-written.**
   `bun run emit:manifest` renders the record table and the status counts from
   `adr graph --format json` between stable markers, and `clean-clone-builds`

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ docker run --rm --read-only --network none -i \
   ghcr.io/mbeacom/adrkit:vX.Y.Z mcp
 ```
 
+Each release manifest includes `linux/amd64` and `linux/arm64`. Docker and
+Podman select the host architecture automatically; use `--platform linux/amd64`
+or `--platform linux/arm64` only when running through cross-architecture
+emulation.
+
 The MCP command keeps stdin open because MCP uses stdio. Its repository mount is
 read-only, matching the server contract; use an absolute host path in MCP client
 configuration. For CLI commands that intentionally write (`new`, or
@@ -91,6 +96,10 @@ inspection; the registry publishes only the all-in-one `adrkit` target:
 
 ```sh
 docker build -f Containerfile -t adrkit:local .
+docker buildx build --platform linux/amd64 --load \
+  -f Containerfile -t adrkit:local-amd64 .
+docker buildx build --platform linux/arm64 --load \
+  -f Containerfile -t adrkit:local-arm64 .
 docker build -f Containerfile --target mcp -t adrkit-mcp:local .
 docker run --rm --read-only --network none -i \
   -v "$PWD:/workspace:ro" \

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -523,7 +523,10 @@ The image is built for `linux/amd64` and `linux/arm64`. Docker Buildx pushes one
 manifest-list digest, and `actions/attest` attaches registry provenance to that
 digest. Only the all-in-one `adrkit` target is published. Dedicated `cli`,
 `mcp`, `ci`, and `queue-action` targets remain local build surfaces whose
-isolation is asserted in CI.
+isolation is asserted in CI. A QEMU-backed CI matrix builds and runs the
+all-in-one image for both architectures. During publication, the workflow also
+reads the pushed manifest by digest and requires both platform entries before
+attestation and public tag promotion.
 
 ### One-time GHCR setup and first publish
 

--- a/scripts/container-contract.test.ts
+++ b/scripts/container-contract.test.ts
@@ -6,9 +6,14 @@ const ROOT = resolve(import.meta.dir, '..');
 const CONTAINERFILE = readFileSync(join(ROOT, 'Containerfile'), 'utf8');
 const ENTRYPOINT_PATH = join(ROOT, 'scripts', 'container-entrypoint.sh');
 const ENTRYPOINT = readFileSync(ENTRYPOINT_PATH, 'utf8');
+const CONTAINER_SMOKE = readFileSync(join(ROOT, 'scripts', 'smoke-container.mjs'), 'utf8');
 const DOCKERIGNORE = readFileSync(join(ROOT, '.dockerignore'), 'utf8');
 const README = readFileSync(join(ROOT, 'README.md'), 'utf8');
 const CI_WORKFLOW = readFileSync(join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
+const RELEASE_WORKFLOW = readFileSync(
+  join(ROOT, '.github', 'workflows', 'container-release.yml'),
+  'utf8',
+);
 const PACKAGE = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')) as {
   packageManager: string;
 };
@@ -99,6 +104,22 @@ describe('container contract', () => {
     expect(CI_WORKFLOW).toContain('scripts/smoke-container.mjs adrkit:ci mcp');
     expect(CI_WORKFLOW).toContain('adrkit:ci ci 2>&1');
     expect(CI_WORKFLOW).toContain('adrkit:ci queue-action 2>&1');
+  });
+
+  test('builds, runs, publishes, and verifies amd64 and arm64 images', () => {
+    for (const platform of ['linux/amd64', 'linux/arm64']) {
+      expect(CI_WORKFLOW).toContain(`platform: ${platform}`);
+      expect(README).toContain(`\`${platform}\``);
+    }
+
+    expect(CI_WORKFLOW).toContain('platforms: ${{ matrix.platform }}');
+    expect(CI_WORKFLOW).toContain('CONTAINER_PLATFORM: ${{ matrix.platform }}');
+    expect(CONTAINER_SMOKE).toContain('process.env.CONTAINER_PLATFORM');
+    expect(CONTAINER_SMOKE).toContain("...(platform ? ['--platform', platform] : [])");
+    expect(RELEASE_WORKFLOW).toContain('PLATFORMS: linux/amd64,linux/arm64');
+    expect(RELEASE_WORKFLOW).toContain('platforms: ${{ env.PLATFORMS }}');
+    expect(RELEASE_WORKFLOW).toContain('Verify the published architecture manifest');
+    expect(RELEASE_WORKFLOW).toContain('Expected container platforms');
   });
 
   test('admits only runtime source and the committed Action bundles', () => {

--- a/scripts/smoke-container.mjs
+++ b/scripts/smoke-container.mjs
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const runtime = process.env.CONTAINER_RUNTIME || 'docker';
+const platform = process.env.CONTAINER_PLATFORM;
 const image = process.argv[2] || 'adrkit-mcp:ci';
 const imageArgs = process.argv.slice(3);
 const repoRoot = fileURLToPath(new URL('../', import.meta.url));
@@ -42,6 +43,7 @@ async function smokeEra(era) {
     [
       'run',
       '--rm',
+      ...(platform ? ['--platform', platform] : []),
       '--read-only',
       '--network',
       'none',


### PR DESCRIPTION
## What and why

The release workflow already declared `linux/amd64` and `linux/arm64`, but pull request CI exercised only the runner's native architecture and publication did not verify the pushed manifest. This makes the two-platform contract executable end to end.

A QEMU-backed Buildx matrix now builds and runs the all-in-one image for both architectures, including CLI and both MCP protocol eras. Publication centralizes the supported platform set and checks the content-addressed registry manifest before attestation or public tag promotion. Usage and release documentation now names both platforms and explains explicit cross-architecture selection.

## Checklist

- [x] Commits are **DCO signed off** (`git commit -s`). No CLA is required. This is enforced by the `dco` check; to sign commits you already made, see [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-is-required).
- [x] If this changes a recorded decision in `docs/adr/`, an ADR is **added or supersedes** the affected record - with the argument, not just a status flip. The architecture set is already recorded by ADR-0032; this change enforces it without changing the decision.
- [x] If the schema changed, I edited the Zod source `packages/core/src/schema/adr.schema.ts` (not the root re-export), re-ran `bun run schema:emit`, and committed the generated `schema/adr.schema.json`. N/A: no schema change.
- [x] If `packages/ci/src` **or** `@adrkit/core` changed, I regenerated `packages/ci/dist` under **linux/amd64 bun 1.3.14** and committed it (see CONTRIBUTING.md - a Mac-built bundle fails the diff gate). N/A: neither source surface changed; the pinned rebuild remains byte-for-byte clean.
- [x] New or changed behavior is covered by tests, and each test was **observed failing before it passed** - a check that never failed is not coverage ([ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).
- [ ] `bun run typecheck && bun run build && bun test && bun run lint` pass from a clean clone with no credentials configured ([ADR-0007](docs/adr/0007-adapter-isolation-and-public-surface-build.md)). The full command passes in this worktree; the clean-clone/no-credentials run remains CI evidence.

## Notes for reviewers

The architecture matrix exercises the published all-in-one target on both platforms; dedicated target isolation remains covered by the existing native container job. The release gate requires exactly `linux/amd64` and `linux/arm64`, so an accidental extra or missing manifest blocks attestation and tag promotion.