### PR TITLE
feat(markers): warn on stale source declarations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,11 @@ Two properties are load-bearing and easy to break:
   first 10,000 in code-unit path then source order after concurrent reads finish.
   Exact overflow is collapsed into one advisory report/finding, never one object
   per dropped declaration, and never gains exit-code authority.
+- **A marker naming history stays historical and gets an advisory warning.**
+  `superseded`, `rejected`, and `deprecated` declarations emit `stale-marker`;
+  a resolvable supersession chain names its terminal live successor, but the
+  resolver never silently substitutes that record. The original declaration
+  remains under `history`, and the warning never changes an exit code.
 - **A marker must not be able to lie.** The scanner requires the comment
   introducer to begin the physical line with `@adr` as the comment's first
   content, so prose discussing a decision, a string literal containing one, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ Until `1.0.0`, minor releases may include breaking changes
   container
   ([ADR-0036](docs/adr/0036-expose-the-governing-decisions-action-through-one-root-marketplace-entry-point.md)).
 
+- **Advisory stale-marker diagnostics.** An inbound `@adr` declaration that
+  names a superseded, rejected, or deprecated record now emits a
+  `stale-marker` warning in `adr explain`, `adr check`, and the
+  governing-decisions Action. Superseded chains resolve to their terminal live
+  successor when one exists, but adrkit never substitutes that successor or
+  changes marker-derived exit-code behavior. The warning remains advisory under
+  ADR-0022 ([#116](https://github.com/mbeacom/adrkit/issues/116)).
+
 ### Fixed
 
 - **Completed locale-independent ordering for `check --json` and the

--- a/README.md
+++ b/README.md
@@ -313,7 +313,8 @@ answer where the next decision is actually being made.
   on the PRs that touch or explicitly declare them; pattern matches render as `via`
   and PR-authored marker claims as `declared by`. The comment also distinguishes
   marker files it could not inspect, marker declarations omitted at a safety cap,
-  and claims it read but could not bind. All are advisory: they never fail the job.
+  claims it read but could not bind, and stale claims naming historical records.
+  All are advisory: they never fail the job.
   It runs with only the default
   `GITHUB_TOKEN` and degrades (never fails the job) on a read-only fork token.
 - **MCP server** — let agents retrieve prior decisions, including the rejected

--- a/packages/ci/dist/index.js
+++ b/packages/ci/dist/index.js
@@ -48429,11 +48429,48 @@ function unresolvableFinding(marker) {
     pattern: marker.ref
   };
 }
+function terminalLiveSuccessor(record2, byId) {
+  let next = record2.frontmatter.supersededBy;
+  const seen = new Set([record2.frontmatter.id]);
+  while (next) {
+    if (seen.has(next))
+      return;
+    seen.add(next);
+    const successor = byId.get(next);
+    if (!successor)
+      return;
+    if (successor.frontmatter.status === "accepted")
+      return successor.frontmatter.id;
+    if (successor.frontmatter.status === "draft" || successor.frontmatter.status === "proposed") {
+      return successor.frontmatter.id;
+    }
+    if (successor.frontmatter.status !== "superseded")
+      return;
+    next = successor.frontmatter.supersededBy;
+  }
+  return;
+}
+function staleFinding(marker, record2, byId) {
+  const status = record2.frontmatter.status;
+  if (status !== "superseded" && status !== "rejected" && status !== "deprecated") {
+    return;
+  }
+  const successor = status === "superseded" ? terminalLiveSuccessor(record2, byId) : undefined;
+  const action = successor ? `update it to "@adr ${successor}" or re-affirm ${marker.id}` : `update the marker or re-affirm ${marker.id}`;
+  return {
+    rule: "stale-marker",
+    severity: "warn",
+    message: `Source marker "@adr ${marker.ref}" in ${marker.path}:${marker.line} names ${status} ADR ${marker.id}; ${action}`,
+    path: marker.path,
+    field: "marker",
+    pattern: marker.ref
+  };
+}
 function compareDeclarations(a, b) {
   return compareCodeUnits(a.path, b.path) || a.line - b.line || compareCodeUnits(a.ref, b.ref);
 }
 function resolveSourceMarkers(input) {
-  const ids = new Set(input.records.map((record2) => record2.frontmatter.id));
+  const byId = new Map(input.records.map((record2) => [record2.frontmatter.id, record2]));
   const byRecord = new Map;
   const findings = [];
   const seen = new Set;
@@ -48446,10 +48483,14 @@ function resolveSourceMarkers(input) {
       findings.push(unresolvableFinding(marker));
       continue;
     }
-    if (!ids.has(marker.id)) {
+    const record2 = byId.get(marker.id);
+    if (!record2) {
       findings.push(danglingFinding(marker));
       continue;
     }
+    const stale = staleFinding(marker, record2, byId);
+    if (stale)
+      findings.push(stale);
     const declarations = byRecord.get(marker.id) ?? [];
     declarations.push({ path: marker.path, line: marker.line, ref: marker.ref });
     byRecord.set(marker.id, declarations);
@@ -48751,9 +48792,9 @@ function markerClaimLines(outcome) {
     return [];
   const shown = claims.slice(0, MAX_MARKER_CLAIMS);
   const lines = [
-    "#### Marker claims not bound",
+    "#### Marker claims needing attention",
     "",
-    "Marker scanning was healthy for these changed files, but the claims did not bind to a record in this corpus:"
+    "Marker scanning was healthy for these changed files, but these claims need attention:"
   ];
   for (const finding of shown) {
     lines.push(`- ${code(finding.path ?? "(unknown)")} — ${code(boundedDetail(finding.message, MAX_FINDING_MESSAGE_CHARS, "message"))}`);

--- a/packages/ci/src/comment.ts
+++ b/packages/ci/src/comment.ts
@@ -153,9 +153,9 @@ function markerClaimLines(outcome: CheckOutcome): string[] {
 
   const shown = claims.slice(0, MAX_MARKER_CLAIMS);
   const lines = [
-    '#### Marker claims not bound',
+    '#### Marker claims needing attention',
     '',
-    'Marker scanning was healthy for these changed files, but the claims did not bind to a record in this corpus:',
+    'Marker scanning was healthy for these changed files, but these claims need attention:',
   ];
   for (const finding of shown) {
     lines.push(`- ${code(finding.path ?? '(unknown)')} — ${code(boundedDetail(finding.message, MAX_FINDING_MESSAGE_CHARS, 'message'))}`);

--- a/packages/ci/test/action.test.ts
+++ b/packages/ci/test/action.test.ts
@@ -167,7 +167,7 @@ describe('runAction (end to end with a fake client)', () => {
     expect(result.failed).toBe(false);
     expect(result.outcome?.ok).toBe(true);
     expect(result.outcome?.findings.map((finding) => finding.rule)).toContain('dangling-marker');
-    expect(client.created[0]).toContain('#### Marker claims not bound');
+    expect(client.created[0]).toContain('#### Marker claims needing attention');
     expect(client.created[0]).toContain('@adr 9999');
   });
 

--- a/packages/ci/test/comment-render.test.ts
+++ b/packages/ci/test/comment-render.test.ts
@@ -126,7 +126,7 @@ describe('renderComment', () => {
 
     const body = renderComment(outcome);
 
-    expect(body).toContain('#### Marker claims not bound');
+    expect(body).toContain('#### Marker claims needing attention');
     expect(body).toContain('src/owned.ts');
     expect(body).toContain('@adr 9999');
     expect(body).not.toContain('#### Marker scan health');
@@ -259,6 +259,23 @@ describe('renderComment status awareness (#39)', () => {
     expect(body).toContain('#### Active proposals touching this change');
     expect(body).toContain('**0002** — Draft record _(draft)_');
     expect(body).toContain('#### Historical records that once covered this change');
+    expect(body).toContain('**0003** — Superseded record _(superseded)_ — superseded by **0001**');
+  });
+
+  test('a bound stale marker is reported as needing attention, not as unbound', async () => {
+    const root = await seedMixed();
+    const file = 'src/stale.ts';
+    await writeText(join(root, file), '// @adr 0003\n');
+    const lint = await lintCorpus({ cwd: root, dir: 'docs/adr' });
+    const markerScans = await readSourceMarkersBatch([file], root);
+    const outcome = checkChanges({ lint, changedFiles: [file], dir: 'docs/adr', markerScans });
+
+    const body = renderComment(outcome);
+
+    expect(outcome.ok).toBe(true);
+    expect(body).toContain('#### Marker claims needing attention');
+    expect(body).not.toContain('Marker claims not bound');
+    expect(body).toContain('names superseded ADR 0003; update it to "@adr 0001" or re-affirm 0003');
     expect(body).toContain('**0003** — Superseded record _(superseded)_ — superseded by **0001**');
   });
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -140,6 +140,12 @@ Marker scanning is intentionally narrow:
 
 Nothing is written back to the record.
 
+A marker that names a superseded, rejected, or deprecated record still resolves
+to that historical record and emits an advisory `stale-marker` warning. For a
+superseded chain, the warning names the terminal live successor when one can be
+resolved; adrkit never silently substitutes it. The warning does not affect the
+exit code.
+
 In `--json`, pattern matches appear in `firedMatchers` and file declarations in
 `declaredBy`. `explain --json` includes a single-file `markers` block plus
 `scannedBytes`, `fileBytes`, and exact retained/omitted declaration counts.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -237,7 +237,9 @@ that matches it ("via path: src/**"), or the file itself declares the record in 
 comment ("declared by src/sync.ts:3 (@adr 0012)"). If <path> exists, at most its first
 8192 bytes are scanned for dedicated "@adr <id>" comment lines -- the scan stops at the
 last complete line inside that bound, and --json reports the extent it reached. A marker
-naming a record the corpus does not have is reported as a dangling-marker warning.
+naming a record the corpus does not have is reported as a dangling-marker warning. A
+marker naming a superseded, rejected, or deprecated record is reported as a stale-marker
+warning; a resolvable supersession chain names its terminal live successor.
 
 Arguments:
   <path>          Repo-relative path to explain

--- a/packages/cli/test/check.test.ts
+++ b/packages/cli/test/check.test.ts
@@ -143,6 +143,29 @@ describe('adr check CLI', () => {
     expect(result.stdout).toContain('marker scan: 1 scanned, 0 absent');
   });
 
+  test('a stale marker stays advisory in human and JSON output', async () => {
+    const root = await seedCorpus();
+    const dir = join(root, 'docs/adr');
+    await writeText(
+      join(dir, '0002-cli.md'),
+      supersededRecordMarkdown('0002', '0003', 'Use the old CLI paths'),
+    );
+    await writeText(join(dir, '0003-current.md'), acceptedRecordMarkdown('0003', 'Use current CLI paths'));
+    await writeText(join(root, 'src/owned.ts'), '// @adr 0002\n');
+
+    const human = await runAdr(['check', 'src/owned.ts', '--dir', 'docs/adr'], root);
+    const json = await runAdr(['check', 'src/owned.ts', '--dir', 'docs/adr', '--json'], root);
+    const outcome = JSON.parse(json.stdout);
+
+    expect(human.exitCode).toBe(0);
+    expect(json.exitCode).toBe(0);
+    expect(human.stdout).toContain('warn stale-marker');
+    expect(human.stdout).toContain('update it to "@adr 0003" or re-affirm 0002');
+    expect(outcome.history.map((decision: { recordId: string }) => decision.recordId)).toEqual(['0002']);
+    expect(outcome.findings.map((finding: { rule: string }) => finding.rule)).toContain('stale-marker');
+    expect(outcome.ok).toBe(true);
+  });
+
   test('--json distinguishes an absent changed path from a scanned file with no markers', async () => {
     const root = await seedCorpus();
 

--- a/packages/cli/test/explain-markers.test.ts
+++ b/packages/cli/test/explain-markers.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { join, resolve } from 'node:path';
-import { acceptedRecordMarkdown, cleanupTestDir, resetTestDir, writeText } from '../../core/test/helpers.ts';
+import {
+  acceptedRecordMarkdown,
+  cleanupTestDir,
+  resetTestDir,
+  supersededRecordMarkdown,
+  writeText,
+} from '../../core/test/helpers.ts';
 
 const CLI_PATH = resolve(process.cwd(), 'packages/cli/src/index.ts');
 const DIR_NAME = 'cli-explain-markers';
@@ -119,6 +125,33 @@ describe('adr explain — inbound @adr markers', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('warn dangling-marker');
     expect(result.stdout).toContain('Source marker "@adr 0099" in src/sync/retry.ts:1');
+  });
+
+  test('a superseded marker reports its terminal successor without becoming blocking', async () => {
+    const root = await resetTestDir(DIR_NAME);
+    const dir = join(root, 'docs/adr');
+    await writeText(
+      join(dir, '0001-old.md'),
+      supersededRecordMarkdown('0001', '0002', 'Use the old protocol'),
+    );
+    await writeText(
+      join(dir, '0002-middle.md'),
+      supersededRecordMarkdown('0002', '0003', 'Use the middle protocol'),
+    );
+    await writeText(
+      join(dir, '0003-current.md'),
+      acceptedRecordMarkdown('0003', 'Use the current protocol'),
+    );
+    await writeText(join(root, 'src/sync/retry.ts'), '// @adr 0001\n');
+
+    const result = await runAdr(['explain', 'src/sync/retry.ts', '--dir', 'docs/adr'], root);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('0001  [superseded] Use the old protocol (superseded by 0002)');
+    expect(result.stdout).toContain('warn stale-marker');
+    expect(result.stdout).toContain(
+      'names superseded ADR 0001; update it to "@adr 0003" or re-affirm 0001',
+    );
   });
 
   test('reports exact per-file declaration overflow without resolving omitted claims', async () => {

--- a/packages/core/src/markers/resolve.ts
+++ b/packages/core/src/markers/resolve.ts
@@ -64,13 +64,71 @@ function unresolvableFinding(marker: SourceMarker): Finding {
   };
 }
 
+function terminalLiveSuccessor(
+  record: Adr,
+  byId: ReadonlyMap<string, Adr>,
+): string | undefined {
+  let next = record.frontmatter.supersededBy;
+  const seen = new Set([record.frontmatter.id]);
+
+  while (next) {
+    if (seen.has(next)) return undefined;
+    seen.add(next);
+
+    const successor = byId.get(next);
+    if (!successor) return undefined;
+    if (successor.frontmatter.status === 'accepted') return successor.frontmatter.id;
+    if (
+      successor.frontmatter.status === 'draft' ||
+      successor.frontmatter.status === 'proposed'
+    ) {
+      return successor.frontmatter.id;
+    }
+    if (successor.frontmatter.status !== 'superseded') return undefined;
+    next = successor.frontmatter.supersededBy;
+  }
+
+  return undefined;
+}
+
+/**
+ * A source declaration naming history is a stronger stale claim than ordinary prose.
+ * It still binds to that historical record — no successor is silently substituted —
+ * but the warning gives the author an exact line and, when the chain resolves, the
+ * terminal live successor to consider. Advisory marker findings never affect an exit
+ * code (ADR-0022).
+ */
+function staleFinding(
+  marker: SourceMarker,
+  record: Adr,
+  byId: ReadonlyMap<string, Adr>,
+): Finding | undefined {
+  const status = record.frontmatter.status;
+  if (status !== 'superseded' && status !== 'rejected' && status !== 'deprecated') {
+    return undefined;
+  }
+
+  const successor = status === 'superseded' ? terminalLiveSuccessor(record, byId) : undefined;
+  const action = successor
+    ? `update it to "@adr ${successor}" or re-affirm ${marker.id}`
+    : `update the marker or re-affirm ${marker.id}`;
+  return {
+    rule: 'stale-marker',
+    severity: 'warn',
+    message: `Source marker "@adr ${marker.ref}" in ${marker.path}:${marker.line} names ${status} ADR ${marker.id}; ${action}`,
+    path: marker.path,
+    field: 'marker',
+    pattern: marker.ref,
+  };
+}
+
 function compareDeclarations(a: MarkerDeclaration, b: MarkerDeclaration): number {
   return compareCodeUnits(a.path, b.path) || a.line - b.line || compareCodeUnits(a.ref, b.ref);
 }
 
 /** Bind markers to the records they name, and report the ones that bind to nothing. */
 export function resolveSourceMarkers(input: ResolveSourceMarkersInput): ResolveSourceMarkersResult {
-  const ids = new Set(input.records.map((record) => record.frontmatter.id));
+  const byId = new Map(input.records.map((record) => [record.frontmatter.id, record]));
   const byRecord = new Map<string, MarkerDeclaration[]>();
   const findings: Finding[] = [];
   const seen = new Set<string>();
@@ -84,10 +142,14 @@ export function resolveSourceMarkers(input: ResolveSourceMarkersInput): ResolveS
       findings.push(unresolvableFinding(marker));
       continue;
     }
-    if (!ids.has(marker.id)) {
+    const record = byId.get(marker.id);
+    if (!record) {
       findings.push(danglingFinding(marker));
       continue;
     }
+
+    const stale = staleFinding(marker, record, byId);
+    if (stale) findings.push(stale);
 
     const declarations = byRecord.get(marker.id) ?? [];
     declarations.push({ path: marker.path, line: marker.line, ref: marker.ref });

--- a/packages/core/test/markers-resolve.test.ts
+++ b/packages/core/test/markers-resolve.test.ts
@@ -7,7 +7,11 @@ import {
 } from '../src/markers/index.ts';
 import { toGoverningDecisions } from '../src/check/index.ts';
 
-function record(id: string, status: Adr['frontmatter']['status'] = 'accepted'): Adr {
+function record(
+  id: string,
+  status: Adr['frontmatter']['status'] = 'accepted',
+  supersededBy?: string,
+): Adr {
   return {
     frontmatter: {
       schemaVersion: '0.1.0',
@@ -23,6 +27,7 @@ function record(id: string, status: Adr['frontmatter']['status'] = 'accepted'): 
       reversibility: 'unknown',
       blastRadius: 'component',
       supersedes: [],
+      ...(supersededBy ? { supersededBy } : {}),
       relatesTo: [],
       conflictsWith: [],
       affects: [],
@@ -83,6 +88,65 @@ describe('resolveSourceMarkers', () => {
     expect(result.findings.map((finding) => [finding.rule, finding.severity])).toEqual([
       ['marker-unresolvable', 'info'],
     ]);
+  });
+
+  test('historical markers warn without losing their matches, following supersession to the terminal successor', () => {
+    const result = resolveSourceMarkers({
+      records: [
+        record('0001', 'superseded', '0002'),
+        record('0002', 'superseded', '0003'),
+        record('0003'),
+        record('0004', 'rejected'),
+        record('0005', 'deprecated'),
+      ],
+      markers: [
+        marker('0005', 'src/deprecated.ts', 5),
+        marker('0001', 'src/superseded.ts', 3),
+        marker('0004', 'src/rejected.ts', 4),
+        marker('0001', 'src/superseded.ts', 3),
+      ],
+    });
+
+    expect(result.matches.map((match) => match.recordId)).toEqual(['0001', '0004', '0005']);
+    expect(result.findings).toEqual([
+      {
+        rule: 'stale-marker',
+        severity: 'warn',
+        message:
+          'Source marker "@adr 0001" in src/superseded.ts:3 names superseded ADR 0001; update it to "@adr 0003" or re-affirm 0001',
+        path: 'src/superseded.ts',
+        field: 'marker',
+        pattern: '0001',
+      },
+      {
+        rule: 'stale-marker',
+        severity: 'warn',
+        message:
+          'Source marker "@adr 0004" in src/rejected.ts:4 names rejected ADR 0004; update the marker or re-affirm 0004',
+        path: 'src/rejected.ts',
+        field: 'marker',
+        pattern: '0004',
+      },
+      {
+        rule: 'stale-marker',
+        severity: 'warn',
+        message:
+          'Source marker "@adr 0005" in src/deprecated.ts:5 names deprecated ADR 0005; update the marker or re-affirm 0005',
+        path: 'src/deprecated.ts',
+        field: 'marker',
+        pattern: '0005',
+      },
+    ]);
+  });
+
+  test('accepted and active-proposal markers do not warn', () => {
+    const result = resolveSourceMarkers({
+      records: [record('0001'), record('0002', 'draft'), record('0003', 'proposed')],
+      markers: [marker('0001'), marker('0002'), marker('0003')],
+    });
+
+    expect(result.matches.map((match) => match.recordId)).toEqual(['0001', '0002', '0003']);
+    expect(result.findings).toEqual([]);
   });
 
   test('groups every declaring file under one record, sorted and deduplicated', () => {

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -59,10 +59,11 @@ The comment reports marker results separately from governing decisions. **Marker
 scan health** lists changed files that could not be inspected (`absent`,
 `unreadable`, `out-of-tree`, or skipped at the scan cap), so an empty marker
 result is not mistaken for a healthy scan. It also reports declaration overflow
-after the 64-per-file or 10,000-per-batch safety limits. **Marker claims not
-bound** lists `@adr` claims that were read successfully but did not resolve in
-this corpus. Both sections are bounded and advisory: they never affect the
-Action's exit status, and changed-record validation errors retain priority if
+after the 64-per-file or 10,000-per-batch safety limits. **Marker claims needing
+attention** lists `@adr` claims that either did not resolve in this corpus or
+resolved to superseded, rejected, or deprecated records. Both sections are
+bounded and advisory: they never affect the Action's exit status, and
+changed-record validation errors retain priority if
 the comment reaches GitHub's size limit. Keep the default checkout rooted at
 `GITHUB_WORKSPACE`; if a workflow checks out elsewhere, marker health will
 identify files the Action could not inspect.

--- a/site/src/content/docs/commands.mdx
+++ b/site/src/content/docs/commands.mdx
@@ -249,7 +249,11 @@ export function syncOnce() { … }
 
 A marker naming a record the corpus does not have is a `dangling-marker`
 finding at `warn`. A log-qualified marker is `marker-unresolvable` at `info` —
-inert against this corpus, not broken. Neither changes the exit code.
+inert against this corpus, not broken. A marker naming a `superseded`,
+`rejected`, or `deprecated` record is a `stale-marker` warning. It still binds
+to that historical record, and a superseded chain names its terminal live
+successor when one can be resolved; adrkit never silently substitutes the
+successor. None of these marker findings changes the exit code.
 
 The `--json` output reports what was actually scanned, so an empty result never
 has to be guessed at:


### PR DESCRIPTION
## Summary

- emit advisory stale-marker findings for source declarations naming superseded, rejected, or deprecated ADRs
- keep the historical ADR bound while suggesting only a terminal live successor
- surface the same deterministic warning through explain, check, and the governing-decisions Action without changing exit behavior

This implements Part A of #116. The optional as-of evaluation remains separate.

## Verification

- bun install --frozen-lockfile (Bun 1.3.14)
- bun run typecheck
- bun test — 2,812 pass, 1 platform-specific skip, 0 fail
- bun run lint
- bun run build in a clean archived workspace

The local host is macOS arm64, so the Linux/amd64 Action-bundle byte match is intentionally delegated to clean-clone-builds in CI.

## Maintainer note

This touches packages/core and packages/ci. The trusted integrity gate will require the gate-change-acknowledged label after review of the gate surface.