### PR TITLE
Release v0.12.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: adrkit version
       description: Output of `adr --version` (or the package version you installed).
-      placeholder: '0.11.0'
+      placeholder: '0.12.0'
     validations:
       required: true
   - type: dropdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Decision memory for human- and agent-authored plans — machine-readable ADRs
 that are enforceable in CI and legible to agents, without leaving git.
-Status: early — phases 0–6 landed and v0.11.0 is public. `@adrkit/core`,
+Status: early — phases 0–6 landed and v0.12.0 is public. `@adrkit/core`,
 `@adrkit/evaluator`, `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
 `check`, `queue`, `migrate --from madr`, `evaluate`) are published on npm, as is
 the independently versioned `@adrkit/spec-kit` Spec Kit extension (0.1.3); the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-27
+
 ### Added
 
 - **A guarded recovery path for the moving `v0` Action tag.** Manual recovery
@@ -40,27 +42,6 @@ Until `1.0.0`, minor releases may include breaking changes
   was added: the CLI stays read-only and the writing lives in a repo-local
   script ([#132](https://github.com/mbeacom/adrkit/issues/132)). Judgment prose
   outside the markers stays hand-maintained.
-
-### Fixed
-
-- **Inbound marker amplification is bounded before resolution.** One file now
-  retains at most the first 64 parsed declarations, and one batch at most the
-  first 10,000 in deterministic code-unit path plus source order. Exact overflow
-  collapses into one advisory `marker-declarations-capped` finding and
-  `markerScan.declarations` metadata; `explain`, `check`, and the Action report
-  it without giving PR-authored markers exit-code authority
-  ([#113](https://github.com/mbeacom/adrkit/issues/113)).
-
-- **`adr queue` no longer stays silent when a proposed record has a review
-  deadline but no routing tier.** `item.tier-absent` now fires whenever the tier
-  cannot be determined on a record that has entered review — a `review` block,
-  or a top-level `reviewBy`. The carve-out the spec actually states is
-  two-conditioned (both absent), but only the first condition was implemented,
-  so a `cross-team` record with `reviewBy` and no `review` block was listed with
-  `tier=None` and no finding at all
-  ([#111](https://github.com/mbeacom/adrkit/issues/111)). A `proposed` record
-  with neither remains `not-queued` and silent. Severity stays `info`, so no
-  exit code changes.
 
 - **Trusted CI gates that the pull request cannot edit.** A new
   `.github/workflows/trusted-gates.yml` runs on `pull_request_target`, which
@@ -104,8 +85,18 @@ Until `1.0.0`, minor releases may include breaking changes
   would otherwise have passed clean and deleted the gate on merge.
 
 - **[`docs/repository-trust-operations.md`](docs/repository-trust-operations.md)**,
-  separating the controls that are active from the ones that cannot be applied
-  until this lands, with the exact verified commands and the evidence for each.
+  separating the controls that are active from the ones that could not be applied
+  until the trusted workflow reached `main`, with the exact verified commands and
+  the evidence for each. Both gates are now deployed and required: the live `main`
+  ruleset lists `trusted-dco` and `gate-integrity` among its ten required
+  contexts, and the pull-request-controlled `dco` context was removed from that
+  set only after the trusted one reported green on real pull requests. Both were
+  observed failing before being relied on
+  ([ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)):
+  `gate-integrity` went red before an acknowledgment and green after it on three
+  ordinary pull requests, and `trusted-dco` went red on a commit that deliberately
+  omitted `Signed-off-by` and green once it was signed. That is deployed evidence
+  in both directions, not a fixture or a local invocation.
 
 ### Changed
 
@@ -124,6 +115,27 @@ Until `1.0.0`, minor releases may include breaking changes
 - **`scripts/check-dco.ts` no longer carries a "known limitation" note.** It now
   states which invocation is the authority and which is advisory, because the
   limitation stopped being true for the one that gates the merge.
+
+### Fixed
+
+- **Inbound marker amplification is bounded before resolution.** One file now
+  retains at most the first 64 parsed declarations, and one batch at most the
+  first 10,000 in deterministic code-unit path plus source order. Exact overflow
+  collapses into one advisory `marker-declarations-capped` finding and
+  `markerScan.declarations` metadata; `explain`, `check`, and the Action report
+  it without giving PR-authored markers exit-code authority
+  ([#113](https://github.com/mbeacom/adrkit/issues/113)).
+
+- **`adr queue` no longer stays silent when a proposed record has a review
+  deadline but no routing tier.** `item.tier-absent` now fires whenever the tier
+  cannot be determined on a record that has entered review — a `review` block,
+  or a top-level `reviewBy`. The carve-out the spec actually states is
+  two-conditioned (both absent), but only the first condition was implemented,
+  so a `cross-team` record with `reviewBy` and no `review` block was listed with
+  `tier=None` and no finding at all
+  ([#111](https://github.com/mbeacom/adrkit/issues/111)). A `proposed` record
+  with neither remains `not-queued` and silent. Severity stays `info`, so no
+  exit code changes.
 
 ## [0.11.0] - 2026-08-26
 
@@ -1297,7 +1309,8 @@ against live Spec Kit, rather than reasoning about it:
 - Node-targeted published distribution of all packages, smoke-tested under Node
   22 and 24.
 
-[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/mbeacom/adrkit/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/mbeacom/adrkit/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/mbeacom/adrkit/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/mbeacom/adrkit/compare/v0.8.0...v0.9.0

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "bin": {
         "adr": "./dist/index.js",
         "adrkit": "./dist/index.js",
@@ -70,7 +70,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -85,7 +85,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -96,7 +96,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,13 +9,13 @@ Action, and one lockstep OCI image:
 | `@adrkit/evaluator` | npm |
 | `@adrkit/cli` (`adr`, `adrkit`) | npm |
 | `@adrkit/mcp` (`adrkit-mcp`) | npm |
-| `packages/ci/action.yml` | Git tag (latest immutable release `v0.11.0`, moving `v0`) |
+| `packages/ci/action.yml` | Git tag (latest immutable release `v0.12.0`, moving `v0`) |
 | `ghcr.io/mbeacom/adrkit` | GitHub Container Registry (`vX.Y.Z`, moving `vX`, `latest`; begins with the first release containing ADR-0032) |
 
 `@adrkit/ci` stays private because GitHub executes the committed Action bundle
 directly from the referenced repository ref.
 
-The coordinated lockstep surface is published; the current release is `v0.11.0`. `@adrkit/core`,
+The coordinated lockstep surface is published; the current release is `v0.12.0`. `@adrkit/core`,
 `@adrkit/evaluator`, and `@adrkit/cli` use GitHub Actions Trusted Publishing.
 `@adrkit/mcp` was created with the isolated one-time bootstrap path below; its
 Trusted Publisher and token-restriction cleanup must be completed before the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Decision memory for human and agent-authored plans \u2014 machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -63,7 +63,7 @@ import { getPresentation, setPresentation, styleUsageBlock, type ColorMode, type
  * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
  * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
  */
-export const CLI_VERSION = '0.11.0';
+export const CLI_VERSION = '0.12.0';
 
 function topLevelUsage(style?: StreamStyle): string {
   return renderTopLevelUsage(CLI_VERSION, style);

--- a/packages/cli/test/color.test.ts
+++ b/packages/cli/test/color.test.ts
@@ -33,7 +33,7 @@ describe('CLI color presentation', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe('');
     expect(result.stdout).toContain('\u001b[');
-    expect(result.stdout).toContain('adrkit 0.11.0');
+    expect(result.stdout).toContain('adrkit 0.12.0');
   });
 
   test('forced color keeps lint stdout and stderr separated', async () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adrkit/mcp",
   "mcpName": "dev.adrkit/mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetDecisionContext } from './tools/get-decision-context.ts';
 import { registerListSuperseded } from './tools/list-superseded.ts';
 import type { ToolConfig } from './tools/shared.ts';
 
-export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.11.0' } as const;
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.12.0' } as const;
 
 /**
  * The MCP protocol revision this server serves through `serveStdio`'s modern era.

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -14,7 +14,7 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
 				</svg>
 				CLI works today
 			</span>
-			<span>v0.11.0 on npm · decision memory in git</span>
+			<span>v0.12.0 on npm · decision memory in git</span>
 		</div>
 
 		<h1 id="_top" data-page-title set:html={title} />

--- a/site/src/content/docs/badges.mdx
+++ b/site/src/content/docs/badges.mdx
@@ -100,8 +100,8 @@ jobs:
       # current release.
       - run: |
           mkdir -p .adrkit
-          npx @adrkit/cli@0.11.0 queue --format json > .adrkit/queue.json.tmp
-          npx @adrkit/cli@0.11.0 lint --json  > .adrkit/lint.json.tmp
+          npx @adrkit/cli@0.12.0 queue --format json > .adrkit/queue.json.tmp
+          npx @adrkit/cli@0.12.0 lint --json  > .adrkit/lint.json.tmp
 
       # A truncated or malformed write renders as `no result` on the badge, which
       # reads as a bug in your tooling. Fail here instead of committing it.

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -55,8 +55,8 @@ the comment reaches GitHub's size limit. Keep the default checkout rooted at
 `GITHUB_WORKSPACE`; if a workflow checks out elsewhere, marker health will
 identify files the Action could not inspect.
 
-`v0` is a moving major tag, and it now resolves to a `v0.11.0` build. Pin the
-immutable `v0.11.0` tag or a commit SHA for maximum reproducibility.
+`v0` is a moving major tag, and it now resolves to a `v0.12.0` build. Pin the
+immutable `v0.12.0` tag or a commit SHA for maximum reproducibility.
 
 <Aside type="note" title="Comments from before the upgrade">
 	The Action is comment-only and deletes nothing, so duplicate comments a pull request
@@ -65,14 +65,14 @@ immutable `v0.11.0` tag or a commit SHA for maximum reproducibility.
 </Aside>
 
 <Aside type="caution" title="Pinning a release tag by SHA">
-	The `v*` release tags are **annotated**, so `refs/tags/v0.11.0` resolves to a tag
+	The `v*` release tags are **annotated**, so `refs/tags/v0.12.0` resolves to a tag
 	object rather than a commit, and `uses:` rejects that SHA. Pin the commit the tag
 	points *at*:
 
 	```sh
