### PR TITLE
release: prepare v0.13.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: adrkit version
       description: Output of `adr --version` (or the package version you installed).
-      placeholder: '0.12.0'
+      placeholder: '0.13.0'
     validations:
       required: true
   - type: dropdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,13 @@
 
 Decision memory for human- and agent-authored plans — machine-readable ADRs
 that are enforceable in CI and legible to agents, without leaving git.
-Status: early — phases 0–6 landed and v0.12.0 is public. `@adrkit/core`,
+Status: early — phases 0–6 landed and v0.13.0 is public. `@adrkit/core`,
 `@adrkit/evaluator`, `@adrkit/cli` (`lint`, `new`, `graph`, `explain`,
 `check`, `queue`, `migrate --from madr`, `evaluate`) are published on npm, as is
 the independently versioned `@adrkit/spec-kit` Spec Kit extension (0.1.3); the
 repository-backed CI Action is available at `mbeacom/adrkit/packages/ci@v0`.
 The governing-decisions Action also has a root `action.yml` alias for GitHub
-Marketplace beginning with the first compatible release after v0.12.0. Root
+Marketplace beginning with v0.13.0. Root
 Marketplace guidance uses immutable release tags; never advertise
 `mbeacom/adrkit@v0`, because recovery may move that shared tag to a pre-alias
 release. The queue Action remains nested because GitHub lists only root Action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,27 @@ Until `1.0.0`, minor releases may include breaking changes
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-08-30
+
 ### Added
