### PR TITLE
fix: deterministic ordering on affects surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+### Fixed
+
+- **Completed locale-independent ordering for `check --json` and the
+  governing-decisions Action.** The final three `affects/**` sorts now compare
+  record ids, fired matcher `(type, pattern)` tuples, and changed dependency
+  `(name, version)` tuples by UTF-16 code unit. Identical inputs therefore
+  produce the same serialized order across ICU locales. Consumers golden-diffing
+  output may see one intentional reordering for mixed-case ULIDs or
+  case-sensitive matcher and dependency values. The committed Action bundle was
+  rebuilt with the same behavior
+  ([#115](https://github.com/mbeacom/adrkit/issues/115)).
+
 ## [0.12.0] - 2026-08-27
 
 ### Added

--- a/packages/catalog-envelope/test/no-core-schema-change.test.ts
+++ b/packages/catalog-envelope/test/no-core-schema-change.test.ts
@@ -17,10 +17,12 @@
  * `ownershipState` field, which is a different route to the same forbidden
  * outcome.
  *
- * So this pins a **specific observed value** per file — the SHA-256 of its bytes
- * at `99ba8d2500eaf37625ea164f66b4a17870e40dad`, the commit Phase C branched
+ * So this pins a **specific observed value** per file — initially the SHA-256 of
+ * its bytes at `99ba8d2500eaf37625ea164f66b4a17870e40dad`, the commit Phase C branched
  * from — plus the exact file list under `affects/`, so that adding or removing a
- * file is caught too.
+ * file is caught too. The separately authorized #115 comparator migration
+ * re-pinned only `affects/index.ts` and `affects/matchers/package.ts`; neither
+ * matcher semantics nor the protected type and schema shapes changed.
  *
  * ## Why the pin table lives in a JSON sidecar
  *
@@ -47,7 +49,8 @@
  * A failure means a protected surface changed. Under this feature that is a
  * **violation**, not a stale pin — FR-004 is unconditional, and updating the pin
  * to match would be amending the expectation to fit the output. A legitimate
- * change to these files belongs to separately-authorized later work.
+ * change to these files belongs to separately-authorized later work, which must
+ * explain and narrowly re-baseline the affected pins as #115 does.
  *
  * Observed failing before being relied on, in two ways:
  * `specs/010-catalog-backstage/evidence/negative-cases/consumer-core-surface-pin/`.

--- a/packages/catalog-envelope/test/protected-surfaces.json
+++ b/packages/catalog-envelope/test/protected-surfaces.json
@@ -1,5 +1,5 @@
 {
-  "//": "Pin table for `test/no-core-schema-change.test.ts` (T026, spec.md FR-004/FR-005). Digests read at 99ba8d2500eaf37625ea164f66b4a17870e40dad in this worktree. See that file's header for why these live in data rather than in the test source.",
+  "//": "Pin table for `test/no-core-schema-change.test.ts` (T026, spec.md FR-004/FR-005). Initial digests were read at 99ba8d2500eaf37625ea164f66b4a17870e40dad; #115 re-pinned only the two comparator-migration files. See that file's header for why these live in data rather than in the test source.",
   "protectedFiles": [
     {
       "path": "packages/core/src/affects/catalog.ts",
@@ -8,7 +8,7 @@
     },
     {
       "path": "packages/core/src/affects/index.ts",
-      "sha256": "bc347e49280412413a005c5f96aec1943f838213c1fc9c7df6b86bdfadc7b66c",
+      "sha256": "dec53795d47490d67451f5bff8130f613c7944e9bf3f96a41e0e2d62eeefe0c1",
       "why": "the affects resolution entry point — FR-004's matcher semantics"
     },
     {
@@ -18,7 +18,7 @@
     },
     {
       "path": "packages/core/src/affects/matchers/package.ts",
-      "sha256": "262dee9be89be0d13b843a61d48d6bc5b028cef0adb9d1ac65ba69ba38f0753a",
+      "sha256": "299f29d535f4052262c740785ebc64421ee605596efe82dd6168015c8bde7fde",
       "why": "package matcher — FR-004's matcher semantics"
     },
     {

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -47962,7 +47962,7 @@ function deriveChangedDependenciesFromBunLockDiff(diff) {
   return [...changedNames].flatMap((name) => {
     const versions2 = new Set([...added.get(name) ?? [], ...removed.get(name) ?? []]);
     return [...versions2].map((version2) => ({ name, version: version2 }));
-  }).sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
+  }).sort((a, b) => compareCodeUnits(a.name, b.name) || compareCodeUnits(a.version, b.version));
 }
 
 // ../core/src/affects/matchers/path.ts
@@ -47996,7 +47996,7 @@ function matchPathPattern(pattern, changedFiles) {
 
 // ../core/src/affects/index.ts
 function compareFiredMatcher(a, b) {
-  return a.type.localeCompare(b.type) || a.pattern.localeCompare(b.pattern);
+  return compareCodeUnits(a.type, b.type) || compareCodeUnits(a.pattern, b.pattern);
 }
 function uniqueSortedFiredMatchers(matchers) {
   const byKey = new Map;
@@ -48106,7 +48106,7 @@ function resolveAffects(input) {
     }
   }
   return {
-    matches: matches.sort((a, b) => a.recordId.localeCompare(b.recordId)),
+    matches: matches.sort((a, b) => compareCodeUnits(a.recordId, b.recordId)),
     findings: sortFindings(findings)
   };
 }

--- a/packages/core/src/affects/index.ts
+++ b/packages/core/src/affects/index.ts
@@ -1,4 +1,5 @@
 import type { Adr } from '../schema/adr.schema.ts';
+import { compareCodeUnits } from '../ordering/index.ts';
 import { sortFindings, type Finding, type FindingSeverity } from '../validate/findings.ts';
 import type { CatalogSnapshot } from './catalog.ts';
 import { isAlwaysInertType, matchEntityPattern } from './inert.ts';
@@ -59,7 +60,7 @@ interface MatcherEvaluation {
 }
 
 function compareFiredMatcher(a: FiredMatcher, b: FiredMatcher): number {
-  return a.type.localeCompare(b.type) || a.pattern.localeCompare(b.pattern);
+  return compareCodeUnits(a.type, b.type) || compareCodeUnits(a.pattern, b.pattern);
 }
 
 function uniqueSortedFiredMatchers(matchers: readonly FiredMatcher[]): FiredMatcher[] {
@@ -234,7 +235,7 @@ export function resolveAffects(input: ResolveAffectsInput): ResolveAffectsResult
   }
 
   return {
-    matches: matches.sort((a, b) => a.recordId.localeCompare(b.recordId)),
+    matches: matches.sort((a, b) => compareCodeUnits(a.recordId, b.recordId)),
     findings: sortFindings(findings),
   };
 }

--- a/packages/core/src/affects/matchers/package.ts
+++ b/packages/core/src/affects/matchers/package.ts
@@ -1,4 +1,5 @@
 import semver from 'semver';
+import { compareCodeUnits } from '../../ordering/index.ts';
 
 export interface ChangedDependency {
   name: string;
@@ -98,5 +99,7 @@ export function deriveChangedDependenciesFromBunLockDiff(diff: string): ChangedD
       const versions = new Set([...(added.get(name) ?? []), ...(removed.get(name) ?? [])]);
       return [...versions].map((version) => ({ name, version }));
     })
-    .sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
+    .sort(
+      (a, b) => compareCodeUnits(a.name, b.name) || compareCodeUnits(a.version, b.version),
+    );
 }