-	git rev-parse v0.11.0^{commit}
+	git rev-parse v0.12.0^{commit}
 	# or, over the API — this endpoint peels the tag for you:
-	gh api repos/mbeacom/adrkit/commits/v0.11.0 --jq .sha
+	gh api repos/mbeacom/adrkit/commits/v0.12.0 --jq .sha
 	```
 
 	Note that `GET /git/ref/tags/{tag}` does **not** peel: its `object.sha` is the tag

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
 <div class="adr-home">
 	<section class="adr-status-band" aria-label="Project status">
 		<div class="adr-status-band__item">
-			<span class="adr-status adr-status--current">Published · v0.11.0</span>
+			<span class="adr-status adr-status--current">Published · v0.12.0</span>
 			<p><code>@adrkit/core</code>, <code>@adrkit/cli</code>, <code>@adrkit/evaluator</code>, and <code>@adrkit/mcp</code> are on npm, plus the independently versioned <code>@adrkit/spec-kit</code> extension; the CI Action ships at <code>mbeacom/adrkit/packages/ci@v0</code>.</p>
 		</div>
 		<div class="adr-status-band__item">

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -10,7 +10,7 @@ decisions govern a file, renders the decision graph, migrates an existing MADR
 corpus in place, emits the ARB operations queue, and runs the deterministic
 evaluator.
 
-<Aside type="tip" title="Published on npm (v0.11.0)">
+<Aside type="tip" title="Published on npm (v0.12.0)">
 	`@adrkit/cli` is live. Consumers install it with your Node package manager and
 	run the `adr` binary — no clone required.
 </Aside>


### PR DESCRIPTION
Cuts the unreleased changelog into `## [0.12.0] - 2026-08-27` and moves every lockstep version-bearing surface from `0.11.0` to `0.12.0`. Release preparation only — no new features and no unrelated fixes.