+
+- **A repository-native, ADR-aware Copilot code-review skill.** The read-only
+  reviewer retrieves governing decisions through adrkit's MCP server, walks both
+  result and finding pagination channels, treats proposals as non-binding
+  context, and declines to hand-parse frontmatter when MCP is unavailable. It
+  reports only demonstrable, actionable defects and decision conflicts
+  ([#184](https://github.com/mbeacom/adrkit/pull/184)).
+
+- **A provisional authority boundary and coexistence recipe for generated
+  knowledge systems.** Proposed ADR-0037 keeps human-reviewed ADRs authoritative
+  while allowing generated documentation to consume them as read-only evidence.
+  The OpenWiki example builds the reviewed source revision from its frozen
+  dependency lock, confines generated output to non-executable Markdown and JSON,
+  and opens draft pull requests for lifecycle and relationship review. The
+  decision remains proposed until explicit human ratification and a public
+  end-to-end reference exercise
+  ([ADR-0037](docs/adr/0037-treat-generated-knowledge-systems-as-downstream-read-models-not-decision-authorities.md),
+  [#192](https://github.com/mbeacom/adrkit/pull/192)).
 
 - **A GitHub Actions Marketplace entry point for governing decisions.** The
   repository-root `action.yml` runs the existing committed Action bundle while
@@ -1344,7 +1364,8 @@ against live Spec Kit, rather than reasoning about it:
 - Node-targeted published distribution of all packages, smoke-tested under Node
   22 and 24.
 
-[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/mbeacom/adrkit/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/mbeacom/adrkit/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/mbeacom/adrkit/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/mbeacom/adrkit/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/mbeacom/adrkit/compare/v0.9.0...v0.10.0

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Actions remain the simpler interface:
 documented in [`docs/RELEASING.md`](docs/RELEASING.md#oci-container-image).
 
 The governing-decisions Action also has a repository-root entry point for its
-GitHub Marketplace listing. That root form begins with the first compatible
-release after `v0.12.0`; the existing `packages/ci` form remains supported.
+GitHub Marketplace listing. That root form is available beginning with
+`v0.13.0`; the existing `packages/ci` form remains supported.
 GitHub lists only root Action metadata, so the queue Action stays at its nested
 path.
 

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
     },
     "packages/cli": {
       "name": "@adrkit/cli",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "bin": {
         "adr": "./dist/index.js",
         "adrkit": "./dist/index.js",
@@ -70,7 +70,7 @@
     },
     "packages/core": {
       "name": "@adrkit/core",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "picomatch": "^4",
         "semver": "^7",
@@ -85,7 +85,7 @@
     },
     "packages/evaluator": {
       "name": "@adrkit/evaluator",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@adrkit/core": "workspace:*",
         "jsonpath-rfc9535": "1.3.0",
@@ -96,7 +96,7 @@
     },
     "packages/mcp": {
       "name": "@adrkit/mcp",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "bin": {
         "adrkit-mcp": "./dist/bin.js",
       },

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,9 +9,9 @@ Actions, one Marketplace entry point, and one lockstep OCI image:
 | `@adrkit/evaluator` | npm |
 | `@adrkit/cli` (`adr`, `adrkit`) | npm |
 | `@adrkit/mcp` (`adrkit-mcp`) | npm |
-| `action.yml` | GitHub Actions Marketplace and Git tag (governing-decisions alias; begins with the first compatible release after `v0.12.0`) |
-| `packages/ci/action.yml` | Git tag (existing governing-decisions subpath, latest immutable release `v0.12.0`, moving `v0`) |
-| `packages/ci/queue/action.yml` | Git tag (nested queue Action, latest immutable release `v0.12.0`, moving `v0`) |
+| `action.yml` | GitHub Actions Marketplace and Git tag (governing-decisions alias; available beginning with `v0.13.0`) |
+| `packages/ci/action.yml` | Git tag (existing governing-decisions subpath, latest immutable release `v0.13.0`, moving `v0`) |
+| `packages/ci/queue/action.yml` | Git tag (nested queue Action, latest immutable release `v0.13.0`, moving `v0`) |
 | `ghcr.io/mbeacom/adrkit` | GitHub Container Registry (`vX.Y.Z`, moving `vX`, `latest`; begins with the first release containing ADR-0032) |
 
 `@adrkit/ci` stays private because GitHub executes the committed Action bundle
@@ -23,7 +23,7 @@ Action intentionally remains nested. `scripts/marketplace-action-contract.test.t
 keeps the two governing-decisions metadata contracts identical except for their
 different bundle paths.
 
-The coordinated lockstep surface is published; the current release is `v0.12.0`. `@adrkit/core`,
+The coordinated lockstep surface is published; the current release is `v0.13.0`. `@adrkit/core`,
 `@adrkit/evaluator`, and `@adrkit/cli` use GitHub Actions Trusted Publishing.
 `@adrkit/mcp` was created with the isolated one-time bootstrap path below; its
 Trusted Publisher and token-restriction cleanup must be completed before the
@@ -127,7 +127,9 @@ it by hand is exactly the drift this arrangement avoids:
 ```sh
 (
   cd .release/smoke
-  npm install --no-audit --no-fund   # already installed by the step 2 smoke run
+  # release:pack installs the runtime smoke with Bun; materialize npm's genuine
+  # consumer tree and lock before asking npm to audit it.
+  npm install --ignore-scripts --no-audit --no-fund
   npm audit
 )
 ```

--- a/docs/adr/0037-treat-generated-knowledge-systems-as-downstream-read-models-not-decision-authorities.md
+++ b/docs/adr/0037-treat-generated-knowledge-systems-as-downstream-read-models-not-decision-authorities.md
@@ -101,17 +101,22 @@ human-reviewed decision corpus, not as decision authorities.
    connect decisions to its description of the current architecture. Its output
    is a projection and must link back to the source record when authority
    matters.
-3. **Lifecycle meanings remain distinct.** Integrations must preserve the
-   difference between governing (`accepted`), under-review (`draft` and
+3. **Lifecycle meanings remain distinct.** Projections must preserve the
+   difference between ratified (`accepted`), under-review (`draft` and
    `proposed`), and historical (`rejected`, `superseded`, and `deprecated`)
-   decisions. They must not map adrkit acceptance to a documentation format's
-   "stable" state, or machine verification to `provenance.ratifiedBy`, as though
-   those concepts were equivalent.
+   decisions. Acceptance alone does not make a record govern every target: a
+   record governs a path only when adrkit resolution reports it through a
+   matching `affects` declaration or an inbound `@adr` marker on that path. A
+   projection must preserve `scope`, `affects`, and marker provenance where the
+   consuming contract exposes them, and must not describe a record as governing
+   a target without that resolution. It also must not map adrkit acceptance to a
+   documentation format's "stable" state, or machine verification to
+   `provenance.ratifiedBy`, as though those concepts were equivalent.
 4. **Typed relationships must remain legible.** A projection may render ordinary
-   links, but it must label `supersedes`, `relatesTo`, and `conflictsWith` rather
-   than flattening them into one relationship. When a target format cannot
-   preserve a type structurally, the projection must disclose that loss and link
-   to the original record.
+   links, but it must label `supersedes`, its inverse `supersededBy`,
+   `relatesTo`, and `conflictsWith` rather than flattening them into one
+   relationship. When a target format cannot preserve a type structurally, the
+   projection must disclose that loss and link to the original record.
 5. **Evidence drift is advisory until evaluated.** A changed or missing source
    means the affected description or decision evidence needs review. It does not
    by itself prove that an accepted decision was violated or should change.
@@ -126,13 +131,15 @@ human-reviewed decision corpus, not as decision authorities.
    dependency, model credential, network call, or update failure may become a
    prerequisite for `@adrkit/core`, the CLI's deterministic commands, the MCP
    read path, or the governing-decisions Action.
-8. **Start with a public recipe, not a runtime adapter.** The first integration
-   is documentation showing how to run adrkit and OpenWiki side by side and how
-   to instruct OpenWiki to treat the ADR corpus as read-only normative evidence.
-   A documentation agent may read the source records directly under this
-   version-bounded guidance; that is evidence consumption, not a programmatic
-   parsing contract. Programmatic consumers remain bound to documented adrkit
-   CLI or SDK contracts.
+8. **Start with a public recipe, not a runtime adapter.** The first
+   interoperability step is documentation showing how to run adrkit and
+   OpenWiki side by side and how to instruct OpenWiki to treat the ADR corpus as
+   read-only normative evidence. This coexistence recipe is guidance, not an
+   adrkit integration package under ADR-0007. A documentation agent may read the
+   source records directly under this version-bounded guidance; that is evidence
+   consumption, not a programmatic parsing contract. Any programmatic
+   integration remains an optional, separately published adapter under ADR-0007
+   and must use documented adrkit CLI or SDK contracts.
    A package, bidirectional synchronization protocol, persistent claims mirror,
    or evaluator input requires a separate decision supported by observed
    consumer need.
@@ -216,8 +223,8 @@ when those capabilities could improve adrkit's presentation.
        qualifier until this record is ratified.
 2. [~] Draft a provisional generated-knowledge coexistence guide with an
        OpenWiki `INSTRUCTIONS.md` example.
-3. [~] Keep the first integration documentation-only and dependency-free;
-       reference validation remains open.
+3. [~] Keep the first interoperability step documentation-only and
+       dependency-free; reference validation remains open.
 4. [ ] Exercise the recipe in a public reference repository using active,
        proposed, rejected, and superseded decisions.
 5. [ ] Propose the verified recipe to OpenWiki's public documentation or examples.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adrkit",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Decision memory for human and agent-authored plans \u2014 machine-readable, CI-enforceable architecture decision records.",
   "type": "module",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Git-native architecture decision record tooling from adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -63,7 +63,7 @@ import { getPresentation, setPresentation, styleUsageBlock, type ColorMode, type
  * (mirroring `@adrkit/mcp`'s `SERVER_INFO`) so the bundled `dist/index.js` never has
  * to locate `package.json` at runtime. `version.test.ts` asserts the two agree.
  */
-export const CLI_VERSION = '0.12.0';
+export const CLI_VERSION = '0.13.0';
 
 function topLevelUsage(style?: StreamStyle): string {
   return renderTopLevelUsage(CLI_VERSION, style);

--- a/packages/cli/test/color.test.ts
+++ b/packages/cli/test/color.test.ts
@@ -33,7 +33,7 @@ describe('CLI color presentation', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe('');
     expect(result.stdout).toContain('\u001b[');
-    expect(result.stdout).toContain('adrkit 0.12.0');
+    expect(result.stdout).toContain('adrkit 0.13.0');
   });
 
   test('forced color keeps lint stdout and stderr separated', async () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/core",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Pure ADR parsing, validation, migration, and affects resolution for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrkit/evaluator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Deterministic, model-free ADR proposal evaluation and routing for adrkit.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adrkit/mcp",
   "mcpName": "dev.adrkit/mcp",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Local, read-only Model Context Protocol server exposing adrkit decision retrieval over stdio.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "dev.adrkit/mcp",
   "title": "adrkit decision memory",
   "description": "Deterministic, offline, read-only ADR decision memory for coding agents. No model or network calls.",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "websiteUrl": "https://adrkit.dev",
   "repository": {
     "url": "https://github.com/mbeacom/adrkit",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@adrkit/mcp",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetDecisionContext } from './tools/get-decision-context.ts';
 import { registerListSuperseded } from './tools/list-superseded.ts';
 import type { ToolConfig } from './tools/shared.ts';
 
-export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.12.0' } as const;
+export const SERVER_INFO = { name: '@adrkit/mcp', version: '0.13.0' } as const;
 
 /**
  * The MCP protocol revision this server serves through `serveStdio`'s modern era.

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -14,7 +14,7 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
 				</svg>
 				CLI works today
 			</span>
-			<span>v0.12.0 on npm · decision memory in git</span>
+			<span>v0.13.0 on npm · decision memory in git</span>
 		</div>
 
 		<h1 id="_top" data-page-title set:html={title} />

--- a/site/src/content/docs/badges.mdx
+++ b/site/src/content/docs/badges.mdx
@@ -100,8 +100,8 @@ jobs:
       # current release.
       - run: |
           mkdir -p .adrkit
-          npx @adrkit/cli@0.12.0 queue --format json > .adrkit/queue.json.tmp
-          npx @adrkit/cli@0.12.0 lint --json  > .adrkit/lint.json.tmp
+          npx @adrkit/cli@0.13.0 queue --format json > .adrkit/queue.json.tmp
+          npx @adrkit/cli@0.13.0 lint --json  > .adrkit/lint.json.tmp
 
       # A truncated or malformed write renders as `no result` on the badge, which
       # reads as a bug in your tooling. Fail here instead of committing it.

--- a/site/src/content/docs/ci.mdx
+++ b/site/src/content/docs/ci.mdx
@@ -11,7 +11,7 @@ the corpus and write a comment or an issue.
 
 <Aside type="note" title="GitHub Marketplace">
 	The governing-decisions Action has a repository-root Marketplace entry point
-	planned for v0.13.0. The established
+	available beginning with v0.13.0. The established
 	`mbeacom/adrkit/packages/ci@&lt;ref&gt;` form remains supported, including
 	through its moving `v0` tag. Root Marketplace examples use immutable release
 	tags because recovery may move `v0` to a release from before the root alias.
@@ -48,8 +48,7 @@ jobs:
         #   token: ${{ github.token }}
 ```
 
-Until `v0.13.0` is published, use
-`mbeacom/adrkit/packages/ci@v0`. That nested form remains supported afterward.
+The established `mbeacom/adrkit/packages/ci@v0` nested form remains supported.
 
 The Action updates its existing comment on later pushes, so each pull request
 keeps one current governing-decisions comment. No additional token environment
@@ -68,7 +67,7 @@ the comment reaches GitHub's size limit. Keep the default checkout rooted at
 `GITHUB_WORKSPACE`; if a workflow checks out elsewhere, marker health will
 identify files the Action could not inspect.
 
-The Marketplace form will be pinned to the immutable `v0.13.0` release. For
+The Marketplace form is pinned to the immutable `v0.13.0` release. For
 the nested compatibility form, `v0` is a moving major tag; pin an immutable
 release tag or commit SHA when maximum reproducibility matters.
 
@@ -79,14 +78,14 @@ release tag or commit SHA when maximum reproducibility matters.
 </Aside>
 
 <Aside type="caution" title="Pinning a release tag by SHA">
-	The `v*` release tags are **annotated**, so `refs/tags/v0.12.0` resolves to a tag
+	The `v*` release tags are **annotated**, so `refs/tags/v0.13.0` resolves to a tag
 	object rather than a commit, and `uses:` rejects that SHA. Pin the commit the tag
 	points *at*:
 
 	```sh
-	git rev-parse v0.12.0^{commit}
+	git rev-parse v0.13.0^{commit}
 	# or, over the API — this endpoint peels the tag for you:
-	gh api repos/mbeacom/adrkit/commits/v0.12.0 --jq .sha
+	gh api repos/mbeacom/adrkit/commits/v0.13.0 --jq .sha
 	```
 
 	Note that `GET /git/ref/tags/{tag}` does **not** peel: its `object.sha` is the tag

--- a/site/src/content/docs/generated-knowledge.mdx
+++ b/site/src/content/docs/generated-knowledge.mdx
@@ -41,7 +41,8 @@ giving generated content authority over human decisions.
 |---|---|---|
 | `docs/adr/**` | Ratified intent, alternatives, lifecycle, typed relationships, and what a decision affects | People and agents through the repository's normal pull-request review |
 | Source and tests | Current implementation and executable behavior | The product development workflow |
-| `openwiki/**` | Generated explanations and current-state architecture projections | OpenWiki through its own update workflow |
+| `openwiki/INSTRUCTIONS.md` | Human-reviewed instructions that constrain the generated projection | People and agents through a separate pull request |
+| Other Markdown plus OpenWiki claims and manifest JSON under `openwiki/**` | Generated explanations, claims, and current-state architecture projections | OpenWiki through its own update workflow |
 | OpenWiki-managed blocks in `AGENTS.md` and `CLAUDE.md` | Pointers that help coding agents discover the generated wiki | OpenWiki within its documented marker boundaries |
 
 An OpenWiki page may cite an ADR and explain it. It must not accept, reject,
@@ -136,8 +137,20 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install OpenWiki
-        run: npm install --global openwiki@0.4.3
+      - name: Build the reviewed OpenWiki source revision
+        shell: bash
+        run: |
+          source_dir="$RUNNER_TEMP/openwiki-source"
+          git init "$source_dir"
+          git -C "$source_dir" remote add origin https://github.com/langchain-ai/openwiki.git
+          git -C "$source_dir" fetch --depth=1 origin c666f4262e4340e5675fa9804bb342b87bf87f1a
+          git -C "$source_dir" checkout --detach FETCH_HEAD
+          corepack enable
+          (
+            cd "$source_dir"
+            pnpm install --frozen-lockfile
+            pnpm run build
+          )
 
       # This example uses OpenAI. Substitute the provider-specific environment
       # documented by OpenWiki when you use another provider.
@@ -145,7 +158,7 @@ jobs:
         run: |
           : "${OPENWIKI_MODEL_ID:?Set repository variable OPENWIKI_MODEL_ID}"
           : "${OPENAI_API_KEY:?Set repository secret OPENAI_API_KEY}"
-          openwiki code --update --print
+          node "$RUNNER_TEMP/openwiki-source/dist/cli/cli.js" code --update --print
         env:
           OPENWIKI_PROVIDER: openai
           OPENWIKI_MODEL_ID: ${{ vars.OPENWIKI_MODEL_ID }}
@@ -186,9 +199,23 @@ jobs:
             echo 'OpenWiki output root must be a real directory.' >&2
             exit 1
           fi
-          non_regular="$(find openwiki -mindepth 1 ! -type f ! -type d -print)"
-          if [[ -n "$non_regular" ]]; then
-            printf 'OpenWiki created non-regular output:\n%s\n' "$non_regular" >&2
+          invalid=()
+          while IFS= read -r -d '' path; do
+            invalid+=("$path")
+          done < <(find openwiki -mindepth 1 ! -type f ! -type d -print0)
+          while IFS= read -r -d '' path; do
+            case "$path" in
+              openwiki/INSTRUCTIONS.md | openwiki/*.md) ;;
+              openwiki/.claims/*.json | openwiki/.last-update.json | openwiki/.page-manifest.json) ;;
+              *) invalid+=("$path") ;;
+            esac
+          done < <(find openwiki -type f -print0)
+          while IFS= read -r -d '' path; do
+            invalid+=("$path")
+          done < <(find openwiki -type f -perm /111 -print0)
+          if (( ${#invalid[@]} )); then
+            printf 'OpenWiki created unsupported or executable output:\n' >&2
+            printf '  %q\n' "${invalid[@]}" >&2
             exit 1
           fi
           tar \
@@ -237,6 +264,13 @@ jobs:
           branch: openwiki/update
           commit-message: 'docs: update OpenWiki'
           title: 'docs: update OpenWiki'
+          body: |
+            Automated OpenWiki documentation update.
+
+            Keep this pull request in draft until a reviewer confirms that ADR
+            lifecycle states, applicability, relationships, and source links
+            agree with the cited decision records.
+          draft: always-true
           signoff: true
 ```
 
@@ -263,10 +297,16 @@ Treat `docs/adr/**` as read-only normative decision evidence.
 
 - Never create, edit, delete, accept, reject, deprecate, or supersede an ADR.
 - Preserve each record's id and link to the original file.
-- Present `accepted` records as governing decisions.
+- Present `accepted` records as ratified decisions. Call one governing for a
+  target only when `adr check` or `adr explain` reports it through a matching
+  `affects` declaration or inbound `@adr` marker; do not reimplement resolution.
 - Present `draft` and `proposed` records as under review, not as current policy.
 - Keep `rejected`, `superseded`, and `deprecated` records in decision history.
-- Label `supersedes`, `relatesTo`, and `conflictsWith` relationships explicitly.
+- Preserve `scope`, `affects`, and marker provenance where the consuming
+  contract exposes them. Label `supersedes`, `supersededBy`, `relatesTo`, and
+  `conflictsWith` relationships explicitly.
+- Label every ADR-derived page as a non-authoritative generated projection and
+  record the source ADR-corpus git revision.
 - When code differs from an accepted ADR, report the mismatch for human review.
   Do not revise the ADR or infer a new decision from implementation alone.
 - Treat machine verification of generated content as documentation provenance,
@@ -282,10 +322,11 @@ distinctions that make the corpus useful to review and retrieval.
 repository permission boundary. Pair it with controls the generated workflow
 cannot reinterpret:
 
-1. Keep scheduled update commits limited to generated files under
-   `openwiki/**`, and fail the run if `openwiki/INSTRUCTIONS.md` changes.
-   Establish changes to that brief, `AGENTS.md`, `CLAUDE.md`, and the workflow
-   in a separate human-reviewed pull request.
+1. Keep scheduled update commits limited to non-executable Markdown, JSON below
+   `openwiki/.claims/`, and OpenWiki's two root JSON manifests. Fail the run if
+   `openwiki/INSTRUCTIONS.md` changes. Establish changes to that brief,
+   `AGENTS.md`, `CLAUDE.md`, and the workflow in a separate human-reviewed pull
+   request.
 2. Add `docs/adr/**`, `openwiki/INSTRUCTIONS.md`, `AGENTS.md`, `CLAUDE.md`, and
    the OpenWiki workflow to `CODEOWNERS`.
 3. Where a distinct reviewer is available, configure branch protection or a
@@ -298,9 +339,9 @@ cannot reinterpret:
 4. Keep OpenWiki's managed blocks in `AGENTS.md` and `CLAUDE.md` limited to
    pointers that help agents find the wiki. Review any change outside the
    documented markers as an ordinary source change.
-5. Do not enable automatic merging for a generated-documentation pull request
-   that also changes a decision record, an agent-instruction file, or the update
-   workflow.
+5. Open every generated-documentation pull request as a draft. Do not enable
+   automatic merging; a reviewer must first compare ADR lifecycle,
+   applicability, relationship, and source-link claims with the cited records.
 
 For example:
 
@@ -344,20 +385,22 @@ when an applicable deterministic assertion actually evaluates and fails.
    the implementation or propose a new ADR that explicitly supersedes the old
    decision.
 
-## Recover from a write-boundary breach
+## Recover from a generated-output breach
 
-If a generated-documentation change reaches a protected path:
+If a generated-documentation change reaches a protected path or misrepresents
+an ADR's lifecycle, applicability, relationship, or source:
 
 1. Disable the update workflow before its next scheduled run.
-2. Open a human-reviewed revert pull request that restores `docs/adr/**`,
-   `openwiki/INSTRUCTIONS.md`, `AGENTS.md`, `CLAUDE.md`, and the workflow to
-   their last reviewed state, and verify `.github/CODEOWNERS` was not weakened.
-   Do not hide the event by rewriting shared history.
+2. Open a human-reviewed revert pull request that restores any protected paths
+   and generated claims to their last reviewed state, and verify
+   `.github/CODEOWNERS` was not weakened. Do not hide the event by rewriting
+   shared history.
 3. Run `adr lint` and `adr check` against the restored corpus and affected
    source paths.
 4. Review generated-documentation pull requests since the last known-good run
    for the same boundary crossing.
-5. Narrow the committed-path allowlist and confirm the branch-protection or
+5. Correct the brief or output grammar that admitted the breach, regenerate
+   from the last reviewed source revision, and confirm the branch-protection or
    ruleset configuration still enforces its intended review policy before
    re-enabling automation.
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
 <div class="adr-home">
 	<section class="adr-status-band" aria-label="Project status">
 		<div class="adr-status-band__item">
-			<span class="adr-status adr-status--current">Published · v0.12.0</span>
+			<span class="adr-status adr-status--current">Published · v0.13.0</span>
 			<p><code>@adrkit/core</code>, <code>@adrkit/cli</code>, <code>@adrkit/evaluator</code>, and <code>@adrkit/mcp</code> are on npm, plus the independently versioned <code>@adrkit/spec-kit</code> extension; the CI Action ships at <code>mbeacom/adrkit/packages/ci@v0</code>.</p>
 		</div>
 		<div class="adr-status-band__item">

--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -10,7 +10,7 @@ decisions govern a file, renders the decision graph, migrates an existing MADR
 corpus in place, emits the ARB operations queue, and runs the deterministic
 evaluator.
 
-<Aside type="tip" title="Published on npm (v0.12.0)">
+<Aside type="tip" title="Published on npm (v0.13.0)">
 	`@adrkit/cli` is live. Consumers install it with your Node package manager and
 	run the `adr` binary — no clone required.
 </Aside>


### PR DESCRIPTION
## What and why

Prepare the coordinated v0.13.0 release for the Marketplace entry point, stale-marker diagnostics, deterministic ordering fix, ADR-aware Copilot review skill, and provisional generated-knowledge guidance.

This advances the four lockstep npm packages and embedded CLI/MCP versions, refreshes release-facing documentation, and records the release notes. ADR-0037 remains proposed: the change separates ratification from path applicability, preserves marker and relationship provenance, and hardens the OpenWiki recipe with a pinned source build, a strict non-executable output grammar, draft-only publication, and human review before merge. It also corrects the packed-consumer audit instructions so npm materializes its own lock before auditing.

## Checklist

- [x] Commits are **DCO signed off** (`git commit -s`). No CLA is required. This is
      enforced by the `dco` check; to sign commits you already made, see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-is-required).
- [x] If this changes a recorded decision in `docs/adr/`, an ADR is **added or
      supersedes** the affected record - with the argument, not just a status flip.
- [x] If the schema changed, I edited the Zod source
      `packages/core/src/schema/adr.schema.ts` (not the root re-export), re-ran
      `bun run schema:emit`, and committed the generated `schema/adr.schema.json`.
- [x] If `packages/ci/src` **or** `@adrkit/core` changed, I regenerated
      `packages/ci/dist` under **linux/amd64 bun 1.3.14** and committed it
      (see CONTRIBUTING.md - a Mac-built bundle fails the diff gate).
- [x] New or changed behavior is covered by tests, and each test was **observed
      failing before it passed** - a check that never failed is not coverage
      ([ADR-0016](docs/adr/0016-require-every-check-to-be-observed-failing-before-it-counts-as-coverage.md)).
- [x] `bun run typecheck && bun run build && bun test && bun run lint` pass from a
      clean clone with no credentials configured
      ([ADR-0007](docs/adr/0007-adapter-isolation-and-public-surface-build.md)).

## Notes for reviewers

ADR-0037 is intentionally not accepted here. Explicit human ratification and the public end-to-end reference-repository exercise remain open. The core change is version-only package metadata, so the committed Action bundle has no runtime delta; schema and runtime API surfaces are unchanged.