--- a/packages/core/test/ordering-contract.test.ts
+++ b/packages/core/test/ordering-contract.test.ts
@@ -8,30 +8,13 @@
  *
  * The expected orderings below are derived from the comparator's definition —
  * `a < b ? -1 : a > b ? 1 : 0` over UTF-16 code units.
- *
- * ## What this file deliberately does not scan
- *
- * `packages/core/src/affects/**` still contains three `localeCompare` sorts
- * that reach `CheckOutcome` (`compareFiredMatcher`, the match `recordId` sort,
- * and the changed-dependency sort in `matchers/package.ts`). That tree is
- * pinned byte-identical by feature 010's FR-004 guard
- * (`packages/catalog-envelope/test/no-core-schema-change.test.ts`), which names
- * any change there a violation and routes legitimate changes to
- * separately-authorized later work. Those sites stay recorded on #115 until the
- * freeze lifts; scanning them here would only force one guard to break another.
- *
- * That exclusion is load-bearing for how this suite's name should be read:
- * `affects/index.ts`'s `matches.sort((a, b) => a.recordId.localeCompare(...))`
- * is a *total* re-sort of the resolver's output, so for distinct record ids it
- * is the frozen sort — not any scanned module — that fixes `governedBy` order.
- * A clean run of this file therefore means "no scanned module reaches for
- * `localeCompare`", not "`check --json` is locale-independent end to end".
- * The second claim is only true once #115's `affects/**` remainder lands.
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import * as ts from 'typescript';
+import { deriveChangedDependenciesFromBunLockDiff } from '../src/affects/index.ts';
 import { checkChanges, type CheckLintResult } from '../src/check/index.ts';
 import {
   discoverAdrFiles,
@@ -39,6 +22,7 @@ import {
   expandRecordInputs,
 } from '../src/load/corpus.ts';
 import { compareCodeUnits } from '../src/ordering/index.ts';
+import { AdrFrontmatter, type Adr } from '../src/schema/adr.schema.ts';
 import { lintCorpus } from '../src/validate/index.ts';
 import { sortFindings, type Finding } from '../src/validate/findings.ts';
 import { cleanupTestDir, recordMarkdown, resetTestDir, writeText } from './helpers.ts';
@@ -48,6 +32,29 @@ const emptyLint = (findings: Finding[] = []): CheckLintResult => ({ records: [],
 /** The #115 repro set: names a locale-aware comparison interleaves differently. */
 const HOSTILE_FILES = ['src/a_b.ts', 'src/a-b.ts', 'src/a.ts', 'src/A.ts', 'src/ab.ts', 'src/aB.ts'];
 const CODE_UNIT_ORDER = ['src/A.ts', 'src/a-b.ts', 'src/a.ts', 'src/aB.ts', 'src/a_b.ts', 'src/ab.ts'];
+const UPPER_ULID = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+const LOWER_ULID = '01arz3ndektsv4rrffq69g5fav';
+
+function affectsRecord(id: string, affects: Record<string, unknown>[]): Adr {
+  return {
+    frontmatter: AdrFrontmatter.parse({
+      schemaVersion: '0.1.0',
+      id,
+      title: `Ordering record ${id}`,
+      status: 'draft',
+      date: '2026-08-27',
+      deciders: [],
+      tags: [],
+      scope: 'component',
+      reversibility: 'unknown',
+      blastRadius: 'component',
+      affects,
+      provenance: { authoredBy: 'human' },
+    }),
+    body: '',
+    path: `docs/adr/${id}-ordering.md`,
+  };
+}
 
 describe('checkChanges orders changedFiles by code unit, not by locale', () => {
   test('the #115 repro set comes back in code-unit order', () => {
@@ -72,6 +79,68 @@ describe('checkChanges orders changedFiles by code unit, not by locale', () => {
   });
 });
 
+describe('affects output orders every serialized tuple by code unit', () => {
+  const HOSTILE_AFFECTS = [
+    { type: 'path', pattern: 'src/**' },
+    { type: 'package', pattern: 'a' },
+    { type: 'package', pattern: 'B' },
+  ];
+  const SNAPSHOTS = {
+    changedDependencies: [
+      { name: 'a', version: '1.0.0' },
+      { name: 'B', version: '1.0.0' },
+    ],
+  };
+
+  test('checkChanges is byte-identical across record input orders', () => {
+    const upper = affectsRecord(UPPER_ULID, HOSTILE_AFFECTS);
+    const lower = affectsRecord(LOWER_ULID, HOSTILE_AFFECTS);
+    const outcomes = [
+      checkChanges({
+        lint: { records: [lower, upper], findings: [], checked: 2 },
+        changedFiles: ['src/app.ts', 'bun.lock'],
+        snapshots: SNAPSHOTS,
+      }),
+      checkChanges({
+        lint: { records: [upper, lower], findings: [], checked: 2 },
+        changedFiles: ['bun.lock', 'src/app.ts'],
+        snapshots: SNAPSHOTS,
+      }),
+    ];
+
+    expect(JSON.stringify(outcomes[0])).toBe(JSON.stringify(outcomes[1]));
+    expect(outcomes[0]?.governedBy.map((decision) => decision.recordId)).toEqual([
+      UPPER_ULID,
+      LOWER_ULID,
+    ]);
+    for (const decision of outcomes[0]?.governedBy ?? []) {
+      expect(decision.firedMatchers).toEqual([
+        { type: 'package', pattern: 'B' },
+        { type: 'package', pattern: 'a' },
+        { type: 'path', pattern: 'src/**' },
+      ]);
+    }
+  });
+
+  test('lockfile dependencies order names and versions by code unit', () => {
+    const diff = [
+      'diff --git a/bun.lock b/bun.lock',
+      '@@',
+      '+    "a": ["a@1.0.0", "", {}, "sha512-a"],',
+      '+    "B": ["B@1.0.0", "", {}, "sha512-b"],',
+      '-    "pkg": ["pkg@1.0.0-a", "", {}, "sha512-old"],',
+      '+    "pkg": ["pkg@1.0.0-B", "", {}, "sha512-new"],',
+    ].join('\n');
+
+    expect(deriveChangedDependenciesFromBunLockDiff(diff)).toEqual([
+      { name: 'B', version: '1.0.0' },
+      { name: 'a', version: '1.0.0' },
+      { name: 'pkg', version: '1.0.0-B' },
+      { name: 'pkg', version: '1.0.0-a' },
+    ]);
+  });
+});
+
 describe('sortFindings orders every tuple field by code unit', () => {
   const finding = (rule: string, message = 'm'): Finding => ({ rule, severity: 'warn', message });
 
@@ -93,16 +162,14 @@ describe('sortFindings orders every tuple field by code unit', () => {
 });
 
 describe('no scanned module on a serialized-output path reaches for localeCompare', () => {
-  // The same source-scan shape as the adapter's
-  // `test/glob-order.test.ts` guard, widened to every core module that feeds
-  // `CheckOutcome`: `check/`, `load/`, `markers/`, `ordering/`, and `validate/`.
+  // The same source-scan shape as the adapter's `test/glob-order.test.ts` guard,
+  // widened to every core module that feeds `CheckOutcome`.
   // `queue/` is scanned for the same reason on its own contract rather than on
   // `CheckOutcome`'s: QueueReport v1 promises byte-for-byte identical output for
   // identical inputs (007-arb-queue SC-001), which a locale-dependent sort would
   // break as a difference between machines.
   //
-  // `graph/` is deliberately NOT scanned, for the same shape of reason as
-  // `affects/` and with the same honesty about what a clean run therefore means.
+  // `graph/` is deliberately NOT scanned.
   // `buildAdrGraph` still orders nodes and edges with `localeCompare`, and
   // ADR-0033 clause 8 pins that: "The graph JSON shape remains exactly
   // `{ nodes, edges }`, with existing node and edge fields, **historical locale
@@ -115,9 +182,9 @@ describe('no scanned module on a serialized-output path reaches for localeCompar
   // These are scanned as whole directories rather than as a file allowlist, so a
   // new module added to any of them is covered the day it lands — an allowlist
   // silently exempts new files, which is how `validate/index.ts` stayed unscanned
-  // while `validate/findings.ts` was named individually. See the header for why
-  // `affects/` is excluded.
+  // while `validate/findings.ts` was named individually.
   const SCANNED_DIRS = [
+    'src/affects',
     'src/check',
     'src/load',
     'src/markers',
@@ -142,10 +209,31 @@ describe('no scanned module on a serialized-output path reaches for localeCompar
 
   const scanned = SCANNED_DIRS.flatMap(tsFilesUnder);
 
+  function executableLocaleCompareUses(source: string, file: string): string[] {
+    const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+    const uses: string[] = [];
+    const visit = (node: ts.Node): void => {
+      const isIdentifier = ts.isIdentifier(node) && node.text === 'localeCompare';
+      const isComputedProperty =
+        ts.isElementAccessExpression(node) &&
+        ts.isStringLiteralLike(node.argumentExpression) &&
+        node.argumentExpression.text === 'localeCompare';
+      if (isIdentifier || isComputedProperty) {
+        const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+        uses.push(`${file}:${line + 1}:${character + 1}`);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    return uses;
+  }
+
   test('the scan examined a non-trivial module list', () => {
     // Report what was examined, not only what was concluded (ADR-0016 clause 3):
     // an empty walk would make the per-file assertions below vacuous.
     expect(scanned.length).toBeGreaterThanOrEqual(8);
+    expect(scanned).toContain('src/affects/index.ts');
+    expect(scanned).toContain('src/affects/matchers/package.ts');
     expect(scanned).toContain('src/check/index.ts');
     expect(scanned).toContain('src/load/corpus.ts');
     expect(scanned).toContain('src/markers/resolve.ts');
@@ -156,11 +244,22 @@ describe('no scanned module on a serialized-output path reaches for localeCompar
     expect(scanned).toContain('src/validate/index.ts');
   });
 
+  test('the scan ignores comments and strings but catches code after comment-like literals', () => {
+    const source = [
+      '// localeCompare in documentation is not executable',
+      'const prose = "localeCompare";',
+      'const url = "https://example"; values.sort((a, b) => a.localeCompare(b));',
+    ].join('\n');
+
+    const uses = executableLocaleCompareUses(source, 'fixture.ts');
+    expect(uses).toHaveLength(1);
+    expect(uses[0]).toMatch(/^fixture\.ts:3:\d+$/);
+  });
+
   for (const file of scanned) {
     test(`${file} sorts with compareCodeUnits only`, () => {
       const source = readFileSync(join(import.meta.dir, '..', file), 'utf8');
-      const code = source.replace(/\/\*[\s\S]*?\*\//gu, '').replace(/\/\/[^\n]*/gu, '');
-      expect(code).not.toContain('localeCompare');
+      expect(executableLocaleCompareUses(source, file)).toEqual([]);
     });
   }
 });


### PR DESCRIPTION
## What and why

`CheckOutcome` promises byte-stable output for identical inputs, but the final three `packages/core/src/affects/**` sorts still depended on runtime ICU collation. Valid mixed-case ULID ids and case-sensitive matcher or dependency values could therefore reorder `adr check --json` and the governing-decisions Action across environments.

This completes the #115 migration by using the canonical `compareCodeUnits` comparator for record ids, fired matcher tuples, and changed dependency tuples. It also expands the syntax-aware ordering guard to `affects/**`, records the observable ordering change, narrowly refreshes the two authorized freeze pins, and rebuilds the committed Action bundle under linux/amd64 Bun 1.3.14.

Closes #115

## Checklist

- [x] Commits are **DCO signed off** (`git commit -s`). No CLA is required. This is
      enforced by the `dco` check; to sign commits you already made, see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-is-required).
- [x] If this changes a recorded decision in `docs/adr/`, an ADR is **added or
      supersedes** the affected record — with the argument, not just a status flip.
- [x] If the schema changed, I edited the Zod source
      `packages/core/src/schema/adr.schema.ts` (not the root re-export), re-ran
      `bun run schema:emit`, and committed the generated `schema/adr.schema.json`.
- [x] If `packages/ci/src` **or** `@adrkit/core` changed, I regenerated
      `packages/ci/dist` under **linux/amd64 bun 1.3.14** and committed it
      (see CONTRIBUTING.md — a Mac-built bundle fails the diff gate).
- [x] New or changed behavior is covered by tests, and each test was **observed
      failing before it passed** — a check that never failed is not coverage
      ([ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).
- [ ] `bun run typecheck && bun run build && bun test && bun run lint` pass from a
      clean clone with no credentials configured
      ([ADR-0007](docs/adr/0007-adapter-isolation-and-public-surface-build.md)).

## Notes for reviewers

The complete clean-clone matrix is left to CI because a local macOS root build would rewrite the committed Action bundle with host-specific Bun output. Targeted and full core tests, affected CI and freeze guards, type checking, and changelog validation pass locally.

Because this changes `packages/ci/dist/index.js`, the final PR head and base require the `gate-change-acknowledged` label and trusted `gate-integrity` context under ADR-0035.