## What v0.12.0 actually matures

Six commits landed since `v0.11.0`, and they are mostly about making this repository's own guarantees enforceable rather than aspirational.

- **The gates that certify a pull request now execute from the default branch** (#179, ADR-0035). `trusted-gates.yml` runs on `pull_request_target`, so the workflow file, its referenced actions, and the `actions/checkout` commit all come from `main` rather than from the branch under review. `trusted-dco` is the authority for sign-off; `gate-integrity` blocks changes to gate-defining paths without a maintainer acknowledgment that is dismissed on every event that can move the head or the base. Scope is stated rather than overstated: this does **not** make the advisory `ci.yml` gates tamper-proof, and the unprotected routes are enumerated and pinned by a test.
- **Those gates are now deployed, required, and observed failing** (#180). `trusted-dco` and `gate-integrity` are among the ten required contexts on the `main` ruleset, and the pull-request-controlled `dco` context was removed from that set only after the trusted one reported green on real pull requests. `gate-integrity` went red before an acknowledgment and green after it on three ordinary pull requests; `trusted-dco` went red on a commit that deliberately omitted `Signed-off-by` and green once it was signed. Deployed evidence in both directions, per ADR-0016 — not a fixture.
- **A guarded recovery path for the moving `v0` Action tag** (#175, #136, #122). Recovery accepts only a stable release whose annotated tag peels to a commit on `main`, whose exact `Release` run succeeded, whose root version matches, and whose committed Action bundles exist. It pushes under a lease and leaves a durable withdrawal marker so the removed commit cannot be republished on a rerun.
- **`MANIFEST.md`'s decision-corpus inventory is generated and gated** (#131, #132). It had drifted six records before anyone noticed. `bun run emit:manifest` renders it from `adr graph --format json`, and `clean-clone-builds` regenerates it and asserts no diff. The CLI stays read-only; the writing lives in a repo-local script.
- **Marker scan health and unbound claims surface in the CI comment** (#178, #112, #126) — changed files that were absent, unreadable, out of tree, or skipped, reported separately from `@adr` claims that read cleanly but bound to nothing in this corpus. Bounded, escaped, advisory, ordered behind changed-record errors.
- **Inbound marker amplification is bounded before resolution** (#113) — 64 declarations per file, 10,000 per batch, in deterministic code-unit path plus source order, collapsing into one advisory finding. PR-authored markers still gain no exit-code authority.
- **`adr queue` no longer stays silent on a reviewed record with no routing tier** (#111). The spec's carve-out is two-conditioned; only the first condition was implemented, so a `cross-team` record with `reviewBy` and no `review` block was listed with `tier=None` and no finding at all. Severity stays `info`, so no exit code changes.

### Two changelog corrections, not a mechanical rename

The trusted-gates trio was authored under `### Added` in #179, but #177 later inserted a `### Fixed` heading above it and silently swallowed all three entries into the wrong section. They are restored to `### Added`, and `### Fixed` now follows `### Changed` as in every prior release section.

The `docs/repository-trust-operations.md` entry claimed those controls "cannot be applied until this lands." That stopped being true when #180 recorded the deployed state, so the entry now says what is actually deployed. Every other entry is carried across verbatim, with no duplicates and no upgraded evidence-rung wording.

## Versions

| Surface | Before | After |
|---|---|---|
| root, `@adrkit/core`, `@adrkit/evaluator`, `@adrkit/cli`, `@adrkit/mcp` | 0.11.0 | **0.12.0** |
| `CLI_VERSION`, `SERVER_INFO`, both `packages/mcp/server.json` fields | 0.11.0 | **0.12.0** |
| `bun.lock` (four workspace `version` lines) | 0.11.0 | **0.12.0** |
| `@adrkit/spec-kit` | 0.1.3 | **0.1.3 — unchanged** |
| agent plugin (`packages/adapters/agent-plugin`) | 0.2.0 | **0.2.0 — unchanged** |

Both adapters are independently versioned under [ADR-0007](https://github.com/mbeacom/adrkit/blob/main/docs/adr/0007-adapter-isolation-and-public-surface-build.md) and deliberately do **not** move with the repository release.

`bun.lock`'s diff is exactly the four workspace `version` lines, edited directly rather than by regenerating the lockfile, so no transitive drift rides along in the release commit. The version-narrative sweep covers `AGENTS.md`, `docs/RELEASING.md`, the bug-report template placeholder, and all five site surfaces including the deliberately pinned `@adrkit/cli@0.12.0` badges recipe.

## Validation evidence

Every command below was run against this branch.

| Check | Result |
|---|---|
| `bun install --frozen-lockfile` | clean, no lockfile drift |
| `bun test` | **2790 pass, 1 skip, 0 fail** (194 files, 37526 assertions) |
| `bun run typecheck` / `bun run lint` | pass |
| `bun run adr lint` | 35 records, 0 errors, 0 warnings |
| `actionlint` | clean across all 7 workflows |
| `check:deps`, `check:freeze-hashes`, `check:doc-pins`, `check:clause8`, `check:no-spike-heuristics`, `check:site-grammar`, `check:changelog`, `check:clean-clone`, `check:dco` | all pass |
| `schema:emit` + `git diff --exit-code schema/adr.schema.json` | clean |
| `emit:manifest` + `git diff --exit-code MANIFEST.md` | clean — already matched the corpus (35 records) |
| `git diff --exit-code packages/ci/dist` | clean |
| Action bundles vs canonical **Linux Bun 1.3.14** rebuild | `index.js` and `queue-action.js` **byte-identical** |
| `bun run release:pack -- --tag v0.12.0` | 5 artifacts: core/evaluator/cli/mcp at 0.12.0 + spec-kit at 0.1.3 |
| Installed-tarball smoke, **Node 22.22.2** | pass |
| Installed-tarball smoke, **Node 24.16.0** | pass |
| `bun run release:publish -- --dry-run` | exit 0; `@adrkit/spec-kit@0.1.3 already matches; skipping` |
| spec-kit registry vs packed shasum | `bb9eb41076dba85c8c1dc6f86fa293a6d0a2e14c` on both sides — the real run will skip it |
| `npm audit` over `.release/smoke` (all 5 packed artifacts) | **0 vulnerabilities**, reconciled against an empty `KNOWN_CONSUMER_ADVISORY_ACCEPTANCES` |
| `bun run audit:gate` (workspace scope) | pass — 0 high, 0 critical |
| OCI `--target adrkit` and `--target mcp` build | both succeeded |
| `scripts/smoke-container.mjs` on the MCP image | served **both** MCP protocol eras |
| All-in-one selectors `cli` / `adr` / `adrkit` | all report `0.12.0`; `ci` and `queue-action` resolve; `adr lint` and `adr queue --format json` run read-only and networkless against a `:ro` mount |

Two notes worth carrying into the next cutover, both already-documented hazards that fired here:

- `release:pack` runs a **non-frozen** `bun install` and rebuilds, and local Bun 1.4.0 rewrites unrelated runtime helpers throughout both committed Action bundles. They were restored to the canonical Bun 1.3.14 output and re-verified byte-identical. `@adrkit/ci` is private and absent from the release manifest, so the packed tarballs are unaffected.
- The #104 dry-run failure on the adapter is **gone** — the `release-publish` change that shipped in v0.11.0 makes the dry run skip registry-identical artifacts, and it did so here.

## Not done yet — deliberately

This PR prepares the release and nothing more. **No** `v0.12.0` tag has been created or pushed, **no** npm package has been published, the moving `v0` Action tag has **not** moved, and **nothing** has been pushed to GHCR. Those happen only after this merges, via the normal protected `Release` workflow and its downstream `Publish container` run, followed by the manual MCP registry re-publish — `docs/RELEASING.md`, "Subsequent releases" steps 6 through 10.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
